### PR TITLE
Add JSON reporter support for debugging VM tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 * Add support for debugging VM tests.
 
+* Add the ability to control test debugging when using the JSON reporter via
+  JSON-RPC 2.0 over WebSockets. This bumps the protocol version to 0.1.1 and
+  adds the `StartEvent.controllerUrl` and `DebugEvent.isolateID` fields.
+
+* JSON reporter users communicating with the test runner via JavaScript methods
+  in the browser is deprecated. The WebSocket API should be used instead.
+
 * Automatically configure the [`term_glyph`][term_glyph] package to use ASCII
   glyphs when the test runner is running on Windows.
 

--- a/doc/json_reporter.md
+++ b/doc/json_reporter.md
@@ -154,6 +154,10 @@ class DebugEvent extends Event {
   /// The HTTP URL for the remote debugger for this suite's host page, or `null`
   /// if no remote debugger is available for this suite.
   String remoteDebugger;
+
+  /// The VM service ID of the isolate in which the suite is running, if
+  /// available.
+  String isolateID;
 }
 ```
 

--- a/json_reporter.schema.json
+++ b/json_reporter.schema.json
@@ -101,6 +101,9 @@
         "protocolVersion": {"type": "string", "pattern": "^0\\.1\\."},
         "runnerVersion": {
           "oneOf": [{"type": "string"}, {"type": "null"}]
+        },
+        "controllerUrl": {
+          "oneOf": [{"type": "string"}, {"type": "null"}]
         }
       }
     },
@@ -140,6 +143,9 @@
         "suiteID": {"type": "integer", "minimum": 0},
         "observatory": {
           "oneOf": [{"type": "string", "format": "uri"}, {"type": "null"}]
+        },
+        "isolateID": {
+          "oneOf": [{"type": "string"}, {"type": "null"}]
         },
         "remoteDebugger": {
           "oneOf": [{"type": "string", "format": "uri"}, {"type": "null"}]

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -157,7 +157,7 @@ transformers:
     return;
   }
 
-  var runner = new Runner(configuration);
+  var runner = await Runner.start(configuration);
 
   var signalSubscription;
   close() async {

--- a/lib/src/runner.dart
+++ b/lib/src/runner.dart
@@ -46,6 +46,10 @@ class Runner {
   /// The reporter that's emitting the test runner's results.
   final Reporter _reporter;
 
+  /// The controller that controls suite debugging, or `null` if we aren't in
+  /// debug mode or we aren't using the JSON reporter.
+  final DebugController _debugController;
+
   /// The subscription to the stream returned by [_loadSuites].
   StreamSubscription _suiteSubscription;
 
@@ -66,10 +70,12 @@ class Runner {
   bool get _closed => _closeMemo.hasRun;
 
   /// Creates a new runner based on [configuration].
-  factory Runner(Configuration config) => config.asCurrent(() {
+  static Future<Runner> start(Configuration config) =>
+      config.asCurrent(() async {
     var engine = new Engine(concurrency: config.concurrency);
 
-    var reporter;
+    Reporter reporter;
+    DebugController controller;
     switch (config.reporter) {
       case "expanded":
         reporter = ExpandedReporter.watch(
@@ -85,14 +91,15 @@ class Runner {
         break;
 
       case "json":
-        reporter = JsonReporter.watch(engine);
+        if (config.pauseAfterLoad) controller = await DebugController.start();
+        reporter = JsonReporter.watch(engine, controller?.url);
         break;
     }
 
-    return new Runner._(engine, reporter);
+    return new Runner._(engine, reporter, controller);
   });
 
-  Runner._(this._engine, this._reporter);
+  Runner._(this._engine, this._reporter, this._debugController);
 
   /// Starts the runner.
   ///
@@ -207,9 +214,10 @@ class Runner {
       });
     }
 
-    if (_debugOperation != null) await _debugOperation.cancel();
+    await _debugOperation?.cancel();
+    await _debugController?.close();
 
-    if (_suiteSubscription != null) _suiteSubscription.cancel();
+    _suiteSubscription?.cancel();
     _suiteSubscription = null;
 
     // Make sure we close the engine *before* the loader. Otherwise,
@@ -372,7 +380,7 @@ class Runner {
   /// that support debugging.
   Future<bool> _loadThenPause(Stream<LoadSuite> suites) async {
     _suiteSubscription = suites.asyncMap((loadSuite) async {
-      _debugOperation = debug(_engine, _reporter, loadSuite);
+      _debugOperation = debug(_engine, _reporter, loadSuite, _debugController);
       await _debugOperation.valueOrCancellation();
     }).listen(null);
 

--- a/lib/src/runner/browser/browser_manager.dart
+++ b/lib/src/runner/browser/browser_manager.dart
@@ -305,6 +305,8 @@ class _BrowserEnvironment implements Environment {
 
   final Uri remoteDebuggerUrl;
 
+  final String isolateID = null;
+
   final Stream onRestart;
 
   _BrowserEnvironment(this._manager, this.observatoryUrl,

--- a/lib/src/runner/debugger.dart
+++ b/lib/src/runner/debugger.dart
@@ -3,8 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:async/async.dart';
+import 'package:http_multi_server/http_multi_server.dart';
+import 'package:json_rpc_2/json_rpc_2.dart' as rpc;
+import 'package:shelf_web_socket/shelf_web_socket.dart';
+import 'package:shelf/shelf_io.dart' as io;
 
 import '../backend/test_platform.dart';
 import '../util/io.dart';
@@ -22,11 +27,14 @@ import 'runner_suite.dart';
 /// watching [engine], and the [config] should contain the user configuration
 /// for the test runner.
 ///
+/// If [controller] is passed, the debugger will hook into it to allow debugging
+/// to be controlled via WebSocket.
+///
 /// Returns a [CancelableOperation] that will complete once the suite has
 /// finished running. If the operation is canceled, the debugger will clean up
 /// any resources it allocated.
 CancelableOperation debug(Engine engine, Reporter reporter,
-    LoadSuite loadSuite) {
+    LoadSuite loadSuite, [DebugController controller]) {
   var debugger;
   var canceled = false;
   return new CancelableOperation.fromFuture(() async {
@@ -41,7 +49,9 @@ CancelableOperation debug(Engine engine, Reporter reporter,
     if (canceled || suite == null) return;
 
     debugger = new _Debugger(engine, reporter, suite);
+    controller?._debugger = debugger;
     await debugger.run();
+    controller?._debugger = null;
   }(), onCancel: () {
     canceled = true;
     // Make sure the load test finishes so the engine can close.
@@ -73,8 +83,7 @@ class _Debugger {
   /// overlap with the reporter's reporting.
   final Console _console;
 
-  /// A completer that's used to manually unpause the test if the debugger is
-  /// closed.
+  /// A completer that's used to manually unpause the test.
   final _pauseCompleter = new CancelableCompleter();
 
   /// The subscription to [_suite.onDebugging].
@@ -221,10 +230,56 @@ class _Debugger {
 
   /// Closes the debugger and releases its resources.
   void close() {
-    _pauseCompleter.complete();
+    if (!_pauseCompleter.isCompleted) _pauseCompleter.complete();
     _closed = true;
     _onDebuggingSubscription?.cancel();
     _onRestartSubscription.cancel();
     _console.stop();
   }
+}
+
+/// A singleton WebSocket server with a JSON-RPC 2.0 protocol that services RPCs
+/// that allow IDEs using the JSON reporter to control the debugger.
+class DebugController {
+  /// The HTTP server that handles WebSocket connections to this controller.
+  final HttpServer _server;
+
+  /// The currently-active debugger, or `null` if no debugger is currently
+  /// active.
+  _Debugger _debugger;
+
+  /// The URL for the controller's WebSocket server.
+  Uri get url => Uri.parse("ws://localhost:${_server.port}");
+
+  /// Starts serving WebSocket connections for a debug controller.
+  static Future<DebugController> start() async =>
+      new DebugController._(await HttpMultiServer.loopback(0));
+
+  DebugController._(this._server) {
+    io.serveRequests(_server, webSocketHandler((webSocket) {
+      var server = new rpc.Server(webSocket);
+      server.registerMethod("resume", () {
+        _assertDebugger();
+        _debugger._pauseCompleter.complete();
+        return null;
+      });
+
+      server.registerMethod("restartTest", () {
+        _assertDebugger();
+        _debugger._restartTest();
+        return null;
+      });
+
+      server.listen();
+    }));
+  }
+
+  /// Throws an [rpc.RpcException] if [_debugger] isn't set.
+  void _assertDebugger() {
+    if (_debugger != null) return;
+    throw new rpc.RpcException(1, "No suite is being debugged.");
+  }
+
+  /// Closes the underlying server.
+  Future close() => _server.close();
 }

--- a/lib/src/runner/environment.dart
+++ b/lib/src/runner/environment.dart
@@ -20,6 +20,10 @@ abstract class Environment {
   /// enabled.
   Uri get remoteDebuggerUrl;
 
+  /// The VM service ID of the isolate running the test, or `null` if the test
+  /// isn't running on the Dart VM or the isolate ID is unavailable.
+  String get isolateID;
+
   /// A broadcast stream that emits a `null` event whenever the user tells the
   /// environment to restart the current test once it's finished.
   ///

--- a/lib/src/runner/plugin/environment.dart
+++ b/lib/src/runner/plugin/environment.dart
@@ -19,6 +19,8 @@ class PluginEnvironment implements Environment {
 
   Uri get remoteDebuggerUrl => null;
 
+  String get isolateID => null;
+
   CancelableOperation displayPause() =>
       throw new UnsupportedError(
           "PluginEnvironment.displayPause is not supported.");

--- a/lib/src/runner/vm/environment.dart
+++ b/lib/src/runner/vm/environment.dart
@@ -13,11 +13,12 @@ import '../environment.dart';
 class VMEnvironment implements Environment {
   final supportsDebugging = true;
   final Uri observatoryUrl;
+  final String isolateID;
 
   /// The VM service isolate object used to control this isolate.
   final VMIsolate _isolate;
 
-  VMEnvironment(this.observatoryUrl, this._isolate);
+  VMEnvironment(this.observatoryUrl, this.isolateID, this._isolate);
 
   Uri get remoteDebuggerUrl => null;
 

--- a/lib/src/runner/vm/platform.dart
+++ b/lib/src/runner/vm/platform.dart
@@ -79,7 +79,7 @@ class VMPlatform extends PlatformPlugin {
     var library = (await vmIsolate.loadRunnable())
         .libraries[p.toUri(p.absolute(path))];
     var url = info.serverUri.resolveUri(library.observatoryUrl);
-    var environment = new VMEnvironment(url, vmIsolate);
+    var environment = new VMEnvironment(url, isolateID, vmIsolate);
     var controller = await deserializeSuite(
         path, platform, suiteConfig, environment, channel);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   collection: '^1.8.0'
   glob: '^1.0.0'
   http_multi_server: '>=1.0.0 <3.0.0'
+  json_rpc_2: '^2.0.0'
   package_resolver: '^1.0.0'
   path: '^1.2.0'
   pool: '^1.2.0'

--- a/test/runner/json_debugging_test.dart
+++ b/test/runner/json_debugging_test.dart
@@ -1,0 +1,145 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn("vm")
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:json_rpc_2/json_rpc_2.dart' as rpc;
+import 'package:path/path.dart' as p;
+import 'package:scheduled_test/descriptor.dart' as d;
+import 'package:scheduled_test/scheduled_process.dart';
+import 'package:scheduled_test/scheduled_stream.dart';
+import 'package:scheduled_test/scheduled_test.dart';
+import 'package:vm_service_client/vm_service_client.dart';
+import 'package:web_socket_channel/io.dart';
+
+import 'package:test/src/runner/version.dart';
+
+import '../io.dart';
+
+void main() {
+  useSandbox();
+
+  test("waits for a resume command to start running tests", () {
+    d.file("test.dart", """
+      import 'package:test/test.dart';
+
+      void main() {
+        test("success", () {});
+      }
+    """).create();
+
+    var test = runTest(["test.dart", "--pause-after-load"], reporter: "json");
+    var client = _connectClient(test);
+
+    // Wait for the virtual test that loads the suite to complete.
+    test.stdout.expect(consumeThrough(_jsonContainsPair("type", "testDone")));
+
+    schedule(() async {
+      // The group event is emitted before the TestStartEvents.
+      var testStarted = false;
+      var testStartedFuture = test.stdout.next().then((line) {
+        expect(line, _jsonContainsPair("type", "group"));
+        testStarted = true;
+      });
+
+      // Wait a little bit to ensure that the first test hasn't started
+      // running.
+      await new Future.delayed(new Duration(seconds: 1));
+      expect(testStarted, isFalse);
+
+      // Once we send "resume", the test should finish.
+      await (await client).sendRequest("resume");
+      await (await client).close();
+      await testStartedFuture;
+    });
+
+    test.stdout.expect(consumeThrough(_jsonContainsPair("type", "done")));
+    test.shouldExit();
+  });
+
+  test("restarts the test after a restartTest command", () {
+    d.file("test.dart", """
+      import 'package:test/test.dart';
+
+      void main() {
+        test("success", () {
+          expect(true, isTrue);
+        });
+      }
+    """).create();
+
+    var test = runTest(["test.dart", "--pause-after-load"], reporter: "json");
+    var client = _connectClient(test);
+
+    test.stdout.expect(consumeWhile(isNot(_jsonContainsPair("type", "debug"))));
+
+    schedule(() async {
+      var debug = JSON.decode(await test.stdout.next());
+      var vmServiceClient = new VMServiceClient.connect(debug["observatory"]);
+      var isolate = await (await vmServiceClient.getVM()).isolates
+          .firstWhere((isolate) => isolate.name == "test.dart")
+          .loadRunnable();
+      var library = await isolate.libraries.values
+          .firstWhere((value) => value.uri.path.endsWith("/test.dart"))
+          .load();
+      var breakpoint = await library.scripts.single.addBreakpoint(6);
+
+      // Resuming the isolate should also resume the test runner.
+      await isolate.waitUntilPaused();
+      await isolate.resume();
+
+      // Wait for the breakpoint to be hit.
+      await breakpoint.onPause.first;
+      await breakpoint.remove();
+
+      // Restart the test.
+      await (await client).sendRequest("restartTest");
+      await (await client).close();
+
+      await isolate.resume();
+      await vmServiceClient.close();
+    });
+
+    // The success test should run twice, since we restart it in the middle.
+    test.stdout.expect(inOrder([
+      consumeThrough(allOf([
+        _jsonContainsPair("type", "testStart"),
+        _jsonContainsPair("test", containsPair("name", "success")),
+      ])),
+      consumeThrough(allOf([
+        _jsonContainsPair("type", "testStart"),
+        _jsonContainsPair("test", containsPair("name", "success")),
+      ])),
+      consumeThrough(_jsonContainsPair("type", "done")),
+    ]));
+
+    test.shouldExit();
+  });
+}
+
+/// Schedules a client connection to the web socket client emitted by [test].
+Future<rpc.Client> _connectClient(ScheduledProcess test) => schedule(() async {
+  var start = JSON.decode(await test.stdout.next());
+  expect(start, containsPair("type", "start"));
+  var channel = new IOWebSocketChannel.connect(await start["controllerUrl"]);
+  var client = new rpc.Client(channel);
+  client.listen();
+  return client;
+});
+
+/// Returns a matcher that verifies that the value is a JSON-encoded map with
+/// the given [key] and [value].
+Matcher _jsonContainsPair(String key, value) => predicate((line) {
+  var valueMatcher = wrapMatcher(value);
+  try {
+    var object = JSON.decode(line);
+    return object is Map && valueMatcher.matches(object[key], {});
+  } on FormatException {
+    return false;
+  }
+}, 'contains "$key": $value');
+

--- a/test/runner/json_reporter_test.dart
+++ b/test/runner/json_reporter_test.dart
@@ -18,8 +18,9 @@ import '../io.dart';
 /// The first event emitted by the JSON reporter.
 final _start = {
   "type": "start",
-  "protocolVersion": "0.1.0",
-  "runnerVersion": testVersion
+  "protocolVersion": "0.1.1",
+  "runnerVersion": testVersion,
+  "controllerUrl": null,
 };
 
 void main() {


### PR DESCRIPTION
This adds a JSON-RPC 2.0-via-WebSocket protocol for communicating with
the test runner and telling it to resume running tests after breakpoints
are added. Talking to the runner via JavaScript methods in the browser
is still supported for backwards-compatibility, but is deprecated.

Closes #50