### PR TITLE
Fix a race condition in BrowserManager.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.15+12
+
+* Fix a race condition that could cause the runner to stall for up to three
+  seconds after completing.
+
 ## 0.12.15+11
 
 * Make test iframes visible when debugging.

--- a/lib/src/runner/browser/browser_manager.dart
+++ b/lib/src/runner/browser/browser_manager.dart
@@ -163,7 +163,7 @@ class BrowserManager {
     _channel = new MultiChannel(webSocket.transform(jsonDocument)
         .changeStream((stream) {
       return stream.map((message) {
-        _timer.reset();
+        if (!_closed) _timer.reset();
         for (var controller in _controllers) {
           controller.setDebugging(false);
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.16-dev
+version: 0.12.15+12
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
If a web test emitted any kind of message after the browser manager was
closed, the debugging timer would reset and cause the VM not to exit for
an extra three seconds.