### PR TITLE
Extensible reporters and test platforms

### DIFF
--- a/lib/src/backend/test_platform.dart
+++ b/lib/src/backend/test_platform.dart
@@ -46,7 +46,8 @@ class TestPlatform {
       isBrowser: true, isJS: true);
 
   /// A list of all instances of [TestPlatform].
-  static var all = new UnmodifiableListView<TestPlatform>(_all);
+  static final UnmodifiableListView<TestPlatform> all =
+      new UnmodifiableListView<TestPlatform>(_allPlatforms);
 
   /// Finds a platform by its identifier string.
   ///
@@ -86,7 +87,7 @@ class TestPlatform {
   String toString() => name;
 }
 
-List<TestPlatform> _all = [
+final List<TestPlatform> _allPlatforms = [
   TestPlatform.vm,
   TestPlatform.dartium,
   TestPlatform.contentShell,
@@ -108,12 +109,12 @@ TestPlatform registerTestPlatform(String name, String identifier,
     bool isJS: false,
     bool isBlink: false,
     bool isHeadless: false}) {
-  TestPlatform platform = new TestPlatform._(name, identifier,
+  var platform = new TestPlatform._(name, identifier,
       isDartVM: isDartVM,
       isBrowser: isBrowser,
       isJS: isJS,
       isBlink: isBlink,
       isHeadless: isHeadless);
-  _all.add(platform);
+  _allPlatforms.add(platform);
   return platform;
 }

--- a/lib/src/backend/test_platform.dart
+++ b/lib/src/backend/test_platform.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:collection';
+
 // TODO(nweiz): support pluggable platforms.
 /// An enum of all platforms on which tests can run.
 class TestPlatform {
@@ -44,16 +46,7 @@ class TestPlatform {
       isBrowser: true, isJS: true);
 
   /// A list of all instances of [TestPlatform].
-  static const List<TestPlatform> all = const [
-    vm,
-    dartium,
-    contentShell,
-    chrome,
-    phantomJS,
-    firefox,
-    safari,
-    internetExplorer
-  ];
+  static var all = new UnmodifiableListView<TestPlatform>(_all);
 
   /// Finds a platform by its identifier string.
   ///
@@ -91,4 +84,36 @@ class TestPlatform {
       this.isHeadless: false});
 
   String toString() => name;
+}
+
+List<TestPlatform> _all = [
+  TestPlatform.vm,
+  TestPlatform.dartium,
+  TestPlatform.contentShell,
+  TestPlatform.chrome,
+  TestPlatform.phantomJS,
+  TestPlatform.firefox,
+  TestPlatform.safari,
+  TestPlatform.internetExplorer
+];
+
+/// **Do not call this function without express permission from the test package
+/// authors**.
+///
+/// This constructs and globally registers a new TestPlatform with the provided
+/// details.
+TestPlatform registerTestPlatform(String name, String identifier,
+    {bool isDartVM: false,
+    bool isBrowser: false,
+    bool isJS: false,
+    bool isBlink: false,
+    bool isHeadless: false}) {
+  TestPlatform platform = new TestPlatform._(name, identifier,
+      isDartVM: isDartVM,
+      isBrowser: isBrowser,
+      isJS: isJS,
+      isBlink: isBlink,
+      isHeadless: isHeadless);
+  _all.add(platform);
+  return platform;
 }

--- a/lib/src/runner.dart
+++ b/lib/src/runner.dart
@@ -16,6 +16,7 @@ import 'backend/test.dart';
 import 'backend/test_platform.dart';
 import 'runner/application_exception.dart';
 import 'runner/configuration.dart';
+import 'runner/configuration/reporters.dart';
 import 'runner/debugger.dart';
 import 'runner/engine.dart';
 import 'runner/load_exception.dart';
@@ -69,26 +70,8 @@ class Runner {
   factory Runner(Configuration config) => config.asCurrent(() {
         var engine = new Engine(concurrency: config.concurrency);
 
-        var reporter;
-        switch (config.reporter) {
-          case "expanded":
-            reporter = ExpandedReporter.watch(engine,
-                color: config.color,
-                printPath: config.paths.length > 1 ||
-                    new Directory(config.paths.single).existsSync(),
-                printPlatform: config.suiteDefaults.platforms.length > 1);
-            break;
-
-          case "compact":
-            reporter = CompactReporter.watch(engine);
-            break;
-
-          case "json":
-            reporter = JsonReporter.watch(engine);
-            break;
-        }
-
-        return new Runner._(engine, reporter);
+        var reporterDetails = allReporters[config.reporter];
+        return new Runner._(engine, reporterDetails.factory(config, engine));
       });
 
   Runner._(this._engine, this._reporter);

--- a/lib/src/runner/configuration.dart
+++ b/lib/src/runner/configuration.dart
@@ -16,6 +16,7 @@ import '../frontend/timeout.dart';
 import '../util/io.dart';
 import 'configuration/args.dart' as args;
 import 'configuration/load.dart';
+import 'configuration/reporters.dart';
 import 'configuration/suite.dart';
 import 'configuration/values.dart';
 

--- a/lib/src/runner/configuration/args.dart
+++ b/lib/src/runner/configuration/args.dart
@@ -10,6 +10,7 @@ import 'package:boolean_selector/boolean_selector.dart';
 import '../../backend/test_platform.dart';
 import '../../frontend/timeout.dart';
 import '../configuration.dart';
+import 'reporters.dart';
 import 'values.dart';
 
 /// The parser used to parse the command-line arguments.
@@ -92,17 +93,18 @@ final ArgParser _parser = (() {
           'debuggability.',
       defaultsTo: true);
 
+  Map reporterDescriptions = {};
+  for (var reporter in allReporters.keys) {
+    reporterDescriptions[reporter] = allReporters[reporter].description;
+  }
+
   parser.addSeparator("======== Output");
   parser.addOption("reporter",
       abbr: 'r',
       help: 'The runner used to print test results.',
       defaultsTo: defaultReporter,
-      allowed: allReporters,
-      allowedHelp: {
-        'compact': 'A single line, updated continuously.',
-        'expanded': 'A separate line for each update.',
-        'json': 'A machine-readable format (see https://goo.gl/gBsV1a).'
-      });
+      allowed: reporterDescriptions.keys.toList(),
+      allowedHelp: reporterDescriptions);
   parser.addFlag("verbose-trace",
       negatable: false,
       help: 'Whether to emit stack traces with core library frames.');

--- a/lib/src/runner/configuration/args.dart
+++ b/lib/src/runner/configuration/args.dart
@@ -93,7 +93,7 @@ final ArgParser _parser = (() {
           'debuggability.',
       defaultsTo: true);
 
-  Map reporterDescriptions = {};
+  var reporterDescriptions = <String, String>{};
   for (var reporter in allReporters.keys) {
     reporterDescriptions[reporter] = allReporters[reporter].description;
   }

--- a/lib/src/runner/configuration/load.dart
+++ b/lib/src/runner/configuration/load.dart
@@ -19,7 +19,7 @@ import '../../utils.dart';
 import '../../util/io.dart';
 import '../configuration.dart';
 import '../configuration/suite.dart';
-import 'values.dart';
+import 'reporters.dart';
 
 /// Loads configuration information from a YAML file at [path].
 ///
@@ -176,7 +176,7 @@ class _ConfigurationLoader {
     var runSkipped = _getBool("run_skipped");
 
     var reporter = _getString("reporter");
-    if (reporter != null && !allReporters.contains(reporter)) {
+    if (reporter != null && !allReporters.keys.contains(reporter)) {
       _error('Unknown reporter "$reporter".', "reporter");
     }
 

--- a/lib/src/runner/configuration/reporters.dart
+++ b/lib/src/runner/configuration/reporters.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+import 'dart:collection';
+
+import '../engine.dart';
+import '../configuration.dart';
+import '../reporter.dart';
+import '../reporter/compact.dart';
+import '../reporter/expanded.dart';
+import '../reporter/json.dart';
+import '../../util/io.dart';
+
+/// Constructs a reporter for the provided engine with the provided
+/// configuration.
+typedef Reporter ReporterFactory(Configuration configuration, Engine engine);
+
+/// Container for a reporter description and corresponding factory.
+class ReporterDetails {
+  final String description;
+  final ReporterFactory factory;
+  ReporterDetails(this.description, this.factory);
+}
+
+/// All reporters and their corresponding details.
+final UnmodifiableMapView<String, ReporterDetails> allReporters =
+    new UnmodifiableMapView<String, ReporterDetails>(_allReporters);
+
+final Map<String, ReporterDetails> _allReporters = {
+  "expanded": new ReporterDetails(
+      "A separate line for each update.",
+      (config, engine) => ExpandedReporter.watch(engine,
+          color: config.color,
+          printPath: config.paths.length > 1 ||
+              new Directory(config.paths.single).existsSync(),
+          printPlatform: config.suiteDefaults.platforms.length > 1)),
+  "compact": new ReporterDetails("A single line, updated continuously.",
+      (_, engine) => CompactReporter.watch(engine)),
+  "json": new ReporterDetails(
+      "A machine-readable format (see https://goo.gl/gBsV1a).",
+      (_, engine) => JsonReporter.watch(engine)),
+};
+
+final defaultReporter =
+    inTestTests ? 'expanded' : (Platform.isWindows ? 'expanded' : 'compact');
+
+/// **Do not call this function without express permission from the test package
+/// authors**.
+///
+/// This globally registers a reporter.
+void registerReporter(String name, ReporterDetails reporterDetails) {
+  _allReporters[name] = reporterDetails;
+}

--- a/lib/src/runner/configuration/reporters.dart
+++ b/lib/src/runner/configuration/reporters.dart
@@ -28,7 +28,7 @@ class ReporterDetails {
 final UnmodifiableMapView<String, ReporterDetails> allReporters =
     new UnmodifiableMapView<String, ReporterDetails>(_allReporters);
 
-final Map<String, ReporterDetails> _allReporters = {
+final _allReporters = <String, ReporterDetails>{
   "expanded": new ReporterDetails(
       "A separate line for each update.",
       (config, engine) => ExpandedReporter.watch(engine,

--- a/lib/src/runner/configuration/values.dart
+++ b/lib/src/runner/configuration/values.dart
@@ -7,20 +7,11 @@ import 'dart:math' as math;
 
 import 'package:glob/glob.dart';
 
-import '../../util/io.dart';
-
 /// The default number of test suites to run at once.
 ///
 /// This defaults to half the available processors, since presumably some of
 /// them will be used for the OS and other processes.
 final defaultConcurrency = math.max(1, Platform.numberOfProcessors ~/ 2);
-
-/// The reporters supported by the test runner.
-const allReporters = const ["compact", "expanded", "json"];
-
-/// The default reporter.
-final defaultReporter =
-    inTestTests ? 'expanded' : (Platform.isWindows ? 'expanded' : 'compact');
 
 /// The default filename pattern.
 ///

--- a/test/runner/configuration/configuration_test.dart
+++ b/test/runner/configuration/configuration_test.dart
@@ -7,7 +7,7 @@ import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import 'package:test/src/runner/configuration.dart';
-import 'package:test/src/runner/configuration/values.dart';
+import 'package:test/src/runner/configuration/reporters.dart';
 import 'package:test/src/util/io.dart';
 
 void main() {


### PR DESCRIPTION
Adding hooks for new reporters and test platforms. These hooks are not intended to be a part of the external API and thus are aptly documented. 