### PR TITLE
Require meta 1.1.5 and use @isTest and @isTestGroup to mark test() and group().

### DIFF
--- a/lib/test.dart
+++ b/lib/test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
 import 'src/backend/declarer.dart';
@@ -130,6 +131,7 @@ Declarer get _declarer {
 ///
 /// If multiple platforms match, the annotations apply in order as through
 /// they were in nested groups.
+@isTest
 void test(description, body(),
     {String testOn,
     Timeout timeout,
@@ -199,6 +201,7 @@ void test(description, body(),
 ///
 /// If multiple platforms match, the annotations apply in order as through
 /// they were in nested groups.
+@isTestGroup
 void group(description, body(),
     {String testOn,
     Timeout timeout,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   http_multi_server: '>=1.0.0 <3.0.0'
   io: '^0.3.0'
   js: '^0.6.0'
-  meta: '^1.1.0'
+  meta: '^1.1.5'
   multi_server_socket: '^1.0.0'
   node_preamble: '^1.3.0'
   package_resolver: '^1.0.0'


### PR DESCRIPTION
See https://github.com/flutter/flutter-intellij/issues/2055 for the context.
