### PR TITLE
Fix additional strong-mode warnings.

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -1,0 +1,2 @@
+analyzer:
+  strong-mode: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+##0.11.6+4
+
+* Fix some strong mode warnings we missed in the `vm_config.dart` and
+  `html_config.dart` libraries.
+
 ##0.11.6+3
 
 * Fix a bug introduced in 0.11.6+2 in which operator matchers broke when taking

--- a/lib/html_config.dart
+++ b/lib/html_config.dart
@@ -140,7 +140,7 @@ class HtmlConfiguration extends SimpleConfiguration {
   void onInit() {
     // For Dart internal tests, we want to turn off stack frame
     // filtering, which we do with this meta-header.
-    var meta = querySelector('meta[name="dart.unittest"]');
+    MetaElement meta = querySelector('meta[name="dart.unittest"]');
     filterStacks =
         meta == null ? true : !meta.content.contains('full-stack-traces');
     _installHandlers();

--- a/lib/vm_config.dart
+++ b/lib/vm_config.dart
@@ -20,8 +20,8 @@ class VMConfiguration extends SimpleConfiguration {
   bool useColor;
 
   VMConfiguration()
-      : super(),
-        useColor = stdioType(stdout) == StdioType.TERMINAL;
+      : useColor = stdioType(stdout) == StdioType.TERMINAL,
+        super();
 
   String formatResult(TestCase testCase) {
     String result = super.formatResult(testCase);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: unittest
-version: 0.11.6+3
+version: 0.11.6+4
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/old_unittest


### PR DESCRIPTION
Looks like we hadn't run the analyzer against all the top-level
libraries.