### PR TITLE
new flag "failFast" - testing stops after the first error

### DIFF
--- a/lib/src/runner.dart
+++ b/lib/src/runner.dart
@@ -63,7 +63,8 @@ class Runner {
         verboseTrace: config.verboseTrace,
         printPath: config.paths.length > 1 ||
             new Directory(config.paths.single).existsSync(),
-        printPlatform: config.platforms.length > 1);
+        printPlatform: config.platforms.length > 1,
+        failFast: config.failFast);
 
     return new Runner._(config, loader, engine, reporter);
   }

--- a/lib/src/runner/configuration.dart
+++ b/lib/src/runner/configuration.dart
@@ -71,6 +71,10 @@ class Configuration {
       'compact': 'A single line, updated continuously.',
       'expanded': 'A separate line for each update.'
     });
+    parser.addFlag("failFast",
+        abbr: 'f',
+        help: 'Stop testing after the first error.',
+        negatable: false);
     parser.addFlag("verbose-trace", negatable: false,
         help: 'Whether to emit stack traces with core library frames.');
     parser.addFlag("js-trace", negatable: false,
@@ -130,6 +134,9 @@ class Configuration {
   /// The set of platforms on which to run tests.
   final List<TestPlatform> platforms;
 
+  /// Whether testing stops after the first error.
+  final bool failFast;
+
   /// The global test metadata derived from this configuration.
   Metadata get metadata =>
       new Metadata(
@@ -169,7 +176,8 @@ class Configuration {
             orElse: () => _defaultConcurrency),
         pattern: pattern,
         platforms: options['platform'].map(TestPlatform.find),
-        paths: options.rest.isEmpty ? null : options.rest);
+        paths: options.rest.isEmpty ? null : options.rest,
+        failFast: options['failFast']);
   }
 
   /// Runs [parse] on the value of the option [name], and wraps any
@@ -191,7 +199,7 @@ class Configuration {
           this.verboseTrace: false, this.jsTrace: false,
           bool pauseAfterLoad: false, bool color, String packageRoot,
           String reporter, int pubServePort, int concurrency, this.pattern,
-          Iterable<TestPlatform> platforms, Iterable<String> paths})
+          Iterable<TestPlatform> platforms, Iterable<String> paths, this.failFast})
       : pauseAfterLoad = pauseAfterLoad,
         color = color == null ? canUseSpecialChars : color,
         packageRoot = packageRoot == null

--- a/lib/src/runner/configuration.dart
+++ b/lib/src/runner/configuration.dart
@@ -71,7 +71,7 @@ class Configuration {
       'compact': 'A single line, updated continuously.',
       'expanded': 'A separate line for each update.'
     });
-    parser.addFlag("failFast",
+    parser.addFlag("fail-fast",
         abbr: 'f',
         help: 'Stop testing after the first error.',
         negatable: false);

--- a/lib/src/runner/configuration.dart
+++ b/lib/src/runner/configuration.dart
@@ -177,7 +177,7 @@ class Configuration {
         pattern: pattern,
         platforms: options['platform'].map(TestPlatform.find),
         paths: options.rest.isEmpty ? null : options.rest,
-        failFast: options['failFast']);
+        failFast: options['fail-fast']);
   }
 
   /// Runs [parse] on the value of the option [name], and wraps any

--- a/lib/src/runner/reporter/compact.dart
+++ b/lib/src/runner/reporter/compact.dart
@@ -104,6 +104,9 @@ class CompactReporter implements Reporter {
   /// The set of all subscriptions to various streams.
   final _subscriptions = new Set<StreamSubscription>();
 
+  /// Whether testing stops after the first error
+  var _failFast = false;
+
   /// Watches the tests run by [engine] and prints their results to the
   /// terminal.
   ///
@@ -114,20 +117,22 @@ class CompactReporter implements Reporter {
   /// the platform as part of the test description.
   static CompactReporter watch(Engine engine, {bool color: true,
       bool verboseTrace: false, bool printPath: true,
-      bool printPlatform: true}) {
+      bool printPlatform: true, bool failFast: false}) {
     return new CompactReporter._(
         engine,
         color: color,
         verboseTrace: verboseTrace,
         printPath: printPath,
-        printPlatform: printPlatform);
+        printPlatform: printPlatform,
+        failFast: failFast);
   }
 
   CompactReporter._(this._engine, {bool color: true, bool verboseTrace: false,
-          bool printPath: true, bool printPlatform: true})
+          bool printPath: true, bool printPlatform: true, bool failFast: false})
       : _verboseTrace = verboseTrace,
         _printPath = printPath,
         _printPlatform = printPlatform,
+        _failFast = failFast,
         _color = color,
         _green = color ? '\u001b[32m' : '',
         _red = color ? '\u001b[31m' : '',
@@ -228,6 +233,7 @@ class CompactReporter implements Reporter {
 
   /// A callback called when [liveTest] throws [error].
   void _onError(LiveTest liveTest, error, StackTrace stackTrace) {
+    if (_failFast == true) cancel();
     if (liveTest.state.status != Status.complete) return;
 
     _progressLine(_description(liveTest), truncate: false);

--- a/lib/src/runner/reporter/expanded.dart
+++ b/lib/src/runner/reporter/expanded.dart
@@ -96,6 +96,9 @@ class ExpandedReporter implements Reporter {
   /// The set of all subscriptions to various streams.
   final _subscriptions = new Set<StreamSubscription>();
 
+  /// Whether testing stops after the first error
+  var _failFast = false;
+
   /// Watches the tests run by [engine] and prints their results to the
   /// terminal.
   ///
@@ -106,20 +109,22 @@ class ExpandedReporter implements Reporter {
   /// the platform as part of the test description.
   static ExpandedReporter watch(Engine engine, {bool color: true,
       bool verboseTrace: false, bool printPath: true,
-      bool printPlatform: true}) {
+      bool printPlatform: true, bool failFast: false}) {
     return new ExpandedReporter._(
         engine,
         color: color,
         verboseTrace: verboseTrace,
         printPath: printPath,
-        printPlatform: printPlatform);
+        printPlatform: printPlatform,
+        failFast: failFast);
   }
 
   ExpandedReporter._(this._engine, {bool color: true, bool verboseTrace: false,
-          bool printPath: true, bool printPlatform: true})
+          bool printPath: true, bool printPlatform: true, bool failFast: false})
       : _verboseTrace = verboseTrace,
         _printPath = printPath,
         _printPlatform = printPlatform,
