### PR TITLE
Remove unnecessary cast

### DIFF
--- a/lib/src/runner/browser/dartium.dart
+++ b/lib/src/runner/browser/dartium.dart
@@ -155,7 +155,7 @@ class Dartium extends Browser {
     /// parameter name will change in Dart 2.0.
     try {
       return (await inCompletionOrder(operations)
-          .firstWhere((url) => url != null)) as Uri;
+          .firstWhere((url) => url != null));
     } on StateError catch (_) {
       return null;
     }


### PR DESCRIPTION
In 2.0.0-dev.23.0, having the explicit cast is an error. 

@nex3, waiting for travis to see if this passes with stable.