### PR TITLE
Drop semicolon following annotation

### DIFF
--- a/lib/src/frontend/throws_matcher.dart
+++ b/lib/src/frontend/throws_matcher.dart
@@ -14,7 +14,7 @@ import 'async_matcher.dart';
 /// Use [throwsA] instead. We strongly recommend that you add assertions about
 /// at least the type of the error, but you can write `throwsA(anything)` to
 /// mimic the behavior of this matcher.
-@Deprecated("Will be removed in 0.13.0");
+@Deprecated("Will be removed in 0.13.0")
 const Matcher throws = const Throws();
 
 /// This can be used to match two kinds of objects:


### PR DESCRIPTION
Fixes error when running with pub.

Failed to precompile test:test:
'package:test/src/frontend/throws_matcher.dart': error: line 17 pos 41: unexpected token ';'