### PR TITLE
Make addTearDown() play nice with setUpAll()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.12.27
 
+* When `addTearDown()` is called within a call to `setUpAll()`, it runs its
+  callback after *all* tests instead of running it after the `setUpAll()`
+  callback.
+
 * When running in an interactive terminal, the test runner now prints status
   lines as wide as the terminal and no wider.
 

--- a/lib/src/backend/declarer.dart
+++ b/lib/src/backend/declarer.dart
@@ -155,10 +155,14 @@ class Declarer {
         }
       }
 
-      await Invoker.current.waitForOutstandingCallbacks(() async {
-        await _runSetUps();
-        await body();
-      });
+      await runZoned(
+          () => Invoker.current.waitForOutstandingCallbacks(() async {
+                await _runSetUps();
+                await body();
+              }),
+          // Make the declarer visible to running tests so that they'll throw
+          // useful errors when calling `test()` and `group()` within a test.
+          zoneValues: {#test.declarer: this});
     }, trace: _collectTraces ? new Trace.current(2) : null, guarded: false));
   }
 
@@ -224,6 +228,10 @@ class Declarer {
     _tearDownAlls.add(callback);
   }
 
+  /// Like [tearDownAll], but called from within a running [setUpAll] test to
+  /// dynamically add a [tearDownAll].
+  void addTearDownAll(callback()) => _tearDownAlls.add(callback);
+
   /// Finalizes and returns the group being declared.
   ///
   /// **Note**: The tests in this group must be run in a [Invoker.guard]
@@ -261,18 +269,30 @@ class Declarer {
     if (_setUpAlls.isEmpty) return null;
 
     return new LocalTest(_prefix("(setUpAll)"), _metadata, () {
-      return Future.forEach(_setUpAlls, (setUp) => setUp());
-    }, trace: _setUpAllTrace, guarded: false);
+      return runZoned(() => Future.forEach(_setUpAlls, (setUp) => setUp()),
+          // Make the declarer visible to running scaffolds so they can add to
+          // the declarer's `tearDownAll()` list.
+          zoneValues: {#test.declarer: this});
+    }, trace: _setUpAllTrace, guarded: false, isScaffoldAll: true);
   }
 
   /// Returns a [Test] that runs the callbacks in [_tearDownAll].
   Test get _tearDownAll {
-    if (_tearDownAlls.isEmpty) return null;
+    // We have to create a tearDownAll if there's a setUpAll, since it might
+    // dynamically add tear-down code using [addTearDownAll].
+    if (_setUpAlls.isEmpty && _tearDownAlls.isEmpty) return null;
 
     return new LocalTest(_prefix("(tearDownAll)"), _metadata, () {
-      return Invoker.current.unclosable(() {
-        return Future.forEach(_tearDownAlls.reversed, errorsDontStopTest);
-      });
-    }, trace: _tearDownAllTrace, guarded: false);
+      return runZoned(() {
+        return Invoker.current.unclosable(() async {
+          while (_tearDownAlls.isNotEmpty) {
+            await errorsDontStopTest(_tearDownAlls.removeLast());
+          }
+        });
+      },
+          // Make the declarer visible to running scaffolds so they can add to
+          // the declarer's `tearDownAll()` list.
+          zoneValues: {#test.declarer: this});
+    }, trace: _tearDownAllTrace, guarded: false, isScaffoldAll: true);
   }
 }

--- a/lib/src/backend/declarer.dart
+++ b/lib/src/backend/declarer.dart
@@ -159,7 +159,7 @@ class Declarer {
         await _runSetUps();
         await body();
       });
-    }, trace: _collectTraces ? new Trace.current(2) : null));
+    }, trace: _collectTraces ? new Trace.current(2) : null, guarded: false));
   }
 
   /// Creates a group of tests.
@@ -225,6 +225,9 @@ class Declarer {
   }
 
   /// Finalizes and returns the group being declared.
+  ///
+  /// **Note**: The tests in this group must be run in a [Invoker.guard]
+  /// context; otherwise, test errors won't be captured.
   Group build() {
     _checkNotBuilt("build");
 
@@ -259,7 +262,7 @@ class Declarer {
 
     return new LocalTest(_prefix("(setUpAll)"), _metadata, () {
       return Future.forEach(_setUpAlls, (setUp) => setUp());
-    }, trace: _setUpAllTrace);
+    }, trace: _setUpAllTrace, guarded: false);
   }
 
   /// Returns a [Test] that runs the callbacks in [_tearDownAll].
@@ -270,6 +273,6 @@ class Declarer {
       return Invoker.current.unclosable(() {
         return Future.forEach(_tearDownAlls.reversed, errorsDontStopTest);
       });
-    }, trace: _tearDownAllTrace);
+    }, trace: _tearDownAllTrace, guarded: false);
   }
 }

--- a/lib/src/runner/remote_listener.dart
+++ b/lib/src/runner/remote_listener.dart
@@ -9,6 +9,7 @@ import 'package:term_glyph/term_glyph.dart' as glyph;
 
 import '../backend/declarer.dart';
 import '../backend/group.dart';
+import '../backend/invoker.dart';
 import '../backend/live_test.dart';
 import '../backend/metadata.dart';
 import '../backend/operating_system.dart';
