### PR TITLE
Reduce Travis flakiness

### DIFF
--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -31,7 +31,9 @@ tags:
   # Tests that run pub. These tests may need to be excluded when there are local
   # dependency_overrides.
   pub:
+    timeout: 2x
 
   # Tests that use Node.js. These tests may need to be excluded on systems that
   # don't have Node installed.
   node:
+    timeout: 2x


### PR DESCRIPTION
Submits in the recent past have been flaky. It looks like these are isolated to Node and Pub tests. Increasing these timeouts to hopefully reduce the chance of failures.