### PR TITLE
Factor out a SuiteConfiguration object.

### DIFF
--- a/lib/src/runner.dart
+++ b/lib/src/runner.dart
@@ -67,9 +67,7 @@ class Runner {
 
   /// Creates a new runner based on [configuration].
   factory Runner(Configuration config) => config.asCurrent(() {
-    var engine = new Engine(
-        concurrency: config.concurrency,
-        runSkipped: config.runSkipped);
+    var engine = new Engine(concurrency: config.concurrency);
 
     var reporter;
     switch (config.reporter) {
@@ -77,10 +75,9 @@ class Runner {
         reporter = ExpandedReporter.watch(
             engine,
             color: config.color,
-            verboseTrace: config.verboseTrace,
             printPath: config.paths.length > 1 ||
                 new Directory(config.paths.single).existsSync(),
-            printPlatform: config.platforms.length > 1);
+            printPlatform: config.suiteDefaults.platforms.length > 1);
         break;
 
       case "compact":
@@ -124,9 +121,11 @@ class Runner {
 
     if (_closed) return false;
 
-    if (_engine.passed.length == 0 && _engine.failed.length == 0 &&
-        _engine.skipped.length == 0 && _config.patterns.isNotEmpty) {
-      var patterns = toSentence(_config.patterns.map(
+    if (_engine.passed.length == 0 &&
+        _engine.failed.length == 0 &&
+        _engine.skipped.length == 0 &&
+        _config.suiteDefaults.patterns.isNotEmpty) {
+      var patterns = toSentence(_config.suiteDefaults.patterns.map(
           (pattern) => pattern is RegExp
               ? 'regular expression "${pattern.pattern}"'
               : '"$pattern"'));
@@ -142,11 +141,12 @@ class Runner {
   /// Emits a warning if the user is trying to run on a platform that's
   /// unsupported for the entire package.
   void _warnForUnsupportedPlatforms() {
-    if (_config.testOn == PlatformSelector.all) return;
+    var testOn = _config.suiteDefaults.metadata.testOn;
+    if (testOn == PlatformSelector.all) return;
 
-    var unsupportedPlatforms = _config.platforms.where((platform) {
-      return !_config.testOn.evaluate(platform, os: currentOS);
-    }).toList();
+    var unsupportedPlatforms = _config.suiteDefaults.platforms
+        .where((platform) => !testOn.evaluate(platform, os: currentOS))
+        .toList();
     if (unsupportedPlatforms.isEmpty) return;
 
     // Human-readable names for all unsupported platforms.
@@ -160,7 +160,7 @@ class Runner {
     if (unsupportedBrowsers.isNotEmpty) {
       var supportsAnyBrowser = TestPlatform.all
           .where((platform) => platform.isBrowser)
-          .any((platform) => _config.testOn.evaluate(platform));
+          .any((platform) => testOn.evaluate(platform));
 
       if (supportsAnyBrowser) {
         unsupportedNames.addAll(
@@ -174,7 +174,7 @@ class Runner {
     // that's because of the current OS or whether the VM is unsupported.
     if (unsupportedPlatforms.contains(TestPlatform.vm)) {
       var supportsAnyOS = OperatingSystem.all.any((os) =>
-          _config.testOn.evaluate(TestPlatform.vm, os: os));
+          testOn.evaluate(TestPlatform.vm, os: os));
 
       if (supportsAnyOS) {
         unsupportedNames.add(currentOS.name);
@@ -232,29 +232,37 @@ class Runner {
   /// suites once they're loaded.
   Stream<LoadSuite> _loadSuites() {
     return StreamGroup.merge(_config.paths.map((path) {
-      if (new Directory(path).existsSync()) return _loader.loadDir(path);
-      if (new File(path).existsSync()) return _loader.loadFile(path);
-
-      return new Stream.fromIterable([
-        new LoadSuite.forLoadException(
-            new LoadException(path, 'Does not exist.'))
-      ]);
+      if (new Directory(path).existsSync()) {
+        return _loader.loadDir(path, _config.suiteDefaults);
+      } else if (new File(path).existsSync()) {
+        return _loader.loadFile(path, _config.suiteDefaults);
+      } else {
+        return new Stream.fromIterable([
+          new LoadSuite.forLoadException(
+              new LoadException(path, 'Does not exist.'),
+              _config.suiteDefaults)
+        ]);
+      }
     })).map((loadSuite) {
       return loadSuite.changeSuite((suite) {
         _warnForUnknownTags(suite);
 
         return _shardSuite(suite.filter((test) {
           // Skip any tests that don't match all the given patterns.
-          if (!_config.patterns
+          if (!suite.config.patterns
               .every((pattern) => test.name.contains(pattern))) {
             return false;
           }
 
           // If the user provided tags, skip tests that don't match all of them.
-          if (!_config.includeTags.evaluate(test.metadata.tags)) return false;
+          if (!suite.config.includeTags.evaluate(test.metadata.tags)) {
+            return false;
+          }
 
           // Skip tests that do match any tags the user wants to exclude.
-          if (_config.excludeTags.evaluate(test.metadata.tags)) return false;
+          if (suite.config.excludeTags.evaluate(test.metadata.tags)) {
+            return false;
+          }
 
           return true;
         }));
@@ -363,7 +371,7 @@ class Runner {
   /// Loads each suite in [suites] in order, pausing after load for platforms
   /// that support debugging.
   Future<bool> _loadThenPause(Stream<LoadSuite> suites) async {
-    if (_config.platforms.contains(TestPlatform.vm)) {
+    if (_config.suiteDefaults.platforms.contains(TestPlatform.vm)) {
       warn("Debugging is currently unsupported on the Dart VM.",
           color: _config.color);
     }

--- a/lib/src/runner/browser/browser_manager.dart
+++ b/lib/src/runner/browser/browser_manager.dart
@@ -10,10 +10,10 @@ import 'package:pool/pool.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
-import '../../backend/metadata.dart';
 import '../../backend/test_platform.dart';
 import '../../util/stack_trace_mapper.dart';
 import '../application_exception.dart';
+import '../configuration/suite.dart';
 import '../environment.dart';
 import '../plugin/platform_helpers.dart';
 import '../runner_suite.dart';
@@ -193,14 +193,14 @@ class BrowserManager {
   ///
   /// [url] should be an HTML page with a reference to the JS-compiled test
   /// suite. [path] is the path of the original test suite file, which is used
-  /// for reporting. [metadata] is the parsed metadata for the test suite.
+  /// for reporting. [suiteConfig] is the configuration for the test suite.
   ///
   /// If [mapper] is passed, it's used to map stack traces for errors coming
   /// from this test suite.
-  Future<RunnerSuite> load(String path, Uri url, Metadata metadata,
+  Future<RunnerSuite> load(String path, Uri url, SuiteConfiguration suiteConfig,
       {StackTraceMapper mapper}) async {
     url = url.replace(fragment: Uri.encodeFull(JSON.encode({
-      "metadata": metadata.serialize(),
+      "metadata": suiteConfig.metadata.serialize(),
       "browser": _platform.identifier
     })));
 
@@ -235,7 +235,7 @@ class BrowserManager {
 
       try {
         controller = await deserializeSuite(
-            path, _platform, metadata, await _environment, suiteChannel,
+            path, _platform, suiteConfig, await _environment, suiteChannel,
             mapTrace: mapper?.mapStackTrace);
         _controllers.add(controller);
         return controller.suite;

--- a/lib/src/runner/browser/compiler_pool.dart
+++ b/lib/src/runner/browser/compiler_pool.dart
@@ -13,6 +13,7 @@ import 'package:pool/pool.dart';
 
 import '../../util/io.dart';
 import '../configuration.dart';
+import '../configuration/suite.dart';
 import '../load_exception.dart';
 
 /// A regular expression matching the first status line printed by dart2js.
@@ -47,7 +48,8 @@ class CompilerPool {
   ///
   /// The returned [Future] will complete once the `dart2js` process completes
   /// *and* all its output has been printed to the command line.
-  Future compile(String dartPath, String jsPath) {
+  Future compile(String dartPath, String jsPath,
+      SuiteConfiguration suiteConfig) {
     return _pool.withResource(() {
       if (_closed) return null;
 
@@ -75,7 +77,7 @@ class CompilerPool {
           wrapperPath,
           "--out=$jsPath",
           await PackageResolver.current.processArgument
-        ]..addAll(_config.dart2jsArgs);
+        ]..addAll(suiteConfig.dart2jsArgs);
 
         if (_config.color) args.add("--enable-diagnostic-colors");
 

--- a/lib/src/runner/configuration.dart
+++ b/lib/src/runner/configuration.dart
@@ -457,10 +457,8 @@ class Configuration {
     if (chosenPresets.isEmpty || presets.isEmpty) return this;
 
     var newPresets = new Map<String, Configuration>.from(presets);
-    var merged = chosenPresets.fold(empty, (merged, preset) {
-      if (!newPresets.containsKey(preset)) return merged;
-      return merged.merge(newPresets.remove(preset));
-    });
+    var merged = chosenPresets.fold(empty, (merged, preset) =>
+        merged.merge(newPresets.remove(preset) ?? Configuration.empty));
 
     if (merged == empty) return this;
     var result = this.change(presets: newPresets).merge(merged);

--- a/lib/src/runner/configuration/suite.dart
+++ b/lib/src/runner/configuration/suite.dart
@@ -1,0 +1,318 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:boolean_selector/boolean_selector.dart';
+import 'package:collection/collection.dart';
+
+import '../../backend/metadata.dart';
+import '../../backend/operating_system.dart';
+import '../../backend/platform_selector.dart';
+import '../../backend/test_platform.dart';
+import '../../frontend/timeout.dart';
+
+/// Suite-level configuration.
+///
+/// This tracks configuration that can differ from suite to suite.
+class SuiteConfiguration {
+  /// Empty configuration with only default values.
+  ///
+  /// Using this is slightly more efficient than manually constructing a new
+  /// configuration with no arguments.
+  static final empty = new SuiteConfiguration._();
+
+  /// Whether JavaScript stack traces should be left as-is or converted to
+  /// Dart-like traces.
+  bool get jsTrace => _jsTrace ?? false;
+  final bool _jsTrace;
+
+  /// Whether skipped tests should be run.
+  bool get runSkipped => _runSkipped ?? false;
+  final bool _runSkipped;
+
+  /// The path to a mirror of this package containing HTML that points to
+  /// precompiled JS.
+  ///
+  /// This is used by the internal Google test runner so that test compilation
+  /// can more effectively make use of Google's build tools.
+  final String precompiledPath;
+
+  /// Additional arguments to pass to dart2js.
+  ///
+  /// Note that this if multiple suites run the same JavaScript on different
+  /// platforms, and they have different [dart2jsArgs], only one (undefined)
+  /// suite's arguments will be used.
+  final List<String> dart2jsArgs;
+
+  /// The patterns to match against test names to decide which to run, or `null`
+  /// if all tests should be run.
+  ///
+  /// All patterns must match in order for a test to be run.
+  final Set<Pattern> patterns;
+
+  /// The set of platforms on which to run tests.
+  List<TestPlatform> get platforms => _platforms ?? const [TestPlatform.vm];
+  final List<TestPlatform> _platforms;
+
+  /// Only run tests whose tags match this selector.
+  ///
+  /// When [merge]d, this is intersected with the other configuration's included
+  /// tags.
+  final BooleanSelector includeTags;
+
+  /// Do not run tests whose tags match this selector.
+  ///
+  /// When [merge]d, this is unioned with the other configuration's
+  /// excluded tags.
+  final BooleanSelector excludeTags;
+
+  /// Configuration for particular tags.
+  ///
+  /// The keys are tag selectors, and the values are configurations for tests
+  /// whose tags match those selectors.
+  final Map<BooleanSelector, SuiteConfiguration> tags;
+
+  /// Configuration for particular platforms.
+  ///
+  /// The keys are platform selectors, and the values are configurations for
+  /// those platforms. These configuration should only contain test-level
+  /// configuration fields, but that isn't enforced.
+  final Map<PlatformSelector, SuiteConfiguration> onPlatform;
+
+  /// The global test metadata derived from this configuration.
+  Metadata get metadata {
+    if (tags.isEmpty && onPlatform.isEmpty) return _metadata;
+    return _metadata.change(
+        forTag: mapMap(tags, value: (_, config) => config.metadata),
+        onPlatform: mapMap(onPlatform, value: (_, config) => config.metadata));
+  }
+  final Metadata _metadata;
+
+  /// The set of tags that have been declared in any way in this configuration.
+  Set<String> get knownTags {
+    if (_knownTags != null) return _knownTags;
+
+    var known = includeTags.variables.toSet()
+      ..addAll(excludeTags.variables)
+      ..addAll(_metadata.tags);
+
+    for (var selector in tags.keys) {
+      known.addAll(selector.variables);
+    }
+
+    for (var configuration in _children) {
+      known.addAll(configuration.knownTags);
+    }
+
+    _knownTags = new UnmodifiableSetView(known);
+    return _knownTags;
+  }
+  Set<String> _knownTags;
+
+  /// All child configurations of [this] that may be selected under various
+  /// circumstances.
+  Iterable<SuiteConfiguration> get _children sync* {
+    yield* tags.values;
+    yield* onPlatform.values;
+  }
+
+  factory SuiteConfiguration({
+      bool jsTrace,
+      bool runSkipped,
+      Iterable<String> dart2jsArgs,
+      String precompiledPath,
+      Iterable<Pattern> patterns,
+      Iterable<TestPlatform> platforms,
+      BooleanSelector includeTags,
+      BooleanSelector excludeTags,
+      Map<BooleanSelector, SuiteConfiguration> tags,
+      Map<PlatformSelector, SuiteConfiguration> onPlatform,
+
+      // Test-level configuration
+      Timeout timeout,
+      bool verboseTrace,
+      bool skip,
+      String skipReason,
+      PlatformSelector testOn,
+      Iterable<String> addTags}) {
+    var config = new SuiteConfiguration._(
+        jsTrace: jsTrace,
+        runSkipped: runSkipped,
+        dart2jsArgs: dart2jsArgs,
+        precompiledPath: precompiledPath,
+        patterns: patterns,
+        platforms: platforms,
+        includeTags: includeTags,
+        excludeTags: excludeTags,
+        tags: tags,
+        onPlatform: onPlatform,
+        metadata: new Metadata(
+            timeout: timeout,
+            verboseTrace: verboseTrace,
+            skip: skip,
+            skipReason: skipReason,
+            testOn: testOn,
+            tags: addTags));
+    return config._resolveTags();
+  }
+
+  /// Creates new SuiteConfiguration.
+  ///
+  /// Unlike [new SuiteConfiguration], this assumes [tags] is already
+  /// resolved.
+  SuiteConfiguration._({
+          bool jsTrace,
+          bool runSkipped,
+          Iterable<String> dart2jsArgs,
+          this.precompiledPath,
+          Iterable<Pattern> patterns,
+          Iterable<TestPlatform> platforms,
+          BooleanSelector includeTags,
+          BooleanSelector excludeTags,
+          Map<BooleanSelector, SuiteConfiguration> tags,
+          Map<PlatformSelector, SuiteConfiguration> onPlatform,
+          Metadata metadata})
+      : _jsTrace = jsTrace,
+        _runSkipped = runSkipped,
+        dart2jsArgs = _list(dart2jsArgs) ?? const [],
+        patterns = new UnmodifiableSetView(patterns?.toSet() ?? new Set()),
+        _platforms = _list(platforms),
+        includeTags = includeTags ?? BooleanSelector.all,
+        excludeTags = excludeTags ?? BooleanSelector.none,
+        tags = _map(tags),
+        onPlatform = _map(onPlatform),
+        _metadata = metadata ?? Metadata.empty;
+
+  /// Creates a new [SuiteConfiguration] that takes its configuration from
+  /// [metadata].
+  factory SuiteConfiguration.fromMetadata(Metadata metadata) =>
+      new SuiteConfiguration._(
+          tags: mapMap(metadata.forTag,
+              value: (_, child) => new SuiteConfiguration.fromMetadata(child)),
+          onPlatform: mapMap(metadata.onPlatform,
+              value: (_, child) => new SuiteConfiguration.fromMetadata(child)),
+          metadata: metadata.change(forTag: {}, onPlatform: {}));
+
+  /// Returns an unmodifiable copy of [input].
+  ///
+  /// If [input] is `null` or empty, this returns `null`.
+  static List/*<T>*/ _list/*<T>*/(Iterable/*<T>*/ input) {
+    if (input == null) return null;
+    var list = new List/*<T>*/.unmodifiable(input);
+    if (list.isEmpty) return null;
+    return list;
+  }
+
+  /// Returns an unmodifiable copy of [input] or an empty unmodifiable map.
+  static Map/*<K, V>*/ _map/*<K, V>*/(Map/*<K, V>*/ input) {
+    if (input == null || input.isEmpty) return const {};
+    return new Map.unmodifiable(input);
+  }
+
+  /// Merges this with [other].
+  ///
+  /// For most fields, if both configurations have values set, [other]'s value
+  /// takes precedence. However, certain fields are merged together instead.
+  /// This is indicated in those fields' documentation.
+  SuiteConfiguration merge(SuiteConfiguration other) {
+    if (this == SuiteConfiguration.empty) return other;
+    if (other == SuiteConfiguration.empty) return this;
+
+    var config = new SuiteConfiguration._(
+        jsTrace: other._jsTrace ?? _jsTrace,
+        runSkipped: other._runSkipped ?? _runSkipped,
+        dart2jsArgs: dart2jsArgs.toList()..addAll(other.dart2jsArgs),
+        precompiledPath: other.precompiledPath ?? precompiledPath,
+        patterns: patterns.union(other.patterns),
+        platforms: other._platforms ?? _platforms,
+        includeTags: includeTags.intersection(other.includeTags),
+        excludeTags: excludeTags.union(other.excludeTags),
+        tags: _mergeConfigMaps(tags, other.tags),
+        onPlatform: _mergeConfigMaps(onPlatform, other.onPlatform),
+        metadata: metadata.merge(other.metadata));
+    return config._resolveTags();
+  }
+
+  /// Returns a copy of this configuration with the given fields updated.
+  ///
+  /// Note that unlike [merge], this has no merging behavior—the old value is
+  /// always replaced by the new one.
+  SuiteConfiguration change({
+      bool jsTrace,
+      bool runSkipped,
+      Iterable<String> dart2jsArgs,
+      String precompiledPath,
+      Iterable<Pattern> patterns,
+      Iterable<TestPlatform> platforms,
+      BooleanSelector includeTags,
+      BooleanSelector excludeTags,
+      Map<BooleanSelector, SuiteConfiguration> tags,
+      Map<PlatformSelector, SuiteConfiguration> onPlatform,
+
+      // Test-level configuration
+      Timeout timeout,
+      bool verboseTrace,
+      bool skip,
+      String skipReason,
+      PlatformSelector testOn,
+      Iterable<String> addTags}) {
+    var config = new SuiteConfiguration._(
+        jsTrace: jsTrace ?? _jsTrace,
+        runSkipped: runSkipped ?? _runSkipped,
+        dart2jsArgs: dart2jsArgs?.toList() ?? this.dart2jsArgs,
+        precompiledPath: precompiledPath ?? this.precompiledPath,
+        patterns: patterns ?? this.patterns,
+        platforms: platforms ?? _platforms,
+        includeTags: includeTags ?? this.includeTags,
+        excludeTags: excludeTags ?? this.excludeTags,
+        tags: tags ?? this.tags,
+        onPlatform: onPlatform ?? this.onPlatform,
+        metadata: _metadata.change(
+            timeout: timeout,
+            verboseTrace: verboseTrace,
+            skip: skip,
+            skipReason: skipReason,
+            testOn: testOn,
+            tags: addTags));
+    return config._resolveTags();
+  }
+
+  /// Returns a copy of [this] with all platform-specific configuration from
+  /// [onPlatform] resolved.
+  SuiteConfiguration forPlatform(TestPlatform platform, {OperatingSystem os}) {
+    if (onPlatform.isEmpty) return this;
+
+    var config = this;
+    onPlatform.forEach((platformSelector, platformConfig) {
+      if (!platformSelector.evaluate(platform, os: os)) return;
+      config = config.merge(platformConfig);
+    });
+    return config.change(onPlatform: {});
+  }
+
+  /// Merges two maps whose values are [SuiteConfiguration]s.
+  ///
+  /// Any overlapping keys in the maps have their configurations merged in the
+  /// returned map.
+  Map<Object, SuiteConfiguration> _mergeConfigMaps(
+          Map<Object, SuiteConfiguration> map1,
+          Map<Object, SuiteConfiguration> map2) =>
+      mergeMaps(map1, map2,
+          value: (config1, config2) => config1.merge(config2));
+
+  SuiteConfiguration _resolveTags() {
+    // If there's no tag-specific configuration, or if none of it applies, just
+    // return the configuration as-is.
+    if (_metadata.tags.isEmpty || tags.isEmpty) return this;
+
+    // Otherwise, resolve the tag-specific components.
+    var newTags = new Map<BooleanSelector, SuiteConfiguration>.from(tags);
+    var merged = tags.keys.fold(empty, (merged, selector) {
+      if (!selector.evaluate(_metadata.tags)) return merged;
+      return merged.merge(newTags.remove(selector));
+    });
+
+    if (merged == empty) return this;
+    return this.change(tags: newTags).merge(merged);
+  }
+}

--- a/lib/src/runner/loader.dart
+++ b/lib/src/runner/loader.dart
@@ -11,12 +11,12 @@ import 'package:path/path.dart' as p;
 
 import '../backend/group.dart';
 import '../backend/invoker.dart';
-import '../backend/metadata.dart';
 import '../backend/test_platform.dart';
 import '../util/io.dart';
 import '../utils.dart';
 import 'browser/platform.dart';
 import 'configuration.dart';
+import 'configuration/suite.dart';
 import 'load_exception.dart';
 import 'load_suite.dart';
 import 'parse_metadata.dart';
@@ -81,20 +81,15 @@ class Loader {
     }
   }
 
-  /// Loads all test suites in [dir].
+  /// Loads all test suites in [dir] according to [suiteConfig].
   ///
-  /// This will load tests from files that match the configuration's filename
-  /// glob. Any tests that fail to load will be emitted as [LoadException]s.
+  /// This will load tests from files that match the global configuration's
+  /// filename glob. Any tests that fail to load will be emitted as
+  /// [LoadException]s.
   ///
   /// This emits [LoadSuite]s that must then be run to emit the actual
   /// [RunnerSuite]s defined in the file.
-  ///
-  /// If [platforms] is passed, these suites will only be loaded on those
-  /// platforms. It must be a subset of the current configuration's platforms.
-  /// Note that the suites aren't guaranteed to be loaded on all platforms in
-  /// [platforms]: their `@TestOn` declarations are still respected.
-  Stream<LoadSuite> loadDir(String dir, {Iterable<TestPlatform> platforms}) {
-    platforms = _validatePlatformSubset(platforms);
+  Stream<LoadSuite> loadDir(String dir, SuiteConfiguration suiteConfig) {
     return StreamGroup.merge(new Directory(dir).listSync(recursive: true)
         .map((entry) {
       if (entry is! File) return new Stream.fromIterable([]);
@@ -107,69 +102,64 @@ class Loader {
          return new Stream.fromIterable([]);
       }
 
-      return loadFile(entry.path);
+      return loadFile(entry.path, suiteConfig);
     }));
   }
 
-  /// Loads a test suite from the file at [path].
+  /// Loads a test suite from the file at [path] according to [suiteConfig].
   ///
   /// This emits [LoadSuite]s that must then be run to emit the actual
   /// [RunnerSuite]s defined in the file.
   ///
-  /// If [platforms] is passed, these suites will only be loaded on those
-  /// platforms. It must be a subset of the current configuration's platforms.
-  /// Note that the suites aren't guaranteed to be loaded on all platforms in
-  /// [platforms]: their `@TestOn` declarations are still respected.
-  ///
   /// This will emit a [LoadException] if the file fails to load.
-  Stream<LoadSuite> loadFile(String path, {Iterable<TestPlatform> platforms}) =>
-      // Ensure that the right config is current when invoking platform plugins.
-      _config.asCurrent(() async* {
-    platforms = _validatePlatformSubset(platforms);
-
-    var suiteMetadata;
+  Stream<LoadSuite> loadFile(String path, SuiteConfiguration suiteConfig)
+      async* {
     try {
-      suiteMetadata = parseMetadata(path);
+      suiteConfig = suiteConfig.merge(
+          new SuiteConfiguration.fromMetadata(parseMetadata(path)));
     } on AnalyzerErrorGroup catch (_) {
       // Ignore the analyzer's error, since its formatting is much worse than
       // the VM's or dart2js's.
-      suiteMetadata = new Metadata();
     } on FormatException catch (error, stackTrace) {
       yield new LoadSuite.forLoadException(
-          new LoadException(path, error), stackTrace: stackTrace);
+          new LoadException(path, error), suiteConfig, stackTrace: stackTrace);
       return;
     }
-    suiteMetadata = _config.metadata.merge(suiteMetadata);
 
     if (_config.pubServeUrl != null && !p.isWithin('test', path)) {
-      yield new LoadSuite.forLoadException(new LoadException(
-          path, 'When using "pub serve", all test files must be in test/.'));
+      yield new LoadSuite.forLoadException(
+          new LoadException(
+              path, 'When using "pub serve", all test files must be in test/.'),
+          suiteConfig);
       return;
     }
 
-    for (var platform in platforms ?? _config.platforms) {
-      if (!suiteMetadata.testOn.evaluate(platform, os: currentOS)) continue;
+    for (var platform in suiteConfig.platforms) {
+      if (!suiteConfig.metadata.testOn.evaluate(platform, os: currentOS)) {
+        continue;
+      }
 
-      var metadata = suiteMetadata.forPlatform(platform, os: currentOS);
+      var platformConfig = suiteConfig.forPlatform(platform, os: currentOS);
 
       // Don't load a skipped suite.
-      if (metadata.skip && !_config.runSkipped) {
+      if (platformConfig.metadata.skip && !platformConfig.runSkipped) {
         yield new LoadSuite.forSuite(new RunnerSuite(
             const PluginEnvironment(),
+            platformConfig,
             new Group.root(
-                [new LocalTest("(suite)", metadata, () {})],
-                metadata: metadata),
+                [new LocalTest("(suite)", platformConfig.metadata, () {})],
+                metadata: platformConfig.metadata),
             path: path, platform: platform));
         continue;
       }
 
       var name = (platform.isJS ? "compiling " : "loading ") + path;
-      yield new LoadSuite(name, () async {
+      yield new LoadSuite(name, platformConfig, () async {
         var memo = _platformPlugins[platform];
 
         try {
           var plugin = await memo.runOnce(_platformCallbacks[platform]);
-          var suite = await plugin.load(path, platform, metadata);
+          var suite = await plugin.load(path, platform, platformConfig);
           _suites.add(suite);
           return suite;
         } catch (error, stackTrace) {
@@ -178,18 +168,6 @@ class Loader {
         }
       }, path: path, platform: platform);
     }
-  });
-
-  /// Asserts that [platforms] is a subset of [_config.platforms], and returns
-  /// it as a set.
-  ///
-  /// Returns `null` if [platforms] is `null`.
-  Set<TestPlatform> _validatePlatformSubset(Iterable<TestPlatform> platforms) {
-    if (platforms == null) return null;
-    platforms = platforms.toSet();
-    if (platforms.every(_config.platforms.contains)) return platforms;
-    throw new ArgumentError.value(platforms, 'platforms',
-        "must be a subset of ${_config.platforms}.");
   }
 
   Future closeEphemeral() async {

--- a/lib/src/runner/parse_metadata.dart
+++ b/lib/src/runner/parse_metadata.dart
@@ -86,7 +86,7 @@ class _Parser {
     return new Metadata(
         testOn: testOn,
         timeout: timeout,
-        skip: skip != null,
+        skip: skip == null ? null : true,
         skipReason: skip is String ? skip : null,
         onPlatform: onPlatform,
         tags: tags);

--- a/lib/src/runner/plugin/platform.dart
+++ b/lib/src/runner/plugin/platform.dart
@@ -8,6 +8,7 @@ import 'package:stream_channel/stream_channel.dart';
 
 import '../../backend/metadata.dart';
 import '../../backend/test_platform.dart';
+import '../configuration/suite.dart';
 import '../environment.dart';
 import '../runner_suite.dart';
 import 'environment.dart';
@@ -45,7 +46,7 @@ abstract class PlatformPlugin {
   StreamChannel loadChannel(String path, TestPlatform platform);
 
   /// Loads the runner suite for the test file at [path] using [platform], with
-  /// [metadata] parsed from the test file's top-level annotations.
+  /// [suiteConfig] encoding the suite-specific configuration.
   ///
   /// By default, this just calls [loadChannel] and passes its result to
   /// [deserializeSuite]. However, it can be overridden to provide more
@@ -56,12 +57,12 @@ abstract class PlatformPlugin {
   /// [deserializeSuite] in `platform_helpers.dart` to obtain a
   /// [RunnerSuiteController].
   Future<RunnerSuite> load(String path, TestPlatform platform,
-      Metadata metadata) async {
+      SuiteConfiguration suiteConfig) async {
     // loadChannel may throw an exception. That's fine; it will cause the
     // LoadSuite to emit an error, which will be presented to the user.
     var channel = loadChannel(path, platform);
     var controller = await deserializeSuite(
-        path, platform, metadata, new PluginEnvironment(), channel);
+        path, platform, suiteConfig, new PluginEnvironment(), channel);
     return controller.suite;
   }
 

--- a/lib/src/runner/plugin/platform_helpers.dart
+++ b/lib/src/runner/plugin/platform_helpers.dart
@@ -14,6 +14,7 @@ import '../../backend/test_platform.dart';
 import '../../util/io.dart';
 import '../../util/remote_exception.dart';
 import '../configuration.dart';
+import '../configuration/suite.dart';
 import '../environment.dart';
 import '../load_exception.dart';
 import '../runner_suite.dart';
@@ -32,8 +33,9 @@ typedef StackTrace _MapTrace(StackTrace trace);
 /// If [mapTrace] is passed, it will be used to adjust stack traces for any
 /// errors emitted by tests.
 Future<RunnerSuiteController> deserializeSuite(String path,
-    TestPlatform platform, Metadata metadata, Environment environment,
-    StreamChannel channel, {StackTrace mapTrace(StackTrace trace)}) async {
+    TestPlatform platform, SuiteConfiguration suiteConfig,
+    Environment environment, StreamChannel channel,
+    {StackTrace mapTrace(StackTrace trace)}) async {
   if (mapTrace == null) mapTrace = (trace) => trace;
 
   var disconnector = new Disconnector();
@@ -41,7 +43,7 @@ Future<RunnerSuiteController> deserializeSuite(String path,
 
   suiteChannel.sink.add({
     'platform': platform.identifier,
-    'metadata': metadata.serialize(),
+    'metadata': suiteConfig.metadata.serialize(),
     'os': platform == TestPlatform.vm ? currentOS.identifier : null,
     'collectTraces': Configuration.current.reporter == 'json'
   });
@@ -95,6 +97,7 @@ Future<RunnerSuiteController> deserializeSuite(String path,
 
   return new RunnerSuiteController(
       environment,
+      suiteConfig,
       await completer.future,
       path: path,
       platform: platform,

--- a/lib/src/runner/reporter/compact.dart
+++ b/lib/src/runner/reporter/compact.dart
@@ -204,7 +204,8 @@ class CompactReporter implements Reporter {
 
     if (error is! LoadException) {
       print(indent(error.toString()));
-      var chain = terseChain(stackTrace, verbose: _config.verboseTrace);
+      var chain = terseChain(stackTrace,
+          verbose: liveTest.test.metadata.verboseTrace);
       print(indent(chain.toString()));
       return;
     }
@@ -350,7 +351,8 @@ class CompactReporter implements Reporter {
       name = "${liveTest.suite.path}: $name";
     }
 
-    if (_config.platforms.length > 1 && liveTest.suite.platform != null) {
+    if (_config.suiteDefaults.platforms.length > 1 &&
+        liveTest.suite.platform != null) {
       name = "[${liveTest.suite.platform.name}] $name";
     }
 

--- a/lib/src/runner/reporter/expanded.dart
+++ b/lib/src/runner/reporter/expanded.dart
@@ -53,9 +53,6 @@ class ExpandedReporter implements Reporter {
   /// this is Windows or not outputting to a terminal.
   final String _noColor;
 
-  /// Whether to use verbose stack traces.
-  final bool _verboseTrace;
-
   /// The engine used to run the tests.
   final Engine _engine;
 
@@ -101,25 +98,21 @@ class ExpandedReporter implements Reporter {
   /// terminal.
   ///
   /// If [color] is `true`, this will use terminal colors; if it's `false`, it
-  /// won't. If [verboseTrace] is `true`, this will print core library frames.
-  /// If [printPath] is `true`, this will print the path name as part of the
-  /// test description. Likewise, if [printPlatform] is `true`, this will print
-  /// the platform as part of the test description.
+  /// won't. If [printPath] is `true`, this will print the path name as part of
+  /// the test description. Likewise, if [printPlatform] is `true`, this will
+  /// print the platform as part of the test description.
   static ExpandedReporter watch(Engine engine, {bool color: true,
-      bool verboseTrace: false, bool printPath: true,
-      bool printPlatform: true}) {
+      bool printPath: true, bool printPlatform: true}) {
     return new ExpandedReporter._(
         engine,
         color: color,
-        verboseTrace: verboseTrace,
         printPath: printPath,
         printPlatform: printPlatform);
   }
 
-  ExpandedReporter._(this._engine, {bool color: true, bool verboseTrace: false,
-          bool printPath: true, bool printPlatform: true})
-      : _verboseTrace = verboseTrace,
-        _printPath = printPath,
+  ExpandedReporter._(this._engine, {bool color: true, bool printPath: true,
+      bool printPlatform: true})
+      : _printPath = printPath,
         _printPlatform = printPlatform,
         _color = color,
         _green = color ? '\u001b[32m' : '',
@@ -214,7 +207,8 @@ class ExpandedReporter implements Reporter {
 
     if (error is! LoadException) {
       print(indent(error.toString()));
-      var chain = terseChain(stackTrace, verbose: _verboseTrace);
+      var chain = terseChain(stackTrace,
+          verbose: liveTest.test.metadata.verboseTrace);
       print(indent(chain.toString()));
       return;
     }

--- a/lib/src/runner/runner_suite.dart
+++ b/lib/src/runner/runner_suite.dart
@@ -12,6 +12,7 @@ import '../backend/suite.dart';
 import '../backend/test.dart';
 import '../backend/test_platform.dart';
 import '../utils.dart';
+import 'configuration/suite.dart';
 import 'environment.dart';
 
 /// A suite produced and consumed by the test runner that has runner-specific
@@ -29,6 +30,9 @@ class RunnerSuite extends Suite {
   /// The environment in which this suite runs.
   Environment get environment => _controller._environment;
 
+  /// The configuration for this suite.
+  SuiteConfiguration get config => _controller._config;
+
   /// Whether the suite is paused for debugging.
   ///
   /// When using a dev inspector, this may also mean that the entire browser is
@@ -43,9 +47,10 @@ class RunnerSuite extends Suite {
 
   /// A shortcut constructor for creating a [RunnerSuite] that never goes into
   /// debugging mode.
-  factory RunnerSuite(Environment environment, Group group, {String path,
-      TestPlatform platform, OperatingSystem os, AsyncFunction onClose}) {
-    var controller = new RunnerSuiteController(environment, group,
+  factory RunnerSuite(Environment environment, SuiteConfiguration config,
+      Group group, {String path, TestPlatform platform, OperatingSystem os,
+      AsyncFunction onClose}) {
+    var controller = new RunnerSuiteController(environment, config, group,
         path: path, platform: platform, os: os, onClose: onClose);
     return controller.suite;
   }
@@ -73,6 +78,9 @@ class RunnerSuiteController {
   /// The backing value for [suite.environment].
   final Environment _environment;
 
+  /// The configuration for this suite.
+  final SuiteConfiguration _config;
+
   /// The function to call when the suite is closed.
   final AsyncFunction _onClose;
 
@@ -82,8 +90,9 @@ class RunnerSuiteController {
   /// The controller for [suite.onDebugging].
   final _onDebuggingController = new StreamController<bool>.broadcast();
 
-  RunnerSuiteController(this._environment, Group group, {String path,
-          TestPlatform platform, OperatingSystem os, AsyncFunction onClose})
+  RunnerSuiteController(this._environment, this._config, Group group,
+          {String path, TestPlatform platform,
+          OperatingSystem os, AsyncFunction onClose})
       : _onClose = onClose {
     _suite = new RunnerSuite._(this, group, path, platform, os);
   }

--- a/lib/test.dart
+++ b/lib/test.dart
@@ -9,6 +9,7 @@ import 'package:path/path.dart' as p;
 import 'src/backend/declarer.dart';
 import 'src/backend/test_platform.dart';
 import 'src/frontend/timeout.dart';
+import 'src/runner/configuration/suite.dart';
 import 'src/runner/engine.dart';
 import 'src/runner/plugin/environment.dart';
 import 'src/runner/reporter/expanded.dart';
@@ -52,6 +53,7 @@ Declarer get _declarer {
   scheduleMicrotask(() async {
     var suite = new RunnerSuite(
         const PluginEnvironment(),
+        SuiteConfiguration.empty,
         _globalDeclarer.build(),
         path: p.prettyUri(Uri.base),
         platform: TestPlatform.vm,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.15+12
+version: 0.12.16-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test

--- a/test/runner/configuration/configuration_test.dart
+++ b/test/runner/configuration/configuration_test.dart
@@ -21,20 +21,13 @@ void main() {
         var merged = new Configuration().merge(new Configuration());
         expect(merged.help, isFalse);
         expect(merged.version, isFalse);
-        expect(merged.verboseTrace, isFalse);
-        expect(merged.jsTrace, isFalse);
-        expect(merged.skip, isFalse);
-        expect(merged.skipReason, isNull);
-        expect(merged.runSkipped, isFalse);
         expect(merged.pauseAfterLoad, isFalse);
         expect(merged.color, equals(canUseSpecialChars));
-        expect(merged.shardIndex, isNull);
-        expect(merged.totalShards, isNull);
         expect(merged.dart2jsPath, equals(p.join(sdkDir, 'bin', 'dart2js')));
-        expect(merged.precompiledPath, isNull);
         expect(merged.reporter, equals(defaultReporter));
         expect(merged.pubServeUrl, isNull);
-        expect(merged.platforms, equals([TestPlatform.vm]));
+        expect(merged.shardIndex, isNull);
+        expect(merged.totalShards, isNull);
         expect(merged.paths, equals(["test"]));
       });
 
@@ -42,39 +35,25 @@ void main() {
         var merged = new Configuration(
                 help: true,
                 version: true,
-                verboseTrace: true,
-                jsTrace: true,
-                skip: true,
-                skipReason: "boop",
-                runSkipped: true,
                 pauseAfterLoad: true,
                 color: true,
-                shardIndex: 3,
-                totalShards: 10,
                 dart2jsPath: "/tmp/dart2js",
-                precompiledPath: "/tmp/js",
                 reporter: "json",
                 pubServePort: 1234,
-                platforms: [TestPlatform.chrome],
+                shardIndex: 3,
+                totalShards: 10,
                 paths: ["bar"])
             .merge(new Configuration());
 
         expect(merged.help, isTrue);
         expect(merged.version, isTrue);
-        expect(merged.verboseTrace, isTrue);
-        expect(merged.jsTrace, isTrue);
-        expect(merged.skip, isTrue);
-        expect(merged.skipReason, equals("boop"));
-        expect(merged.runSkipped, isTrue);
         expect(merged.pauseAfterLoad, isTrue);
         expect(merged.color, isTrue);
-        expect(merged.shardIndex, equals(3));
-        expect(merged.totalShards, equals(10));
         expect(merged.dart2jsPath, equals("/tmp/dart2js"));
-        expect(merged.precompiledPath, equals("/tmp/js"));
         expect(merged.reporter, equals("json"));
         expect(merged.pubServeUrl.port, equals(1234));
-        expect(merged.platforms, equals([TestPlatform.chrome]));
+        expect(merged.shardIndex, equals(3));
+        expect(merged.totalShards, equals(10));
         expect(merged.paths, equals(["bar"]));
       });
 
@@ -82,38 +61,24 @@ void main() {
         var merged = new Configuration().merge(new Configuration(
             help: true,
             version: true,
-            verboseTrace: true,
-            jsTrace: true,
-            skip: true,
-            skipReason: "boop",
-            runSkipped: true,
             pauseAfterLoad: true,
             color: true,
-            shardIndex: 3,
-            totalShards: 10,
             dart2jsPath: "/tmp/dart2js",
-            precompiledPath: "/tmp/js",
             reporter: "json",
             pubServePort: 1234,
-            platforms: [TestPlatform.chrome],
+            shardIndex: 3,
+            totalShards: 10,
             paths: ["bar"]));
 
         expect(merged.help, isTrue);
         expect(merged.version, isTrue);
-        expect(merged.verboseTrace, isTrue);
-        expect(merged.jsTrace, isTrue);
-        expect(merged.skip, isTrue);
-        expect(merged.skipReason, equals("boop"));
-        expect(merged.runSkipped, isTrue);
         expect(merged.pauseAfterLoad, isTrue);
         expect(merged.color, isTrue);
-        expect(merged.shardIndex, equals(3));
-        expect(merged.totalShards, equals(10));
         expect(merged.dart2jsPath, equals("/tmp/dart2js"));
-        expect(merged.precompiledPath, equals("/tmp/js"));
         expect(merged.reporter, equals("json"));
         expect(merged.pubServeUrl.port, equals(1234));
-        expect(merged.platforms, equals([TestPlatform.chrome]));
+        expect(merged.shardIndex, equals(3));
+        expect(merged.totalShards, equals(10));
         expect(merged.paths, equals(["bar"]));
       });
 
@@ -122,331 +87,112 @@ void main() {
         var older = new Configuration(
             help: true,
             version: false,
-            verboseTrace: true,
-            jsTrace: false,
-            skip: true,
-            skipReason: "foo",
-            runSkipped: true,
             pauseAfterLoad: true,
             color: false,
-            shardIndex: 2,
-            totalShards: 4,
             dart2jsPath: "/tmp/dart2js",
-            precompiledPath: "/tmp/js",
             reporter: "json",
             pubServePort: 1234,
-            platforms: [TestPlatform.chrome],
+            shardIndex: 2,
+            totalShards: 4,
             paths: ["bar"]);
         var newer = new Configuration(
             help: false,
             version: true,
-            verboseTrace: false,
-            jsTrace: true,
-            skip: true,
-            skipReason: "bar",
-            runSkipped: false,
             pauseAfterLoad: false,
             color: true,
-            shardIndex: 3,
-            totalShards: 10,
             dart2jsPath: "../dart2js",
-            precompiledPath: "../js",
             reporter: "compact",
             pubServePort: 5678,
-            platforms: [TestPlatform.dartium],
+            shardIndex: 3,
+            totalShards: 10,
             paths: ["blech"]);
         var merged = older.merge(newer);
 
         expect(merged.help, isFalse);
         expect(merged.version, isTrue);
-        expect(merged.verboseTrace, isFalse);
-        expect(merged.jsTrace, isTrue);
-        expect(merged.skipReason, equals("bar"));
-        expect(merged.runSkipped, isFalse);
         expect(merged.pauseAfterLoad, isFalse);
         expect(merged.color, isTrue);
-        expect(merged.shardIndex, equals(3));
-        expect(merged.totalShards, equals(10));
         expect(merged.dart2jsPath, equals("../dart2js"));
-        expect(merged.precompiledPath, equals("../js"));
         expect(merged.reporter, equals("compact"));
         expect(merged.pubServeUrl.port, equals(5678));
-        expect(merged.platforms, equals([TestPlatform.dartium]));
+        expect(merged.shardIndex, equals(3));
+        expect(merged.totalShards, equals(10));
         expect(merged.paths, equals(["blech"]));
       });
     });
 
-    group("for testOn", () {
+    group("for chosenPresets", () {
       test("if neither is defined, preserves the default", () {
         var merged = new Configuration().merge(new Configuration());
-        expect(merged.testOn, equals(PlatformSelector.all));
+        expect(merged.chosenPresets, isEmpty);
       });
 
       test("if only the old configuration's is defined, uses it", () {
-        var merged = new Configuration(
-                testOn: new PlatformSelector.parse("chrome"))
+        var merged = new Configuration(chosenPresets: ["baz", "bang"])
             .merge(new Configuration());
-        expect(merged.testOn, equals(new PlatformSelector.parse("chrome")));
+        expect(merged.chosenPresets, equals(["baz", "bang"]));
       });
 
       test("if only the new configuration's is defined, uses it", () {
         var merged = new Configuration()
-            .merge(new Configuration(
-                testOn: new PlatformSelector.parse("chrome")));
-        expect(merged.testOn, equals(new PlatformSelector.parse("chrome")));
-      });
-
-      test("if both are defined, intersects them", () {
-        var older = new Configuration(
-            testOn: new PlatformSelector.parse("vm"));
-        var newer = new Configuration(
-            testOn: new PlatformSelector.parse("linux"));
-        var merged = older.merge(newer);
-        expect(merged.testOn,
-            equals(new PlatformSelector.parse("vm && linux")));
-      });
-    });
-
-    group("for include and excludeTags", () {
-      test("if neither is defined, preserves the default", () {
-        var merged = new Configuration().merge(new Configuration());
-        expect(merged.includeTags, equals(BooleanSelector.all));
-        expect(merged.excludeTags, equals(BooleanSelector.none));
-      });
-
-      test("if only the old configuration's is defined, uses it", () {
-        var merged = new Configuration(
-                includeTags: new BooleanSelector.parse("foo || bar"),
-                excludeTags: new BooleanSelector.parse("baz || bang"))
-            .merge(new Configuration());
-
-        expect(merged.includeTags,
-            equals(new BooleanSelector.parse("foo || bar")));
-        expect(merged.excludeTags,
-            equals(new BooleanSelector.parse("baz || bang")));
-      });
-
-      test("if only the new configuration's is defined, uses it", () {
-        var merged = new Configuration().merge(new Configuration(
-            includeTags: new BooleanSelector.parse("foo || bar"),
-            excludeTags: new BooleanSelector.parse("baz || bang")));
-
-        expect(merged.includeTags,
-            equals(new BooleanSelector.parse("foo || bar")));
-        expect(merged.excludeTags,
-            equals(new BooleanSelector.parse("baz || bang")));
-      });
-
-      test("if both are defined, unions or intersects them", () {
-        var older = new Configuration(
-            includeTags: new BooleanSelector.parse("foo || bar"),
-            excludeTags: new BooleanSelector.parse("baz || bang"));
-        var newer = new Configuration(
-            includeTags: new BooleanSelector.parse("blip"),
-            excludeTags: new BooleanSelector.parse("qux"));
-        var merged = older.merge(newer);
-
-        expect(merged.includeTags,
-            equals(new BooleanSelector.parse("(foo || bar) && blip")));
-        expect(merged.excludeTags,
-            equals(new BooleanSelector.parse("(baz || bang) || qux")));
-      });
-    });
-
-    group("for sets", () {
-      test("if neither is defined, preserves the default", () {
-        var merged = new Configuration().merge(new Configuration());
-        expect(merged.addTags, isEmpty);
-        expect(merged.chosenPresets, isEmpty);
-        expect(merged.patterns, isEmpty);
-      });
-
-      test("if only the old configuration's is defined, uses it", () {
-        var merged = new Configuration(
-                addTags: ["foo", "bar"],
-                chosenPresets: ["baz", "bang"],
-                patterns: ["beep", "boop"])
-            .merge(new Configuration());
-
-        expect(merged.addTags, unorderedEquals(["foo", "bar"]));
+            .merge(new Configuration(chosenPresets: ["baz", "bang"]));
         expect(merged.chosenPresets, equals(["baz", "bang"]));
-        expect(merged.patterns, equals(["beep", "boop"]));
-      });
-
-      test("if only the new configuration's is defined, uses it", () {
-        var merged = new Configuration().merge(new Configuration(
-            addTags: ["foo", "bar"],
-            chosenPresets: ["baz", "bang"],
-            patterns: ["beep", "boop"]));
-
-        expect(merged.addTags, unorderedEquals(["foo", "bar"]));
-        expect(merged.chosenPresets, equals(["baz", "bang"]));
-        expect(merged.patterns, equals(["beep", "boop"]));
       });
 
       test("if both are defined, unions them", () {
-        var older = new Configuration(
-            addTags: ["foo", "bar"],
-            chosenPresets: ["baz", "bang"],
-            patterns: ["beep", "boop"]);
-        var newer = new Configuration(
-            addTags: ["blip"],
-            chosenPresets: ["qux"],
-            patterns: ["bonk"]);
-        var merged = older.merge(newer);
-
-        expect(merged.addTags, unorderedEquals(["foo", "bar", "blip"]));
+        var merged = new Configuration(chosenPresets: ["baz", "bang"])
+            .merge(new Configuration(chosenPresets: ["qux"]));
         expect(merged.chosenPresets, equals(["baz", "bang", "qux"]));
-        expect(merged.patterns, unorderedEquals(["beep", "boop", "bonk"]));
-      });
-    });
-
-    group("for timeout", () {
-      test("if neither is defined, preserves the default", () {
-        var merged = new Configuration().merge(new Configuration());
-        expect(merged.timeout, equals(new Timeout.factor(1)));
-      });
-
-      test("if only the old configuration's is defined, uses it", () {
-        var merged = new Configuration(timeout: new Timeout.factor(2))
-            .merge(new Configuration());
-        expect(merged.timeout, equals(new Timeout.factor(2)));
-      });
-
-      test("if only the new configuration's is defined, uses it", () {
-        var merged = new Configuration()
-            .merge(new Configuration(timeout: new Timeout.factor(2)));
-        expect(merged.timeout, equals(new Timeout.factor(2)));
-      });
-
-      test("if both are defined, merges them", () {
-        var older = new Configuration(timeout: new Timeout.factor(2));
-        var newer = new Configuration(timeout: new Timeout.factor(3));
-        var merged = older.merge(newer);
-        expect(merged.timeout, equals(new Timeout.factor(6)));
-      });
-
-      test("if the merge conflicts, prefers the new value", () {
-        var older = new Configuration(
-            timeout: new Timeout(new Duration(seconds: 1)));
-        var newer = new Configuration(
-            timeout: new Timeout(new Duration(seconds: 2)));
-        var merged = older.merge(newer);
-        expect(merged.timeout, equals(new Timeout(new Duration(seconds: 2))));
-      });
-    });
-
-    group("for dart2jsArgs", () {
-      test("if neither is defined, preserves the default", () {
-        var merged = new Configuration().merge(new Configuration());
-        expect(merged.dart2jsArgs, isEmpty);
-      });
-
-      test("if only the old configuration's is defined, uses it", () {
-        var merged = new Configuration(dart2jsArgs: ["--foo", "--bar"])
-            .merge(new Configuration());
-        expect(merged.dart2jsArgs, equals(["--foo", "--bar"]));
-      });
-
-      test("if only the new configuration's is defined, uses it", () {
-        var merged = new Configuration()
-            .merge(new Configuration(dart2jsArgs: ["--foo", "--bar"]));
-        expect(merged.dart2jsArgs, equals(["--foo", "--bar"]));
-      });
-
-      test("if both are defined, concatenates them", () {
-        var older = new Configuration(dart2jsArgs: ["--foo", "--bar"]);
-        var newer = new Configuration(dart2jsArgs: ["--baz"]);
-        var merged = older.merge(newer);
-        expect(merged.dart2jsArgs, equals(["--foo", "--bar", "--baz"]));
-      });
-    });
-
-    group("for config maps", () {
-      test("merges each nested configuration", () {
-        var merged = new Configuration(
-          tags: {
-            new BooleanSelector.parse("foo"):
-                new Configuration(verboseTrace: true),
-            new BooleanSelector.parse("bar"): new Configuration(jsTrace: true)
-          },
-          onPlatform: {
-            new PlatformSelector.parse("vm"):
-                new Configuration(verboseTrace: true),
-            new PlatformSelector.parse("chrome"):
-                new Configuration(jsTrace: true)
-          },
-          presets: {
-            "bang": new Configuration(verboseTrace: true),
-            "qux": new Configuration(jsTrace: true)
-          }
-        ).merge(new Configuration(
-          tags: {
-            new BooleanSelector.parse("bar"): new Configuration(jsTrace: false),
-            new BooleanSelector.parse("baz"): new Configuration(skip: true)
-          },
-          onPlatform: {
-            new PlatformSelector.parse("chrome"):
-                new Configuration(jsTrace: false),
-            new PlatformSelector.parse("firefox"): new Configuration(skip: true)
-          },
-          presets: {
-            "qux": new Configuration(jsTrace: false),
-            "zap": new Configuration(skip: true)
-          }
-        ));
-
-        expect(merged.tags[new BooleanSelector.parse("foo")].verboseTrace,
-            isTrue);
-        expect(merged.tags[new BooleanSelector.parse("bar")].jsTrace, isFalse);
-        expect(merged.tags[new BooleanSelector.parse("baz")].skip, isTrue);
-
-        expect(merged.onPlatform[new PlatformSelector.parse("vm")].verboseTrace,
-            isTrue);
-        expect(merged.onPlatform[new PlatformSelector.parse("chrome")].jsTrace,
-            isFalse);
-        expect(merged.onPlatform[new PlatformSelector.parse("firefox")].skip,
-            isTrue);
-
-        expect(merged.presets["bang"].verboseTrace, isTrue);
-        expect(merged.presets["qux"].jsTrace, isFalse);
-        expect(merged.presets["zap"].skip, isTrue);
       });
     });
 
     group("for presets", () {
+      test("merges each nested configuration", () {
+        var merged = new Configuration(presets: {
+          "bang": new Configuration(pauseAfterLoad: true),
+          "qux": new Configuration(color: true)
+        }).merge(new Configuration(presets: {
+          "qux": new Configuration(color: false),
+          "zap": new Configuration(help: true)
+        }));
+
+        expect(merged.presets["bang"].pauseAfterLoad, isTrue);
+        expect(merged.presets["qux"].color, isFalse);
+        expect(merged.presets["zap"].help, isTrue);
+      });
+
       test("automatically resolves a matching chosen preset", () {
         var configuration = new Configuration(
-            presets: {"foo": new Configuration(verboseTrace: true)},
+            presets: {"foo": new Configuration(color: true)},
             chosenPresets: ["foo"]);
         expect(configuration.presets, isEmpty);
         expect(configuration.chosenPresets, equals(["foo"]));
         expect(configuration.knownPresets, equals(["foo"]));
-        expect(configuration.verboseTrace, isTrue);
+        expect(configuration.color, isTrue);
       });
 
       test("resolves a chosen presets in order", () {
         var configuration = new Configuration(
             presets: {
-              "foo": new Configuration(verboseTrace: true),
-              "bar": new Configuration(verboseTrace: false)
+              "foo": new Configuration(color: true),
+              "bar": new Configuration(color: false)
             },
             chosenPresets: ["foo", "bar"]);
         expect(configuration.presets, isEmpty);
         expect(configuration.chosenPresets, equals(["foo", "bar"]));
         expect(configuration.knownPresets, unorderedEquals(["foo", "bar"]));
-        expect(configuration.verboseTrace, isFalse);
+        expect(configuration.color, isFalse);
 
         configuration = new Configuration(
             presets: {
-              "foo": new Configuration(verboseTrace: true),
-              "bar": new Configuration(verboseTrace: false)
+              "foo": new Configuration(color: true),
+              "bar": new Configuration(color: false)
             },
             chosenPresets: ["bar", "foo"]);
         expect(configuration.presets, isEmpty);
         expect(configuration.chosenPresets, equals(["bar", "foo"]));
         expect(configuration.knownPresets, unorderedEquals(["foo", "bar"]));
-        expect(configuration.verboseTrace, isTrue);
+        expect(configuration.color, isTrue);
       });
 
       test("ignores inapplicable chosen presets", () {
@@ -460,25 +206,25 @@ void main() {
 
       test("resolves presets through merging", () {
         var configuration = new Configuration(presets: {
-          "foo": new Configuration(verboseTrace: true)
+          "foo": new Configuration(color: true)
         }).merge(new Configuration(chosenPresets: ["foo"]));
 
         expect(configuration.presets, isEmpty);
         expect(configuration.chosenPresets, equals(["foo"]));
         expect(configuration.knownPresets, equals(["foo"]));
-        expect(configuration.verboseTrace, isTrue);
+        expect(configuration.color, isTrue);
       });
 
       test("preserves known presets through merging", () {
-        var configuration = new Configuration(presets: {
-          "foo": new Configuration(verboseTrace: true)
-        }, chosenPresets: ["foo"])
+        var configuration = new Configuration(
+                presets: {"foo": new Configuration(color: true)},
+                chosenPresets: ["foo"])
             .merge(new Configuration());
 
         expect(configuration.presets, isEmpty);
         expect(configuration.chosenPresets, equals(["foo"]));
         expect(configuration.knownPresets, equals(["foo"]));
-        expect(configuration.verboseTrace, isTrue);
+        expect(configuration.color, isTrue);
       });
     });
   });

--- a/test/runner/configuration/suite_test.dart
+++ b/test/runner/configuration/suite_test.dart
@@ -1,0 +1,224 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn("vm")
+
+import 'package:boolean_selector/boolean_selector.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'package:test/src/backend/platform_selector.dart';
+import 'package:test/src/backend/test_platform.dart';
+import 'package:test/src/runner/configuration/suite.dart';
+import 'package:test/src/runner/configuration/values.dart';
+import 'package:test/src/util/io.dart';
+
+void main() {
+  group("merge", () {
+    group("for most fields", () {
+      test("if neither is defined, preserves the default", () {
+        var merged = new SuiteConfiguration().merge(new SuiteConfiguration());
+        expect(merged.jsTrace, isFalse);
+        expect(merged.runSkipped, isFalse);
+        expect(merged.precompiledPath, isNull);
+        expect(merged.platforms, equals([TestPlatform.vm]));
+      });
+
+      test("if only the old configuration's is defined, uses it", () {
+        var merged = new SuiteConfiguration(
+                jsTrace: true,
+                runSkipped: true,
+                precompiledPath: "/tmp/js",
+                platforms: [TestPlatform.chrome])
+            .merge(new SuiteConfiguration());
+
+        expect(merged.jsTrace, isTrue);
+        expect(merged.runSkipped, isTrue);
+        expect(merged.precompiledPath, equals("/tmp/js"));
+        expect(merged.platforms, equals([TestPlatform.chrome]));
+      });
+
+      test("if only the new configuration's is defined, uses it", () {
+        var merged = new SuiteConfiguration().merge(new SuiteConfiguration(
+            jsTrace: true,
+            runSkipped: true,
+            precompiledPath: "/tmp/js",
+            platforms: [TestPlatform.chrome]));
+
+        expect(merged.jsTrace, isTrue);
+        expect(merged.runSkipped, isTrue);
+        expect(merged.precompiledPath, equals("/tmp/js"));
+        expect(merged.platforms, equals([TestPlatform.chrome]));
+      });
+
+      test("if the two configurations conflict, uses the new configuration's "
+          "values", () {
+        var older = new SuiteConfiguration(
+            jsTrace: false,
+            runSkipped: true,
+            precompiledPath: "/tmp/js",
+            platforms: [TestPlatform.chrome]);
+        var newer = new SuiteConfiguration(
+            jsTrace: true,
+            runSkipped: false,
+            precompiledPath: "../js",
+            platforms: [TestPlatform.dartium]);
+        var merged = older.merge(newer);
+
+        expect(merged.jsTrace, isTrue);
+        expect(merged.runSkipped, isFalse);
+        expect(merged.precompiledPath, equals("../js"));
+        expect(merged.platforms, equals([TestPlatform.dartium]));
+      });
+    });
+
+    group("for include and excludeTags", () {
+      test("if neither is defined, preserves the default", () {
+        var merged = new SuiteConfiguration().merge(new SuiteConfiguration());
+        expect(merged.includeTags, equals(BooleanSelector.all));
+        expect(merged.excludeTags, equals(BooleanSelector.none));
+      });
+
+      test("if only the old configuration's is defined, uses it", () {
+        var merged = new SuiteConfiguration(
+                includeTags: new BooleanSelector.parse("foo || bar"),
+                excludeTags: new BooleanSelector.parse("baz || bang"))
+            .merge(new SuiteConfiguration());
+
+        expect(merged.includeTags,
+            equals(new BooleanSelector.parse("foo || bar")));
+        expect(merged.excludeTags,
+            equals(new BooleanSelector.parse("baz || bang")));
+      });
+
+      test("if only the new configuration's is defined, uses it", () {
+        var merged = new SuiteConfiguration().merge(new SuiteConfiguration(
+            includeTags: new BooleanSelector.parse("foo || bar"),
+            excludeTags: new BooleanSelector.parse("baz || bang")));
+
+        expect(merged.includeTags,
+            equals(new BooleanSelector.parse("foo || bar")));
+        expect(merged.excludeTags,
+            equals(new BooleanSelector.parse("baz || bang")));
+      });
+
+      test("if both are defined, unions or intersects them", () {
+        var older = new SuiteConfiguration(
+            includeTags: new BooleanSelector.parse("foo || bar"),
+            excludeTags: new BooleanSelector.parse("baz || bang"));
+        var newer = new SuiteConfiguration(
+            includeTags: new BooleanSelector.parse("blip"),
+            excludeTags: new BooleanSelector.parse("qux"));
+        var merged = older.merge(newer);
+
+        expect(merged.includeTags,
+            equals(new BooleanSelector.parse("(foo || bar) && blip")));
+        expect(merged.excludeTags,
+            equals(new BooleanSelector.parse("(baz || bang) || qux")));
+      });
+    });
+
+    group("for sets", () {
+      test("if neither is defined, preserves the default", () {
+        var merged = new SuiteConfiguration().merge(new SuiteConfiguration());
+        expect(merged.patterns, isEmpty);
+      });
+
+      test("if only the old configuration's is defined, uses it", () {
+        var merged = new SuiteConfiguration(patterns: ["beep", "boop"])
+            .merge(new SuiteConfiguration());
+
+        expect(merged.patterns, equals(["beep", "boop"]));
+      });
+
+      test("if only the new configuration's is defined, uses it", () {
+        var merged = new SuiteConfiguration()
+            .merge(new SuiteConfiguration(patterns: ["beep", "boop"]));
+
+        expect(merged.patterns, equals(["beep", "boop"]));
+      });
+
+      test("if both are defined, unions them", () {
+        var older = new SuiteConfiguration(patterns: ["beep", "boop"]);
+        var newer = new SuiteConfiguration(patterns: ["bonk"]);
+        var merged = older.merge(newer);
+
+        expect(merged.patterns, unorderedEquals(["beep", "boop", "bonk"]));
+      });
+    });
+
+    group("for dart2jsArgs", () {
+      test("if neither is defined, preserves the default", () {
+        var merged = new SuiteConfiguration().merge(new SuiteConfiguration());
+        expect(merged.dart2jsArgs, isEmpty);
+      });
+
+      test("if only the old configuration's is defined, uses it", () {
+        var merged = new SuiteConfiguration(dart2jsArgs: ["--foo", "--bar"])
+            .merge(new SuiteConfiguration());
+        expect(merged.dart2jsArgs, equals(["--foo", "--bar"]));
+      });
+
+      test("if only the new configuration's is defined, uses it", () {
+        var merged = new SuiteConfiguration()
+            .merge(new SuiteConfiguration(dart2jsArgs: ["--foo", "--bar"]));
+        expect(merged.dart2jsArgs, equals(["--foo", "--bar"]));
+      });
+
+      test("if both are defined, concatenates them", () {
+        var older = new SuiteConfiguration(dart2jsArgs: ["--foo", "--bar"]);
+        var newer = new SuiteConfiguration(dart2jsArgs: ["--baz"]);
+        var merged = older.merge(newer);
+        expect(merged.dart2jsArgs, equals(["--foo", "--bar", "--baz"]));
+      });
+    });
+
+    group("for config maps", () {
+      test("merges each nested configuration", () {
+        var merged = new SuiteConfiguration(
+          tags: {
+            new BooleanSelector.parse("foo"):
+                new SuiteConfiguration(precompiledPath: "path/"),
+            new BooleanSelector.parse("bar"):
+                new SuiteConfiguration(jsTrace: true)
+          },
+          onPlatform: {
+            new PlatformSelector.parse("vm"):
+                new SuiteConfiguration(precompiledPath: "path/"),
+            new PlatformSelector.parse("chrome"):
+                new SuiteConfiguration(jsTrace: true)
+          }
+        ).merge(new SuiteConfiguration(
+          tags: {
+            new BooleanSelector.parse("bar"):
+                new SuiteConfiguration(jsTrace: false),
+            new BooleanSelector.parse("baz"):
+                new SuiteConfiguration(runSkipped: true)
+          },
+          onPlatform: {
+            new PlatformSelector.parse("chrome"):
+                new SuiteConfiguration(jsTrace: false),
+            new PlatformSelector.parse("firefox"):
+                new SuiteConfiguration(runSkipped: true)
+          }
+        ));
+
+        expect(merged.tags[new BooleanSelector.parse("foo")].precompiledPath,
+            equals("path/"));
+        expect(merged.tags[new BooleanSelector.parse("bar")].jsTrace, isFalse);
+        expect(merged.tags[new BooleanSelector.parse("baz")].runSkipped,
+            isTrue);
+
+        expect(
+            merged.onPlatform[new PlatformSelector.parse("vm")].precompiledPath,
+            "path/");
+        expect(merged.onPlatform[new PlatformSelector.parse("chrome")].jsTrace,
+            isFalse);
+        expect(
+            merged.onPlatform[new PlatformSelector.parse("firefox")].runSkipped,
+            isTrue);
+      });
+    });
+  });
+}

--- a/test/runner/engine_test.dart
+++ b/test/runner/engine_test.dart
@@ -27,8 +27,8 @@ void main() {
     });
 
     var engine = new Engine.withSuites([
-      new RunnerSuite(const PluginEnvironment(), new Group.root(tests.take(2))),
-      new RunnerSuite(const PluginEnvironment(), new Group.root(tests.skip(2)))
+      runnerSuite(new Group.root(tests.take(2))),
+      runnerSuite(new Group.root(tests.skip(2)))
     ]);
 
     await engine.run();
@@ -51,8 +51,7 @@ void main() {
       expect(testsRun, equals(4));
     }), completes);
 
-    engine.suiteSink.add(
-        new RunnerSuite(const PluginEnvironment(), new Group.root(tests)));
+    engine.suiteSink.add(runnerSuite(new Group.root(tests)));
     engine.suiteSink.close();
   });
 
@@ -175,9 +174,7 @@ void main() {
         test("test", () {}, skip: true);
       });
 
-      var engine = new Engine.withSuites([
-        new RunnerSuite(const PluginEnvironment(), new Group.root(tests))
-      ]);
+      var engine = new Engine.withSuites([runnerSuite(new Group.root(tests))]);
 
       engine.onTestStarted.listen(expectAsync((liveTest) {
         expect(liveTest, same(engine.liveTests.single));
@@ -234,9 +231,8 @@ void main() {
         }, skip: true);
       });
 
-      var engine = new Engine.withSuites([
-        new RunnerSuite(const PluginEnvironment(), new Group.root(entries))
-      ]);
+      var engine = new Engine.withSuites(
+          [runnerSuite(new Group.root(entries))]);
 
       engine.onTestStarted.listen(expectAsync((liveTest) {
         expect(liveTest, same(engine.liveTests.single));

--- a/test/runner/loader_test.dart
+++ b/test/runner/loader_test.dart
@@ -10,6 +10,7 @@ import 'package:path/path.dart' as p;
 import 'package:test/src/backend/state.dart';
 import 'package:test/src/backend/test_platform.dart';
 import 'package:test/src/runner/configuration.dart';
+import 'package:test/src/runner/configuration/suite.dart';
 import 'package:test/src/runner/loader.dart';
 import 'package:test/src/util/io.dart';
 import 'package:test/test.dart';
@@ -49,7 +50,8 @@ void main() {
       /// TODO(nweiz): Use scheduled_test for this once it's compatible with
       /// this version of test.
       new File(p.join(_sandbox, 'a_test.dart')).writeAsStringSync(_tests);
-      var suites = await _loader.loadFile(p.join(_sandbox, 'a_test.dart'))
+      var suites = await _loader
+          .loadFile(p.join(_sandbox, 'a_test.dart'), SuiteConfiguration.empty)
           .toList();
       expect(suites, hasLength(1));
       var loadSuite = suites.first;
@@ -90,19 +92,22 @@ void main() {
   group(".loadDir()", () {
     test("ignores non-Dart files", () {
       new File(p.join(_sandbox, 'a_test.txt')).writeAsStringSync(_tests);
-      expect(_loader.loadDir(_sandbox).toList(), completion(isEmpty));
+      expect(_loader.loadDir(_sandbox, SuiteConfiguration.empty).toList(),
+          completion(isEmpty));
     });
 
     test("ignores files in packages/ directories", () {
       var dir = p.join(_sandbox, 'packages');
       new Directory(dir).createSync();
       new File(p.join(dir, 'a_test.dart')).writeAsStringSync(_tests);
-      expect(_loader.loadDir(_sandbox).toList(), completion(isEmpty));
+      expect(_loader.loadDir(_sandbox, SuiteConfiguration.empty).toList(),
+          completion(isEmpty));
     });
 
     test("ignores files that don't end in _test.dart", () {
       new File(p.join(_sandbox, 'test.dart')).writeAsStringSync(_tests);
-      expect(_loader.loadDir(_sandbox).toList(), completion(isEmpty));
+      expect(_loader.loadDir(_sandbox, SuiteConfiguration.empty).toList(),
+          completion(isEmpty));
     });
 
     group("with suites loaded from a directory", () {
@@ -117,7 +122,7 @@ void main() {
         new File(p.join(_sandbox, 'dir/sub_test.dart'))
             .writeAsStringSync(_tests);
 
-        suites = await _loader.loadDir(_sandbox)
+        suites = await _loader.loadDir(_sandbox, SuiteConfiguration.empty)
             .asyncMap((loadSuite) => loadSuite.getSuite())
             .toList();
       });
@@ -145,7 +150,8 @@ void main() {
   print('print within test');
 }
 """);
-    var suites = await _loader.loadFile(p.join(_sandbox, 'a_test.dart'))
+    var suites = await _loader
+        .loadFile(p.join(_sandbox, 'a_test.dart'), SuiteConfiguration.empty)
         .toList();
     expect(suites, hasLength(1));
     var loadSuite = suites.first;

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -14,6 +14,7 @@ import 'package:test/src/backend/metadata.dart';
 import 'package:test/src/backend/state.dart';
 import 'package:test/src/backend/suite.dart';
 import 'package:test/src/runner/application_exception.dart';
+import 'package:test/src/runner/configuration/suite.dart';
 import 'package:test/src/runner/engine.dart';
 import 'package:test/src/runner/load_exception.dart';
 import 'package:test/src/runner/plugin/environment.dart';
@@ -308,6 +309,13 @@ List<GroupEntry> declare(void body()) {
 Engine declareEngine(void body(), {bool runSkipped: false}) {
   var declarer = new Declarer()..declare(body);
   return new Engine.withSuites([
-    new RunnerSuite(const PluginEnvironment(), declarer.build())
-  ], runSkipped: runSkipped);
+    new RunnerSuite(
+        const PluginEnvironment(),
+        new SuiteConfiguration(runSkipped: runSkipped),
+        declarer.build())
+  ]);
 }
+
+/// Returns a [RunnerSuite] with a default environment and configuration.
+RunnerSuite runnerSuite(Group root) =>
+    new RunnerSuite(const PluginEnvironment(), SuiteConfiguration.empty, root);


### PR DESCRIPTION
This tracks configuration that makes sense to apply to test suites, as
opposed to Configuration which applies to an entire run and Metadata
which applies to individual tests. This is intended to make it easier
for load separate configurations for separate targets in a live test
runner.

@goderbauer