@@ -97,7 +98,8 @@ class RemoteListener {
               : OperatingSystem.find(message['os']),
           path: message['path']);
 
-      new RemoteListener._(suite, printZone)._listen(channel);
+      Invoker
+          .guard(() => new RemoteListener._(suite, printZone)._listen(channel));
     }, onError: (error, stackTrace) {
       _sendError(channel, error, stackTrace, verboseChain);
     }, zoneSpecification: new ZoneSpecification(print: (_, __, ___, line) {

--- a/lib/src/runner/remote_listener.dart
+++ b/lib/src/runner/remote_listener.dart
@@ -98,8 +98,14 @@ class RemoteListener {
               : OperatingSystem.find(message['os']),
           path: message['path']);
 
-      Invoker
-          .guard(() => new RemoteListener._(suite, printZone)._listen(channel));
+      runZoned(() {
+        Invoker.guard(
+            () => new RemoteListener._(suite, printZone)._listen(channel));
+      },
+          // Make the declarer visible to running tests so that they'll throw
+          // useful errors when calling `test()` and `group()` within a test,
+          // and so they can add to the declarer's `tearDownAll()` list.
+          zoneValues: {#test.declarer: declarer});
     }, onError: (error, stackTrace) {
       _sendError(channel, error, stackTrace, verboseChain);
     }, zoneSpecification: new ZoneSpecification(print: (_, __, ___, line) {

--- a/lib/test.dart
+++ b/lib/test.dart
@@ -67,7 +67,8 @@ Declarer get _declarer {
     ExpandedReporter.watch(engine,
         color: true, printPath: false, printPlatform: false);
 
-    var success = await Invoker.guard(engine.run);
+    var success = await runZoned(() => Invoker.guard(engine.run),
+        zoneValues: {#test.declarer: _globalDeclarer});
     // TODO(nweiz): Set the exit code on the VM when issue 6943 is fixed.
     if (success) return null;
     print('');
@@ -252,6 +253,9 @@ void tearDown(callback()) => _declarer.tearDown(callback);
 ///
 /// The [callback] is run before any callbacks registered with [tearDown]. Like
 /// [tearDown], the most recently registered callback is run first.
+///
+/// If this is called from within a [setUpAll] or [tearDownAll] callback, it
+/// instead runs the function after *all* tests in the current test suite.
 void addTearDown(callback()) {
   if (Invoker.current == null) {
     throw new StateError("addTearDown() may only be called within a test.");

--- a/lib/test.dart
+++ b/lib/test.dart
@@ -67,7 +67,7 @@ Declarer get _declarer {
     ExpandedReporter.watch(engine,
         color: true, printPath: false, printPlatform: false);
 
-    var success = await engine.run();
+    var success = await Invoker.guard(engine.run);
     // TODO(nweiz): Set the exit code on the VM when issue 6943 is fixed.
     if (success) return null;
     print('');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.27-dev
+version: 0.12.27
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test
@@ -29,7 +29,7 @@ dependencies:
   source_map_stack_trace: '^1.1.4'
   source_maps: '^0.10.2'
   source_span: '^1.4.0'
-  stack_trace: '^1.6.0'
+  stack_trace: '^1.9.0'
   stream_channel: '^1.6.0'
   string_scanner: '>=0.1.1 <2.0.0'
   term_glyph: '^1.0.0'

--- a/test/frontend/add_tear_down_test.dart
+++ b/test/frontend/add_tear_down_test.dart
@@ -7,319 +7,25 @@ import 'dart:async';
 import 'package:async/async.dart';
 import 'package:test/test.dart';
 
+import 'package:test/src/backend/declarer.dart';
+
 import '../utils.dart';
 
 void main() {
-  test("runs after the test body", () {
-    return expectTestsPass(() {
-      var test1Run = false;
-      var tearDownRun = false;
-      test("test 1", () {
-        addTearDown(() {
-          expect(test1Run, isTrue);
-          expect(tearDownRun, isFalse);
-          tearDownRun = true;
-        });
-
-        expect(tearDownRun, isFalse);
-        test1Run = true;
-      });
-
-      test("test 2", () {
-        expect(tearDownRun, isTrue);
-      });
-    });
-  });
-
-  test("multiples run in reverse order", () {
-    return expectTestsPass(() {
-      var tearDown1Run = false;
-      var tearDown2Run = false;
-      var tearDown3Run = false;
-
-      test("test 1", () {
-        addTearDown(() {
-          expect(tearDown1Run, isFalse);
-          expect(tearDown2Run, isTrue);
-          expect(tearDown3Run, isTrue);
-          tearDown1Run = true;
-        });
-
-        addTearDown(() {
-          expect(tearDown1Run, isFalse);
-          expect(tearDown2Run, isFalse);
-          expect(tearDown3Run, isTrue);
-          tearDown2Run = true;
-        });
-
-        addTearDown(() {
-          expect(tearDown1Run, isFalse);
-          expect(tearDown2Run, isFalse);
-          expect(tearDown3Run, isFalse);
-          tearDown3Run = true;
-        });
-
-        expect(tearDown1Run, isFalse);
-        expect(tearDown2Run, isFalse);
-        expect(tearDown3Run, isFalse);
-      });
-
-      test("test 2", () {
-        expect(tearDown1Run, isTrue);
-        expect(tearDown2Run, isTrue);
-        expect(tearDown3Run, isTrue);
-      });
-    });
-  });
-
-  test("can be called in addTearDown", () {
-    return expectTestsPass(() {
-      var tearDown2Run = false;
-      var tearDown3Run = false;
-
-      test("test 1", () {
-        addTearDown(() {
-          expect(tearDown2Run, isTrue);
-          expect(tearDown3Run, isFalse);
-          tearDown3Run = true;
-        });
-
-        addTearDown(() {
-          addTearDown(() {
-            expect(tearDown2Run, isFalse);
-            expect(tearDown3Run, isFalse);
-            tearDown2Run = true;
-          });
-        });
-      });
-
-      test("test 2", () {
-        expect(tearDown2Run, isTrue);
-        expect(tearDown3Run, isTrue);
-      });
-    });
-  });
-
-  test("can be called in tearDown", () {
-    return expectTestsPass(() {
-      var tearDown2Run = false;
-      var tearDown3Run = false;
-
-      tearDown(() {
-        expect(tearDown2Run, isTrue);
-        expect(tearDown3Run, isFalse);
-        tearDown3Run = true;
-      });
-
-      tearDown(() {
-        tearDown2Run = false;
-        tearDown3Run = false;
-
-        addTearDown(() {
-          expect(tearDown2Run, isFalse);
-          expect(tearDown3Run, isFalse);
-          tearDown2Run = true;
-        });
-      });
-
-      test("test 1", () {});
-
-      test("test 2", () {
-        expect(tearDown2Run, isTrue);
-        expect(tearDown3Run, isTrue);
-      });
-    });
-  });
-
-  test("runs before a normal tearDown", () {
-    return expectTestsPass(() {
-      var groupTearDownRun = false;
-      var testTearDownRun = false;
-      group("group", () {
-        tearDown(() {
-          expect(testTearDownRun, isTrue);
-          expect(groupTearDownRun, isFalse);
-          groupTearDownRun = true;
-        });
-
-        test("test 1", () {
-          addTearDown(() {
-            expect(groupTearDownRun, isFalse);
-            expect(testTearDownRun, isFalse);
-            testTearDownRun = true;
-          });
-
-          expect(groupTearDownRun, isFalse);
-          expect(testTearDownRun, isFalse);
-        });
-      });
-
-      test("test 2", () {
-        expect(groupTearDownRun, isTrue);
-        expect(testTearDownRun, isTrue);
-      });
-    });
-  });
-
-  test("runs in the same error zone as the test", () {
-    return expectTestsPass(() {
-      test("test", () {
-        var future = new Future.error("oh no");
-        expect(future, throwsA("oh no"));
-
-        addTearDown(() {
-          // If the tear-down is in a different error zone than the test, the
-          // error will try to cross the zone boundary and get top-leveled.
-          expect(future, throwsA("oh no"));
-        });
-      });
-    });
-  });
-
-  group("asynchronously", () {
-    test("blocks additional test tearDowns on in-band async", () {
+  group("in a test", () {
+    test("runs after the test body", () {
       return expectTestsPass(() {
-        var tearDown1Run = false;
-        var tearDown2Run = false;
-        var tearDown3Run = false;
-        test("test", () {
-          addTearDown(() async {
-            expect(tearDown1Run, isFalse);
-            expect(tearDown2Run, isTrue);
-            expect(tearDown3Run, isTrue);
-            await pumpEventQueue();
-            tearDown1Run = true;
-          });
-
-          addTearDown(() async {
-            expect(tearDown1Run, isFalse);
-            expect(tearDown2Run, isFalse);
-            expect(tearDown3Run, isTrue);
-            await pumpEventQueue();
-            tearDown2Run = true;
-          });
-
-          addTearDown(() async {
-            expect(tearDown1Run, isFalse);
-            expect(tearDown2Run, isFalse);
-            expect(tearDown3Run, isFalse);
-            await pumpEventQueue();
-            tearDown3Run = true;
-          });
-
-          expect(tearDown1Run, isFalse);
-          expect(tearDown2Run, isFalse);
-          expect(tearDown3Run, isFalse);
-        });
-      });
-    });
-
-    test("doesn't block additional test tearDowns on out-of-band async", () {
-      return expectTestsPass(() {
-        var tearDown1Run = false;
-        var tearDown2Run = false;
-        var tearDown3Run = false;
-        test("test", () {
-          addTearDown(() {
-            expect(tearDown1Run, isFalse);
-            expect(tearDown2Run, isFalse);
-            expect(tearDown3Run, isFalse);
-
-            expect(new Future(() {
-              tearDown1Run = true;
-            }), completes);
-          });
-
-          addTearDown(() {
-            expect(tearDown1Run, isFalse);
-            expect(tearDown2Run, isFalse);
-            expect(tearDown3Run, isFalse);
-
-            expect(new Future(() {
-              tearDown2Run = true;
-            }), completes);
-          });
-
-          addTearDown(() {
-            expect(tearDown1Run, isFalse);
-            expect(tearDown2Run, isFalse);
-            expect(tearDown3Run, isFalse);
-
-            expect(new Future(() {
-              tearDown3Run = true;
-            }), completes);
-          });
-
-          expect(tearDown1Run, isFalse);
-          expect(tearDown2Run, isFalse);
-          expect(tearDown3Run, isFalse);
-        });
-      });
-    });
-
-    test("blocks additional group tearDowns on in-band async", () {
-      return expectTestsPass(() {
-        var groupTearDownRun = false;
-        var testTearDownRun = false;
-        tearDown(() async {
-          expect(groupTearDownRun, isFalse);
-          expect(testTearDownRun, isTrue);
-          await pumpEventQueue();
-          groupTearDownRun = true;
-        });
-
-        test("test", () {
-          addTearDown(() async {
-            expect(groupTearDownRun, isFalse);
-            expect(testTearDownRun, isFalse);
-            await pumpEventQueue();
-            testTearDownRun = true;
-          });
-
-          expect(groupTearDownRun, isFalse);
-          expect(testTearDownRun, isFalse);
-        });
-      });
-    });
-
-    test("doesn't block additional group tearDowns on out-of-band async", () {
-      return expectTestsPass(() {
-        var groupTearDownRun = false;
-        var testTearDownRun = false;
-        tearDown(() {
-          expect(groupTearDownRun, isFalse);
-          expect(testTearDownRun, isFalse);
-
-          expect(new Future(() {
-            groupTearDownRun = true;
-          }), completes);
-        });
-
-        test("test", () {
-          addTearDown(() {
-            expect(groupTearDownRun, isFalse);
-            expect(testTearDownRun, isFalse);
-
-            expect(new Future(() {
-              testTearDownRun = true;
-            }), completes);
-          });
-
-          expect(groupTearDownRun, isFalse);
-          expect(testTearDownRun, isFalse);
-        });
-      });
-    });
-
-    test("blocks further tests on in-band async", () {
-      return expectTestsPass(() {
+        var test1Run = false;
         var tearDownRun = false;
         test("test 1", () {
-          addTearDown(() async {
+          addTearDown(() {
+            expect(test1Run, isTrue);
             expect(tearDownRun, isFalse);
-            await pumpEventQueue();
             tearDownRun = true;
           });
+
+          expect(tearDownRun, isFalse);
+          test1Run = true;
         });
 
         test("test 2", () {
@@ -328,74 +34,768 @@ void main() {
       });
     });
 
-    test("blocks further tests on out-of-band async", () {
+    test("multiples run in reverse order", () {
       return expectTestsPass(() {
-        var tearDownRun = false;
+        var tearDown1Run = false;
+        var tearDown2Run = false;
+        var tearDown3Run = false;
+
         test("test 1", () {
-          addTearDown(() async {
-            expect(tearDownRun, isFalse);
-            expect(
-                pumpEventQueue().then((_) {
-                  tearDownRun = true;
-                }),
-                completes);
+          addTearDown(() {
+            expect(tearDown1Run, isFalse);
+            expect(tearDown2Run, isTrue);
+            expect(tearDown3Run, isTrue);
+            tearDown1Run = true;
+          });
+
+          addTearDown(() {
+            expect(tearDown1Run, isFalse);
+            expect(tearDown2Run, isFalse);
+            expect(tearDown3Run, isTrue);
+            tearDown2Run = true;
+          });
+
+          addTearDown(() {
+            expect(tearDown1Run, isFalse);
+            expect(tearDown2Run, isFalse);
+            expect(tearDown3Run, isFalse);
+            tearDown3Run = true;
+          });
+
+          expect(tearDown1Run, isFalse);
+          expect(tearDown2Run, isFalse);
+          expect(tearDown3Run, isFalse);
+        });
+
+        test("test 2", () {
+          expect(tearDown1Run, isTrue);
+          expect(tearDown2Run, isTrue);
+          expect(tearDown3Run, isTrue);
+        });
+      });
+    });
+
+    test("can be called in addTearDown", () {
+      return expectTestsPass(() {
+        var tearDown2Run = false;
+        var tearDown3Run = false;
+
+        test("test 1", () {
+          addTearDown(() {
+            expect(tearDown2Run, isTrue);
+            expect(tearDown3Run, isFalse);
+            tearDown3Run = true;
+          });
+
+          addTearDown(() {
+            addTearDown(() {
+              expect(tearDown2Run, isFalse);
+              expect(tearDown3Run, isFalse);
+              tearDown2Run = true;
+            });
           });
         });
 
-        test("after", () {
-          expect(tearDownRun, isTrue);
+        test("test 2", () {
+          expect(tearDown2Run, isTrue);
+          expect(tearDown3Run, isTrue);
         });
+      });
+    });
+
+    test("can be called in tearDown", () {
+      return expectTestsPass(() {
+        var tearDown2Run = false;
+        var tearDown3Run = false;
+
+        tearDown(() {
+          expect(tearDown2Run, isTrue);
+          expect(tearDown3Run, isFalse);
+          tearDown3Run = true;
+        });
+
+        tearDown(() {
+          tearDown2Run = false;
+          tearDown3Run = false;
+
+          addTearDown(() {
+            expect(tearDown2Run, isFalse);
+            expect(tearDown3Run, isFalse);
+            tearDown2Run = true;
+          });
+        });
+
+        test("test 1", () {});
+
+        test("test 2", () {
+          expect(tearDown2Run, isTrue);
+          expect(tearDown3Run, isTrue);
+        });
+      });
+    });
+
+    test("runs before a normal tearDown", () {
+      return expectTestsPass(() {
+        var groupTearDownRun = false;
+        var testTearDownRun = false;
+        group("group", () {
+          tearDown(() {
+            expect(testTearDownRun, isTrue);
+            expect(groupTearDownRun, isFalse);
+            groupTearDownRun = true;
+          });
+
+          test("test 1", () {
+            addTearDown(() {
+              expect(groupTearDownRun, isFalse);
+              expect(testTearDownRun, isFalse);
+              testTearDownRun = true;
+            });
+
+            expect(groupTearDownRun, isFalse);
+            expect(testTearDownRun, isFalse);
+          });
+        });
+
+        test("test 2", () {
+          expect(groupTearDownRun, isTrue);
+          expect(testTearDownRun, isTrue);
+        });
+      });
+    });
+
+    test("runs in the same error zone as the test", () {
+      return expectTestsPass(() {
+        test("test", () {
+          var future = new Future.error("oh no");
+          expect(future, throwsA("oh no"));
+
+          addTearDown(() {
+            // If the tear-down is in a different error zone than the test, the
+            // error will try to cross the zone boundary and get top-leveled.
+            expect(future, throwsA("oh no"));
+          });
+        });
+      });
+    });
+
+    group("asynchronously", () {
+      test("blocks additional test tearDowns on in-band async", () {
+        return expectTestsPass(() {
+          var tearDown1Run = false;
+          var tearDown2Run = false;
+          var tearDown3Run = false;
+          test("test", () {
+            addTearDown(() async {
+              expect(tearDown1Run, isFalse);
+              expect(tearDown2Run, isTrue);
+              expect(tearDown3Run, isTrue);
+              await pumpEventQueue();
+              tearDown1Run = true;
+            });
+
+            addTearDown(() async {
+              expect(tearDown1Run, isFalse);
+              expect(tearDown2Run, isFalse);
+              expect(tearDown3Run, isTrue);
+              await pumpEventQueue();
+              tearDown2Run = true;
+            });
+
+            addTearDown(() async {
+              expect(tearDown1Run, isFalse);
+              expect(tearDown2Run, isFalse);
+              expect(tearDown3Run, isFalse);
+              await pumpEventQueue();
+              tearDown3Run = true;
+            });
+
+            expect(tearDown1Run, isFalse);
+            expect(tearDown2Run, isFalse);
+            expect(tearDown3Run, isFalse);
+          });
+        });
+      });
+
+      test("doesn't block additional test tearDowns on out-of-band async", () {
+        return expectTestsPass(() {
+          var tearDown1Run = false;
+          var tearDown2Run = false;
+          var tearDown3Run = false;
+          test("test", () {
+            addTearDown(() {
+              expect(tearDown1Run, isFalse);
+              expect(tearDown2Run, isFalse);
+              expect(tearDown3Run, isFalse);
+
+              expect(new Future(() {
+                tearDown1Run = true;
+              }), completes);
+            });
+
+            addTearDown(() {
+              expect(tearDown1Run, isFalse);
+              expect(tearDown2Run, isFalse);
+              expect(tearDown3Run, isFalse);
+
+              expect(new Future(() {
+                tearDown2Run = true;
+              }), completes);
+            });
+
+            addTearDown(() {
+              expect(tearDown1Run, isFalse);
+              expect(tearDown2Run, isFalse);
+              expect(tearDown3Run, isFalse);
+
+              expect(new Future(() {
+                tearDown3Run = true;
+              }), completes);
+            });
+
+            expect(tearDown1Run, isFalse);
+            expect(tearDown2Run, isFalse);
+            expect(tearDown3Run, isFalse);
+          });
+        });
+      });
+
+      test("blocks additional group tearDowns on in-band async", () {
+        return expectTestsPass(() {
+          var groupTearDownRun = false;
+          var testTearDownRun = false;
+          tearDown(() async {
+            expect(groupTearDownRun, isFalse);
+            expect(testTearDownRun, isTrue);
+            await pumpEventQueue();
+            groupTearDownRun = true;
+          });
+
+          test("test", () {
+            addTearDown(() async {
+              expect(groupTearDownRun, isFalse);
+              expect(testTearDownRun, isFalse);
+              await pumpEventQueue();
+              testTearDownRun = true;
+            });
+
+            expect(groupTearDownRun, isFalse);
+            expect(testTearDownRun, isFalse);
+          });
+        });
+      });
+
+      test("doesn't block additional group tearDowns on out-of-band async", () {
+        return expectTestsPass(() {
+          var groupTearDownRun = false;
+          var testTearDownRun = false;
+          tearDown(() {
+            expect(groupTearDownRun, isFalse);
+            expect(testTearDownRun, isFalse);
+
+            expect(new Future(() {
+              groupTearDownRun = true;
+            }), completes);
+          });
+
+          test("test", () {
+            addTearDown(() {
+              expect(groupTearDownRun, isFalse);
+              expect(testTearDownRun, isFalse);
+
+              expect(new Future(() {
+                testTearDownRun = true;
+              }), completes);
+            });
+
+            expect(groupTearDownRun, isFalse);
+            expect(testTearDownRun, isFalse);
+          });
+        });
+      });
+
+      test("blocks further tests on in-band async", () {
+        return expectTestsPass(() {
+          var tearDownRun = false;
+          test("test 1", () {
+            addTearDown(() async {
+              expect(tearDownRun, isFalse);
+              await pumpEventQueue();
+              tearDownRun = true;
+            });
+          });
+
+          test("test 2", () {
+            expect(tearDownRun, isTrue);
+          });
+        });
+      });
+
+      test("blocks further tests on out-of-band async", () {
+        return expectTestsPass(() {
+          var tearDownRun = false;
+          test("test 1", () {
+            addTearDown(() async {
+              expect(tearDownRun, isFalse);
+              expect(
+                  pumpEventQueue().then((_) {
+                    tearDownRun = true;
+                  }),
+                  completes);
+            });
+          });
+
+          test("after", () {
+            expect(tearDownRun, isTrue);
+          });
+        });
+      });
+    });
+
+    group("with an error", () {
+      test("reports the error", () async {
+        var engine = declareEngine(() {
+          test("test", () {
+            addTearDown(() => throw new TestFailure("fail"));
+          });
+        });
+
+        var queue = new StreamQueue(engine.onTestStarted);
+        var liveTestFuture = queue.next;
+
+        expect(await engine.run(), isFalse);
+
+        var liveTest = await liveTestFuture;
+        expect(liveTest.test.name, equals("test"));
+        expectTestFailed(liveTest, "fail");
+      });
+
+      test("runs further test tearDowns", () async {
+        // Declare this in the outer test so if it doesn't run, the outer test
+        // will fail.
+        var shouldRun = expectAsync0(() {});
+
+        var engine = declareEngine(() {
+          test("test", () {
+            addTearDown(() => throw "error");
+            addTearDown(shouldRun);
+          });
+        });
+
+        expect(await engine.run(), isFalse);
+      });
+
+      test("runs further group tearDowns", () async {
+        // Declare this in the outer test so if it doesn't run, the outer test
+        // will fail.
+        var shouldRun = expectAsync0(() {});
+
+        var engine = declareEngine(() {
+          tearDown(shouldRun);
+
+          test("test", () {
+            addTearDown(() => throw "error");
+          });
+        });
+
+        expect(await engine.run(), isFalse);
       });
     });
   });
 
-  group("with an error", () {
-    test("reports the error", () async {
-      var engine = declareEngine(() {
-        test("test", () {
-          addTearDown(() => throw new TestFailure("fail"));
+  group("in setUpAll()", () {
+    test("runs after all tests", () async {
+      var test1Run = false;
+      var test2Run = false;
+      var tearDownRun = false;
+      await expectTestsPass(() {
+        setUpAll(() {
+          addTearDown(() {
+            expect(test1Run, isTrue);
+            expect(test2Run, isTrue);
+            expect(tearDownRun, isFalse);
+            tearDownRun = true;
+          });
+        });
+
+        test("test 1", () {
+          test1Run = true;
+          expect(tearDownRun, isFalse);
+        });
+
+        test("test 2", () {
+          test2Run = true;
+          expect(tearDownRun, isFalse);
         });
       });
 
-      var queue = new StreamQueue(engine.onTestStarted);
-      var liveTestFuture = queue.next;
-
-      expect(await engine.run(), isFalse);
-
-      var liveTest = await liveTestFuture;
-      expect(liveTest.test.name, equals("test"));
-      expectTestFailed(liveTest, "fail");
+      expect(test1Run, isTrue);
+      expect(test2Run, isTrue);
+      expect(tearDownRun, isTrue);
     });
 
-    test("runs further test tearDowns", () async {
-      // Declare this in the outer test so if it doesn't run, the outer test
-      // will fail.
-      var shouldRun = expectAsync0(() {});
+    test("multiples run in reverse order", () async {
+      var tearDown1Run = false;
+      var tearDown2Run = false;
+      var tearDown3Run = false;
+      await expectTestsPass(() {
+        setUpAll(() {
+          addTearDown(() {
+            expect(tearDown1Run, isFalse);
+            expect(tearDown2Run, isTrue);
+            expect(tearDown3Run, isTrue);
+            tearDown1Run = true;
+          });
 
-      var engine = declareEngine(() {
+          addTearDown(() {
+            expect(tearDown1Run, isFalse);
+            expect(tearDown2Run, isFalse);
+            expect(tearDown3Run, isTrue);
+            tearDown2Run = true;
+          });
+
+          addTearDown(() {
+            expect(tearDown1Run, isFalse);
+            expect(tearDown2Run, isFalse);
+            expect(tearDown3Run, isFalse);
+            tearDown3Run = true;
+          });
+
+          expect(tearDown1Run, isFalse);
+          expect(tearDown2Run, isFalse);
+          expect(tearDown3Run, isFalse);
+        });
+
         test("test", () {
-          addTearDown(() => throw "error");
-          addTearDown(shouldRun);
+          expect(tearDown1Run, isFalse);
+          expect(tearDown2Run, isFalse);
+          expect(tearDown3Run, isFalse);
         });
       });
 
-      expect(await engine.run(), isFalse);
+      expect(tearDown1Run, isTrue);
+      expect(tearDown2Run, isTrue);
+      expect(tearDown3Run, isTrue);
     });
 
-    test("runs further group tearDowns", () async {
-      // Declare this in the outer test so if it doesn't run, the outer test
-      // will fail.
-      var shouldRun = expectAsync0(() {});
+    test("can be called in addTearDown", () async {
+      var tearDown2Run = false;
+      var tearDown3Run = false;
+      await expectTestsPass(() {
+        setUpAll(() {
+          addTearDown(() {
+            expect(tearDown2Run, isTrue);
+            expect(tearDown3Run, isFalse);
+            tearDown3Run = true;
+          });
 
-      var engine = declareEngine(() {
-        tearDown(shouldRun);
+          addTearDown(() {
+            addTearDown(() {
+              expect(tearDown2Run, isFalse);
+              expect(tearDown3Run, isFalse);
+              tearDown2Run = true;
+            });
+          });
+        });
 
         test("test", () {
-          addTearDown(() => throw "error");
+          expect(tearDown2Run, isFalse);
+          expect(tearDown3Run, isFalse);
         });
       });
 
-      expect(await engine.run(), isFalse);
+      expect(tearDown2Run, isTrue);
+      expect(tearDown3Run, isTrue);
+    });
+
+    test("can be called in tearDownAll", () async {
+      var tearDown2Run = false;
+      var tearDown3Run = false;
+      await expectTestsPass(() {
+        tearDownAll(() {
+          expect(tearDown2Run, isTrue);
+          expect(tearDown3Run, isFalse);
+          tearDown3Run = true;
+        });
+
+        tearDownAll(() {
+          tearDown2Run = false;
+          tearDown3Run = false;
+
+          addTearDown(() {
+            expect(tearDown2Run, isFalse);
+            expect(tearDown3Run, isFalse);
+            tearDown2Run = true;
+          });
+        });
+
+        test("test", () {});
+      });
+
+      expect(tearDown2Run, isTrue);
+      expect(tearDown3Run, isTrue);
+    });
+
+    test("runs before a normal tearDownAll", () async {
+      var groupTearDownRun = false;
+      var testTearDownRun = false;
+      await expectTestsPass(() {
+        tearDownAll(() {
+          expect(testTearDownRun, isTrue);
+          expect(groupTearDownRun, isFalse);
+          groupTearDownRun = true;
+        });
+
+        setUpAll(() {
+          addTearDown(() {
+            expect(groupTearDownRun, isFalse);
+            expect(testTearDownRun, isFalse);
+            testTearDownRun = true;
+          });
+        });
+
+        test("test", () {
+          expect(groupTearDownRun, isFalse);
+          expect(testTearDownRun, isFalse);
+        });
+      });
+
+      expect(groupTearDownRun, isTrue);
+      expect(testTearDownRun, isTrue);
+    });
+
+    test("runs in the same error zone as the setUpAll", () async {
+      return expectTestsPass(() {
+        setUpAll(() {
+          var future = new Future.error("oh no");
+          expect(future, throwsA("oh no"));
+
+          addTearDown(() {
+            // If the tear-down is in a different error zone than the setUpAll,
+            // the error will try to cross the zone boundary and get
+            // top-leveled.
+            expect(future, throwsA("oh no"));
+          });
+        });
+
+        test("test", () {});
+      });
+    });
+
+    group("asynchronously", () {
+      test("blocks additional tearDowns on in-band async", () async {
+        var tearDown1Run = false;
+        var tearDown2Run = false;
+        var tearDown3Run = false;
+        await expectTestsPass(() {
+          setUpAll(() {
+            addTearDown(() async {
+              expect(tearDown1Run, isFalse);
+              expect(tearDown2Run, isTrue);
+              expect(tearDown3Run, isTrue);
+              await pumpEventQueue();
+              tearDown1Run = true;
+            });
+
+            addTearDown(() async {
+              expect(tearDown1Run, isFalse);
+              expect(tearDown2Run, isFalse);
+              expect(tearDown3Run, isTrue);
+              await pumpEventQueue();
+              tearDown2Run = true;
+            });
+
+            addTearDown(() async {
+              expect(tearDown1Run, isFalse);
+              expect(tearDown2Run, isFalse);
+              expect(tearDown3Run, isFalse);
+              await pumpEventQueue();
+              tearDown3Run = true;
+            });
+          });
+
+          test("test", () {
+            expect(tearDown1Run, isFalse);
+            expect(tearDown2Run, isFalse);
+            expect(tearDown3Run, isFalse);
+          });
+        });
+
+        expect(tearDown1Run, isTrue);
+        expect(tearDown2Run, isTrue);
+        expect(tearDown3Run, isTrue);
+      });
+
+      test("doesn't block additional tearDowns on out-of-band async", () async {
+        var tearDown1Run = false;
+        var tearDown2Run = false;
+        var tearDown3Run = false;
+        await expectTestsPass(() {
+          setUpAll(() {
+            addTearDown(() {
+              expect(tearDown1Run, isFalse);
+              expect(tearDown2Run, isFalse);
+              expect(tearDown3Run, isFalse);
+
+              expect(new Future(() {
+                tearDown1Run = true;
+              }), completes);
+            });
+
+            addTearDown(() {
+              expect(tearDown1Run, isFalse);
+              expect(tearDown2Run, isFalse);
+              expect(tearDown3Run, isFalse);
+
+              expect(new Future(() {
+                tearDown2Run = true;
+              }), completes);
+            });
+
+            addTearDown(() {
+              expect(tearDown1Run, isFalse);
+              expect(tearDown2Run, isFalse);
+              expect(tearDown3Run, isFalse);
+
+              expect(new Future(() {
+                tearDown3Run = true;
+              }), completes);
+            });
+          });
+
+          test("test", () {
+            expect(tearDown1Run, isFalse);
+            expect(tearDown2Run, isFalse);
+            expect(tearDown3Run, isFalse);
+          });
+        });
+
+        expect(tearDown1Run, isTrue);
+        expect(tearDown2Run, isTrue);
+        expect(tearDown3Run, isTrue);
+      });
+
+      test("blocks additional tearDownAlls on in-band async", () async {
+        var groupTearDownRun = false;
+        var testTearDownRun = false;
+        await expectTestsPass(() {
+          tearDownAll(() async {
+            expect(groupTearDownRun, isFalse);
+            expect(testTearDownRun, isTrue);
+            await pumpEventQueue();
+            groupTearDownRun = true;
+          });
+
+          setUpAll(() {
+            addTearDown(() async {
+              expect(groupTearDownRun, isFalse);
+              expect(testTearDownRun, isFalse);
+              await pumpEventQueue();
+              testTearDownRun = true;
+            });
+          });
+
+          test("test", () {
+            expect(groupTearDownRun, isFalse);
+            expect(testTearDownRun, isFalse);
+          });
+        });
+
+        expect(groupTearDownRun, isTrue);
+        expect(testTearDownRun, isTrue);
+      });
+
+      test("doesn't block additional tearDownAlls on out-of-band async",
+          () async {
+        var groupTearDownRun = false;
+        var testTearDownRun = false;
+        await expectTestsPass(() {
+          tearDownAll(() {
+            expect(groupTearDownRun, isFalse);
+            expect(testTearDownRun, isFalse);
+
+            expect(new Future(() {
+              groupTearDownRun = true;
+            }), completes);
+          });
+
+          setUpAll(() {
+            addTearDown(() {
+              expect(groupTearDownRun, isFalse);
+              expect(testTearDownRun, isFalse);
+
+              expect(new Future(() {
+                testTearDownRun = true;
+              }), completes);
+            });
+          });
+
+          test("test", () {
+            expect(groupTearDownRun, isFalse);
+            expect(testTearDownRun, isFalse);
+          });
+        });
+
+        expect(groupTearDownRun, isTrue);
+        expect(testTearDownRun, isTrue);
+      });
+    });
+
+    group("with an error", () {
+      test("reports the error", () async {
+        var engine = declareEngine(() {
+          setUpAll(() {
+            addTearDown(() => throw new TestFailure("fail"));
+          });
+
+          test("test", () {});
+        });
+
+        var queue = new StreamQueue(engine.onTestStarted);
+        queue.skip(2);
+        var liveTestFuture = queue.next;
+
+        expect(await engine.run(), isFalse);
+
+        var liveTest = await liveTestFuture;
+        expect(liveTest.test.name, equals("(tearDownAll)"));
+        expectTestFailed(liveTest, "fail");
+      });
+
+      test("runs further tearDowns", () async {
+        // Declare this in the outer test so if it doesn't run, the outer test
+        // will fail.
+        var shouldRun = expectAsync0(() {});
+
+        var engine = declareEngine(() {
+          setUpAll(() {
+            addTearDown(() => throw "error");
+            addTearDown(shouldRun);
+          });
+
+          test("test", () {});
+        });
+
+        expect(await engine.run(), isFalse);
+      });
+
+      test("runs further tearDownAlls", () async {
+        // Declare this in the outer test so if it doesn't run, the outer test
+        // will fail.
+        var shouldRun = expectAsync0(() {});
+
+        var engine = declareEngine(() {
+          tearDownAll(shouldRun);
+
+          setUpAll(() {
+            addTearDown(() => throw "error");
+          });
+
+          test("test", () {});
+        });
+
+        expect(await engine.run(), isFalse);
+      });
     });
   });
 }

--- a/test/runner/json_reporter_test.dart
+++ b/test/runner/json_reporter_test.dart
@@ -447,6 +447,8 @@ void main() {
         _testDone(3, hidden: true),
         _testStart(4, "success", line: 9, column: 9),
         _testDone(4),
+        _testStart(5, "(tearDownAll)"),
+        _testDone(5, hidden: true),
         _done()
       ]);
     });


### PR DESCRIPTION
addTearDown() now adds a tearDownAll() rather than adding a plain
tearDown() when called from within setUpAll() (or tearDownAll()). This
is technically a behavioral change, but the old behavior was so
useless I doubt anyone was relying on it.

Closes #712