### PR TITLE
Fix lower bound of stack_trace

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   source_map_stack_trace: '^1.1.4'
   source_maps: '^0.10.2'
   source_span: '^1.4.0'
-  stack_trace: '^1.2.1'
+  stack_trace: '^1.6.0'
   stream_channel: '^1.6.0'
   string_scanner: '>=0.1.1 <2.0.0'
   term_glyph: '^1.0.0'


### PR DESCRIPTION
## Problem

I hit an error earlier when running tests in a repo whose dependencies hadn't been updated in a while:

> ```
> NoSuchMethodError: No static method 'capture' with matching arguments declared in class 'Chain'.
> Receiver: Type: class 'Chain'
> Tried calling: capture(Closure: () => dynamic, when: true)
> Found: capture(() => dynamic, {ChainHandler onError})
> #0      NoSuchMethodError._throwNew (dart:core-patch/errors_patch.dart:196)
> #1      Invoker._onRun (package:test/src/backend/invoker.dart:336)
> ...
> ```

The `when` parameter to `Chain.capture` is currently used in [invoker.dart#L388](https://github.com/dart-lang/test/blob/master/lib/src/backend/invoker.dart#L388), which wasn't added until stack_trace [1.6.0](https://github.com/dart-lang/stack_trace/blob/master/CHANGELOG.md#160).

## Solution
Bump minimum version of stack_trace to ensure this error doesn't happen.
