### PR TITLE
Add a hidden --configuration flag.

### DIFF
--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -105,9 +105,9 @@ main(List<String> args) async {
           new Configuration.load(_globalConfigPath, global: true));
     }
 
-    if (new File("dart_test.yaml").existsSync()) {
+    if (new File(configuration.configurationPath).existsSync()) {
       fileConfiguration = fileConfiguration.merge(
-          new Configuration.load("dart_test.yaml"));
+          new Configuration.load(configuration.configurationPath));
     }
 
     configuration = fileConfiguration.merge(configuration);

--- a/lib/src/runner/configuration.dart
+++ b/lib/src/runner/configuration.dart
@@ -45,6 +45,12 @@ class Configuration {
   bool get pauseAfterLoad => _pauseAfterLoad ?? false;
   final bool _pauseAfterLoad;
 
+  /// The path to the file from which to load more configuration information.
+  ///
+  /// This is *not* resolved automatically.
+  String get configurationPath => _configurationPath ?? "dart_test.yaml";
+  final String _configurationPath;
+
   /// The path to dart2js.
   String get dart2jsPath => _dart2jsPath ?? p.join(sdkDir, 'bin', 'dart2js');
   final String _dart2jsPath;
@@ -178,6 +184,7 @@ class Configuration {
       bool version,
       bool pauseAfterLoad,
       bool color,
+      String configurationPath,
       String dart2jsPath,
       String reporter,
       int pubServePort,
@@ -214,6 +221,7 @@ class Configuration {
         version: version,
         pauseAfterLoad: pauseAfterLoad,
         color: color,
+        configurationPath: configurationPath,
         dart2jsPath: dart2jsPath,
         reporter: reporter,
         pubServePort: pubServePort,
@@ -261,6 +269,7 @@ class Configuration {
           bool version,
           bool pauseAfterLoad,
           bool color,
+          String configurationPath,
           String dart2jsPath,
           String reporter,
           int pubServePort,
@@ -276,6 +285,7 @@ class Configuration {
         _version = version,
         _pauseAfterLoad = pauseAfterLoad,
         _color = color,
+        _configurationPath = configurationPath,
         _dart2jsPath = dart2jsPath,
         _reporter = reporter,
         pubServeUrl = pubServePort == null
@@ -349,6 +359,7 @@ class Configuration {
         version: other._version ?? _version,
         pauseAfterLoad: other._pauseAfterLoad ?? _pauseAfterLoad,
         color: other._color ?? _color,
+        configurationPath: other._configurationPath ?? _configurationPath,
         dart2jsPath: other._dart2jsPath ?? _dart2jsPath,
         reporter: other._reporter ?? _reporter,
         pubServePort: (other.pubServeUrl ?? pubServeUrl)?.port,
@@ -377,6 +388,7 @@ class Configuration {
       bool version,
       bool pauseAfterLoad,
       bool color,
+      String configurationPath,
       String dart2jsPath,
       String reporter,
       int pubServePort,
@@ -412,6 +424,7 @@ class Configuration {
         version: version ?? _version,
         pauseAfterLoad: pauseAfterLoad ?? _pauseAfterLoad,
         color: color ?? _color,
+        configurationPath: configurationPath ?? _configurationPath,
         dart2jsPath: dart2jsPath ?? _dart2jsPath,
         reporter: reporter ?? _reporter,
         pubServePort: pubServePort ?? pubServeUrl?.port,

--- a/lib/src/runner/configuration/args.dart
+++ b/lib/src/runner/configuration/args.dart
@@ -107,6 +107,8 @@ final ArgParser _parser = (() {
   /// The following options are used only by the internal Google test runner.
   /// They're hidden and not supported as stable API surface outside Google.
 
+  parser.addOption("configuration",
+      help: 'The path to the configuration file.', hide: true);
   parser.addOption("dart2js-path",
       help: 'The path to the dart2js executable.', hide: true);
   parser.addOption("dart2js-args",
@@ -191,6 +193,7 @@ class _Parser {
         jsTrace: _ifParsed('js-trace'),
         pauseAfterLoad: _ifParsed('pause-after-load'),
         color: _ifParsed('color'),
+        configurationPath: _ifParsed('configuration'),
         dart2jsPath: _ifParsed('dart2js-path'),
         dart2jsArgs: _ifParsed('dart2js-args') as List<String>,
         precompiledPath: _ifParsed('precompiled'),

--- a/test/runner/configuration/configuration_test.dart
+++ b/test/runner/configuration/configuration_test.dart
@@ -20,6 +20,7 @@ void main() {
         expect(merged.version, isFalse);
         expect(merged.pauseAfterLoad, isFalse);
         expect(merged.color, equals(canUseSpecialChars));
+        expect(merged.configurationPath, equals('dart_test.yaml'));
         expect(merged.dart2jsPath, equals(p.join(sdkDir, 'bin', 'dart2js')));
         expect(merged.reporter, equals(defaultReporter));
         expect(merged.pubServeUrl, isNull);
@@ -34,6 +35,7 @@ void main() {
                 version: true,
                 pauseAfterLoad: true,
                 color: true,
+                configurationPath: "special_test.yaml",
                 dart2jsPath: "/tmp/dart2js",
                 reporter: "json",
                 pubServePort: 1234,
@@ -46,6 +48,7 @@ void main() {
         expect(merged.version, isTrue);
         expect(merged.pauseAfterLoad, isTrue);
         expect(merged.color, isTrue);
+        expect(merged.configurationPath, equals("special_test.yaml"));
         expect(merged.dart2jsPath, equals("/tmp/dart2js"));
         expect(merged.reporter, equals("json"));
         expect(merged.pubServeUrl.port, equals(1234));
@@ -60,6 +63,7 @@ void main() {
             version: true,
             pauseAfterLoad: true,
             color: true,
+            configurationPath: "special_test.yaml",
             dart2jsPath: "/tmp/dart2js",
             reporter: "json",
             pubServePort: 1234,
@@ -71,6 +75,7 @@ void main() {
         expect(merged.version, isTrue);
         expect(merged.pauseAfterLoad, isTrue);
         expect(merged.color, isTrue);
+        expect(merged.configurationPath, equals("special_test.yaml"));
         expect(merged.dart2jsPath, equals("/tmp/dart2js"));
         expect(merged.reporter, equals("json"));
         expect(merged.pubServeUrl.port, equals(1234));
@@ -86,6 +91,7 @@ void main() {
             version: false,
             pauseAfterLoad: true,
             color: false,
+            configurationPath: "special_test.yaml",
             dart2jsPath: "/tmp/dart2js",
             reporter: "json",
             pubServePort: 1234,
@@ -97,6 +103,7 @@ void main() {
             version: true,
             pauseAfterLoad: false,
             color: true,
+            configurationPath: "test_special.yaml",
             dart2jsPath: "../dart2js",
             reporter: "compact",
             pubServePort: 5678,
@@ -109,6 +116,7 @@ void main() {
         expect(merged.version, isTrue);
         expect(merged.pauseAfterLoad, isFalse);
         expect(merged.color, isTrue);
+        expect(merged.configurationPath, equals("test_special.yaml"));
         expect(merged.dart2jsPath, equals("../dart2js"));
         expect(merged.reporter, equals("compact"));
         expect(merged.pubServeUrl.port, equals(5678));

--- a/test/runner/configuration/top_level_test.dart
+++ b/test/runner/configuration/top_level_test.dart
@@ -34,6 +34,29 @@ void main() {
     test.shouldExit(0);
   });
 
+  test("loads configuration from the path passed to --configuration", () {
+    // Make sure dart_test.yaml is ignored.
+    d.file("dart_test.yaml", JSON.encode({
+      "run_skipped": true
+    })).create();
+
+    d.file("special_test.yaml", JSON.encode({
+      "skip": true
+    })).create();
+
+    d.file("test.dart", """
+      import 'package:test/test.dart';
+
+      void main() {
+        test("test", () => throw "oh no");
+      }
+    """).create();
+
+    var test = runTest(["--configuration", "special_test.yaml", "test.dart"]);
+    test.stdout.expect(consumeThrough(contains('All tests skipped.')));
+    test.shouldExit(0);
+  });
+
   test("pauses the test runner after a suite loads with pause_after_load: true",
       () {
     d.file("dart_test.yaml", JSON.encode({


### PR DESCRIPTION
This is necessary to make configuration work with Google's internal
build system.