### PR TITLE
Allow object to be passed in as a group / test description

### DIFF
--- a/lib/test.dart
+++ b/lib/test.dart
@@ -78,7 +78,8 @@ Declarer get _declarer {
 
 // TODO(nweiz): This and other top-level functions should throw exceptions if
 // they're called after the declarer has finished declaring.
-/// Creates a new test case with the given description and body.
+/// Creates a new test case with the given description (converted to a string)
+/// and body.
 ///
 /// The description will be added to the descriptions of any surrounding
 /// [group]s. If [testOn] is passed, it's parsed as a [platform selector][]; the
@@ -133,9 +134,9 @@ void test(description, body(),
 
 /// Creates a group of tests.
 ///
-/// A group's description is included in the descriptions of any tests or
-/// sub-groups it contains. [setUp] and [tearDown] are also scoped to the
-/// containing group.
+/// A group's description (converted to a string) is included in the descriptions
+/// of any tests or sub-groups it contains. [setUp] and [tearDown] are also scoped
+/// to the containing group.
 ///
 /// If [testOn] is passed, it's parsed as a [platform selector][]; the test will
 /// only be run on matching platforms.
@@ -176,17 +177,13 @@ void test(description, body(),
 /// If multiple platforms match, the annotations apply in order as through
 /// they were in nested groups.
 void group(description, body(),
-    {String testOn,
-    Timeout timeout,
-    skip,
-    tags,
-    Map<String, dynamic> onPlatform}) =>
-  description == null
-      ? _declarer.group(description, body,
-          testOn: testOn, timeout: timeout, skip: skip, tags: tags)
-      : _declarer.group(description.toString(), body,
-          testOn: testOn, timeout: timeout, skip: skip, tags: tags);
-
+        {String testOn,
+        Timeout timeout,
+        skip,
+        tags,
+        Map<String, dynamic> onPlatform}) =>
+    _declarer.group(description.toString(), body,
+        testOn: testOn, timeout: timeout, skip: skip, tags: tags);
 
 /// Registers a function to be run before tests.
 ///

--- a/lib/test.dart
+++ b/lib/test.dart
@@ -118,9 +118,13 @@ Declarer get _declarer {
 ///
 /// If multiple platforms match, the annotations apply in order as through
 /// they were in nested groups.
-void test(String description, body(), {String testOn, Timeout timeout, skip,
-        tags, Map<String, dynamic> onPlatform}) =>
-    _declarer.test(description, body,
+void test(description, body(),
+        {String testOn,
+        Timeout timeout,
+        skip,
+        tags,
+        Map<String, dynamic> onPlatform}) =>
+    _declarer.test(description.toString(), body,
         testOn: testOn,
         timeout: timeout,
         skip: skip,
@@ -171,10 +175,18 @@ void test(String description, body(), {String testOn, Timeout timeout, skip,
 ///
 /// If multiple platforms match, the annotations apply in order as through
 /// they were in nested groups.
-void group(String description, body(), {String testOn, Timeout timeout, skip,
-        tags, Map<String, dynamic> onPlatform}) =>
-    _declarer.group(description, body,
-        testOn: testOn, timeout: timeout, skip: skip, tags: tags);
+void group(description, body(),
+    {String testOn,
+    Timeout timeout,
+    skip,
+    tags,
+    Map<String, dynamic> onPlatform}) =>
+  description == null
+      ? _declarer.group(description, body,
+          testOn: testOn, timeout: timeout, skip: skip, tags: tags)
+      : _declarer.group(description.toString(), body,
+          testOn: testOn, timeout: timeout, skip: skip, tags: tags);
+
 
 /// Registers a function to be run before tests.
 ///

--- a/test/backend/declarer_test.dart
+++ b/test/backend/declarer_test.dart
@@ -36,6 +36,15 @@ void main() {
       expect(bodyRun, isTrue);
     });
 
+    test("declares a test with an object as the description", () async {
+      var tests = declare(() {
+        test(Object, () {
+        });
+      });
+
+      expect(tests.single.name, equals("Object"));
+    });
+
     test("declares multiple tests", () {
       var tests = declare(() {
         test("description 1", () {});
@@ -275,6 +284,21 @@ void main() {
       expect(entries.single.entries, hasLength(1));
       expect(entries.single.entries.single, new isInstanceOf<Test>());
       expect(entries.single.entries.single.name, "group description");
+    });
+
+    test("tests inherit the group's description when it's not a string", () {
+      var entries = declare(() {
+        group(Object, () {
+          test("description", () {});
+        });
+      });
+
+      expect(entries, hasLength(1));
+      expect(entries.single, new isInstanceOf<Group>());
+      expect(entries.single.name, equals("Object"));
+      expect(entries.single.entries, hasLength(1));
+      expect(entries.single.entries.single, new isInstanceOf<Test>());
+      expect(entries.single.entries.single.name, "Object description");
     });
 
     test("a test's timeout factor is applied to the group's", () {


### PR DESCRIPTION
There was an issue created, https://github.com/dart-lang/test/issues/372, that requested the ability to pass in an object as the description for the group and test methods.  

```
group(MyAwesomeClass, () {
  ...
});
```

This change allows a user to do that and is accompanied with unit tests exercising the intended change.