### PR TITLE
Drop sanitizeForWindows workaround

### DIFF
--- a/lib/src/runner/compiler_pool.dart
+++ b/lib/src/runner/compiler_pool.dart
@@ -90,8 +90,8 @@ class CompilerPool {
         var buffer = new StringBuffer();
 
         await Future.wait([
-          _printOutputStream(process.stdout, buffer),
-          _printOutputStream(process.stderr, buffer),
+          process.stdout.map(utf8.decode).listen(buffer.write).asFuture(),
+          process.stderr.map(utf8.decode).listen(buffer.write).asFuture(),
         ]);
 
         var exitCode = await process.exitCode;
@@ -123,14 +123,6 @@ class CompilerPool {
     }).toList();
 
     new File(mapPath).writeAsStringSync(jsonEncode(map));
-  }
-
-  /// Sanitizes the bytes emitted by [stream], converts them to text, and writes
-  /// them to [buffer].
-  Future _printOutputStream(Stream<List<int>> stream, StringBuffer buffer) {
-    return sanitizeForWindows(stream)
-        .listen((data) => buffer.write(utf8.decode(data)))
-        .asFuture();
   }
 
   /// Closes the compiler pool.

--- a/lib/src/util/io.dart
+++ b/lib/src/util/io.dart
@@ -17,12 +17,6 @@ import '../backend/runtime.dart';
 import '../backend/suite_platform.dart';
 import '../utils.dart';
 
-/// The ASCII code for a newline character.
-const _newline = 0xA;
-
-/// The ASCII code for a carriage return character.
-const _carriageReturn = 0xD;
-
 /// The default line length for output when there isn't a terminal attached to
 /// stdout.
 const _defaultLineLength = 200;

--- a/lib/src/util/io.dart
+++ b/lib/src/util/io.dart
@@ -114,34 +114,6 @@ Future withTempDir(Future fn(String path)) {
   });
 }
 
-/// Return a transformation of [input] with all null bytes removed.
-///
-/// This works around the combination of issue 23295 and 22667 by removing null
-/// bytes. This workaround can be removed when either of those are fixed in the
-/// oldest supported SDK.
-///
-/// It also somewhat works around issue 23303 by removing any carriage returns
-/// that are followed by newlines, to ensure that carriage returns aren't
-/// doubled up in the output. This can be removed when the issue is fixed in the
-/// oldest supported SDk.
-Stream<List<int>> sanitizeForWindows(Stream<List<int>> input) {
-  if (!Platform.isWindows) return input;
-
-  return input.map((list) {
-    var previous;
-    return list.reversed
-        .where((byte) {
-          if (byte == 0) return false;
-          if (byte == _carriageReturn && previous == _newline) return false;
-          previous = byte;
-          return true;
-        })
-        .toList()
-        .reversed
-        .toList();
-  });
-}
-
 /// Wraps [text] so that it fits within [lineLength].
 ///
 /// This preserves existing newlines and doesn't consider terminal color escapes


### PR DESCRIPTION
We no longer support an SDK old enough that any of the reference issues
are still a problem.