### PR TITLE
Fix test hang and prep for release - 0.12.26+1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.12.26+1
 
 * Fix lower bound on package `stack_trace`. Now 1.6.0.
+* Manually close browser process streams to prevent test hangs.
 
 ## 0.12.26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.26+1
+
+* Fix lower bound on package `stack_trace`. Now 1.6.0.
+
 ## 0.12.26
 
 * The `spawnHybridUri()` function now allows root-relative URLs, which are

--- a/lib/src/runner/browser/browser.dart
+++ b/lib/src/runner/browser/browser.dart
@@ -51,12 +51,12 @@ abstract class Browser {
   Future get onExit => _onExitCompleter.future;
   final _onExitCompleter = new Completer();
 
-  /// IO streams for the underlying browser process.
-  final _ioStreams = <StreamSubscription>[];
+  /// Standard IO streams for the underlying browser process.
+  final _ioSubscriptions = <StreamSubscription>[];
 
   Future _drainAndIgnore(Stream s) async {
     try {
-      _ioStreams.add(s.listen(null, cancelOnError: true));
+      _ioSubscriptions.add(s.listen(null, cancelOnError: true));
     } on StateError catch (_) {}
   }
 
@@ -125,7 +125,8 @@ abstract class Browser {
 
     // If we don't manually close the stream the test runner can hang.
     // For example this happens with Chrome Headless.
-    for (var stream in _ioStreams) {
+    // See SDK issue: https://github.com/dart-lang/sdk/issues/31264
+    for (var stream in _ioSubscriptions) {
       stream.cancel();
     }
 

--- a/lib/src/runner/browser/browser.dart
+++ b/lib/src/runner/browser/browser.dart
@@ -51,9 +51,12 @@ abstract class Browser {
   Future get onExit => _onExitCompleter.future;
   final _onExitCompleter = new Completer();
 
+  /// IO streams for the underlying browser process.
+  final _ioStreams = <StreamSubscription>[];
+
   Future _drainAndIgnore(Stream s) async {
     try {
-      await s.drain();
+      _ioStreams.add(s.listen(null, cancelOnError: true));
     } on StateError catch (_) {}
   }
 
@@ -72,8 +75,8 @@ abstract class Browser {
       _processCompleter.complete(process);
 
       // If we don't drain the stdout and stderr the process can hang.
-      await Future.wait(
-          [_drainAndIgnore(process.stdout), _drainAndIgnore(process.stderr)]);
+      _drainAndIgnore(process.stdout);
+      _drainAndIgnore(process.stderr);
 
       var exitCode = await process.exitCode;
 
@@ -119,6 +122,12 @@ abstract class Browser {
   /// exceptions.
   Future close() {
     _closed = true;
+
+    // If we don't manually close the stream the test runner can hang.
+    // For example this happens with Chrome Headless.
+    for (var stream in _ioStreams) {
+      stream.cancel();
+    }
 
     _process.then((process) {
       // Dartium has a difficult time being killed on Linux. To ensure it is

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.26
+version: 0.12.26+1
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
We declared an incorrect constraint for package stack_trace. This was fixed in https://github.com/dart-lang/test/pull/714

Also fixing potential test hangs by manually closing IO streams.

Preparing for a new release.