### PR TITLE
Gracefully handle platform errors on close.

### DIFF
--- a/lib/src/runner/engine.dart
+++ b/lib/src/runner/engine.dart
@@ -91,7 +91,7 @@ class Engine {
   /// This will be `null` if [close] was called before all the tests finished
   /// running.
   Future<bool> get success async {
-    await _group.future;
+    await Future.wait([_group.future, _loadPool.done], eagerError: true);
     if (_closedBeforeDone) return null;
     return liveTests.every((liveTest) => liveTest.state.result.isPassing);
   }
@@ -280,6 +280,7 @@ class Engine {
       _subscriptions.remove(subscription);
       _onSuiteAddedController.close();
       _group.close();
+      _loadPool.close();
     });
     _subscriptions.add(subscription);
 

--- a/lib/src/runner/plugin/platform_helpers.dart
+++ b/lib/src/runner/plugin/platform_helpers.dart
@@ -57,6 +57,7 @@ Future<RunnerSuiteController> deserializeSuite(String path,
 
   var completer = new Completer();
 
+  var loadSuiteZone = Zone.current;
   handleError(error, stackTrace) {
     disconnector.disconnect();
 
@@ -64,7 +65,7 @@ Future<RunnerSuiteController> deserializeSuite(String path,
       // If we've already provided a controller, send the error to the
       // LoadSuite. This will cause the virtual load test to fail, which will
       // notify the user of the error.
-      Zone.current.handleUncaughtError(error, mapTrace(stackTrace));
+      loadSuiteZone.handleUncaughtError(error, mapTrace(stackTrace));
     } else {
       completer.completeError(error, mapTrace(stackTrace));
     }
@@ -109,7 +110,7 @@ Future<RunnerSuiteController> deserializeSuite(String path,
       path: path,
       platform: platform,
       os: currentOS,
-      onClose: disconnector.disconnect);
+      onClose: () => disconnector.disconnect().catchError(handleError));
 }
 
 /// A utility class for storing state while deserializing tests.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   meta: '^1.0.0'
   package_resolver: '^1.0.0'
   path: '^1.2.0'
-  pool: '^1.2.0'
+  pool: '^1.3.0'
   pub_semver: '^1.0.0'
   shelf: '>=0.6.5 <0.8.0'
   shelf_packages_handler: '^1.0.0'


### PR DESCRIPTION
If the StreamChannel returned by PlatformPlugin.loadChannel() emits an
error through sink.close(), that error is now properly treated as an
error in the load suite for that channel.

Closes #542