### PR TITLE
Allow Chrome's headless mode to be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
+## 0.12.31
+
+* Add a `headless` configuration option for Chrome.
+
+* Re-enable headless mode for Chrome by default.
+
 ## 0.12.30+4
 
-* No longer run with headless mode as there are issues with the browser.
-  The headless option will be added in the future when issues are
-  resolved. 
+* Stop running Chrome in headless mode temporarily to work around a browser bug.
 
 ## 0.12.30+3
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -55,7 +55,9 @@ tags:
   * [`override_platforms`](#override_platforms)
   * [`define_platforms`](#define_platforms)
   * [Browser/Node.js Settings](#browser-and-node-js-settings)
+    * [`arguments`](#arguments)
     * [`executable`](#executable)
+    * [`headless`](#headless)
 * [Configuration Presets](#configuration-presets)
   * [`presets`](#presets)
   * [`add_preset`](#add_preset)
@@ -690,6 +692,20 @@ define_platforms:
     settings:
       executable: chromium
 ```
+
+#### `headless`
+
+The `headless` field says whether or not to run the browser in headless mode.
+It defaults to `true`. It's currently only supported for Chrome:
+
+```yaml
+override_platforms:
+  chrome:
+    settings:
+      headless: false
+```
+
+Note that headless mode is always disabled when debugging.
 
 ## Configuration Presets
 

--- a/lib/src/runner/browser/chrome.dart
+++ b/lib/src/runner/browser/chrome.dart
@@ -44,8 +44,9 @@ class Chrome extends Browser {
           "--disable-translate",
         ];
 
-        if (!debug) {
+        if (!debug && settings.headless) {
           args.addAll([
+            "--headless",
             "--disable-gpu",
             // We don't actually connect to the remote debugger, but Chrome will
             // close as soon as the page is loaded if we don't turn it on.

--- a/lib/src/runner/executable_settings.dart
+++ b/lib/src/runner/executable_settings.dart
@@ -63,6 +63,12 @@ class ExecutableSettings {
         _windowsExecutable);
   }
 
+  /// Whether to invoke the browser in headless mode.
+  ///
+  /// This is currently only supported by Chrome.
+  bool get headless => _headless ?? true;
+  final bool _headless;
+
   /// Parses settings from a user-provided YAML mapping.
   factory ExecutableSettings.parse(YamlMap settings) {
     List<String> arguments;
@@ -105,11 +111,23 @@ class ExecutableSettings {
       }
     }
 
+    var headless = true;
+    var headlessNode = settings.nodes["headless"];
+    if (headlessNode != null) {
+      if (headlessNode.value is bool) {
+        headless = headlessNode.value;
+      } else {
+        throw new SourceSpanFormatException(
+            "Must be a boolean.", headlessNode.span);
+      }
+    }
+
     return new ExecutableSettings(
         arguments: arguments,
         linuxExecutable: linuxExecutable,
         macOSExecutable: macOSExecutable,
-        windowsExecutable: windowsExecutable);
+        windowsExecutable: windowsExecutable,
+        headless: headless);
   }
 
   /// Asserts that [executableNode] is a string or `null` and returns it.
@@ -146,16 +164,19 @@ class ExecutableSettings {
       {Iterable<String> arguments,
       String linuxExecutable,
       String macOSExecutable,
-      String windowsExecutable})
+      String windowsExecutable,
+      bool headless})
       : arguments =
             arguments == null ? const [] : new List.unmodifiable(arguments),
         _linuxExecutable = linuxExecutable,
         _macOSExecutable = macOSExecutable,
-        _windowsExecutable = windowsExecutable;
+        _windowsExecutable = windowsExecutable,
+        _headless = headless;
 
   /// Merges [this] with [other], with [other]'s settings taking priority.
   ExecutableSettings merge(ExecutableSettings other) => new ExecutableSettings(
       arguments: arguments.toList()..addAll(other.arguments),
+      headless: other._headless ?? _headless,
       linuxExecutable: other._linuxExecutable ?? _linuxExecutable,
       macOSExecutable: other._macOSExecutable ?? _macOSExecutable,
       windowsExecutable: other._windowsExecutable ?? _windowsExecutable);


### PR DESCRIPTION
Also re-enable headless mode by default.

See #772 for an example of a failure that only occurs in headless
mode.