### PR TITLE
Expose bootstrap methods publicly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Don’t commit the following directories created by pub.
 .buildlog
+.dart_tool/
 .pub/
 build/
 packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.36
+
+* Expose the test bootstrapping methods, so that build systems can precompile
+  tests without relying on internal apis.
+
 ## 0.12.35
 
 * Dropped support for Dart 1. Going forward only Dart 2 will be supported.

--- a/lib/bootstrap/browser.dart
+++ b/lib/bootstrap/browser.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export '../src/bootstrap/browser.dart';

--- a/lib/bootstrap/node.dart
+++ b/lib/bootstrap/node.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export '../src/bootstrap/node.dart';

--- a/lib/bootstrap/vm.dart
+++ b/lib/bootstrap/vm.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export '../src/bootstrap/vm.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.35
+version: 0.12.36
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
This allows build systems (or other tools) to precompile tests without using `src` imports.

Note that there is still one convention that tools have to know to follow, which is the bootstrap file naming. 
The files must live at `original.dart.<plaform>_test.dart`. We could expose functions which expose this publicly as well, but we wouldn't be able to reference those within `build.yaml` when setting up the build extensions so it wouldn't really help. I am open to suggestions if you have an idea otherwise we can just go with the convention approach.