### PR TITLE
Trim Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ dart:
  - dev
  - stable
  - 1.23.0
- - 1.22.1
 
 # Content shell needs these fonts.
 addons:
@@ -39,11 +38,7 @@ before_install:
   - ln -s `pwd`/`echo drt-linux-*`/content_shell bin/content_shell
 
 dart_task:
- # Browser tests take particularly long on Dartium, so we split them up into different tasks.
- - test: --platform dartium
-   install_dartium: true
-
- # Split the tests into four shards to help parallelize them across Travis workers.
+ # Split the tests into five shards to help parallelize them across Travis workers.
  - test: --preset travis --total-shards 5 --shard-index 0
    install_dartium: true
  - test: --preset travis --total-shards 5 --shard-index 1
@@ -56,10 +51,6 @@ dart_task:
    install_dartium: true
 
 matrix:
-  exclude:
-    # Repo was formatted with the 1.23 SDK.
-    - dart: 1.22.1
-      dart_task: dartfmt
   include:
     - dart: stable
       dart_task: dartfmt

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,10 @@ before_install:
   - ln -s `pwd`/`echo drt-linux-*`/content_shell bin/content_shell
 
 dart_task:
+ # Browser tests take particularly long on Dartium, so we split them up into different tasks.
+ - test: --platform dartium
+   install_dartium: true
+
  # Split the tests into five shards to help parallelize them across Travis workers.
  - test: --preset travis --total-shards 5 --shard-index 0
    install_dartium: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test
 environment:
-  sdk: '>=1.14.0 <2.0.0'
+  sdk: '>=1.23.0 <2.0.0'
 dependencies:
   analyzer: '>=0.23.0 <0.31.0'
   args: '^0.13.1'


### PR DESCRIPTION
Dartium tests are included in the sharded tests so explicitly running with platform Dartium should be redundant. Also remove 1.22.1 given the SDK release today.

We should have a discussion around which versions of the SDK we would like to run the browser tests. I'm under the opinion that we lose some confidence and only run browser tests for the stable SDK. I'm not a fan of the very long Travis runs. It also negatively impacts other teams as we starve Travis of resources.