### PR TITLE
Require at least Dart 1.24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ dist: trusty
 
 dart:
  - stable
- - 1.23.0
 
 env: FORCE_TEST_EXIT=true DARTIUM_EXPIRATION_TIME=1550044800LL
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.12.34-dev
 
+* Requires at least Dart 1.24.0.
 * The `--precompiled` flag is now supported for the vm platform.
 * On browser platforms the `--precompiled` flag now serves all sources directly
   from the precompiled directory, and will never attempt to do its own

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test
 environment:
-  sdk: '>=1.23.0 <2.0.0'
+  sdk: '>=1.24.0 <2.0.0'
 dependencies:
   analyzer: '>=0.26.4 <0.32.0'
   args: '>=0.13.1 <2.0.0'


### PR DESCRIPTION
Usage of 1.23 is almost non-existent
Increase CI velocity on Travis