### PR TITLE
Fix default custom html handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 0.12.34+1
 
 * Fixed an issue `--precompiled` node tests in subdirectories.
+* Fixed default custom html handler so it correctly includes the
+  packages/test/dart.js file. This allows you to get proper errors instead of
+  timeouts if there are load exceptions in the browser.
 
 ## 0.12.34
 

--- a/lib/src/runner/browser/platform.dart
+++ b/lib/src/runner/browser/platform.dart
@@ -177,18 +177,16 @@ class BrowserPlatform extends PlatformPlugin
 
       // Link to the Dart wrapper on Dartium and the compiled JS version
       // elsewhere.
-      var scriptBase =
-          "${HTML_ESCAPE.convert(p.basename(test))}.browser_test.dart";
-      var script = request.headers['user-agent'].contains('(Dart)')
-          ? 'type="application/dart" src="$scriptBase"'
-          : 'src="$scriptBase.js"';
+      var scriptBase = HTML_ESCAPE.convert(p.basename(test));
+      var link = '<link rel="x-dart-test" href="$scriptBase">';
 
       return new shelf.Response.ok('''
         <!DOCTYPE html>
         <html>
         <head>
           <title>${HTML_ESCAPE.convert(test)} Test</title>
-          <script $script></script>
+          $link
+          <script src="packages/test/dart.js"></script>
         </head>
         </html>
       ''', headers: {'Content-Type': 'text/html'});


### PR DESCRIPTION
Previously it only included the main js file directly and not the packages/test/dart.js file which does all the load exception handling.