### PR TITLE
Some more minor dartdoc typos

### DIFF
--- a/lib/test.dart
+++ b/lib/test.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 
 import 'src/backend/declarer.dart';
 import 'src/backend/invoker.dart';
+import 'src/backend/platform_selector.dart' show PlatformSelector; // for the dartdocs
 import 'src/backend/test_platform.dart';
 import 'src/frontend/timeout.dart';
 import 'src/runner/configuration/suite.dart';
@@ -273,7 +274,7 @@ void setUpAll(callback()) => _declarer.setUpAll(callback);
 ///
 /// **Note**: This function makes it very easy to accidentally introduce hidden
 /// dependencies between tests that should be isolated. In general, you should
-/// prefer [tearDown], and only use [tearDOwnAll] if the callback is
+/// prefer [tearDown], and only use [tearDownAll] if the callback is
 /// prohibitively slow.
 void tearDownAll(callback()) => _declarer.tearDownAll(callback);
 


### PR DESCRIPTION
I added the import because otherwise the mention of `[PlatformSelector]` in the docs has no way to figure out what it's referring to since that class isn't exported.