### PR TITLE
Refactor Configuration.

### DIFF
--- a/lib/src/runner/browser/compiler_pool.dart
+++ b/lib/src/runner/browser/compiler_pool.dart
@@ -23,11 +23,11 @@ final _dart2jsStatus =
 ///
 /// This limits the number of compiler instances running concurrently.
 class CompilerPool {
+  /// The test runner configuration.
+  final _config = Configuration.current;
+
   /// The internal pool that controls the number of process running at once.
   final Pool _pool;
-
-  /// The test runner configuration.
-  final Configuration _config;
 
   /// The currently-active dart2js processes.
   final _processes = new Set<Process>();
@@ -39,9 +39,7 @@ class CompilerPool {
   final _closeMemo = new AsyncMemoizer();
 
   /// Creates a compiler pool that multiple instances of `dart2js` at once.
-  CompilerPool(Configuration config)
-      : _pool = new Pool(config.concurrency),
-        _config = config;
+  CompilerPool() : _pool = new Pool(Configuration.current.concurrency);
 
   /// Compile the Dart code at [dartPath] to [jsPath].
   ///

--- a/lib/src/runner/configuration.dart
+++ b/lib/src/runner/configuration.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:boolean_selector/boolean_selector.dart';
@@ -17,6 +18,9 @@ import '../util/io.dart';
 import 'configuration/args.dart' as args;
 import 'configuration/load.dart';
 import 'configuration/values.dart';
+
+/// The key used to look up [Configuration.current] in a zone.
+final _currentKey = new Object();
 
 /// A class that encapsulates the command-line configuration of the test runner.
 class Configuration {
@@ -253,6 +257,13 @@ class Configuration {
     yield* presets.values;
   }
 
+  /// Returns the current configuration, or a default configuration if no
+  /// current configuration is set.
+  ///
+  /// The current configuration is set using [asCurrent].
+  static Configuration get current =>
+      Zone.current[_currentKey] ?? new Configuration();
+
   /// Parses the configuration from [args].
   ///
   /// Throws a [FormatException] if [args] are invalid.
@@ -462,6 +473,13 @@ class Configuration {
     if (input == null || input.isEmpty) return const {};
     return new Map.unmodifiable(input);
   }
+
+  /// Runs [body] with [this] as [Configuration.current].
+  ///
+  /// This is zone-scoped, so [this] will be the current configuration in any
+  /// asynchronous callbacks transitively created by [body].
+  /*=T*/ asCurrent/*<T>*/(/*=T*/ body()) =>
+      runZoned(body, zoneValues: {_currentKey: this});
 
   /// Merges this with [other].
   ///

--- a/lib/src/runner/debugger.dart
+++ b/lib/src/runner/debugger.dart
@@ -24,8 +24,8 @@ import 'runner_suite.dart';
 /// Returns a [CancelableOperation] that will complete once the suite has
 /// finished running. If the operation is canceled, the debugger will clean up
 /// any resources it allocated.
-CancelableOperation debug(Configuration config, Engine engine,
-    Reporter reporter, LoadSuite loadSuite) {
+CancelableOperation debug(Engine engine, Reporter reporter,
+    LoadSuite loadSuite) {
   var debugger;
   var canceled = false;
   return new CancelableOperation.fromFuture(() async {
@@ -36,7 +36,7 @@ CancelableOperation debug(Configuration config, Engine engine,
     var suite = await loadSuite.suite;
     if (canceled || suite == null) return;
 
-    debugger = new _Debugger(config, engine, reporter, suite);
+    debugger = new _Debugger(engine, reporter, suite);
     await debugger.run();
   }(), onCancel: () {
     canceled = true;
@@ -49,8 +49,8 @@ CancelableOperation debug(Configuration config, Engine engine,
 // breakpoints.
 /// A debugger for a single test suite.
 class _Debugger {
-  /// The user configuration for the test runner.
-  final Configuration _config;
+  /// The test runner configuration.
+  final _config = Configuration.current;
 
   /// The engine that will run the suite.
   final Engine _engine;
@@ -73,9 +73,8 @@ class _Debugger {
   /// Whether [close] has been called.
   bool _closed = false;
 
-  _Debugger(Configuration config, this._engine, this._reporter, this._suite)
-      : _config = config,
-        _console = new Console(color: config.color) {
+  _Debugger(this._engine, this._reporter, this._suite)
+      : _console = new Console(color: Configuration.current.color) {
     _console.registerCommand(
         "restart", "Restart the current test after it finishes running.",
         _restartTest);

--- a/lib/src/runner/reporter/expanded.dart
+++ b/lib/src/runner/reporter/expanded.dart
@@ -95,6 +95,8 @@ class ExpandedReporter implements Reporter {
   /// The set of all subscriptions to various streams.
   final _subscriptions = new Set<StreamSubscription>();
 
+  // TODO(nweiz): Get configuration from [Configuration.current] once we have
+  // cross-platform imports.
   /// Watches the tests run by [engine] and prints their results to the
   /// terminal.
   ///

--- a/lib/src/runner/vm/platform.dart
+++ b/lib/src/runner/vm/platform.dart
@@ -17,9 +17,9 @@ import '../plugin/platform.dart';
 /// A platform that loads tests in isolates spawned within this Dart process.
 class VMPlatform extends PlatformPlugin {
   /// The test runner configuration.
-  final Configuration _config;
+  final _config = Configuration.current;
 
-  VMPlatform(this._config);
+  VMPlatform();
 
   StreamChannel loadChannel(String path, TestPlatform platform) {
     assert(platform == TestPlatform.vm);

--- a/test/runner/browser/loader_test.dart
+++ b/test/runner/browser/loader_test.dart
@@ -36,8 +36,8 @@ void main() {
 void main() {
   setUp(() async {
     _sandbox = createTempDir();
-    _loader = new Loader(new Configuration(platforms: [TestPlatform.chrome]),
-        root: _sandbox);
+    _loader = new Configuration(platforms: [TestPlatform.chrome])
+        .asCurrent(() => new Loader(root: _sandbox));
     /// TODO(nweiz): Use scheduled_test for this once it's compatible with this
     /// version of test.
     new File(p.join(_sandbox, 'a_test.dart')).writeAsStringSync(_tests);
@@ -124,9 +124,9 @@ Future main() {
   });
 
   test("loads a suite both in the browser and the VM", () async {
-    var loader = new Loader(
-        new Configuration(platforms: [TestPlatform.vm, TestPlatform.chrome]),
-        root: _sandbox);
+    var loader = new Configuration(
+            platforms: [TestPlatform.vm, TestPlatform.chrome])
+        .asCurrent(() => new Loader(root: _sandbox));
     var path = p.join(_sandbox, 'a_test.dart');
 
     try {

--- a/test/runner/loader_test.dart
+++ b/test/runner/loader_test.dart
@@ -35,9 +35,7 @@ void main() {
 void main() {
   setUp(() async {
     _sandbox = createTempDir();
-    _loader = new Loader(
-        new Configuration(),
-        root: _sandbox);
+    _loader = new Loader(root: _sandbox);
   });
 
   tearDown(() {


### PR DESCRIPTION
This introduces a zone-scoped `Configuration.current`. This makes it
much easier to propagate the configuration everywhere it needs to go,
especially to plugins.

For #457