### PR TITLE
Add timeout for deserializing a test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 * Respect `onPlatform` for groups.
 
+* Gracefully timeout when attempting to deserialize a test suite.
+
 ## 0.12.20+13
 
 * Upgrade to package:matcher 0.12.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 * Only print browser load errors once per browser.
 
-* Gracefully timeout when attempting to deserialize a test suite.
+* Gracefully time out when attempting to deserialize a test suite.
 
 ## 0.12.20+13
 

--- a/lib/src/runner/plugin/platform_helpers.dart
+++ b/lib/src/runner/plugin/platform_helpers.dart
@@ -24,7 +24,7 @@ import '../runner_test.dart';
 
 typedef StackTrace _MapTrace(StackTrace trace);
 
-Duration _deserializeTimeout = new Duration(seconds: 30);
+Duration _deserializeTimeout = new Duration(seconds: 45);
 
 /// A helper method for creating a [RunnerSuiteController] containing tests
 /// that communicate over [channel].

--- a/lib/src/runner/plugin/platform_helpers.dart
+++ b/lib/src/runner/plugin/platform_helpers.dart
@@ -14,6 +14,7 @@ import '../../backend/test.dart';
 import '../../backend/test_platform.dart';
 import '../../util/io.dart';
 import '../../util/remote_exception.dart';
+import '../application_exception.dart';
 import '../configuration.dart';
 import '../configuration/suite.dart';
 import '../environment.dart';
@@ -22,6 +23,8 @@ import '../runner_suite.dart';
 import '../runner_test.dart';
 
 typedef StackTrace _MapTrace(StackTrace trace);
+
+Duration _deserializeTimeout = new Duration(seconds: 15);
 
 /// A helper method for creating a [RunnerSuiteController] containing tests
 /// that communicate over [channel].
@@ -108,7 +111,13 @@ Future<RunnerSuiteController> deserializeSuite(
       });
 
   return new RunnerSuiteController(
-      environment, suiteConfig, await completer.future,
+      environment,
+      suiteConfig,
+      await completer.future.timeout(_deserializeTimeout, onTimeout: () {
+        throw new ApplicationException(
+            "Timed out trying to deserialize the test suite. "
+            "If possible, look for errors within the browser logs.");
+      }),
       path: path,
       platform: platform,
       os: currentOS,

--- a/lib/src/runner/plugin/platform_helpers.dart
+++ b/lib/src/runner/plugin/platform_helpers.dart
@@ -24,7 +24,7 @@ import '../runner_test.dart';
 
 typedef StackTrace _MapTrace(StackTrace trace);
 
-Duration _deserializeTimeout = new Duration(seconds: 15);
+Duration _deserializeTimeout = new Duration(seconds: 30);
 
 /// A helper method for creating a [RunnerSuiteController] containing tests
 /// that communicate over [channel].
@@ -115,8 +115,7 @@ Future<RunnerSuiteController> deserializeSuite(
       suiteConfig,
       await completer.future.timeout(_deserializeTimeout, onTimeout: () {
         throw new ApplicationException(
-            "Timed out trying to deserialize the test suite. "
-            "If possible, look for errors within the browser logs.");
+            "Timed out trying to deserialize the test suite.");
       }),
       path: path,
       platform: platform,

--- a/lib/src/runner/plugin/platform_helpers.dart
+++ b/lib/src/runner/plugin/platform_helpers.dart
@@ -24,7 +24,7 @@ import '../runner_test.dart';
 
 typedef StackTrace _MapTrace(StackTrace trace);
 
-Duration _deserializeTimeout = new Duration(seconds: 45);
+final _deserializeTimeout = new Duration(seconds: 45);
 
 /// A helper method for creating a [RunnerSuiteController] containing tests
 /// that communicate over [channel].
@@ -115,7 +115,8 @@ Future<RunnerSuiteController> deserializeSuite(
       suiteConfig,
       await completer.future.timeout(_deserializeTimeout, onTimeout: () {
         throw new ApplicationException(
-            "Timed out trying to deserialize the test suite.");
+            "Timed out while loading the test suite.\n"
+            "It's likely that there's a missing import or syntax error.");
       }),
       path: path,
       platform: platform,

--- a/test/runner/browser/runner_test.dart
+++ b/test/runner/browser/runner_test.dart
@@ -55,10 +55,8 @@ void main() {
       d.file("test.dart", _importFailure).create();
       var test = runTest(["-p", "content-shell", "test.dart"]);
 
-      test.stdout.expect(containsInOrder([
-        "Timed out trying to deserialize the test suite. "
-            "If possible, look for errors within the browser logs"
-      ]));
+      test.stdout.expect(
+          containsInOrder(["Timed out trying to deserialize the test suite."]));
       test.shouldExit(1);
     }, tags: 'content-shell');
 

--- a/test/runner/browser/runner_test.dart
+++ b/test/runner/browser/runner_test.dart
@@ -25,6 +25,16 @@ void main() {
 }
 """;
 
+final _importFailure = """
+import 'package:test/test.dart';
+import 'blah' as bad_library;
+
+void main() {
+  bad_library.main();
+  test("failure", () => throw new TestFailure("oh no"));
+}
+""";
+
 void main() {
   useSandbox();
 
@@ -40,6 +50,17 @@ void main() {
       ]));
       test.shouldExit(1);
     }, tags: 'chrome');
+
+    test("a test file has import errors", () {
+      d.file("test.dart", _importFailure).create();
+      var test = runTest(["-p", "content-shell", "test.dart"]);
+
+      test.stdout.expect(containsInOrder([
+        "Timed out trying to deserialize the test suite. "
+            "If possible, look for errors within the browser logs"
+      ]));
+      test.shouldExit(1);
+    }, tags: 'content-shell');
 
     test("a test file throws", () {
       d.file("test.dart", "void main() => throw 'oh no';").create();


### PR DESCRIPTION
In Dartium and Content-Shell, run time errors can cause the test to hang as we wait to deserialize the test suite. Add a timeout to prevent this. 

Ideally we would propagate any console errors but I have been unsuccessful in doing so.