### PR TITLE
Avoid constructing our own NoSuchMethodError

### DIFF
--- a/test/frontend/matcher/throws_type_test.dart
+++ b/test/frontend/matcher/throws_type_test.dart
@@ -85,7 +85,7 @@ void main() {
   group('[throwsNoSuchMethodError]', () {
     test("passes when a NoSuchMethodError is thrown", () {
       expect(() {
-        throw new NoSuchMethodError(null, #name, null, null);
+        (1 as dynamic).notAMethodOnInt();
       }, throwsNoSuchMethodError);
     });
 


### PR DESCRIPTION
Fixes #840

Invoke an non-existing method after casting an object to `dynamic` to get
the behavior.