### PR TITLE
Zone.strong.0.12.23+1

### DIFF
--- a/lib/src/runner/load_suite.dart
+++ b/lib/src/runner/load_suite.dart
@@ -159,7 +159,10 @@ class LoadSuite extends Suite implements RunnerSuite {
       if (pair == null) return null;
 
       var zone = pair.last;
-      var newSuite = zone.runUnaryGuarded(change, pair.first);
+      var newSuite;
+      zone.runGuarded(() {
+        newSuite = change(pair.first);
+      });
       return newSuite == null ? null : new Pair(newSuite, zone);
     }));
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.23+1
+version: 0.12.23+2
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
The `dart:async` zone API is in the process of becoming strong-mode clean.
This patch fixes a breakage introduced by this change.

The change should have no semantic difference, even when running with the non-strong zone API.