### PR TITLE
Fix the stream_channel dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.20+1
+
+* Tighten the dependency on `stream_channel` to reflect the APIs being used.
+
 ## 0.12.20
 
 * **Breaking change:** The `expect()` method no longer returns a `Future`, since

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.21-dev
+version: 0.12.20+1
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.20
+version: 0.12.21-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test
@@ -27,7 +27,7 @@ dependencies:
   source_maps: '^0.10.2'
   source_span: '^1.0.0'
   stack_trace: '^1.2.1'
-  stream_channel: '^1.3.1'
+  stream_channel: '^1.6.0'
   string_scanner: '>=0.1.1 <2.0.0'
   term_glyph: '^1.0.0'
   web_socket_channel: '^1.0.0'


### PR DESCRIPTION
We're using a feature that was introduced in
1.6.0 (Disconnector.disconnect's return value).

Closes #556