### PR TITLE
Use finer-grained stack trace folding configuration

### DIFF
--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,5 +1,18 @@
-# Terse traces hide frames from test itself, which is bad.
-verbose_trace: true
+# Fold frames from helper packages we use in our tests, but not from test
+# itself.
+fold_stack_frames:
+  except:
+  - shelf_test_handler
+  - stream_channel
+  - test_descriptor
+  - test_process
+
+presets:
+  # "-P terse-trace" folds frames from test's implementation to make the output
+  # less verbose when
+  terse-trace:
+    fold_stack_frames:
+      except: [test]
 
 tags:
   browser:

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -402,7 +402,7 @@ This field is not supported in the
 ### `fold_stack_frames`
 
 This field controls which packages' stack frames will be folded away
-when displaying stack traces. Packages contained in the `exclude` 
+when displaying stack traces. Packages contained in the `except`
 option will be folded. If `only` is provided, all packages not
 contained in this list will be folded. By default,
 frames from the `test` package and the `stream_channel`


### PR DESCRIPTION
This folds frames from core libraries and packages we don't care
about, but leaves test frames as-is.

Also fix a related documentation error.