### PR TITLE
Make expectAsync work with optional arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Add the `spawnHybridUri()` and `spawnHybridCode()` functions, which allow
   browser tests to run code on the VM.
 
+* Fix the new `expectAsync` functions so that they don't produce analysis errors
+  when passed callbacks with optional arguments.
+
 ## 0.12.17+3
 
 * Internal changes only.

--- a/lib/src/frontend/expect_async.dart
+++ b/lib/src/frontend/expect_async.dart
@@ -12,12 +12,12 @@ const _PLACEHOLDER = const Object();
 
 // Functions used to check how many arguments a callback takes.
 typedef T Func0<T>();
-typedef T Func1<T, A>(A a);
-typedef T Func2<T, A, B>(A a, B b);
-typedef T Func3<T, A, B, C>(A a, B b, C c);
-typedef T Func4<T, A, B, C, D>(A a, B b, C c, D d);
-typedef T Func5<T, A, B, C, D, E>(A a, B b, C c, D d, E e);
-typedef T Func6<T, A, B, C, D, E, F>(A a, B b, C c, D d, E e, F f);
+typedef T Func1<T, A>([A a]);
+typedef T Func2<T, A, B>([A a, B b]);
+typedef T Func3<T, A, B, C>([A a, B b, C c]);
+typedef T Func4<T, A, B, C, D>([A a, B b, C c, D d]);
+typedef T Func5<T, A, B, C, D, E>([A a, B b, C c, D d, E e]);
+typedef T Func6<T, A, B, C, D, E, F>([A a, B b, C c, D d, E e, F f]);
 
 typedef bool _IsDoneCallback();
 


### PR DESCRIPTION
This worked with the old expectAsync(), but was broken when the new
functions were introduced. It was causing an analysis error in the
tests.