### PR TITLE
Correctly kill Dartium on Linux

### DIFF
--- a/lib/src/runner/browser/browser.dart
+++ b/lib/src/runner/browser/browser.dart
@@ -112,11 +112,15 @@ abstract class Browser {
     _process.then((process) {
       // Dartium has a difficult time being killed on Linux. To ensure it is
       // properly closed, find all children processes and kill those first.
-      if (Platform.isLinux) {
-        var result = Process.runSync('pgrep', ['-P', '${process.pid}']);
-        for(var pid in '${result.stdout}'.split('\n')){
-          Process.runSync('kill', ['-9', pid]);
+      try{
+        if (Platform.isLinux) {
+          var result = Process.runSync('pgrep', ['-P', '${process.pid}']);
+          for(var pid in '${result.stdout}'.split('\n')){
+            Process.runSync('kill', ['-9', pid]);
+          }
         }
+      }catch(e){
+        print('Failed to kill browser children: $e');
       }
       process.kill();
     });

--- a/lib/src/runner/browser/browser.dart
+++ b/lib/src/runner/browser/browser.dart
@@ -115,11 +115,11 @@ abstract class Browser {
       try{
         if (Platform.isLinux) {
           var result = Process.runSync('pgrep', ['-P', '${process.pid}']);
-          for(var pid in '${result.stdout}'.split('\n')){
+          for (var pid in '${result.stdout}'.split('\n')) {
             Process.runSync('kill', ['-9', pid]);
           }
         }
-      }catch(e){
+      } catch(e) {
         print('Failed to kill browser children: $e');
       }
       process.kill();


### PR DESCRIPTION
Verified on Ubuntu 14.04:

➜  test git:(LinuxFixes) ✗ pub run test
00:20 +92: test/runner/hybrid_test.dart: spawnHybridCode() kills the isolate when the test closes the channel
  Skip: Enable when sdk#28081 is fixed.
00:20 +92 ~1: test/runner/hybrid_test.dart: spawnHybridCode() kills the isolate when the hybrid isolate closes the channel
  Skip: Enable when sdk#28081 is fixed.
01:23 +343 ~2: test/runner/browser/content_shell_test.dart: starts content shell with the given URL
  Skip: Failing with mysterious WebSocket issues.
09:16 +919 ~3: All tests passed!

Also verified no impact on Mac.