+        _failFast = failFast,
         _color = color,
         _green = color ? '\u001b[32m' : '',
         _red = color ? '\u001b[31m' : '',
@@ -209,6 +214,7 @@ class ExpandedReporter implements Reporter {
 
   /// A callback called when [liveTest] throws [error].
   void _onError(LiveTest liveTest, error, StackTrace stackTrace) {
+    if (_failFast == true) cancel();
     if (liveTest.state.status != Status.complete) return;
 
     _progressLine(_description(liveTest));

--- a/test/io.dart
+++ b/test/io.dart
@@ -95,7 +95,7 @@ StreamMatcher containsInOrder(Iterable<String> strings) =>
 
 /// Runs the test executable with the package root set properly.
 ScheduledProcess runTest(List args, {bool compact: false,
-    int concurrency, Map<String, String> environment, bool failFast: null}) {
+    int concurrency, Map<String, String> environment, bool failFast: false}) {
   if (concurrency == null) concurrency = 1;
 
   var allArgs = [

--- a/test/io.dart
+++ b/test/io.dart
@@ -95,7 +95,7 @@ StreamMatcher containsInOrder(Iterable<String> strings) =>
 
 /// Runs the test executable with the package root set properly.
 ScheduledProcess runTest(List args, {bool compact: false,
-    int concurrency, Map<String, String> environment}) {
+    int concurrency, Map<String, String> environment, bool failFast: null}) {
   if (concurrency == null) concurrency = 1;
 
   var allArgs = [
@@ -105,6 +105,7 @@ ScheduledProcess runTest(List args, {bool compact: false,
   ];
 
   if (!compact) allArgs.addAll(["-r", "expanded"]);
+  if (failFast) allArgs.addAll(["-f"]);
   allArgs.addAll(args);
 
   if (environment == null) environment = {};

--- a/test/runner/compact_reporter_test.dart
+++ b/test/runner/compact_reporter_test.dart
@@ -390,10 +390,34 @@ void main() {
 
           +0 ~2: All tests skipped.""");
     });
+
+    test("test failFast option", () {
+      _expectReport("""
+          test('ok 1', () {expect(1, 1);}, skip: false);
+          test('skip 2', () {expect(1, 2);}, skip: true);
+          test('fail 3', () {expect(1, 3);}, skip: false);
+          test('fail 4', () {expect(1, 4);}, skip: false);
+          """,
+          """
+          +0: loading test.dart
+          +0: ok 1
+          +1: ok 1
+          +1: skip 2
+          +1 ~1: skip 2
+          +1 ~1: fail 3
+          +1 ~1 -1: fail 3
+            Expected: <3>
+              Actual: <1>
+
+            package:test    expect
+            test.dart 8:30  main.<fn>
+          """, failFast: true);
+    });
+
   });
 }
 
-void _expectReport(String tests, String expected) {
+void _expectReport(String tests, String expected, {bool failFast: false}) {
   var dart = """
 import 'dart:async';
 
@@ -406,7 +430,7 @@ $tests
 
   d.file("test.dart", dart).create();
 
-  var test = runTest(["test.dart"], compact: true);
+  var test = runTest(["test.dart"], compact: true, failFast: failFast);
   test.shouldExit();
 
   schedule(() async {

--- a/test/runner/expanded_reporter_test.dart
+++ b/test/runner/expanded_reporter_test.dart
@@ -302,10 +302,30 @@ void main() {
             Skip: or another
           +0 ~2: All tests skipped.""");
     });
+
+    test("test failFast option", () {
+      _expectReport("""
+          test('ok 1', () {expect(1, 1);}, skip: false);
+          test('skip 2', () {expect(1, 2);}, skip: true);
+          test('fail 3', () {expect(1, 3);}, skip: false);
+          test('fail 4', () {expect(1, 4);}, skip: false);
+          """,
+          """
+          +0: ok 1
+          +1: skip 2
+          +1 ~1: fail 3
+          +1 ~1 -1: fail 3
+            Expected: <3>
+              Actual: <1>
+
+            package:test    expect
+            test.dart 8:30  main.<fn>
+          """, failFast: true);
+    });
   });
 }
 
-void _expectReport(String tests, String expected) {
+void _expectReport(String tests, String expected, {bool failFast: false}) {
   var dart = """
 import 'dart:async';
 
@@ -318,7 +338,7 @@ $tests
 
   d.file("test.dart", dart).create();
 
-  var test = runTest(["test.dart"]);
+  var test = runTest(["test.dart"], failFast: failFast);
   test.shouldExit();
 
   schedule(() async {


### PR DESCRIPTION
2 tests added:

```pub run test:test -N failFast test/runner/expanded_reporter_test.dart``` and
```pub run test:test -N failFast test/runner/compact_reporter_test.dart```

This is a first try - the idea is to cancel all subscriptions when an error is detected in the reporter. I am sure there are problems with async tests etc. What do you think? 

New command line option:
```pub run test:test -f```
should run all tests until the first error.