### PR TITLE
Default to using the system packageRoot.

### DIFF
--- a/lib/src/runner/configuration.dart
+++ b/lib/src/runner/configuration.dart
@@ -66,7 +66,7 @@ class Configuration {
   final bool _pauseAfterLoad;
 
   /// The package root for resolving "package:" URLs.
-  String get packageRoot => _packageRoot ?? p.join(p.current, 'packages');
+  String get packageRoot => _packageRoot ?? p.fromUri(Platform.packageRoot);
   final String _packageRoot;
 
   /// The name of the reporter to use to display results.


### PR DESCRIPTION
Currently, the default is to use 'pacakges/' in the cwd as the package
root. That means if you set a different packageRoot as a flag to the
dart vm, you also need to set it as a flag to package:test. To simplify
things, package:test can just use whatever the Platform packageRoot is
by default, so you only need to set it once.