### PR TITLE
Dart 2 fixes for config tests

### DIFF
--- a/test/runner/configuration/global_test.dart
+++ b/test/runner/configuration/global_test.dart
@@ -45,7 +45,7 @@ void main() {
 
     var test = await runTest(["test.dart"],
         environment: {"DART_TEST_CONFIG": "global_test.yaml"});
-    expect(test.stdout, emitsThrough(contains("dart:isolate-patch")));
+    expect(test.stdout, emitsThrough(contains("dart:async")));
     await test.shouldExit(1);
   });
 


### PR DESCRIPTION
More towards test/runner/configuration/global_test.dart

The stack traces are slightly different between Dart 2 and Dart 1. Use another common string to ensure that verbose mode is working.