### PR TITLE
Stop using document.query in tests – use document.querySelector

### DIFF
--- a/test/runner/browser/runner_test.dart
+++ b/test/runner/browser/runner_test.dart
@@ -281,7 +281,7 @@ import 'package:test/test.dart';
 
 void main() {
   test("success", () {
-    expect(document.query('#foo'), isNotNull);
+    expect(document.querySelector('#foo'), isNotNull);
   });
 }
 """).create();
@@ -382,7 +382,7 @@ import 'package:test/test.dart';
 
 void main() {
   test("failure", () {
-    expect(document.query('#foo'), isNull);
+    expect(document.querySelector('#foo'), isNull);
   });
 }
 """).create();

--- a/test/runner/pub_serve_test.dart
+++ b/test/runner/pub_serve_test.dart
@@ -225,7 +225,7 @@ import 'package:test/test.dart';
 
 void main() {
   test("failure", () {
-    expect(document.query('#foo'), isNull);
+    expect(document.querySelector('#foo'), isNull);
   });
 }
 """),


### PR DESCRIPTION
Fixes https://github.com/dart-lang/test/issues/800