### PR TITLE
Update sdk declaration in pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test
 environment:
-  sdk: '>=1.11.0 <1.14.0'
+  sdk: '>=1.11.0 <1.15.0'
 dependencies:
   analyzer: '>=0.23.0 <0.27.0'
   args: '>=0.12.1 <0.14.0'


### PR DESCRIPTION
This solves the problem that "<1.14.0" does not include the current dev release 1.14.0-dev.1.0

With the dev releases of 1.14 already out, this package should declare it is compatible with it.