### PR TITLE
Replace implicit dynamic with Null in arity checks

### DIFF
--- a/lib/src/frontend/expect_async.dart
+++ b/lib/src/frontend/expect_async.dart
@@ -25,12 +25,12 @@ typedef T Func6<T, A, B, C, D, E, F>([A a, B b, C c, D d, E e, F f]);
 // ([dynamic]) -> dynamic.
 
 typedef _Func0();
-typedef _Func1(a);
-typedef _Func2(a, b);
-typedef _Func3(a, b, c);
-typedef _Func4(a, b, c, d);
-typedef _Func5(a, b, c, d, e);
-typedef _Func6(a, b, c, d, e, f);
+typedef _Func1(Null a);
+typedef _Func2(Null a, Null b);
+typedef _Func3(Null a, Null b, Null c);
+typedef _Func4(Null a, Null b, Null c, Null d);
+typedef _Func5(Null a, Null b, Null c, Null d, Null e);
+typedef _Func6(Null a, Null b, Null c, Null d, Null e, Null f);
 
 typedef bool _IsDoneCallback();
 


### PR DESCRIPTION
Fixes #674

dynamic is treated as the bottom type for function arguments, but this
will soon change. Null will continue to be the bottom type.

The question we are asking is "Is this a function that takes one
argument", when dynamic is no longer the bottom type the question will
become "Is this a function that takes one dynamic argument", and a
function which take one argument of a specific type does *not* take a
dynamic argument.