### PR TITLE
Start adding Sky support to test runner

### DIFF
--- a/lib/src/runner/browser/dartium.dart
+++ b/lib/src/runner/browser/dartium.dart
@@ -30,6 +30,11 @@ class Dartium extends Browser {
 
   final Future<Uri> observatoryUrl;
 
+  /// Starts a new instance of Dartium open to the given [url], which may be a
+  /// [Uri] or a [String].
+  ///
+  /// If [executable] is passed, it's used as the Dartium executable. Otherwise
+  /// the default executable name for the current OS will be used.
   factory Dartium(url, {String executable, bool debug: false}) {
     var completer = new Completer.sync();
     return new Dartium._(() async {
@@ -63,12 +68,6 @@ class Dartium extends Browser {
 
   Dartium._(Future<Process> startBrowser(), this.observatoryUrl)
       : super(startBrowser);
-
-  /// Starts a new instance of Dartium open to the given [url], which may be a
-  /// [Uri] or a [String].
-  ///
-  /// If [executable] is passed, it's used as the Dartium executable. Otherwise
-  /// the default executable name for the current OS will be used.
 
   /// Return the default executable for the current operating system.
   static String _defaultExecutable() {

--- a/lib/src/runner/browser/server.dart
+++ b/lib/src/runner/browser/server.dart
@@ -18,7 +18,6 @@ import 'package:shelf_static/shelf_static.dart';
 import 'package:shelf_web_socket/shelf_web_socket.dart';
 
 import '../../backend/metadata.dart';
-import '../../backend/suite.dart';
 import '../../backend/test_platform.dart';
 import '../../util/io.dart';
 import '../../util/one_off_handler.dart';
@@ -27,6 +26,7 @@ import '../../util/stack_trace_mapper.dart';
 import '../../utils.dart';
 import '../configuration.dart';
 import '../load_exception.dart';
+import '../runner_suite.dart';
 import 'browser_manager.dart';
 import 'compiler_pool.dart';
 import 'polymer.dart';
@@ -209,7 +209,7 @@ void main() {
   ///
   /// This will start a browser to load the suite if one isn't already running.
   /// Throws an [ArgumentError] if [browser] isn't a browser platform.
-  Future<Suite> loadSuite(String path, TestPlatform browser,
+  Future<RunnerSuite> loadSuite(String path, TestPlatform browser,
       Metadata metadata) async {
     if (!browser.isBrowser) {
       throw new ArgumentError("$browser is not a browser.");

--- a/lib/src/runner/vm/isolate_listener.dart
+++ b/lib/src/runner/vm/isolate_listener.dart
@@ -9,6 +9,7 @@ import 'dart:async';
 
 import '../../backend/metadata.dart';
 import '../../backend/suite.dart';
+import '../../utils.dart';
 import 'vm_listener.dart';
 
 /// A class that runs tests in a separate isolate and communicates the results

--- a/lib/src/runner/vm/isolate_listener.dart
+++ b/lib/src/runner/vm/isolate_listener.dart
@@ -7,23 +7,13 @@ library test.runner.vm.isolate_listener;
 import 'dart:isolate';
 import 'dart:async';
 
-import 'package:stack_trace/stack_trace.dart';
-
-import '../../backend/declarer.dart';
 import '../../backend/metadata.dart';
 import '../../backend/suite.dart';
-import '../../backend/test.dart';
-import '../../backend/test_platform.dart';
-import '../../util/io.dart';
-import '../../util/remote_exception.dart';
-import '../../utils.dart';
+import 'vm_listener.dart';
 
 /// A class that runs tests in a separate isolate and communicates the results
 /// back to the main isolate.
-class IsolateListener {
-  /// The test suite to run.
-  final Suite _suite;
-
+class IsolateListener extends VMListener {
   /// Extracts metadata about all the tests in the function returned by
   /// [getMain] and sends information about them over [sendPort].
   ///
@@ -34,78 +24,19 @@ class IsolateListener {
   /// run.
   ///
   /// [metadata] is the suite-level metadata defined at the top of the file.
-  static Future start(SendPort sendPort, Metadata metadata, Function getMain())
-      async {
-    // Capture any top-level errors (mostly lazy syntax errors, since other are
-    // caught below) and report them to the parent isolate. We set errors
-    // non-fatal because otherwise they'll be double-printed.
-    var errorPort = new ReceivePort();
-    Isolate.current.setErrorsFatal(false);
-    Isolate.current.addErrorListener(errorPort.sendPort);
-    errorPort.listen((message) {
-      // Masquerade as an IsoalteSpawnException because that's what this would
-      // be if the error had been detected statically.
-      var error = new IsolateSpawnException(message[0]);
-      var stackTrace =
-          message[1] == null ? new Trace([]) : new Trace.parse(message[1]);
-      sendPort.send({
-        "type": "error",
-        "error": RemoteException.serialize(error, stackTrace)
-      });
-    });
-
-    var main;
-    try {
-      main = getMain();
-    } on NoSuchMethodError catch (_) {
-      _sendLoadException(sendPort, "No top-level main() function defined.");
-      return;
-    }
-
-    if (main is! Function) {
-      _sendLoadException(sendPort, "Top-level main getter is not a function.");
-      return;
-    } else if (main is! AsyncFunction) {
-      _sendLoadException(
-          sendPort, "Top-level main() function takes arguments.");
-      return;
-    }
-
-    var declarer = new Declarer();
-    try {
-      await runZoned(() => new Future.sync(main), zoneValues: {
-        #test.declarer: declarer
-      }, zoneSpecification: new ZoneSpecification(print: (_, __, ___, line) {
-        sendPort.send({"type": "print", "line": line});
-      }));
-    } catch (error, stackTrace) {
-      sendPort.send({
-        "type": "error",
-        "error": RemoteException.serialize(error, stackTrace)
-      });
-      return;
-    }
-
-    var suite = new Suite(declarer.tests,
-        platform: TestPlatform.vm, os: currentOS, metadata: metadata);
-    new IsolateListener._(suite)._listen(sendPort);
+  static Future start(SendPort sendPort, Metadata metadata, Function getMain()) {
+    return VMListener.start(sendPort.send, metadata, getMain,
+        (Suite suite) => new IsolateListener(suite));
   }
 
-  /// Sends a message over [sendPort] indicating that the tests failed to load.
-  ///
-  /// [message] should describe the failure.
-  static void _sendLoadException(SendPort sendPort, String message) {
-    sendPort.send({"type": "loadException", "message": message});
-  }
+  IsolateListener(Suite suite) : super(suite);
 
-  IsolateListener._(this._suite);
-
-  /// Send information about [_suite] across [sendPort] and start listening for
+  /// Send information about [suite] via [send] and start listening for
   /// commands to run the tests.
-  void _listen(SendPort sendPort) {
+  void listen(MessageSink send) {
     var tests = [];
-    for (var i = 0; i < _suite.tests.length; i++) {
-      var test = _suite.tests[i];
+    for (var i = 0; i < suite.tests.length; i++) {
+      var test = suite.tests[i];
       var receivePort = new ReceivePort();
       tests.add({
         "name": test.name,
@@ -115,48 +46,13 @@ class IsolateListener {
 
       receivePort.listen((message) {
         assert(message['command'] == 'run');
-        _runTest(test, message['reply']);
+        runTest(test, message['reply'].send);
       });
     }
 
-    sendPort.send({
+    send({
       "type": "success",
       "tests": tests
     });
-  }
-
-  /// Runs [test] and sends the results across [sendPort].
-  void _runTest(Test test, SendPort sendPort) {
-    var liveTest = test.load(_suite);
-
-    var receivePort = new ReceivePort();
-    sendPort.send({"type": "started", "reply": receivePort.sendPort});
-
-    receivePort.listen((message) {
-      assert(message['command'] == 'close');
-      receivePort.close();
-      liveTest.close();
-    });
-
-    liveTest.onStateChange.listen((state) {
-      sendPort.send({
-        "type": "state-change",
-        "status": state.status.name,
-        "result": state.result.name
-      });
-    });
-
-    liveTest.onError.listen((asyncError) {
-      sendPort.send({
-        "type": "error",
-        "error": RemoteException.serialize(
-            asyncError.error, asyncError.stackTrace)
-      });
-    });
-
-    liveTest.onPrint.listen((line) =>
-        sendPort.send({"type": "print", "line": line}));
-
-    liveTest.run().then((_) => sendPort.send({"type": "complete"}));
   }
 }

--- a/lib/src/runner/vm/isolate_loader.dart
+++ b/lib/src/runner/vm/isolate_loader.dart
@@ -1,0 +1,134 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library test.runner.vm.isolate_loader;
+
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:path/path.dart' as p;
+import 'package:stack_trace/stack_trace.dart';
+
+import '../../backend/metadata.dart';
+import '../../backend/test_platform.dart';
+import '../../util/dart.dart' as dart;
+import '../../util/io.dart';
+import '../../util/remote_exception.dart';
+import '../configuration.dart';
+import '../load_exception.dart';
+import '../runner_suite.dart';
+import 'environment.dart';
+import 'isolate_test.dart';
+
+/// A class for loading test files in an Isolate.
+class IsolateLoader {
+  /// The test runner configuration.
+  final Configuration _config;
+
+  /// All suites that have been created by the loader.
+  final _suites = new Set<RunnerSuite>();
+
+  /// Creates a new loader that loads tests on platforms defined in [_config].
+  IsolateLoader(this._config);
+
+  /// Load the test suite at [path] in VM isolate.
+  ///
+  /// [metadata] is the suite-level metadata for the test.
+  Future<RunnerSuite> loadSuite(String path, Metadata metadata) async {
+    var receivePort = new ReceivePort();
+
+    var isolate;
+    try {
+      if (_config.pubServeUrl != null) {
+        var url = _config.pubServeUrl.resolveUri(
+            p.toUri(p.relative(path, from: 'test') + '.vm_test.dart'));
+
+        try {
+          isolate = await Isolate.spawnUri(url, [], {
+            'reply': receivePort.sendPort,
+            'metadata': metadata.serialize()
+          }, checked: true);
+        } on IsolateSpawnException catch (error) {
+          if (error.message.contains("OS Error: Connection refused") ||
+              error.message.contains("The remote computer refused")) {
+            throw new LoadException(path,
+                "Error getting $url: Connection refused\n"
+                'Make sure "pub serve" is running.');
+          } else if (error.message.contains("404 Not Found")) {
+            throw new LoadException(path,
+                "Error getting $url: 404 Not Found\n"
+                'Make sure "pub serve" is serving the test/ directory.');
+          }
+
+          throw new LoadException(path, error);
+        }
+      } else {
+        isolate = await dart.runInIsolate('''
+import "package:test/src/backend/metadata.dart";
+import "package:test/src/runner/vm/isolate_listener.dart";
+
+import "${p.toUri(p.absolute(path))}" as test;
+
+void main(_, Map message) {
+  var sendPort = message['reply'];
+  var metadata = new Metadata.deserialize(message['metadata']);
+  IsolateListener.start(sendPort, metadata, () => test.main);
+}
+''', {
+          'reply': receivePort.sendPort,
+          'metadata': metadata.serialize()
+        }, packageRoot: p.toUri(_config.packageRoot), checked: true);
+      }
+    } catch (error, stackTrace) {
+      receivePort.close();
+      if (error is LoadException) rethrow;
+      await new Future.error(new LoadException(path, error), stackTrace);
+    }
+
+    var completer = new Completer();
+
+    var subscription = receivePort.listen((response) {
+      if (response["type"] == "print") {
+        print(response["line"]);
+      } else if (response["type"] == "loadException") {
+        isolate.kill();
+        completer.completeError(
+            new LoadException(path, response["message"]),
+            new Trace.current());
+      } else if (response["type"] == "error") {
+        isolate.kill();
+        var asyncError = RemoteException.deserialize(response["error"]);
+        completer.completeError(
+            new LoadException(path, asyncError.error),
+            asyncError.stackTrace);
+      } else {
+        assert(response["type"] == "success");
+        completer.complete(response["tests"]);
+      }
+    });
+
+    try {
+      var suite = new RunnerSuite(const VMEnvironment(),
+          (await completer.future).map((test) {
+        var testMetadata = new Metadata.deserialize(test['metadata']);
+        return new IsolateTest(test['name'], testMetadata, test['sendPort']);
+      }),
+          metadata: metadata,
+          path: path,
+          platform: TestPlatform.vm,
+          os: currentOS,
+          onClose: isolate.kill);
+      _suites.add(suite);
+      return suite;
+    } finally {
+      subscription.cancel();
+    }
+  }
+
+  /// Closes the loader and releases all resources allocated by it.
+  Future close() async {
+    await Future.wait(_suites.map((suite) => suite.close()));
+    _suites.clear();
+  }
+}

--- a/lib/src/runner/vm/isolate_test.dart
+++ b/lib/src/runner/vm/isolate_test.dart
@@ -7,82 +7,24 @@ library test.runner.vm.isolate_test;
 import 'dart:async';
 import 'dart:isolate';
 
-import '../../backend/live_test.dart';
-import '../../backend/live_test_controller.dart';
 import '../../backend/metadata.dart';
-import '../../backend/state.dart';
-import '../../backend/suite.dart';
 import '../../backend/test.dart';
-import '../../util/remote_exception.dart';
-import '../../utils.dart';
+import 'vm_test.dart';
 
 /// A test in another isolate.
-class IsolateTest implements Test {
-  final String name;
-  final Metadata metadata;
-
-  /// The port on which to communicate with the remote test.
+class IsolateTest extends VMTest {
   final SendPort _sendPort;
 
-  IsolateTest(this.name, this.metadata, this._sendPort);
+  IsolateTest(String name, Metadata metadata, SendPort sendPort)
+    : _sendPort = sendPort, super(name, metadata, sendPort.send);
 
-  /// Loads a single runnable instance of this test.
-  LiveTest load(Suite suite) {
-    var controller;
-
-    // We get a new send port for communicating with the live test, since
-    // [_sendPort] is only for communicating with the non-live test. This will
-    // be non-null once the test starts running.
-    var sendPortCompleter;
-
-    var receivePort;
-    controller = new LiveTestController(suite, this, () {
-      controller.setState(const State(Status.running, Result.success));
-
-      sendPortCompleter = new Completer();
-      receivePort = new ReceivePort();
-      _sendPort.send({
-        'command': 'run',
-        'reply': receivePort.sendPort
-      });
-
-      receivePort.listen((message) {
-        if (message['type'] == 'started') {
-          sendPortCompleter.complete(message['reply']);
-        } else if (message['type'] == 'error') {
-          var asyncError = RemoteException.deserialize(message['error']);
-          controller.addError(asyncError.error, asyncError.stackTrace);
-        } else if (message['type'] == 'state-change') {
-          controller.setState(
-              new State(
-                  new Status.parse(message['status']),
-                  new Result.parse(message['result'])));
-        } else if (message['type'] == 'print') {
-          controller.print(message['line']);
-        } else {
-          assert(message['type'] == 'complete');
-          controller.completer.complete();
-        }
-      });
-    }, () {
-      // If the test has finished running, just disconnect the receive port. The
-      // Dart process won't terminate if there are any live receive ports open.
-      if (controller.completer.isCompleted) {
-        receivePort.close();
-        return;
-      }
-
-      invoke(() async {
-        // If the test is still running, send it a message telling it to shut
-        // down ASAP. This causes the [Invoker] to eagerly throw exceptions
-        // whenever the test touches it.
-        var sendPort = await sendPortCompleter.future;
-        sendPort.send({'command': 'close'});
-        await controller.completer.future;
-        receivePort.close();
-      });
+  Stream sendRunCommand() {
+    ReceivePort receivePort = new ReceivePort();
+    send({
+      'command': 'run',
+      'reply': receivePort.sendPort
     });
-    return controller.liveTest;
+    return receivePort;
   }
 
   Test change({String name, Metadata metadata}) {

--- a/lib/src/runner/vm/vm_listener.dart
+++ b/lib/src/runner/vm/vm_listener.dart
@@ -18,8 +18,6 @@ import '../../util/io.dart';
 import '../../util/remote_exception.dart';
 import '../../utils.dart';
 
-typedef void MessageSink(dynamic message);
-
 abstract class VMListener {
   /// The test suite to run.
   final Suite suite;

--- a/lib/src/runner/vm/vm_listener.dart
+++ b/lib/src/runner/vm/vm_listener.dart
@@ -1,0 +1,128 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library test.runner.vm.vm_listener;
+
+import 'dart:isolate';
+import 'dart:async';
+
+import 'package:stack_trace/stack_trace.dart';
+
+import '../../backend/declarer.dart';
+import '../../backend/metadata.dart';
+import '../../backend/suite.dart';
+import '../../backend/test.dart';
+import '../../backend/test_platform.dart';
+import '../../util/io.dart';
+import '../../util/remote_exception.dart';
+import '../../utils.dart';
+
+typedef void MessageSink(dynamic message);
+
+abstract class VMListener {
+  /// The test suite to run.
+  final Suite suite;
+
+  static Future start(MessageSink send, Metadata metadata, Function getMain(),
+      VMListener createListener(Suite suite)) async {
+    // Capture any top-level errors (mostly lazy syntax errors, since other are
+    // caught below) and report them to the parent isolate. We set errors
+    // non-fatal because otherwise they'll be double-printed.
+    var errorPort = new ReceivePort();
+    Isolate.current.setErrorsFatal(false);
+    Isolate.current.addErrorListener(errorPort.sendPort);
+    errorPort.listen((message) {
+      // Masquerade as an IsoalteSpawnException because that's what this would
+      // be if the error had been detected statically.
+      var error = new IsolateSpawnException(message[0]);
+      var stackTrace =
+          message[1] == null ? new Trace([]) : new Trace.parse(message[1]);
+      send({
+        "type": "error",
+        "error": RemoteException.serialize(error, stackTrace)
+      });
+    });
+
+    var main;
+    try {
+      main = getMain();
+    } on NoSuchMethodError catch (_) {
+      _sendLoadException(send, "No top-level main() function defined.");
+      return;
+    }
+
+    if (main is! Function) {
+      _sendLoadException(send, "Top-level main getter is not a function.");
+      return;
+    } else if (main is! AsyncFunction) {
+      _sendLoadException(send, "Top-level main() function takes arguments.");
+      return;
+    }
+
+    var declarer = new Declarer();
+    try {
+      await runZoned(() => new Future.sync(main), zoneValues: {
+        #test.declarer: declarer
+      }, zoneSpecification: new ZoneSpecification(print: (_, __, ___, line) {
+        send({"type": "print", "line": line});
+      }));
+    } catch (error, stackTrace) {
+      send({
+        "type": "error",
+        "error": RemoteException.serialize(error, stackTrace)
+      });
+      return;
+    }
+
+    var suite = new Suite(declarer.tests,
+        platform: TestPlatform.vm, os: currentOS, metadata: metadata);
+    createListener(suite).listen(send);
+  }
+
+  /// Sends a message using [send] indicating that the tests failed to load.
+  ///
+  /// [message] should describe the failure.
+  static void _sendLoadException(MessageSink send, String message) {
+    send({"type": "loadException", "message": message});
+  }
+
+  void listen(MessageSink send);
+
+  VMListener(this.suite);
+
+  /// Runs [test] and sends the results via [send].
+  void runTest(Test test, MessageSink send) {
+    var liveTest = test.load(suite);
+
+    var receivePort = new ReceivePort();
+    send({"type": "started", "reply": receivePort.sendPort});
+
+    receivePort.listen((message) {
+      assert(message['command'] == 'close');
+      receivePort.close();
+      liveTest.close();
+    });
+
+    liveTest.onStateChange.listen((state) {
+      send({
+        "type": "state-change",
+        "status": state.status.name,
+        "result": state.result.name
+      });
+    });
+
+    liveTest.onError.listen((asyncError) {
+      send({
+        "type": "error",
+        "error": RemoteException.serialize(
+            asyncError.error, asyncError.stackTrace)
+      });
+    });
+
+    liveTest.onPrint.listen((line) =>
+        send({"type": "print", "line": line}));
+
+    liveTest.run().then((_) => send({"type": "complete"}));
+  }
+}

--- a/lib/src/runner/vm/vm_test.dart
+++ b/lib/src/runner/vm/vm_test.dart
@@ -1,0 +1,82 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library test.runner.vm.vm_test;
+
+import 'dart:async';
+
+import '../../backend/live_test.dart';
+import '../../backend/live_test_controller.dart';
+import '../../backend/metadata.dart';
+import '../../backend/state.dart';
+import '../../backend/suite.dart';
+import '../../backend/test.dart';
+import '../../util/remote_exception.dart';
+import '../../utils.dart';
+
+abstract class VMTest implements Test {
+  final String name;
+  final Metadata metadata;
+
+  /// The port on which to communicate with the remote test.
+  final MessageSink send;
+
+  VMTest(this.name, this.metadata, this.send);
+
+  Stream sendRunCommand();
+
+  /// Loads a single runnable instance of this test.
+  LiveTest load(Suite suite) {
+    LiveTestController controller;
+
+    // We get a new send port for communicating with the live test, since
+    // [_sendPort] is only for communicating with the non-live test. This will
+    // be non-null once the test starts running.
+    var sendPortCompleter;
+
+    StreamSubscription subscription;
+
+    controller = new LiveTestController(suite, this, () {
+      controller.setState(const State(Status.running, Result.success));
+      sendPortCompleter = new Completer();
+
+      subscription = sendRunCommand().listen((message) {
+        if (message['type'] == 'started') {
+          sendPortCompleter.complete(message['reply']);
+        } else if (message['type'] == 'error') {
+          var asyncError = RemoteException.deserialize(message['error']);
+          controller.addError(asyncError.error, asyncError.stackTrace);
+        } else if (message['type'] == 'state-change') {
+          controller.setState(
+              new State(
+                  new Status.parse(message['status']),
+                  new Result.parse(message['result'])));
+        } else if (message['type'] == 'print') {
+          controller.print(message['line']);
+        } else {
+          assert(message['type'] == 'complete');
+          controller.completer.complete();
+        }
+      });
+    }, () {
+      // If the test has finished running, just disconnect the receive port. The
+      // Dart process won't terminate if there are any live receive ports open.
+      if (controller.completer.isCompleted) {
+        subscription.cancel();
+        return;
+      }
+
+      invoke(() async {
+        // If the test is still running, send it a message telling it to shut
+        // down ASAP. This causes the [Invoker] to eagerly throw exceptions
+        // whenever the test touches it.
+        var sendPort = await sendPortCompleter.future;
+        sendPort.send({'command': 'close'});
+        await controller.completer.future;
+        subscription.cancel();
+      });
+    });
+    return controller.liveTest;
+  }
+}

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -29,6 +29,9 @@ typedef AsyncFunction();
 /// A typedef for a zero-argument callback function.
 typedef void Callback();
 
+/// A typedef for a function that can receive an arbitrary message.
+typedef void MessageSink(dynamic message);
+
 /// A converter that decodes bytes using UTF-8 and splits them on newlines.
 final lineSplitter = UTF8.decoder.fuse(const LineSplitter());
 


### PR DESCRIPTION
I'm working on adding support for Sky to `test` by making it possible to run tests in `sky_shell`.  The `sky_shell` is similar to the standalone `dart` command line environment but with the `dart:sky` library available.

The approach I'm using is to run the tests in a `sky_shell` subprocess of the test runner process.  The code will follow the approach used by `TestPlatform.vm` but using subprocesses and WebSockets instead of isolates and SendPorts.

I looked at re-using the browser codepath, but that code makes too many assumptions about how the subprocess works (e.g., that it supports iframes).  It looked like `TestPlatform.vm` was a better starting point.

This pull request just factors base classes out of some of the `runner/vm` code to make it easier to share code with the upcoming `subprocess_listener` and `subprocess_test`.  After these series of pull requests, it will also be possible to run tests in `dart` subprocesses instead of isolates.