### PR TITLE
move bootstrap code to lib/src

### DIFF
--- a/lib/pub_serve.dart
+++ b/lib/pub_serve.dart
@@ -32,7 +32,7 @@ class PubServeTransformer extends Transformer implements DeclaringTransformer {
         '''
           import "dart:isolate";
 
-          import "package:test/bootstrap/vm.dart";
+          import "package:test/src/bootstrap/vm.dart";
 
           import "${p.url.basename(id.path)}" as test;
 
@@ -44,7 +44,7 @@ class PubServeTransformer extends Transformer implements DeclaringTransformer {
     transform.addOutput(new Asset.fromString(
         id.addExtension('.browser_test.dart'),
         '''
-          import "package:test/bootstrap/browser.dart";
+          import "package:test/src/bootstrap/browser.dart";
 
           import "${p.url.basename(id.path)}" as test;
 

--- a/lib/src/bootstrap/browser.dart
+++ b/lib/src/bootstrap/browser.dart
@@ -1,9 +1,9 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-import "../src/runner/browser/post_message_channel.dart";
-import "../src/runner/plugin/remote_platform_helpers.dart";
-import "../src/utils.dart";
+import "../runner/browser/post_message_channel.dart";
+import "../runner/plugin/remote_platform_helpers.dart";
+import "../utils.dart";
 
 /// Bootstraps a browser test to communicate with the test runner.
 ///

--- a/lib/src/bootstrap/browser.dart
+++ b/lib/src/bootstrap/browser.dart
@@ -9,7 +9,6 @@ import "../utils.dart";
 ///
 /// This should NOT be used directly, instead use the `test/pub_serve`
 /// transformer which will bootstrap your test and call this method.
-@deprecated
 void internalBootstrapBrowserTest(AsyncFunction originalMain) {
   var channel = serializeSuite(() => originalMain);
   postMessageChannel().pipe(channel);

--- a/lib/src/bootstrap/vm.dart
+++ b/lib/src/bootstrap/vm.dart
@@ -13,7 +13,6 @@ import "../utils.dart";
 ///
 /// This should NOT be used directly, instead use the `test/pub_serve`
 /// transformer which will bootstrap your test and call this method.
-@deprecated
 void internalBootstrapVmTest(AsyncFunction originalMain, SendPort sendPort) {
   var channel = serializeSuite(() {
     catchIsolateErrors();

--- a/lib/src/bootstrap/vm.dart
+++ b/lib/src/bootstrap/vm.dart
@@ -5,9 +5,9 @@ import "dart:isolate";
 
 import "package:stream_channel/stream_channel.dart";
 
-import "../src/runner/plugin/remote_platform_helpers.dart";
-import "../src/runner/vm/catch_isolate_errors.dart";
-import "../src/utils.dart";
+import "../runner/plugin/remote_platform_helpers.dart";
+import "../runner/vm/catch_isolate_errors.dart";
+import "../utils.dart";
 
 /// Bootstraps a vm test to communicate with the test runner.
 ///


### PR DESCRIPTION
The dartdevc support in pub no longer requires files to be imported by an entry point, so these can be moved under `lib/src` now. I also removed the `@deprecated` annotation since we don't need to send that extra signal any more to not depend on these files (it should be more clean by convention now).