### PR TITLE
Remove a dependency override.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,9 +40,3 @@ dev_dependencies:
   http: '^0.11.0'
   js: '^0.6.0'
   scheduled_test: '^0.12.5'
-
-dependency_overrides:
-  vm_service_client:
-    git:
-      url: git://github.com/dart-lang/vm_service_client
-      ref: observatory-url


### PR DESCRIPTION
dart-lang/vm_service_client#13 has now landed.