### PR TITLE
Don't capture stack traces by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.15+8
+
+* Make test suites with thousands of tests load much faster on the VM (and
+  possibly other platforms).
+
 ## 0.12.15+7
 
 * Fix a bug where tags would be dropped when `on_platform` was defined in a

--- a/lib/src/backend/declarer.dart
+++ b/lib/src/backend/declarer.dart
@@ -38,6 +38,9 @@ class Declarer {
   /// The stack trace for this group.
   final Trace _trace;
 
+  /// Whether to collect stack traces for [GroupEntry]s.
+  final bool _collectTraces;
+
   /// The set-up functions to run for each test in this group.
   final _setUps = new List<AsyncFunction>();
 
@@ -77,10 +80,16 @@ class Declarer {
   /// This is the implicit group that exists outside of any calls to `group()`.
   /// If [metadata] is passed, it's used as the metadata for the implicit root
   /// group.
-  Declarer([Metadata metadata])
-      : this._(null, null, metadata == null ? new Metadata() : metadata, null);
+  ///
+  /// If [collectTraces] is `true`, this will set [GroupEntry.trace] for all
+  /// entries built by the declarer. Note that this can be noticeably slow when
+  /// thousands of tests are being declared (see #457).
+  Declarer({Metadata metadata, bool collectTraces: false})
+      : this._(null, null, metadata == null ? new Metadata() : metadata,
+            collectTraces, null);
 
-  Declarer._(this._parent, this._name, this._metadata, this._trace);
+  Declarer._(this._parent, this._name, this._metadata, this._collectTraces,
+      this._trace);
 
   /// Runs [body] with this declarer as [Declarer.current].
   ///
@@ -106,7 +115,7 @@ class Declarer {
         await body();
       });
       await _runTearDowns();
-    }, trace: new Trace.current(2)));
+    }, trace: _collectTraces ? new Trace.current(2) : null));
   }
 
   /// Creates a group of tests.
@@ -117,9 +126,10 @@ class Declarer {
     var metadata = _metadata.merge(new Metadata.parse(
         testOn: testOn, timeout: timeout, skip: skip, onPlatform: onPlatform,
         tags: tags));
-    var trace = new Trace.current(2);
+    var trace = _collectTraces ? new Trace.current(2) : null;
 
-    var declarer = new Declarer._(this, _prefix(name), metadata, trace);
+    var declarer = new Declarer._(
+        this, _prefix(name), metadata, _collectTraces, trace);
     declarer.declare(body);
     _entries.add(declarer.build());
   }
@@ -142,14 +152,14 @@ class Declarer {
   /// Registers a function to be run once before all tests.
   void setUpAll(callback()) {
     _checkNotBuilt("setUpAll");
-    _setUpAllTrace ??= new Trace.current(2);
+    if (_collectTraces) _setUpAllTrace ??= new Trace.current(2);
     _setUpAlls.add(callback);
   }
 
   /// Registers a function to be run once after all tests.
   void tearDownAll(callback()) {
     _checkNotBuilt("tearDownAll");
-    _tearDownAllTrace ??= new Trace.current(2);
+    if (_collectTraces) _tearDownAllTrace ??= new Trace.current(2);
     _tearDownAlls.add(callback);
   }
 

--- a/lib/src/backend/declarer.dart
+++ b/lib/src/backend/declarer.dart
@@ -85,8 +85,7 @@ class Declarer {
   /// entries built by the declarer. Note that this can be noticeably slow when
   /// thousands of tests are being declared (see #457).
   Declarer({Metadata metadata, bool collectTraces: false})
-      : this._(null, null, metadata == null ? new Metadata() : metadata,
-            collectTraces, null);
+      : this._(null, null, metadata? ?? new Metadata(), collectTraces, null);
 
   Declarer._(this._parent, this._name, this._metadata, this._collectTraces,
       this._trace);

--- a/lib/src/runner/plugin/platform_helpers.dart
+++ b/lib/src/runner/plugin/platform_helpers.dart
@@ -13,6 +13,7 @@ import '../../backend/test.dart';
 import '../../backend/test_platform.dart';
 import '../../util/io.dart';
 import '../../util/remote_exception.dart';
+import '../configuration.dart';
 import '../environment.dart';
 import '../load_exception.dart';
 import '../runner_suite.dart';
@@ -41,7 +42,8 @@ Future<RunnerSuiteController> deserializeSuite(String path,
   suiteChannel.sink.add({
     'platform': platform.identifier,
     'metadata': metadata.serialize(),
-    'os': platform == TestPlatform.vm ? currentOS.identifier : null
+    'os': platform == TestPlatform.vm ? currentOS.identifier : null,
+    'collectTraces': Configuration.current.reporter == 'json'
   });
 
   var completer = new Completer();

--- a/lib/src/runner/remote_listener.dart
+++ b/lib/src/runner/remote_listener.dart
@@ -69,7 +69,9 @@ class RemoteListener {
 
       var message = await channel.stream.first;
       var metadata = new Metadata.deserialize(message['metadata']);
-      var declarer = new Declarer(metadata);
+      var declarer = new Declarer(
+          metadata: metadata,
+          collectTraces: message['collectTraces']);
       await declarer.declare(main);
 
       var os = message['os'] == null

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.15+7
+version: 0.12.16-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
Stack traces are now only captured for the JSON reporter. Capturing
traces was slow enough to be a serious problem for test suites with many
tests.

Closes #457