### PR TITLE
Fix a couple of strong mode runtime cast errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.30
+
+* Fix strong mode runtime cast failures.
+
 ## 0.12.29
 
 * Node.js tests can now import modules from a top-level `node_modules`
@@ -88,13 +92,13 @@
 
 ## 0.12.23+1
 
-* Remove unused imports. 
+* Remove unused imports.
 
 ## 0.12.23
 
 * Add a `fold_stack_frames` field for `dart_test.yaml`. This will
   allow users to customize which packages' frames are folded.
-  
+
 ## 0.12.22+2
 
 * Properly allocate ports when debugging Chrome and Dartium in an IPv6-only
@@ -111,11 +115,11 @@
 ## 0.12.22
 
 * Add a `retry` option to `test()` and `group()` functions, as well
-  as `@Retry()`  annotation for test files and a `retry` 
+  as `@Retry()`  annotation for test files and a `retry`
   configuration field for `dart_test.yaml`.  A test with reties
   enabled will be re-run if it fails for a reason other than a
   `TestFailure`.
-  
+
 * Add a `--no-retry` runner flag that disables retries of failing tests.
 
 * Fix a "concurrent modification during iteration" error when calling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.30
+## 0.12.29+1
 
 * Fix strong mode runtime cast failures.
 

--- a/lib/src/runner/remote_listener.dart
+++ b/lib/src/runner/remote_listener.dart
@@ -80,7 +80,7 @@ class RemoteListener {
       verboseChain = metadata.verboseTrace;
       var declarer = new Declarer(
           metadata: metadata,
-          platformVariables: message['platformVariables'].toSet(),
+          platformVariables: new Set.from(message['platformVariables']),
           collectTraces: message['collectTraces'],
           noRetry: message['noRetry']);
 
@@ -116,8 +116,8 @@ class RemoteListener {
     return controller.foreign;
   }
 
-  /// Returns a [Set] from a JSON serialized list.
-  static Set<String> _deserializeSet(List<String> list) {
+  /// Returns a [Set] from a JSON serialized list of strings.
+  static Set<String> _deserializeSet(List list) {
     if (list == null) return null;
     if (list.isEmpty) return null;
     return new Set.from(list);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.30-dev
+version: 0.12.29+1
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.29
+version: 0.12.30-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.29+1
+version: 0.12.30-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
In strong mode, a generic type instantiated with dynamic is not a
subtype of all types. You can't pass a List<dynamic> to something
expecting, say, List<int>.

These errors are usually detected statically, and most of those have
been fixed. However, sometimes this becomes a runtime cast, as in:

```dart
main() {
  // Store a List<dynamic> in a variable of type dynamic.
  dynamic d = [];

  // Implicit runtime downcast from dynamic to List<String>.
  List<String> s = d;
}
```

In order to ease the migration to strong mode, DDC has been ignoring
these cast failures when they involve certain commonly used types. We
are now in the process of actively fixing those errors.

More context: https://github.com/dart-lang/sdk/issues/27223