### PR TITLE
Add support for --precompiled node tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.12.34-dev
 
-* The `--precompiled` flag is now supported for the vm platform.
+* The `--precompiled` flag is now supported for the vm platform and the node
+  platform.
 * On browser platforms the `--precompiled` flag now serves all sources directly
   from the precompiled directory, and will never attempt to do its own
   compilation.

--- a/lib/src/runner/loader.dart
+++ b/lib/src/runner/loader.dart
@@ -244,12 +244,6 @@ class Loader {
 
       var name = (platform.runtime.isJS ? "compiling " : "loading ") + path;
       yield new LoadSuite(name, platformConfig, platform, () async {
-        if (platformConfig.precompiledPath != null &&
-            (!platform.runtime.isBrowser && !platform.runtime.isDartVM)) {
-          warn("--precompiled is only supported for browser and vm platforms.",
-              print: true);
-        }
-
         var memo = _platformPlugins[platform.runtime];
 
         try {

--- a/test/runner/node/runner_test.dart
+++ b/test/runner/node/runner_test.dart
@@ -217,21 +217,6 @@ void main() {
     await test.shouldExit(1);
   });
 
-  test("prints a warning with --precompiled", () async {
-    await d.file("test.dart", _success).create();
-
-    var test = await runTest(["-p", "node", "--precompiled=.", "test.dart"]);
-    expect(
-        test.stdout,
-        containsInOrder([
-          '+0: compiling test.dart',
-          'Warning: --precompiled is only supported for browser and vm '
-              'platforms.',
-          '+1: All tests passed!'
-        ]));
-    await test.shouldExit(0);
-  });
-
   test("supports node_modules in the package directory", () async {
     await d.dir("node_modules", [
       d.dir("my_module", [d.file("index.js", "module.exports.value = 12;")])


### PR DESCRIPTION
Closes https://github.com/dart-lang/test/issues/766

This does also require the root .packages file which build_runner doesn't provide but I will do that next.