### PR TITLE
More Dart 2 runtime semantic fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.38+3
+
+* Fix Dart 2 runtime errors around communicating with browsers.
+
+
 ## 0.12.38+2
 
 * Fix more Dart 2 runtime type errors.

--- a/lib/src/runner/browser/browser_manager.dart
+++ b/lib/src/runner/browser/browser_manager.dart
@@ -171,7 +171,7 @@ class BrowserManager {
     // Whenever we get a message, no matter which child channel it's for, we the
     // know browser is still running code which means the user isn't debugging.
     _channel = new MultiChannel(
-        webSocket.transform(jsonDocument).changeStream((stream) {
+        webSocket.cast<String>().transform(jsonDocument).changeStream((stream) {
       return stream.map((message) {
         if (!_closed) _timer.reset();
         for (var controller in _controllers) {
@@ -219,15 +219,15 @@ class BrowserManager {
 
     // The virtual channel will be closed when the suite is closed, in which
     // case we should unload the iframe.
-    var suiteChannel = _channel.virtualChannel();
-    var suiteChannelID = suiteChannel.id;
-    suiteChannel = suiteChannel
+    var virtualChannel = _channel.virtualChannel();
+    var suiteChannelID = virtualChannel.id;
+    var suiteChannel = virtualChannel
         .transformStream(new StreamTransformer.fromHandlers(handleDone: (sink) {
       closeIframe();
       sink.close();
     }));
 
-    return await _pool.withResource<Future<RunnerSuite>>(() async {
+    return await _pool.withResource<RunnerSuite>(() async {
       _channel.sink.add({
         "command": "loadSuite",
         "url": url.toString(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.38+2
+version: 0.12.38+3
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
```
type 'WebSocketChannel' is not a subtype of type 'StreamChannel<String>' of 'channel'
```

Cast the `WebSocketChannel` to indicate that all values in each
direction will be `String`.

```
type 'CloseGuaranteeChannel<dynamic>' is not a subtype of type 'VirtualChannel'
```

Avoid using the `suiteChannel` variable for two types. It needs to start
as a `VirtualChannel` which has the `id` field, and then later be a
`StreamChannel`.

```
type 'RunnerSuite' is not a subtype of type 'FutureOr<Future<RunnerSuite>>'
```

Avoid the attempted Future flattenting which was never correct but was
supported in the Dart 1 VM.