### PR TITLE
Extend timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.24-dev
+## 0.12.25-dev
 
 * Extend `deserializeTimeout`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.24-dev
+
+* Extend `deserializeTimeout`.
+
 ## 0.12.24
 
 * Add a `node` platform for compiling tests to JavaScript and running them on

--- a/lib/src/runner/plugin/platform_helpers.dart
+++ b/lib/src/runner/plugin/platform_helpers.dart
@@ -25,7 +25,7 @@ import '../runner_test.dart';
 
 typedef StackTrace _MapTrace(StackTrace trace);
 
-final _deserializeTimeout = new Duration(minutes: 3);
+final _deserializeTimeout = new Duration(minutes: 8);
 
 /// A helper method for creating a [RunnerSuiteController] containing tests
 /// that communicate over [channel].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.24
+version: 0.12.24-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
Extending deserialize timeout as it was impacting long running coverage tests within Google3.