### PR TITLE
Fix travis hack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ dart:
  - stable
  - 1.23.0
 
+env:
+ - FORCE_TEST_EXIT=true
+
 # Content shell needs these fonts.
 addons:
   apt:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.24+2
+
+* Only force exit if `FORCE_TEST_EXIT` is set in the environment.
+
 ## 0.12.24+1
 
 * Widen version constraint on `analyzer`.

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -185,7 +185,7 @@ transformers:
 
   // TODO(grouma) - figure out why the executable can hang in the travis
   // environment. https://github.com/dart-lang/test/issues/599
-  if (Platform.environment["TRAVIS"] == "true") {
+  if (Platform.environment["FORCE_TEST_EXIT"] == "true") {
     exit(exitCode);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.24+1
+version: 0.12.24+2
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
Forcing an exit on Travis is negatively impacting those that collect code coverage after a test is run. The belief is that this hack is necessary only for a subset of tests within package:test itself. Updating the logic so that it makes use of a more specific environment variable.