### PR TITLE
Fix for Dart 2 runtime failures

### DIFF
--- a/lib/src/runner/configuration/suite.dart
+++ b/lib/src/runner/configuration/suite.dart
@@ -237,8 +237,10 @@ class SuiteConfiguration {
         runtimes: other._runtimes ?? _runtimes,
         includeTags: includeTags.intersection(other.includeTags),
         excludeTags: excludeTags.union(other.excludeTags),
-        tags: _mergeConfigMaps(tags, other.tags),
-        onPlatform: _mergeConfigMaps(onPlatform, other.onPlatform),
+        tags: _mergeConfigMaps(tags, other.tags)
+            .cast<BooleanSelector, SuiteConfiguration>(),
+        onPlatform: _mergeConfigMaps(onPlatform, other.onPlatform)
+            .cast<PlatformSelector, SuiteConfiguration>(),
         metadata: metadata.merge(other.metadata));
     return config._resolveTags();
   }

--- a/lib/src/runner/configuration/suite.dart
+++ b/lib/src/runner/configuration/suite.dart
@@ -237,10 +237,8 @@ class SuiteConfiguration {
         runtimes: other._runtimes ?? _runtimes,
         includeTags: includeTags.intersection(other.includeTags),
         excludeTags: excludeTags.union(other.excludeTags),
-        tags: _mergeConfigMaps(tags, other.tags)
-            .cast<BooleanSelector, SuiteConfiguration>(),
-        onPlatform: _mergeConfigMaps(onPlatform, other.onPlatform)
-            .cast<PlatformSelector, SuiteConfiguration>(),
+        tags: _mergeConfigMaps(tags, other.tags),
+        onPlatform: _mergeConfigMaps(onPlatform, other.onPlatform),
         metadata: metadata.merge(other.metadata));
     return config._resolveTags();
   }
@@ -336,9 +334,9 @@ class SuiteConfiguration {
   ///
   /// Any overlapping keys in the maps have their configurations merged in the
   /// returned map.
-  Map<Object, SuiteConfiguration> _mergeConfigMaps(
-          Map<Object, SuiteConfiguration> map1,
-          Map<Object, SuiteConfiguration> map2) =>
+  Map<T, SuiteConfiguration> _mergeConfigMaps<T>(
+          Map<T, SuiteConfiguration> map1,
+          Map<T, SuiteConfiguration> map2) =>
       mergeMaps(map1, map2,
           value: (config1, config2) => config1.merge(config2));
 

--- a/lib/src/runner/configuration/suite.dart
+++ b/lib/src/runner/configuration/suite.dart
@@ -335,8 +335,7 @@ class SuiteConfiguration {
   /// Any overlapping keys in the maps have their configurations merged in the
   /// returned map.
   Map<T, SuiteConfiguration> _mergeConfigMaps<T>(
-          Map<T, SuiteConfiguration> map1,
-          Map<T, SuiteConfiguration> map2) =>
+          Map<T, SuiteConfiguration> map1, Map<T, SuiteConfiguration> map2) =>
       mergeMaps(map1, map2,
           value: (config1, config2) => config1.merge(config2));
 

--- a/lib/src/runner/plugin/platform_helpers.dart
+++ b/lib/src/runner/plugin/platform_helpers.dart
@@ -56,7 +56,7 @@ RunnerSuiteController deserializeSuite(
     'foldTraceOnly': Configuration.current.foldTraceOnly.toList(),
   }..addAll(message as Map));
 
-  var completer = new Completer();
+  var completer = new Completer<Group>();
 
   var loadSuiteZone = Zone.current;
   handleError(error, stackTrace) {


### PR DESCRIPTION
Fixes for Dart 2 runtime failures that showed up during internal testing.

- type '_InternalLinkedHashMap<Object, SuiteConfiguration>' is not a subtype of type 'Map<BooleanSelector, SuiteConfiguration>'
- type 'Future<dynamic>' is not a subtype of type 'Future<Group>'
