### PR TITLE
throws* matchers now support () -> Future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.21
+
+* `throwsA()` and all related matchers will now match functions that return
+  `Future`s that emit exceptions.
+
 ## 0.12.20+13
 
 * Upgrade to package:matcher 0.12.1

--- a/lib/src/frontend/throws_matcher.dart
+++ b/lib/src/frontend/throws_matcher.dart
@@ -17,7 +17,7 @@ import 'async_matcher.dart';
 @Deprecated("Will be removed in 0.13.0")
 const Matcher throws = const Throws();
 
-/// This can be used to match two kinds of objects:
+/// This can be used to match three kinds of objects:
 ///
 /// * A [Function] that throws an exception when called. The function cannot
 ///   take any arguments. If you want to test that a function expecting
@@ -29,7 +29,9 @@ const Matcher throws = const Throws();
 ///   return immediately and execution will continue. Later, when the future
 ///   completes, the actual expectation will run.
 ///
-/// In both cases, when an exception is thrown, this will test that the
+/// * A [Function] that returns a [Future] that completes with an exception.
+///
+/// In all three cases, when an exception is thrown, this will test that the
 /// exception object matches [matcher]. If [matcher] is not an instance of
 /// [Matcher], it will implicitly be treated as `equals(matcher)`.
 Matcher throwsA(matcher) => new Throws(wrapMatcher(matcher));
@@ -55,6 +57,13 @@ class Throws extends AsyncMatcher {
 
     try {
       var value = item();
+      if (value is Future) {
+        return value.then(
+            (value) => indent(prettyPrint(value),
+                first: 'returned a Future that emitted '),
+            onError: _check);
+      }
+
       return indent(prettyPrint(value), first: 'returned ');
     } catch (error, trace) {
       return _check(error, trace);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.20+13
+version: 0.12.21-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test

--- a/test/frontend/matcher/throws_test.dart
+++ b/test/frontend/matcher/throws_test.dart
@@ -126,6 +126,25 @@ void main() {
             ]));
       });
 
+      test("with a closure that returns a Future that throws an error", () {
+        expect(() => new Future.error('oh no'), throws);
+      });
+
+      test("with a closure that returns a Future that doesn't throw", () async {
+        var liveTest = await runTestBody(() {
+          expect(() => new Future.value(), throws);
+        });
+
+        expectTestFailed(
+            liveTest,
+            allOf([
+              startsWith("Expected: throws\n"
+                  "  Actual: <"),
+              endsWith(">\n"
+                  "   Which: returned a Future that emitted <null>\n")
+            ]));
+      });
+
       test("won't let the test end until the Future completes", () {
         return expectTestBlocks(() {
           var completer = new Completer();
@@ -163,6 +182,43 @@ void main() {
       test("with a Future that throws the wrong error", () async {
         var liveTest = await runTestBody(() {
           expect(new Future.error('aw dang'), throwsA('oh no'));
+        });
+
+        expectTestFailed(
+            liveTest,
+            allOf([
+              startsWith("Expected: throws 'oh no'\n"
+                  "  Actual: <"),
+              contains(">\n"
+                  "   Which: threw 'aw dang'\n")
+            ]));
+      });
+
+      test("with a closure that returns a Future that throws a matching error",
+          () {
+        expect(() => new Future.error(new FormatException("bad")),
+            throwsA(isFormatException));
+      });
+
+      test("with a closure that returns a Future that doesn't throw", () async {
+        var liveTest = await runTestBody(() {
+          expect(() => new Future.value(), throwsA('oh no'));
+        });
+
+        expectTestFailed(
+            liveTest,
+            allOf([
+              startsWith("Expected: throws 'oh no'\n"
+                  "  Actual: <"),
+              endsWith(">\n"
+                  "   Which: returned a Future that emitted <null>\n")
+            ]));
+      });
+
+      test("with closure that returns a Future that throws the wrong error",
+          () async {
+        var liveTest = await runTestBody(() {
+          expect(() => new Future.error('aw dang'), throwsA('oh no'));
         });
 
         expectTestFailed(


### PR DESCRIPTION
Closes #579