### PR TITLE
Load Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.24+5
+
+* Expose a way for tests to forward a `loadException` to the server.
+
 ## 0.12.24+4
 
 * Drain browser process `stdout` and `stdin`. This resolves test flakiness, especially in Travis

--- a/lib/dart.js
+++ b/lib/dart.js
@@ -19,6 +19,11 @@ var sendLoadException = function(message) {
   }, window.location.origin);
 }
 
+// Listen for loadException events and forward to the server.
+window.addEventListener('loadException', function(e) {
+  sendLoadException(e.detail);
+});
+
 // The basename of the current page.
 var name = window.location.href.replace(/.*\//, '').replace(/#.*/, '');
 

--- a/lib/dart.js
+++ b/lib/dart.js
@@ -19,8 +19,8 @@ var sendLoadException = function(message) {
   }, window.location.origin);
 }
 
-// Listen for loadException events and forward to the server.
-window.addEventListener('loadException', function(e) {
+// Listen for dartLoadException events and forward to the server.
+window.addEventListener('dartLoadException', function(e) {
   sendLoadException(e.detail);
 });
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.24+4
+version: 0.12.24+5
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
Exposing a way for tests to send a load exception to the test server. This will be used by DDC tests here: https://github.com/dart-lang/sdk/blob/0edc00171a9881d330b633cf0f43b0654e2653c1/pkg/dev_compiler/lib/js/legacy/dart_library.js#L16