### PR TITLE
Fix typo in sample YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ have to make sure that the `test/pub_serve` transformer comes *after* the
 [polymer]: https://www.dartlang.org/polymer/
 
 ```yaml
-transformer:
+transformers:
 - polymer
 - test/pub_serve:
     $include: test/**_test{.*,}.dart


### PR DESCRIPTION
The label should be `transformers`, not `transformer`.