### PR TITLE
move nestingMiddleware to path_handler.dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.15+3
+
+* Move `nestingMiddleware` to `lib/src/util/path_handler.dart` to enable a
+  cleaner separation between test-runner files and test writing files.
+
 ## 0.12.15+2
 
 * Support running without a `packages/` directory.

--- a/lib/src/util/path_handler.dart
+++ b/lib/src/util/path_handler.dart
@@ -47,6 +47,14 @@ class PathHandler {
   }
 }
 
+/// Returns middleware that nests all requests beneath the URL prefix [beneath].
+shelf.Middleware nestingMiddleware(String beneath) {
+  return (handler) {
+    var pathHandler = new PathHandler()..add(beneath, handler);
+    return pathHandler.handler;
+  };
+}
+
 /// A trie node.
 class _Node {
   shelf.Handler handler;

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -9,11 +9,9 @@ import 'dart:typed_data';
 
 import 'package:async/async.dart' hide StreamQueue;
 import 'package:path/path.dart' as p;
-import 'package:shelf/shelf.dart' as shelf;
 import 'package:stack_trace/stack_trace.dart';
 
 import 'backend/operating_system.dart';
-import 'util/path_handler.dart';
 import 'util/stream_queue.dart';
 
 /// The maximum console line length.
@@ -359,12 +357,4 @@ String randomBase64(int bytes, {int seed}) {
     data[i] = random.nextInt(256);
   }
   return BASE64.encode(data);
-}
-
-/// Returns middleware that nests all requests beneath the URL prefix [beneath].
-shelf.Middleware nestingMiddleware(String beneath) {
-  return (handler) {
-    var pathHandler = new PathHandler()..add(beneath, handler);
-    return pathHandler.handler;
-  };
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.15+2
+version: 0.12.15+3
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
This removes a dependency on `shelf` and `path_handler.dart` from `utils.dart`, so that we can more easily separate out test-only deps from test-runner deps. 