### PR TITLE
Allow spawnHybridUri() to take root-relative URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.26
+
+* The `spawnHybridUri()` function now allows root-relative URLs, which are
+  interpreted as relative to the root of the package.
+
 ## 0.12.25
 
 * Add a `override_platforms` configuration field which allows test platforms'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.25
+version: 0.12.26
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
This makes it possible to use the same spawnHybridUri() call from
multiple test files that are in different places in the filesystem.