### PR TITLE
Change the default reporter logic to use `stdout.supportsAnsiEscapes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.12.39
+
+* Change the default reporter and color defaults to be based on
+  `stdout.supportsAnsiEscapes` instead of based on platform (previously both
+  were disabled on windows).
+
 ## 0.12.38+3
 
 * Fix Dart 2 runtime errors around communicating with browsers.

--- a/lib/src/runner/configuration/reporters.dart
+++ b/lib/src/runner/configuration/reporters.dart
@@ -43,7 +43,8 @@ final _allReporters = <String, ReporterDetails>{
       (_, engine) => JsonReporter.watch(engine)),
 };
 
-final defaultReporter = inTestTests ? 'expanded' : 'compact';
+final defaultReporter =
+    inTestTests ? 'expanded' : canUseSpecialChars ? 'compact' : 'expanded';
 
 /// **Do not call this function without express permission from the test package
 /// authors**.

--- a/lib/src/runner/configuration/reporters.dart
+++ b/lib/src/runner/configuration/reporters.dart
@@ -43,8 +43,7 @@ final _allReporters = <String, ReporterDetails>{
       (_, engine) => JsonReporter.watch(engine)),
 };
 
-final defaultReporter =
-    inTestTests ? 'expanded' : (Platform.isWindows ? 'expanded' : 'compact');
+final defaultReporter = inTestTests ? 'expanded' : 'compact';
 
 /// **Do not call this function without express permission from the test package
 /// authors**.

--- a/lib/src/util/io.dart
+++ b/lib/src/util/io.dart
@@ -78,14 +78,9 @@ final _tempDir = Platform.environment.containsKey("_UNITTEST_TEMP_DIR")
     ? Platform.environment["_UNITTEST_TEMP_DIR"]
     : Directory.systemTemp.path;
 
-// TODO(nweiz): Make this check [stdioType] once that works within "pub run".
-/// Whether "special" strings such as Unicode characters or color escapes are
-/// safe to use.
-///
-/// On Windows or when not printing to a terminal, only printable ASCII
-/// characters should be used.
-bool get canUseSpecialChars =>
-    Platform.operatingSystem != 'windows' && !inTestTests;
+// Whether or not the current terminal supports ansi escape codes. Otherwise
+/// only printable ASCII characters should be used.
+bool get canUseSpecialChars => stdout.supportsAnsiEscapes && !inTestTests;
 
 /// Creates a temporary directory and returns its path.
 String createTempDir() => new Directory(_tempDir)

--- a/lib/src/util/io.dart
+++ b/lib/src/util/io.dart
@@ -78,8 +78,9 @@ final _tempDir = Platform.environment.containsKey("_UNITTEST_TEMP_DIR")
     ? Platform.environment["_UNITTEST_TEMP_DIR"]
     : Directory.systemTemp.path;
 
-// Whether or not the current terminal supports ansi escape codes. Otherwise
-/// only printable ASCII characters should be used.
+/// Whether or not the current terminal supports ansi escape codes.
+///
+/// Otherwise only printable ASCII characters should be used.
 bool get canUseSpecialChars => stdout.supportsAnsiEscapes && !inTestTests;
 
 /// Creates a temporary directory and returns its path.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.38+3
+version: 0.12.39
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
Enable the compact reporter and colors based on `stdout.supportsAnsiEscapes` instead of platform.

Tested in a regular windows command prompt, vscode console on windows, appveyor, and my local windows box. All appear to work as expected.

Fixes https://github.com/dart-lang/test/issues/847.