### PR TITLE
Fix Dartium debugging on Windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.17+2
+
+* Fix Dartium debugging on Windows.
+
 ## 0.12.17+1
 
 * Fix a bug where tags couldn't be marked as skipped.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.17+1
+version: 0.12.17+2
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
Dartium wasn't emitting any standard IO on Windows, which caused us to
stall out waiting for the Observatory URL in debug mode.

See dart-lang/sdk#28034
Closes #425