### PR TITLE
Fix flakiness 

### DIFF
--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -182,12 +182,6 @@ transformers:
   } finally {
     await close();
   }
-
-  // TODO(grouma) - figure out why the executable can hang in the travis
-  // environment. https://github.com/dart-lang/test/issues/599
-  if (Platform.environment["TRAVIS"] == "true") {
-    exit(exitCode);
-  }
 }
 
 /// Print usage information for this command.

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -182,6 +182,12 @@ transformers:
   } finally {
     await close();
   }
+
+  // TODO(grouma) - figure out why the executable can hang in the travis
+  // environment. https://github.com/dart-lang/test/issues/599
+  if (Platform.environment["TRAVIS"] == "true") {
+    exit(exitCode);
+  }
 }
 
 /// Print usage information for this command.

--- a/lib/src/runner/browser/browser.dart
+++ b/lib/src/runner/browser/browser.dart
@@ -126,6 +126,8 @@ abstract class Browser {
     });
 
     // Swallow exceptions. The user should explicitly use [onExit] for these.
-    return onExit.catchError((_) {});
+    // However, surface application exceptions which are thrown due to startup
+    // issues with the browser.
+    return onExit.catchError((_) {}, test: (e) => e is! ApplicationException);
   }
 }


### PR DESCRIPTION
I believe this will resolve our flakiness issue. We can get into a condition where the browser is unable to startup. We then complete the onExit with an ApplicationException. Since we swallow all errors, the onExit never completes which keeps the test runner open.