### PR TITLE
stack_trace 1.2.0 isn't compatible with test.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   shelf_static: '^0.2.0'
   shelf_web_socket: '^0.0.1'
   source_span: '^1.0.0'
-  stack_trace: '^1.2.0'
+  stack_trace: '^1.2.1'
   string_scanner: '^0.1.1'
   yaml: '>=0.9.0 <3.0.0'
 


### PR DESCRIPTION
I tried `pub downgrade` and I got the error

 `Class 'LazyTrace' has no instance method 'foldFrames' with matching arguments.`

 After limiting stack_trace to '^1.2.1' it worked again.