### PR TITLE
Prepare for fix of https://github.com/dart-lang/sdk/issues/31963

### DIFF
--- a/lib/src/runner/hybrid_listener.dart
+++ b/lib/src/runner/hybrid_listener.dart
@@ -14,8 +14,8 @@ import "../utils.dart";
 
 /// A sink transformer that wraps data and error events so that errors can be
 /// decoded after being JSON-serialized.
-final _transformer =
-    new StreamSinkTransformer.fromHandlers(handleData: (data, sink) {
+final _transformer = new StreamSinkTransformer<dynamic, dynamic>.fromHandlers(
+    handleData: (data, sink) {
   ensureJsonEncodable(data);
   sink.add({"type": "data", "data": data});
 }, handleError: (error, stackTrace, sink) {


### PR DESCRIPTION
When https://github.com/dart-lang/sdk/issues/31963 is fixed, the analyzer will become more strict about reporting the `TOP_LEVEL_FUNCTION_LITERAL_BLOCK` hint.  This change will prevent the test package from triggering the hint once it is reported more strictly.