### PR TITLE
Add file configuration for chain-stack-traces

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -100,8 +100,10 @@ verbose_trace: true
 ### `chain_stack_traces`
 
 This boolean field controls whether or not stack traces are chained. 
-Disabling stack trace chaining will improve performance at the cost of
-debuggability. 
+Disabling [`stack trace chaining`][stack trace chaining] will improve
+performance for heavily asynchronous code at the cost of debuggability. 
+
+[stack trace chaining]: https://github.com/dart-lang/stack_trace/blob/master/README.md#stack-chains
 
 ```yaml
 chain_stack_traces: false 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -27,6 +27,7 @@ tags:
 * [Test Configuration](#test-configuration)
   * [`timeout`](#timeout)
   * [`verbose_trace`](#verbose_trace)
+  * [`chain_stack_traces`](#chain_stack_traces)
   * [`js_trace`](#js_trace)
   * [`skip`](#skip)
   * [`test_on`](#test_on)
@@ -94,6 +95,16 @@ itself. It defaults to `false`.
 
 ```yaml
 verbose_trace: true
+```
+
+### `chain_stack_traces`
+
+This boolean field controls whether or not stack traces are chained. 
+Disabling stack trace chaining will improve performance at the cost of
+debuggability. 
+
+```yaml
+chain_stack_traces: false 
 ```
 
 ### `js_trace`

--- a/lib/src/runner/configuration/load.dart
+++ b/lib/src/runner/configuration/load.dart
@@ -73,6 +73,7 @@ class _ConfigurationLoader {
   /// Loads test configuration that's allowed in the global configuration file.
   Configuration _loadGlobalTestConfig() {
     var verboseTrace = _getBool("verbose_trace");
+    var chainStackTraces = _getBool("chain_stack_traces");
     var jsTrace = _getBool("js_trace");
 
     var timeout = _parseValue("timeout", (value) => new Timeout.parse(value));
@@ -106,7 +107,8 @@ class _ConfigurationLoader {
             verboseTrace: verboseTrace,
             jsTrace: jsTrace,
             timeout: timeout,
-            presets: presets)
+            presets: presets,
+            chainStackTraces: chainStackTraces)
         .merge(_extractPresets/*<PlatformSelector>*/(
             onPlatform, (map) => new Configuration(onPlatform: map)));
 

--- a/test/runner/configuration/top_level_error_test.dart
+++ b/test/runner/configuration/top_level_error_test.dart
@@ -34,6 +34,17 @@ void main() {
     test.shouldExit(exit_codes.data);
   });
 
+  test("rejects an invalid  chain_stack_traces", () {
+    d
+        .file("dart_test.yaml", JSON.encode({"chain_stack_traces": "flup"}))
+        .create();
+
+    var test = runTest(["test.dart"]);
+    test.stderr.expect(
+        containsInOrder(["chain_stack_traces must be a boolean", "^^^^^^"]));
+    test.shouldExit(exit_codes.data);
+  });
+
   test("rejects an invalid js_trace", () {
     d.file("dart_test.yaml", JSON.encode({"js_trace": "flup"})).create();
 

--- a/test/runner/configuration/top_level_error_test.dart
+++ b/test/runner/configuration/top_level_error_test.dart
@@ -34,7 +34,7 @@ void main() {
     test.shouldExit(exit_codes.data);
   });
 
-  test("rejects an invalid  chain_stack_traces", () {
+  test("rejects an invalid chain_stack_traces", () {
     d
         .file("dart_test.yaml", JSON.encode({"chain_stack_traces": "flup"}))
         .create();

--- a/test/runner/configuration/top_level_test.dart
+++ b/test/runner/configuration/top_level_test.dart
@@ -173,8 +173,8 @@ void main() {
 
     var test = runTest(["test.dart"]);
     test.stdout.expect(containsInOrder([
-      "00:00 +0: failure",
-      "00:00 +0 -1: failure [E]",
+      "+0: failure",
+      "+0 -1: failure [E]",
       "oh no",
       "test.dart 9:15  main.<fn>",
     ]));


### PR DESCRIPTION
Adds a configuration field for chain-stack-traces. See the following issue for more details.

https://github.com/dart-lang/test/issues/615