### PR TITLE
Move off src imports from pkg/analyzer

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,2 +1,5 @@
 analyzer:
   strong-mode: true
+linter:
+  rules:
+    - implementation_imports

--- a/lib/src/runner/parse_metadata.dart
+++ b/lib/src/runner/parse_metadata.dart
@@ -5,7 +5,7 @@
 import 'dart:io';
 
 import 'package:analyzer/analyzer.dart';
-import 'package:analyzer/src/generated/ast.dart';
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:source_span/source_span.dart';

--- a/lib/src/util/string_literal_iterator.dart
+++ b/lib/src/util/string_literal_iterator.dart
@@ -4,7 +4,7 @@
 
 import 'dart:collection';
 
-import 'package:analyzer/src/generated/ast.dart';
+import 'package:analyzer/dart/ast/ast.dart';
 
 // ASCII character codes.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: test
-version: 0.12.22
+version: 0.12.23-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test
 environment:
   sdk: '>=1.14.0 <2.0.0'
 dependencies:
-  analyzer: '>=0.23.0 <0.31.0'
+  analyzer: '>=0.26.4 <0.31.0'
   args: '^0.13.1'
   async: '^1.13.0'
   barback: '>=0.14.0 <0.16.0'


### PR DESCRIPTION
Enable associated lint
Verified the new lower bound (v0.26.4 from Dec 7, 2015) works