### PR TITLE
When using --pub-serve, only compile tests when browser.isJS is true

### DIFF
--- a/lib/src/runner/browser/server.dart
+++ b/lib/src/runner/browser/server.dart
@@ -230,21 +230,21 @@ void main() {
       var suitePrefix = p.withoutExtension(
           p.relative(path, from: p.join(_root, 'test')));
 
-      var jsUrl;
+      var dartUrl;
       // Polymer generates a bootstrap entrypoint that wraps the entrypoint we
       // see on disk, and modifies the HTML file to point to the bootstrap
       // instead. To make sure we get the right source maps and wait for the
       // right file to compile, we have some Polymer-specific logic here to load
       // the boostrap instead of the unwrapped file.
       if (isPolymerEntrypoint(path)) {
-        jsUrl = _config.pubServeUrl.resolve(
-            "$suitePrefix.html.polymer.bootstrap.dart.browser_test.dart.js");
+        dartUrl = _config.pubServeUrl.resolve(
+            "$suitePrefix.html.polymer.bootstrap.dart.browser_test.dart");
       } else {
-        jsUrl = _config.pubServeUrl.resolve(
-          '$suitePrefix.dart.browser_test.dart.js');
+        dartUrl = _config.pubServeUrl.resolve(
+          '$suitePrefix.dart.browser_test.dart');
       }
 
-      await _pubServeSuite(path, jsUrl);
+      await _pubServeSuite(path, dartUrl, browser);
       suiteUrl = _config.pubServeUrl.resolveUri(p.toUri('$suitePrefix.html'));
     } else {
       if (browser.isJS) await _compileSuite(path);
@@ -265,23 +265,29 @@ void main() {
     return suite;
   }
 
-  /// Loads a test suite at [path] from the `pub serve` URL [jsUrl].
+  /// Loads a test suite at [path] from the `pub serve` URL [dartUrl].
   ///
   /// This ensures that only one suite is loaded at a time, and that any errors
   /// are exposed as [LoadException]s.
-  Future _pubServeSuite(String path, Uri jsUrl) {
+  Future _pubServeSuite(String path, Uri dartUrl, TestPlatform browser) {
     return _pubServePool.withResource(() async {
       var timer = new Timer(new Duration(seconds: 1), () {
         print('"pub serve" is compiling $path...');
       });
 
-      var mapUrl = jsUrl.replace(path: jsUrl.path + '.map');
+      // For browsers that run Dart compiled to JavaScript, get the source map
+      // instead of the Dart code for two reasons. We want to verify that the
+      // server's dart2js compiler is running on the Dart code, and also load
+      // the StackTraceMapper.
+      var getSourceMap = browser.isJS;
+
+      var url = getSourceMap
+          ? dartUrl.replace(path: dartUrl.path + '.js.map')
+          : dartUrl;
+
       var response;
       try {
-        // Get the source map here for two reasons. We want to verify that the
-        // server's dart2js compiler is running on the Dart code, and also load
-        // the StackTraceMapper.
-        var request = await _http.getUrl(mapUrl);
+        var request = await _http.getUrl(url);
         response = await request.close();
 
         if (response.statusCode != 200) {
@@ -290,22 +296,22 @@ void main() {
           response.listen((_) {});
 
           throw new LoadException(path,
-              "Error getting $mapUrl: ${response.statusCode} "
+              "Error getting $url: ${response.statusCode} "
                   "${response.reasonPhrase}\n"
               'Make sure "pub serve" is serving the test/ directory.');
         }
 
-        if (_config.jsTrace) {
-          // Drain the response stream.
-          response.listen((_) {});
+        if (getSourceMap && !_config.jsTrace) {
+          _mappers[path] = new StackTraceMapper(
+              await UTF8.decodeStream(response),
+              mapUrl: url,
+              packageRoot: _config.pubServeUrl.resolve('packages'),
+              sdkRoot: _config.pubServeUrl.resolve('packages/\$sdk'));
           return;
         }
 
-        _mappers[path] = new StackTraceMapper(
-            await UTF8.decodeStream(response),
-            mapUrl: mapUrl,
-            packageRoot: _config.pubServeUrl.resolve('packages'),
-            sdkRoot: _config.pubServeUrl.resolve('packages/\$sdk'));
+        // Drain the response stream.
+        response.listen((_) {});
       } on IOException catch (error) {
         var message = getErrorMessage(error);
         if (error is SocketException) {
@@ -314,7 +320,7 @@ void main() {
         }
 
         throw new LoadException(path,
-            "Error getting $mapUrl: $message\n"
+            "Error getting $url: $message\n"
             'Make sure "pub serve" is running.');
       } finally {
         timer.cancel();

--- a/test/runner/pub_serve_test.dart
+++ b/test/runner/pub_serve_test.dart
@@ -121,21 +121,39 @@ void main() {
       pub.kill();
     });
 
-    test("gracefully handles pub serve running on the wrong directory for "
+    group("gracefully handles pub serve running on the wrong directory for "
         "browser tests", () {
-      d.dir("web").create();
+      test("when run on Chrome", () {
+        d.dir("web").create();
 
-      var pub = runPubServe(args: ['web']);
-      var test = runTest([_pubServeArg, '-p', 'chrome']);
-      test.stdout.expect(containsInOrder([
-        '-1: compiling ${p.join("test", "my_test.dart")}',
-        'Failed to load "${p.join("test", "my_test.dart")}":',
-        '404 Not Found',
-        'Make sure "pub serve" is serving the test/ directory.'
-      ]));
-      test.shouldExit(1);
+        var pub = runPubServe(args: ['web']);
+        var test = runTest([_pubServeArg, '-p', 'chrome']);
+        test.stdout.expect(containsInOrder([
+          '-1: compiling ${p.join("test", "my_test.dart")}',
+          'Failed to load "${p.join("test", "my_test.dart")}":',
+          '404 Not Found',
+          'Make sure "pub serve" is serving the test/ directory.'
+        ]));
+        test.shouldExit(1);
 
-      pub.kill();
+        pub.kill();
+      });
+
+      test("when run on content shell", () {
+        d.dir("web").create();
+
+        var pub = runPubServe(args: ['web']);
+        var test = runTest([_pubServeArg, '-p', 'content-shell']);
+        test.stdout.expect(containsInOrder([
+          '-1: loading ${p.join("test", "my_test.dart")}',
+          'Failed to load "${p.join("test", "my_test.dart")}":',
+          '404 Not Found',
+          'Make sure "pub serve" is serving the test/ directory.'
+        ]));
+        test.shouldExit(1);
+
+        pub.kill();
+      });
     });
 
     test("gracefully handles unconfigured transformers", () {


### PR DESCRIPTION
### Ultimate problem
When the  `--pub-serve` option is used, JavaScript source maps are fetched for test suites, which causes the test files to be compiled via dart2js.

These source maps are fetched unnecessarily when run in Dartium and content shell, which causes  unnecessary dart2js compilation.

This compilation can take a while, and makes running browser tests in Dartium and content shell while using `--pub-serve` much more sluggish.

### Changes
* Only fetch the source maps for test suites if `browser.isJs` is true.
* Add test case with content shell that verifies that test suite load errors are still handled gracefully when `browser.isJs == false`.