### PR TITLE
Fix Travis flakiness

### DIFF
--- a/test/runner/compact_reporter_test.dart
+++ b/test/runner/compact_reporter_test.dart
@@ -466,36 +466,34 @@ $tests
     // Skip the first CR, remove excess trailing whitespace, and trim off
     // timestamps.
     var lastLine;
-    var actual = stdoutLines
-        .skip(1)
-        .map((line) {
-          if (line.startsWith("  ") || line.isEmpty) return line.trimRight();
+    var actual = stdoutLines.skip(1).map((line) {
+      if (line.startsWith("  ") || line.isEmpty) return line.trimRight();
 
-          var trimmed =
-              line.trim().replaceFirst(new RegExp("^[0-9]{2}:[0-9]{2} "), "");
+      var trimmed =
+          line.trim().replaceFirst(new RegExp("^[0-9]{2}:[0-9]{2} "), "");
 
-          // Trim identical lines so the test isn't dependent on how fast each test
-          // runs.
-          if (trimmed == lastLine) return null;
-          lastLine = trimmed;
-          return trimmed;
-        })
-        .where((line) => line != null)
-        .join("\n");
+      // Trim identical lines so the test isn't dependent on how fast each test
+      // runs.
+      if (trimmed == lastLine) return null;
+      lastLine = trimmed;
+      return trimmed;
+    }).where((line) => line != null);
 
     // Un-indent the expected string.
     var indentation = expected.indexOf(new RegExp("[^ ]"));
-    expected = expected.split("\n").map((line) {
+    var expectedLines = expected.split("\n").map((line) {
       if (line.isEmpty) return line;
       return line.substring(indentation);
-    }).join("\n");
+    });
 
     // In Dart 1.24, stack traces with Future constructors output as
     // `new Future` instead of `Future.Future`.
     // Support running tests in both old and new styles.
     expect(
         actual,
-        anyOf(equals(expected),
-            equals(expected.replaceAll(' Future.Future.', ' new Future.'))));
+        anyOf(
+            containsAllInOrder(expectedLines),
+            containsAllInOrder(expectedLines
+                .map((s) => s.replaceAll(' Future.Future.', ' new Future.')))));
   });
 }


### PR DESCRIPTION
Travis processes tests much slower which can result in additional lines in a report. Use containsAllInOrder to account for this issue.