### PR TITLE
simplify --precompiled to serve the precompiled directory directly 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.34-dev
+
+* The `--precompiled` flag now serves all sources directly from the precompiled
+  directory, and will never attempt to do its own compilation.
+
 ## 0.12.33
 
 * Pass `--categories=Server` to `dart2js` when compiling tests for Node.js. This

--- a/lib/src/runner.dart
+++ b/lib/src/runner.dart
@@ -39,7 +39,7 @@ class Runner {
   final _config = Configuration.current;
 
   /// The loader that loads the test suites from the filesystem.
-  final Loader _loader;
+  final _loader = new Loader();
 
   /// The engine that runs the test suites.
   final Engine _engine;
@@ -71,12 +71,10 @@ class Runner {
         var engine = new Engine(concurrency: config.concurrency);
 
         var reporterDetails = allReporters[config.reporter];
-        var loader = new Loader(root: config.suiteDefaults.precompiledPath);
-        return new Runner._(
-            engine, reporterDetails.factory(config, engine), loader);
+        return new Runner._(engine, reporterDetails.factory(config, engine));
       });
 
-  Runner._(this._engine, this._reporter, this._loader);
+  Runner._(this._engine, this._reporter);
 
   /// Starts the runner.
   ///

--- a/lib/src/runner.dart
+++ b/lib/src/runner.dart
@@ -39,7 +39,7 @@ class Runner {
   final _config = Configuration.current;
 
   /// The loader that loads the test suites from the filesystem.
-  final _loader = new Loader();
+  final Loader _loader;
 
   /// The engine that runs the test suites.
   final Engine _engine;
@@ -71,10 +71,12 @@ class Runner {
         var engine = new Engine(concurrency: config.concurrency);
 
         var reporterDetails = allReporters[config.reporter];
-        return new Runner._(engine, reporterDetails.factory(config, engine));
+        var loader = new Loader(root: config.suiteDefaults.precompiledPath);
+        return new Runner._(
+            engine, reporterDetails.factory(config, engine), loader);
       });
 
-  Runner._(this._engine, this._reporter);
+  Runner._(this._engine, this._reporter, this._loader);
 
   /// Starts the runner.
   ///

--- a/lib/src/runner/browser/platform.dart
+++ b/lib/src/runner/browser/platform.dart
@@ -114,14 +114,6 @@ class BrowserPlatform extends PlatformPlugin
   final _browserSettings =
       new Map<Runtime, ExecutableSettings>.from(defaultSettings);
 
-  /// A cascade of handlers for suites' precompiled paths.
-  ///
-  /// This is `null` if there are no precompiled suites yet.
-  shelf.Cascade _precompiledCascade;
-
-  /// The precompiled paths that have handlers in [_precompiledHandler].
-  final _precompiledPaths = new Set<String>();
-
   /// A map from test suite paths to Futures that will complete once those
   /// suites are finished compiling.
   ///
@@ -145,12 +137,6 @@ class BrowserPlatform extends PlatformPlugin
           .add(packagesDirHandler())
           .add(_jsHandler.handler)
           .add(createStaticHandler(_root))
-
-          // Add this before the wrapper handler so that its HTML takes
-          // precedence over the test runner's.
-          .add((request) =>
-              _precompiledCascade?.handler(request) ??
-              new shelf.Response.notFound(null))
           .add(_wrapperHandler);
     }
 
@@ -273,33 +259,13 @@ class BrowserPlatform extends PlatformPlugin
       suiteUrl = _config.pubServeUrl.resolveUri(p.toUri('$suitePrefix.html'));
     } else {
       if (browser.isJS) {
-        if (_precompiled(suiteConfig, path)) {
-          if (_precompiledPaths.add(suiteConfig.precompiledPath)) {
-            if (!suiteConfig.jsTrace) {
-              var jsPath = p.join(suiteConfig.precompiledPath,
-                  p.relative(path + ".browser_test.dart.js", from: _root));
-
-              var sourceMapPath = '${jsPath}.map';
-              if (new File(sourceMapPath).existsSync()) {
-                _mappers[path] = new StackTraceMapper(
-                    new File(sourceMapPath).readAsStringSync(),
-                    mapUrl: p.toUri(sourceMapPath),
-                    packageResolver: await PackageResolver.current.asSync,
-                    sdkRoot: p.toUri(sdkDir));
-              }
-            }
-            _precompiledCascade ??= new shelf.Cascade();
-            _precompiledCascade = _precompiledCascade
-                .add(createStaticHandler(suiteConfig.precompiledPath));
-          }
-        } else {
+        if (suiteConfig.precompiledPath == null) {
           await _compileSuite(path, suiteConfig);
         }
       }
 
       if (_closed) return null;
-      suiteUrl = url.resolveUri(
-          p.toUri(p.withoutExtension(p.relative(path, from: _root)) + ".html"));
+      suiteUrl = url.resolveUri(p.toUri(p.withoutExtension(path) + ".html"));
     }
 
     if (_closed) return null;
@@ -312,15 +278,6 @@ class BrowserPlatform extends PlatformPlugin
         mapper: browser.isJS ? _mappers[path] : null);
     if (_closed) return null;
     return suite;
-  }
-
-  /// Returns whether the test at [path] has precompiled HTML available
-  /// underneath [suiteConfig.precompiledPath].
-  bool _precompiled(SuiteConfiguration suiteConfig, String path) {
-    if (suiteConfig.precompiledPath == null) return false;
-    var htmlPath = p.join(suiteConfig.precompiledPath,
-        p.relative(p.withoutExtension(path) + ".html", from: _root));
-    return new File(htmlPath).existsSync();
   }
 
   StreamChannel loadChannel(String path, SuitePlatform platform) =>

--- a/lib/src/runner/browser/platform.dart
+++ b/lib/src/runner/browser/platform.dart
@@ -136,7 +136,8 @@ class BrowserPlatform extends PlatformPlugin
       cascade = cascade
           .add(packagesDirHandler())
           .add(_jsHandler.handler)
-          .add(createStaticHandler(_root))
+          .add(createStaticHandler(
+              config.suiteDefaults.precompiledPath ?? _root))
           .add(_wrapperHandler);
     }
 
@@ -265,7 +266,8 @@ class BrowserPlatform extends PlatformPlugin
       }
 
       if (_closed) return null;
-      suiteUrl = url.resolveUri(p.toUri(p.withoutExtension(path) + ".html"));
+      suiteUrl = url.resolveUri(
+          p.toUri(p.withoutExtension(p.relative(path, from: _root)) + ".html"));
     }
 
     if (_closed) return null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.33
+version: 0.12.34-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
Essentially, this just passes the `--precompiled` directory through to the `Loader` as the `root`, which causes the server to serve that directory directly.

This means no special handlers are set up for the precompiled js, and the precompiled directory is treated as the source of truth, not the root directory (the root dir is not served at all any more). All tests are assumed to be precompiled if the --precompiled flag is passed, and no compilation will ever happen by package:test in that scenario.

I still need to test this with bazel to make sure it still works there as well, and I'm sure I probably broke some package:test tests as well, but sending this out for now to get a first look.