### PR TITLE
Fix for content shell on Mac

### DIFF
--- a/lib/src/runner/browser/content_shell.dart
+++ b/lib/src/runner/browser/content_shell.dart
@@ -60,10 +60,12 @@ class ContentShell extends Browser {
         // make sure it's not expired and that the remote debugging port worked.
         // Any errors from this will always come before the "Running without
         // renderer sandbox" message.
-        while (await stderr
-                .moveNext()
-                .timeout(_errorTimeout)
-                .catchError((_) => false) &&
+        while (await stderr.moveNext().timeout(_errorTimeout).catchError((_) =>
+                throw new ApplicationException(
+                    "Error starting up content_shell.\n"
+                    "Ensure you are using the latest version:\n"
+                    "http://gsdview.appspot.com/dart-archive/channels/stable/"
+                    "release/latest/dartium/")) &&
             !stderr.current.endsWith("Running without renderer sandbox") &&
             !stderr.current.contains("Running without the SUID sandbox") &&
             // Error messages on Mac can get gobbled, we must assume that it

--- a/lib/src/runner/browser/content_shell.dart
+++ b/lib/src/runner/browser/content_shell.dart
@@ -11,6 +11,7 @@ import '../application_exception.dart';
 import 'browser.dart';
 
 final _observatoryRegExp = new RegExp(r"^Observatory listening on ([^ ]+)");
+final _errorTimeout = const Duration(seconds: 30);
 
 /// A class for running an instance of the Dartium content shell.
 ///
@@ -59,9 +60,16 @@ class ContentShell extends Browser {
         // make sure it's not expired and that the remote debugging port worked.
         // Any errors from this will always come before the "Running without
         // renderer sandbox" message.
-        while (await stderr.moveNext() &&
+        while (await stderr
+                .moveNext()
+                .timeout(_errorTimeout)
+                .catchError((_) => false) &&
             !stderr.current.endsWith("Running without renderer sandbox") &&
-            !stderr.current.contains("Running without the SUID sandbox")) {
+            !stderr.current.contains("Running without the SUID sandbox") &&
+            // Error messages on Mac can get gobbled, we must assume that it
+            // it started up successfully.
+            !stderr.current
+                .contains("kq_init: detected broken kqueue; not using")) {
           if (stderr.current == "[dartToStderr]: Dartium build has expired") {
             stderr.cancel();
             process.kill();

--- a/lib/src/runner/browser/content_shell.dart
+++ b/lib/src/runner/browser/content_shell.dart
@@ -11,7 +11,7 @@ import '../application_exception.dart';
 import 'browser.dart';
 
 final _observatoryRegExp = new RegExp(r"^Observatory listening on ([^ ]+)");
-final _errorTimeout = const Duration(seconds: 30);
+final _errorTimeout = const Duration(seconds: 10);
 
 /// A class for running an instance of the Dartium content shell.
 ///


### PR DESCRIPTION
The latest version of Content-Shell on Mac has a bug in which error messages do not properly propagate. If we see evidence of this issue, we then must assume Content-Shell started up correctly. Also, as an additional safety measure, provide a timeout while we try to read the error stream. It is assumed that if we did not find a critical error while waiting on the error stream, Content-Shell started successfully.

This will resolve: https://github.com/dart-lang/angular_test/issues/63