### PR TITLE
Don't use Stream.firstWhere(defaultValue:) as it is being renamed

### DIFF
--- a/lib/src/runner/browser/dartium.dart
+++ b/lib/src/runner/browser/dartium.dart
@@ -150,6 +150,9 @@ class Dartium extends Browser {
     /// check whether it's actually connected to an isolate, indicating that
     /// it's the observatory for the main page. Once we find the one that is, we
     /// cancel the other requests and return it.
+    ///
+    /// Use try/catch rather than `defaultValue` in `firstWhere` since the
+    /// parameter name will change in Dart 2.0.
     try {
       return (await inCompletionOrder(operations)
           .firstWhere((url) => url != null)) as Uri;

--- a/lib/src/runner/browser/dartium.dart
+++ b/lib/src/runner/browser/dartium.dart
@@ -150,8 +150,12 @@ class Dartium extends Browser {
     /// check whether it's actually connected to an isolate, indicating that
     /// it's the observatory for the main page. Once we find the one that is, we
     /// cancel the other requests and return it.
-    return (await inCompletionOrder(operations)
-        .firstWhere((url) => url != null, defaultValue: () => null)) as Uri;
+    try {
+      return (await inCompletionOrder(operations)
+          .firstWhere((url) => url != null)) as Uri;
+    } on StateError catch (_) {
+      return null;
+    }
   }
 
   /// If the URL returned by [future] corresponds to the correct Observatory


### PR DESCRIPTION
As Stream.firstWhere's `defaultValue` parameter is being renamed `orElse`, and this is the only use case in this package, and it's for Dartium, I reckon it will make a few things easier if we just refactor this line to use try/catch instead of `defaultValue`. This file will presumably be deleted after Dart 2.0 final is released.