### PR TITLE
Make neverCalled return Null instead of T

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.38
+
+* Give `neverCalled` a type that works in Dart 2 semantics.
+
 ## 0.12.37
 
 * Removed the transformer, and the `pub_serve.dart` entrypoint. This is not

--- a/lib/src/frontend/never_called.dart
+++ b/lib/src/frontend/never_called.dart
@@ -24,7 +24,7 @@ import 'utils.dart';
 ///
 /// This also ensures that the test doesn't complete until a call to
 /// [pumpEventQueue] finishes, so that the callback has a chance to be called.
-T Function<T>(
+Null Function(
     [Object,
     Object,
     Object,
@@ -40,7 +40,7 @@ T Function<T>(
   expect(pumpEventQueue(), completes);
 
   var zone = Zone.current;
-  return <T>(
+  return (
       [a1 = placeholder,
       a2 = placeholder,
       a3 = placeholder,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.37
+version: 0.12.38-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
Closes #824

Makes test/frontend/never_called_test work with --preview-dart-2