### PR TITLE
Smoke test analyzer 0.31.0-alpha.0 compatibility.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/dart-lang/test
 environment:
   sdk: '>=1.23.0 <2.0.0'
 dependencies:
-  analyzer: '>=0.26.4 <0.31.0'
+  analyzer: 0.31.0-alpha.0
   args: '>=0.13.1 <2.0.0'
   async: '^1.13.0'
   barback: '>=0.14.0 <0.16.0'


### PR DESCRIPTION
FYI @kevmoo 

(Not for landing.)