### PR TITLE
Run tear-downs in the same error zone as tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.12.22+1
+
+* Run tear-down callbacks in the same error zone as the test function. This
+  makes it possible to safely share `Future`s and `Stream`s between tests and
+  their tear-downs.
+
 ## 0.12.22
 
 * Add a `retry` option to `test()` and `group()` functions, as well

--- a/lib/src/backend/invoker.dart
+++ b/lib/src/backend/invoker.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:stack_trace/stack_trace.dart';
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -205,16 +205,6 @@ List flatten(Iterable nested) {
   return result;
 }
 
-/// Like [runZoned], but [zoneValues] are set for the callbacks in
-/// [zoneSpecification] and [onError].
-runZonedWithValues(body(),
-    {Map zoneValues, ZoneSpecification zoneSpecification, Function onError}) {
-  return runZoned(() {
-    return runZoned(body,
-        zoneSpecification: zoneSpecification, onError: onError);
-  }, zoneValues: zoneValues);
-}
-
 /// Truncates [text] to fit within [maxLength].
 ///
 /// This will try to truncate along word boundaries and preserve words both at

--- a/test/backend/declarer_test.dart
+++ b/test/backend/declarer_test.dart
@@ -283,6 +283,22 @@ void main() {
 
       await _runTest(tests.single, shouldFail: true);
     });
+
+    test("runs in the same error zone as the test", () {
+      return expectTestsPass(() {
+        Future future;
+        tearDown(() {
+          // If the tear-down is in a different error zone than the test, the
+          // error will try to cross the zone boundary and get top-leveled.
+          expect(future, throwsA("oh no"));
+        });
+
+        test("test", () {
+          future = new Future.error("oh no");
+          expect(future, throwsA("oh no"));
+        });
+      });
+    });
   });
 
   group("in a group,", () {

--- a/test/frontend/add_tear_down_test.dart
+++ b/test/frontend/add_tear_down_test.dart
@@ -161,6 +161,21 @@ void main() {
     });
   });
 
+  test("runs in the same error zone as the test", () {
+    return expectTestsPass(() {
+      test("test", () {
+        var future = new Future.error("oh no");
+        expect(future, throwsA("oh no"));
+
+        addTearDown(() {
+          // If the tear-down is in a different error zone than the test, the
+          // error will try to cross the zone boundary and get top-leveled.
+          expect(future, throwsA("oh no"));
+        });
+      });
+    });
+  });
+
   group("asynchronously", () {
     test("blocks additional test tearDowns on in-band async", () {
       return expectTestsPass(() {


### PR DESCRIPTION
We used to create a new error zone for each call to
waitForOutstandingCallbacks(), which meant that asynchronous errors
couldn't be safely passed around within a single test. Now we have a
single error handler that manually checks the zone in which the error
was thrown.