### PR TITLE
Add a printOnFailure() function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * `expect()` now returns a Future for the asynchronous matchers `completes`,
   `completion()`, `throws*()`, and `prints()`.
 
+* Add a `printOnFailure()` method for providing debugging information that's
+  only printed when a test fails.
+
 * Automatically configure the [`term_glyph`][term_glyph] package to use ASCII
   glyphs when the test runner is running on Windows.
 

--- a/lib/test.dart
+++ b/lib/test.dart
@@ -283,3 +283,11 @@ void registerException(error, [StackTrace stackTrace]) {
   // going through the zone API allows other zones to consistently see errors.
   Zone.current.handleUncaughtError(error, stackTrace);
 }
+
+/// Prints [message] if and when the current test fails.
+///
+/// This is intended for test infrastructure to provide debugging information
+/// without cluttering the output for successful tests. Note that unlike
+/// [print], each individual message passed to [printOnFailure] will be
+/// separated by a blank line.
+void printOnFailure(String message) => Invoker.current.printOnFailure(message);

--- a/test/backend/invoker_test.dart
+++ b/test/backend/invoker_test.dart
@@ -529,6 +529,31 @@ void main() {
       expect(isComplete, isFalse);
     });
   });
+
+  group("printOnFailure:", () {
+    test("doesn't print anything if the test succeeds", () {
+      expect(() async {
+        var liveTest = _localTest(() {
+          Invoker.current.printOnFailure("only on failure");
+        }).load(suite);
+        liveTest.onError.listen(expectAsync1((_) {}, count: 0));
+
+        await liveTest.run();
+      }, prints(isEmpty));
+    });
+
+    test("prints if the test fails", () {
+      expect(() async {
+        var liveTest = _localTest(() {
+          Invoker.current.printOnFailure("only on failure");
+          expect(true, isFalse);
+        }).load(suite);
+        liveTest.onError.listen(expectAsync1((_) {}, count: 1));
+
+        await liveTest.run();
+      }, prints("only on failure\n"));
+    });
+  });
 }
 
 LocalTest _localTest(body(), {Metadata metadata}) {


### PR DESCRIPTION
This prints debugging information only if the test actually fails.