### PR TITLE
Create psuedo-public entrypoints for bootstrapping vm/browser tests.

### DIFF
--- a/lib/bootstrap/browser.dart
+++ b/lib/bootstrap/browser.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 import "../src/runner/plugin/remote_platform_helpers.dart";
 import "../src/runner/browser/post_message_channel.dart";
-import '../src/utils.dart';
+import "../src/utils.dart";
 
 /// Bootstraps a browser test to communicate with the test runner.
 ///

--- a/lib/bootstrap/browser.dart
+++ b/lib/bootstrap/browser.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import "../src/runner/plugin/remote_platform_helpers.dart";
+import "../src/runner/browser/post_message_channel.dart";
+import '../src/utils.dart';
+
+/// Bootstraps a browser test to communicate with the test runner.
+///
+/// This should NOT be used directly, instead use the `test/pub_serve`
+/// transformer which will bootstrap your test and call this method.
+@deprecated
+void internalBootstrapBrowserTest(AsyncFunction originalMain) {
+  var channel = serializeSuite(() => originalMain);
+  postMessageChannel().pipe(channel);
+}

--- a/lib/bootstrap/vm.dart
+++ b/lib/bootstrap/vm.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import "dart:isolate";
+
+import "package:stream_channel/stream_channel.dart";
+
+import "../src/runner/plugin/remote_platform_helpers.dart";
+import "../src/runner/vm/catch_isolate_errors.dart";
+import "../src/utils.dart";
+
+/// Bootstraps a vm test to communicate with the test runner.
+///
+/// This should NOT be used directly, instead use the `test/pub_serve`
+/// transformer which will bootstrap your test and call this method.
+@deprecated
+void internalBootstrapVmTest(AsyncFunction originalMain, SendPort sendPort) {
+  var channel = serializeSuite(() {
+    catchIsolateErrors();
+    return originalMain;
+  });
+  new IsolateChannel.connectSend(sendPort).pipe(channel);
+}

--- a/lib/pub_serve.dart
+++ b/lib/pub_serve.dart
@@ -30,37 +30,24 @@ class PubServeTransformer extends Transformer implements DeclaringTransformer {
     transform.addOutput(new Asset.fromString(
         id.addExtension('.vm_test.dart'),
         '''
-          import "dart:isolate";
-
-          import "package:stream_channel/stream_channel.dart";
-
-          import "package:test/src/runner/plugin/remote_platform_helpers.dart";
-          import "package:test/src/runner/vm/catch_isolate_errors.dart";
+          import "package:test/bootstrap/vm.dart";
 
           import "${p.url.basename(id.path)}" as test;
 
           void main(_, SendPort message) {
-            var channel = serializeSuite(() {
-              catchIsolateErrors();
-              return test.main;
-            });
-            new IsolateChannel.connectSend(message).pipe(channel);
+            internalBootstrapVmTest(test.main, message);
           }
         '''));
 
     transform.addOutput(new Asset.fromString(
         id.addExtension('.browser_test.dart'),
         '''
-          import "package:stream_channel/stream_channel.dart";
-
-          import "package:test/src/runner/plugin/remote_platform_helpers.dart";
-          import "package:test/src/runner/browser/post_message_channel.dart";
+          import "package:test/bootstrap/browser.dart";
 
           import "${p.url.basename(id.path)}" as test;
 
           void main() {
-            var channel = serializeSuite(() => test.main);
-            postMessageChannel().pipe(channel);
+            internalBootstrapBrowserTest(test.main);
           }
         '''));
 


### PR DESCRIPTION
This proposed change takes the code generated by the pub serve transformer and migrates all the business logic into two new "public" entry points. The methods exposed are marked as `@deprecated` (just to discourage direct use) and have a comment explaining that they should not be used directly. I also prefixed the names with `internal` as yet another signal not to rely on these files directly.

The future dartdevc transformer also doesn't support importing files from lib/src directly which are not included transitively by at least one public entry point (defined as a .dart file under `lib` but not `lib/src`). We could solve this in a couple other ways, but I think this is the most logical.

This also simplifies the transformer implementation, and more importantly it makes it so the transformer doesn't generate code with imports to dependencies that you don't depend on explicitly.

It also enables analyzer errors/warnings for these files, and reduces the amount of code that is just in a raw string. 