### PR TITLE
Exit early on Travis

### DIFF
--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -185,7 +185,9 @@ transformers:
 
   // TODO(grouma) - figure out why the executable can hang in the travis
   // environment. https://github.com/dart-lang/test/issues/599
-  exit(exitCode);
+  if (Platform.environment["TRAVIS"] == "true") {
+    exit(exitCode);
+  }
 }
 
 /// Print usage information for this command.


### PR DESCRIPTION
Some internal coverage tools require the process to remain open. Hack to ensure Travis is not flaky while not impacting these internal tools.