### PR TITLE
Bump to 0.12.24+1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.24+1
+
+* Widen version constraint on `analyzer`.
+
 ## 0.12.24
 
 * Add a `node` platform for compiling tests to JavaScript and running them on

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: test
-version: 0.12.24
+version: 0.12.25
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test
 environment:
   sdk: '>=1.23.0 <2.0.0'
 dependencies:
-  analyzer: '>=0.26.4 <0.31.0'
+  analyzer: '>=0.26.4 <0.32.0'
   args: '>=0.13.1 <2.0.0'
   async: '^1.13.0'
   barback: '>=0.14.0 <0.16.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.25
+version: 0.12.24+1
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test
 environment:
-  sdk: '>=1.23.0 <2.0.0'
+  sdk: '>=1.23.0 <2.0.0-dev.infinity'
 dependencies:
   analyzer: '>=0.26.4 <0.32.0'
   args: '>=0.13.1 <2.0.0'


### PR DESCRIPTION
Widens version constraint on `analyzer` to play nice w/ latest alpha.  (Required by linter.)

@grouma 