### PR TITLE
Remove unused imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.23+1
+
+* Remove unused imports. 
+
 ## 0.12.23
 
 * Add a `fold_stack_frames` field for `dart_test.yaml`. This will

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,13 @@
 analyzer:
   strong-mode: true
+errors:
+  unused_element: error
+  unused_import: error
+  unused_local_variable: error
+  dead_code: error
+  ### Useful to uncomment during development to remove the noise of the many
+  ### deprecated APIs.
+  # deprecated_member_use: ignore
 linter:
   rules:
     - await_only_futures

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,6 @@
 analyzer:
   strong-mode: true
+# Upgrade lints to errors that will break Google3
 errors:
   unused_element: error
   unused_import: error

--- a/lib/src/frontend/stream_matcher.dart
+++ b/lib/src/frontend/stream_matcher.dart
@@ -8,7 +8,6 @@ import 'package:async/async.dart';
 import 'package:matcher/matcher.dart';
 
 import '../utils.dart';
-import '../backend/invoker.dart';
 import 'test_chain.dart';
 import 'async_matcher.dart';
 

--- a/lib/src/frontend/throws_matcher.dart
+++ b/lib/src/frontend/throws_matcher.dart
@@ -9,7 +9,6 @@ import 'package:matcher/matcher.dart';
 import '../utils.dart';
 import 'async_matcher.dart';
 import '../frontend/test_chain.dart';
-import '../backend/invoker.dart';
 
 /// This function is deprecated.
 ///

--- a/lib/src/runner/reporter/json.dart
+++ b/lib/src/runner/reporter/json.dart
@@ -13,7 +13,6 @@ import '../../backend/state.dart';
 import '../../backend/suite.dart';
 import '../../backend/test_platform.dart';
 import '../../frontend/expect.dart';
-import '../../utils.dart';
 import '../configuration.dart';
 import '../configuration/suite.dart';
 import '../engine.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.23
+version: 0.12.23+1
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
These warnings will cause issues with Google3. Upgrading the warnings to errors and resolving the issues.