### PR TITLE
Add solo_test, solo_group API

### DIFF
--- a/lib/test.dart
+++ b/lib/test.dart
@@ -122,12 +122,14 @@ void test(description, body(),
         {String testOn,
         Timeout timeout,
         skip,
+        solo,
         tags,
         Map<String, dynamic> onPlatform}) {
   _declarer.test(description.toString(), body,
       testOn: testOn,
       timeout: timeout,
       skip: skip,
+      solo: solo,
       onPlatform: onPlatform,
       tags: tags);
 
@@ -136,6 +138,21 @@ void test(description, body(),
   // column where the test was defined. See sdk#26705.
   return;
   return;
+}
+
+void solo_test(description, body(),
+    {String testOn,
+    Timeout timeout,
+    skip,
+    tags,
+    Map<String, dynamic> onPlatform}) {
+  test(description.toString(), body,
+      testOn: testOn,
+      timeout: timeout,
+      skip: skip,
+      solo: true,
+      onPlatform: onPlatform,
+      tags: tags);
 }
 
 /// Creates a group of tests.
@@ -189,16 +206,32 @@ void group(description, body(),
         {String testOn,
         Timeout timeout,
         skip,
+        solo,
         tags,
         Map<String, dynamic> onPlatform}) {
   _declarer.group(description.toString(), body,
-      testOn: testOn, timeout: timeout, skip: skip, tags: tags);
+      testOn: testOn, timeout: timeout, skip: skip, solo: solo, tags: tags);
 
   // Force dart2js not to inline this function. We need it to be separate from
   // `main()` in JS stack traces in order to properly determine the line and
   // column where the test was defined. See sdk#26705.
   return;
   return;
+}
+
+void solo_group(description, body(),
+    {String testOn,
+    Timeout timeout,
+    skip,
+    tags,
+    Map<String, dynamic> onPlatform}) {
+  group(description, body,
+      testOn: testOn,
+      timeout: timeout,
+      skip: skip,
+      solo: true,
+      tags: tags,
+      onPlatform: onPlatform);
 }
 
 /// Registers a function to be run before tests.


### PR DESCRIPTION
Fixes #127

This is a fairly simple implementation of `solo_test` and `solo_group`, restricted to the "backend" code (`lib/src/backend/declarer.dart` and `lib/src/backend/metadata.dart`).
#### WIP

This PR is functional, but I'm throwing it out there as a "request for comments." What do the authors think?

TODO:
- [ ] Write up some text in README.
- [ ] Write up some doc comments for `solo_test` and `solo_group`. These should be lengthy, with explanations of inheritance, and what to expect in output.
#### Notes
- The real API change is to add a `solo:` named arg to `test` and `group`, but the backward compatibility, and real beauty, comes in implementing the `package:unittest` methods: `solo_test` and `solo_group`. Those five characters, `solo_` are what people love so much about unittest's feature.
- The feature works by declaring all non-solo tests or groups as "skipped". So there is no new status in the reporting. For example:
  
  ``` text
  $ cat a.dart
  import 'lib/test.dart';
  
  void main() {
    test('foo', () { expect('a', equals('a')); });
    test('bar', () { expect('a', equals('a')); });
    solo_test('baz', () { expect('a', equals('a')); });
  }
  $ dart a.dart
  00:00 +0: foo
  00:00 +0 ~1: bar
  00:00 +0 ~2: baz
  00:00 +1 ~2: All tests passed!
  ```
  
  We see that it looks like one test ran, and two were skipped. This is the analogy of "solo".
- I don't think this feature needs a new status (something like "00:00 !1 ~2: All tests passed!"), but we could if we wanted.
- We could change the "All tests passed!" text to be different if any tests were skipped, but that would be a separate feature, unrelated to this PR.
- I did not change the return code if a solo test/group is found. We could if we wanted to, but again, this could be a separate feature (different return code if any tests are skipped), unrelated to this PR.
- We could add one line of text to the output, like "Solo test/group found! Skipping everything not solo." But I don't think it's required.
- I didn't do anything fancy to `solo` as a metadata attribute, which means it behaves like others (specifically, `skip`. This means it has the same "inheritance" rules as `skip` (tests and groups inherit value from containing group). For example:
  
  ``` text
  $ cat b.dart
  import 'lib/test.dart';
  
  void main() {
    group('group1', () {
      test('test A', () { expect('a', equals('a')); });
      test('test B', () { expect('a', equals('a')); });
    });
  
    solo_group('group2', () {
      test('test C', () { expect('a', equals('a')); });
      solo_test('test D', () { expect('a', equals('a')); });
    });
  }
  $ dart b.dart
  00:00 +0: group1 test A
  00:00 +0 ~1: group1 test B
  00:00 +0 ~2: group2 test C
  00:00 +1 ~2: group2 test D
  00:00 +2 ~2: All tests passed!
  ```
  
  `test A` and `test B` are skipped; simple enough. `test D` is run; no surprise there. `test C` is the only interesting case: it is run, even though it is a _non_ solo test, sitting next to a solo test, because it inherits `group2`'s solo status.
- Other cases are considered in the tests, in this PR.
