### PR TITLE
Prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.22+2
+
+* Properly allocate ports when debugging Chrome and Dartium in an IPv6-only
+  environment.
+
 ## 0.12.22+1
 
 * Support `args` 1.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,6 @@
   makes it possible to safely share `Future`s and `Stream`s between tests and
   their tear-downs.
 
-* Properly allocate ports when debugging Chrome and Dartium in an IPv6-only
-  environment.
-
 ## 0.12.22
 
 * Add a `retry` option to `test()` and `group()` functions, as well

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.22+1
+version: 0.12.22+2
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
The IPv6 change was incorrectly stated to be with release 22+1. Updating changelog and preparing for release.