### PR TITLE
Add Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: dart
+sudo: false
+dart:
+ - dev
+ - stable
+cache:
+ directories:
+   - $HOME/.pub-cache
+dart_task:
+ - test: --platform vm -x content-shell -x chrome -x firefox -x dartium -x phantomjs --timeout 4x
+ - test: --platform dartium
+   install_dartium: true
+ - dartfmt
+ - dartanalyzer
+matrix:
+  allow_failures:
+    - dart: dev
+      dart_task: dartfmt
+    - dart: stable
+      dart_task:
+        test: --platform vm -x content-shell -x chrome -x firefox -x dartium -x phantomjs --timeout 4x
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ matrix:
     # Repo was formatted with stable SDK
     - dart: dev
       dart_task: dartfmt
-    # Pub can hang on tests using stable SDK
-    - dart: stable
+    # Pub can hang on tests using dev SDK
+    - dart: dev
       dart_task:
         test: --platform vm -x content-shell -x chrome -x firefox -x dartium -x phantomjs --timeout 4x
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,3 @@ matrix:
     - dart: dev
       dart_task:
         test: --platform vm -x content-shell -x chrome -x firefox -x dartium -x phantomjs --timeout 4x
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,10 @@ dart_task:
  - dartanalyzer
 matrix:
   allow_failures:
+    # Repo was formatted with stable SDK
     - dart: dev
       dart_task: dartfmt
+    # Pub can hang on tests using stable SDK
     - dart: stable
       dart_task:
         test: --platform vm -x content-shell -x chrome -x firefox -x dartium -x phantomjs --timeout 4x

--- a/test/runner/load_suite_test.dart
+++ b/test/runner/load_suite_test.dart
@@ -46,10 +46,9 @@ void main() {
   });
 
   test("a load test doesn't complete until the body returns", () async {
-    var completer = new Completer();
-    var suite = new LoadSuite("name", SuiteConfiguration.empty, () {
-      return completer.future as FutureOr<RunnerSuite>;
-    });
+    var completer = new Completer<RunnerSuite>();
+    var suite =
+        new LoadSuite("name", SuiteConfiguration.empty, () => completer.future);
     expect(suite.group.entries, hasLength(1));
 
     var liveTest = await (suite.group.entries.single as Test).load(suite);
@@ -77,9 +76,8 @@ void main() {
   });
 
   test("a load test completes early if it's closed", () async {
-    var suite = new LoadSuite("name", SuiteConfiguration.empty, () {
-      return new Completer().future as FutureOr<RunnerSuite>;
-    });
+    var suite = new LoadSuite("name", SuiteConfiguration.empty,
+        () => new Completer<RunnerSuite>().future);
     expect(suite.group.entries, hasLength(1));
 
     var liveTest = await (suite.group.entries.single as Test).load(suite);

--- a/test/runner/load_suite_test.dart
+++ b/test/runner/load_suite_test.dart
@@ -12,6 +12,7 @@ import 'package:test/src/backend/test_platform.dart';
 import 'package:test/src/runner/configuration/suite.dart';
 import 'package:test/src/runner/load_exception.dart';
 import 'package:test/src/runner/load_suite.dart';
+import 'package:test/src/runner/runner_suite.dart';
 import 'package:test/test.dart';
 
 import '../utils.dart';
@@ -46,8 +47,9 @@ void main() {
 
   test("a load test doesn't complete until the body returns", () async {
     var completer = new Completer();
-    var suite =
-        new LoadSuite("name", SuiteConfiguration.empty, () => completer.future);
+    var suite = new LoadSuite("name", SuiteConfiguration.empty, () {
+      return completer.future as FutureOr<RunnerSuite>;
+    });
     expect(suite.group.entries, hasLength(1));
 
     var liveTest = await (suite.group.entries.single as Test).load(suite);
@@ -62,8 +64,9 @@ void main() {
 
   test("a load test forwards errors and completes LoadSuite.suite to null",
       () async {
-    var suite =
-        new LoadSuite("name", SuiteConfiguration.empty, () => fail("error"));
+    var suite = new LoadSuite("name", SuiteConfiguration.empty, () {
+      fail("error");
+    });
     expect(suite.group.entries, hasLength(1));
 
     expect(suite.suite, completion(isNull));
@@ -74,8 +77,9 @@ void main() {
   });
 
   test("a load test completes early if it's closed", () async {
-    var suite = new LoadSuite(
-        "name", SuiteConfiguration.empty, () => new Completer().future);
+    var suite = new LoadSuite("name", SuiteConfiguration.empty, () {
+      return new Completer().future as FutureOr<RunnerSuite>;
+    });
     expect(suite.group.entries, hasLength(1));
 
     var liveTest = await (suite.group.entries.single as Test).load(suite);


### PR DESCRIPTION
Runs the following tests:
- dartanalyzer
- dartfmt
- vm tests excluding all browser tags
- dartium tests

Note that the dev SDK appears to leave pub running after a successful run of tests. This will need to be investigated further.

Passing travis run: https://travis-ci.org/grouma/test/builds/221886642