### PR TITLE
Fix a hang when a Node test failed to compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.30+4
+
+* Don't hang when a Node.js test fails to compile.
+
 ## 0.12.30+3
 
 * Fix a memory leak when loading browser tests.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.30+5
+version: 0.12.31-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.30+3
+version: 0.12.31-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
This wasn't caught by Travis due to our workaround for #599.