### PR TITLE
Fix recieve -> receive typo

### DIFF
--- a/lib/src/backend/invoker.dart
+++ b/lib/src/backend/invoker.dart
@@ -291,7 +291,7 @@ class Invoker {
 
     if (!liveTest.test.metadata.chainStackTraces) {
       _printsOnFailure.add("Consider enabling the flag chain-stack-traces to "
-          "recieve more detailed exceptions.\n"
+          "receive more detailed exceptions.\n"
           "For example, 'pub run test --chain-stack-traces'.");
     }
 

--- a/test/backend/invoker_test.dart
+++ b/test/backend/invoker_test.dart
@@ -584,7 +584,7 @@ void main() {
         await liveTest.run();
       },
           prints("Consider enabling the flag chain-stack-traces to "
-              "recieve more detailed exceptions.\n"
+              "receive more detailed exceptions.\n"
               "For example, 'pub run test --chain-stack-traces'.\n"));
     });
   });


### PR DESCRIPTION
Trivial PR to fix a small typo in warning message suggesting to use complete stack traces.