### PR TITLE
Enable group names containing spaces in HtmlIndividualConfiguration

### DIFF
--- a/lib/html_individual_config.dart
+++ b/lib/html_individual_config.dart
@@ -34,6 +34,8 @@ class HtmlIndividualConfiguration extends htmlconfig.HtmlConfiguration {
         }
 
         var testGroupName = groups.single.split('=')[1];
+        testGroupName =
+            testGroupName.replaceAll('+', ' ').replaceAll('%20', ' ');
         var startsWith = "$testGroupName${unittest.groupSep}";
         unittest.filterTests(
             (unittest.TestCase tc) => tc.description.startsWith(startsWith));


### PR DESCRIPTION
Fixes dart issue http://dartbug.com/23156 and test issue https://github.com/dart-lang/test/issues/61