### PR TITLE
Discussion: use package:stream_transform

### DIFF
--- a/lib/src/runner/browser/browser_manager.dart
+++ b/lib/src/runner/browser/browser_manager.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'package:async/async.dart';
 import 'package:pool/pool.dart';
 import 'package:stream_channel/stream_channel.dart';
+import 'package:stream_transform/stream_transform.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import '../../backend/runtime.dart';
@@ -221,11 +222,8 @@ class BrowserManager {
     // case we should unload the iframe.
     var virtualChannel = _channel.virtualChannel();
     var suiteChannelID = virtualChannel.id;
-    var suiteChannel = virtualChannel
-        .transformStream(new StreamTransformer.fromHandlers(handleDone: (sink) {
-      closeIframe();
-      sink.close();
-    }));
+    var suiteChannel =
+        virtualChannel.transformStream(tap(null, onDone: closeIframe));
 
     return await _pool.withResource<RunnerSuite>(() async {
       _channel.sink.add({

--- a/lib/src/runner/node/platform.dart
+++ b/lib/src/runner/node/platform.dart
@@ -9,10 +9,11 @@ import 'dart:convert';
 import 'package:async/async.dart';
 import 'package:multi_server_socket/multi_server_socket.dart';
 import 'package:node_preamble/preamble.dart' as preamble;
-import 'package:pub_semver/pub_semver.dart';
 import 'package:package_resolver/package_resolver.dart';
 import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
 import 'package:stream_channel/stream_channel.dart';
+import 'package:stream_transform/stream_transform.dart';
 import 'package:yaml/yaml.dart';
 
 import '../../backend/runtime.dart';
@@ -122,11 +123,9 @@ class NodePlatform extends PlatformPlugin
           .transform(new StreamChannelTransformer.fromCodec(utf8))
           .transform(chunksToLines)
           .transform(jsonDocument)
-          .transformStream(
-              new StreamTransformer.fromHandlers(handleDone: (sink) {
-        if (process != null) process.kill();
-        sink.close();
-      }));
+          .transformStream(tap(null, onDone: () {
+            if (process != null) process.kill();
+          }));
 
       return new Pair(channel, pair.last);
     } catch (_) {

--- a/lib/src/runner/vm/platform.dart
+++ b/lib/src/runner/vm/platform.dart
@@ -7,6 +7,7 @@ import 'dart:isolate';
 
 import 'package:path/path.dart' as p;
 import 'package:stream_channel/stream_channel.dart';
+import 'package:stream_transform/stream_transform.dart';
 
 import '../../backend/runtime.dart';
 import '../../backend/suite_platform.dart';
@@ -40,10 +41,8 @@ class VMPlatform extends PlatformPlugin {
     }());
 
     // Once the connection is closed by either end, kill the isolate.
-    return channel
-        .transformStream(new StreamTransformer.fromHandlers(handleDone: (sink) {
+    return channel.transformStream(tap(null, onDone: () {
       if (isolate != null) isolate.kill();
-      sink.close();
     }));
   }
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -12,6 +12,7 @@ import 'package:collection/collection.dart';
 import 'package:matcher/matcher.dart';
 import 'package:path/path.dart' as p;
 import 'package:stream_channel/stream_channel.dart';
+import 'package:stream_transform/stream_transform.dart';
 import 'package:term_glyph/term_glyph.dart' as glyph;
 
 import 'backend/invoker.dart';
@@ -23,11 +24,7 @@ import 'backend/operating_system.dart';
 typedef AsyncFunction();
 
 /// A transformer that decodes bytes using UTF-8 and splits them on newlines.
-final lineSplitter = new StreamTransformer<List<int>, String>(
-    (stream, cancelOnError) => stream
-        .transform(utf8.decoder)
-        .transform(const LineSplitter())
-        .listen(null, cancelOnError: cancelOnError));
+final lineSplitter = chain(utf8.decoder, const LineSplitter());
 
 /// A [StreamChannelTransformer] that converts a chunked string channel to a
 /// line-by-line channel.
@@ -36,8 +33,8 @@ final lineSplitter = new StreamTransformer<List<int>, String>(
 /// to contain newlines.
 final chunksToLines = new StreamChannelTransformer<String, String>(
     const LineSplitter(),
-    new StreamSinkTransformer.fromHandlers(
-        handleData: (data, sink) => sink.add("$data\n")));
+    new StreamSinkTransformer.fromStreamTransformer(
+        forMap((data) => "$data\n")));
 
 /// A regular expression to match the exception prefix that some exceptions'
 /// [Object.toString] values contain.

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -24,7 +24,7 @@ import 'backend/operating_system.dart';
 typedef AsyncFunction();
 
 /// A transformer that decodes bytes using UTF-8 and splits them on newlines.
-final lineSplitter = chain(utf8.decoder, const LineSplitter());
+final lineSplitter = chainTransformers(utf8.decoder, const LineSplitter());
 
 /// A [StreamChannelTransformer] that converts a chunked string channel to a
 /// line-by-line channel.
@@ -33,8 +33,7 @@ final lineSplitter = chain(utf8.decoder, const LineSplitter());
 /// to contain newlines.
 final chunksToLines = new StreamChannelTransformer<String, String>(
     const LineSplitter(),
-    new StreamSinkTransformer.fromStreamTransformer(
-        forMap((data) => "$data\n")));
+    new StreamSinkTransformer.fromStreamTransformer(map((data) => "$data\n")));
 
 /// A regular expression to match the exception prefix that some exceptions'
 /// [Object.toString] values contain.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.38+3
+version: 0.12.38+4-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test
@@ -31,6 +31,7 @@ dependencies:
   source_span: '^1.4.0'
   stack_trace: '^1.9.0'
   stream_channel: '^1.6.0'
+  stream_transform: '^0.0.12'
   string_scanner: '>=0.1.1 <2.0.0'
   term_glyph: '^1.0.0'
   typed_data: '^1.0.0'
@@ -45,3 +46,7 @@ dev_dependencies:
   shelf_test_handler: '^1.0.0'
   test_descriptor: '^1.0.0'
   test_process: '^1.0.0'
+
+dependency_overrides:
+  stream_transform:
+    path: ../stream_transform

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,7 +46,3 @@ dev_dependencies:
   shelf_test_handler: '^1.0.0'
   test_descriptor: '^1.0.0'
   test_process: '^1.0.0'
-
-dependency_overrides:
-  stream_transform:
-    path: ../stream_transform


### PR DESCRIPTION
Removes some of the noise of explicitly dealing with the `sink` so that
the business logic is more prevalent where possible. There are still
usages of `new StreamTransformer.fromHandlers` and similar where the
intent can't be expressed by the lower level building blocks.