### PR TITLE
Default to eagerly closing hybrid isolates.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.18-dev
+version: 0.12.18
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
Users can pass stayAlive: true to keep them open, but this helps ensure
that they won't accidentally have a bunch of isolates hanging around
between tests.

Closes #109