### PR TITLE
Remove headless flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.12.30+4
+
+* No longer run with headless mode as there are issues with the browser.
+  The headless option will be added in the future when issues are
+  resolved. 
+
 ## 0.12.30+3
 
 * Fix a memory leak when loading browser tests.

--- a/lib/src/runner/browser/chrome.dart
+++ b/lib/src/runner/browser/chrome.dart
@@ -46,7 +46,6 @@ class Chrome extends Browser {
 
         if (!debug) {
           args.addAll([
-            "--headless",
             "--disable-gpu",
             // We don't actually connect to the remote debugger, but Chrome will
             // close as soon as the page is loaded if we don't turn it on.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.30+3
+version: 0.12.30+4
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
We are seeing issues with the increased SDK size and headless: https://github.com/dart-lang/test/issues/772#issuecomment-367910465

Disabling headless for now to unblock our users. We can add an option in the future.