### PR TITLE
Drop AsyncFunction typedef

### DIFF
--- a/lib/src/backend/declarer.dart
+++ b/lib/src/backend/declarer.dart
@@ -50,13 +50,13 @@ class Declarer {
   final bool _noRetry;
 
   /// The set-up functions to run for each test in this group.
-  final _setUps = new List<AsyncFunction>();
+  final _setUps = new List<Function()>();
 
   /// The tear-down functions to run for each test in this group.
-  final _tearDowns = new List<AsyncFunction>();
+  final _tearDowns = new List<Function()>();
 
   /// The set-up functions to run once for this group.
-  final _setUpAlls = new List<AsyncFunction>();
+  final _setUpAlls = new List<Function()>();
 
   /// The trace for the first call to [setUpAll].
   ///
@@ -66,7 +66,7 @@ class Declarer {
   Trace _setUpAllTrace;
 
   /// The tear-down functions to run once for this group.
-  final _tearDownAlls = new List<AsyncFunction>();
+  final _tearDownAlls = new List<Function()>();
 
   /// The trace for the first call to [tearDownAll].
   ///

--- a/lib/src/backend/invoker.dart
+++ b/lib/src/backend/invoker.dart
@@ -166,7 +166,7 @@ class Invoker {
   Timer _timeoutTimer;
 
   /// The tear-down functions to run when this test finishes.
-  final _tearDowns = <AsyncFunction>[];
+  final _tearDowns = <Function()>[];
 
   /// Messages to print if and when this test fails.
   final _printsOnFailure = <String>[];

--- a/lib/src/runner/loader.dart
+++ b/lib/src/runner/loader.dart
@@ -29,9 +29,6 @@ import 'plugin/platform.dart';
 import 'runner_suite.dart';
 import 'vm/platform.dart';
 
-// TODO(nweiz): Use inline function types when sdk#30858 is fixed.
-typedef FutureOr<PlatformPlugin> _PlatformPluginFunction();
-
 /// A class for finding test files and loading them into a runnable form.
 class Loader {
   /// The test runner configuration.
@@ -46,7 +43,7 @@ class Loader {
   /// The functions to use to load [_platformPlugins].
   ///
   /// These are passed to the plugins' async memoizers when a plugin is needed.
-  final _platformCallbacks = <Runtime, _PlatformPluginFunction>{};
+  final _platformCallbacks = <Runtime, FutureOr<PlatformPlugin> Function()>{};
 
   /// A map of all runtimes registered in [_platformCallbacks], indexed by
   /// their string identifiers.
@@ -81,7 +78,8 @@ class Loader {
   /// used to load all suites for all matching runtimes. Platform plugins may
   /// override built-in runtimes.
   Loader(
-      {String root, Map<Iterable<Runtime>, _PlatformPluginFunction> plugins}) {
+      {String root,
+      Map<Iterable<Runtime>, FutureOr<PlatformPlugin> Function()> plugins}) {
     _registerPlatformPlugin([Runtime.vm], () => new VMPlatform());
     _registerPlatformPlugin([Runtime.nodeJS], () => new NodePlatform());
     _registerPlatformPlugin([
@@ -107,11 +105,11 @@ class Loader {
 
   /// Registers a [PlatformPlugin] for [runtimes].
   void _registerPlatformPlugin(
-      Iterable<Runtime> runtimes, FutureOr<PlatformPlugin> getPlugin()) {
+      Iterable<Runtime> runtimes, FutureOr<PlatformPlugin> Function() plugin) {
     var memoizer = new AsyncMemoizer<PlatformPlugin>();
     for (var runtime in runtimes) {
       _platformPlugins[runtime] = memoizer;
-      _platformCallbacks[runtime] = getPlugin;
+      _platformCallbacks[runtime] = plugin;
       _runtimesByIdentifier[runtime.identifier] = runtime;
     }
   }

--- a/lib/src/runner/plugin/hack_register_platform.dart
+++ b/lib/src/runner/plugin/hack_register_platform.dart
@@ -2,18 +2,19 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:collection';
 
 import '../../backend/runtime.dart';
-import '../../utils.dart';
 import 'platform.dart';
 
 /// The functions to use to load [_platformPlugins] in all loaders.
 ///
 /// **Do not access this outside the test package**.
 final platformCallbacks =
-    new UnmodifiableMapView<Runtime, AsyncFunction>(_platformCallbacks);
-final _platformCallbacks = <Runtime, AsyncFunction>{};
+    new UnmodifiableMapView<Runtime, FutureOr<PlatformPlugin> Function()>(
+        _platformCallbacks);
+final _platformCallbacks = <Runtime, FutureOr<PlatformPlugin> Function()>{};
 
 /// **Do not call this function without express permission from the test package
 /// authors**.
@@ -22,13 +23,14 @@ final _platformCallbacks = <Runtime, AsyncFunction>{};
 ///
 /// This globally registers a plugin for all [Loader]s. When the runner first
 /// requests that a suite be loaded for one of the given runtimes, this will
-/// call [getPlugin] to load the platform plugin. It may return either a
+/// call [plugin] to load the platform plugin. It may return either a
 /// [PlatformPlugin] or a [Future<PlatformPlugin>]. That plugin is then
 /// preserved and used to load all suites for all matching runtimes.
 ///
 /// This overwrites the default plugins for those runtimes.
-void registerPlatformPlugin(Iterable<Runtime> runtimes, getPlugin()) {
+void registerPlatformPlugin(
+    Iterable<Runtime> runtimes, FutureOr<PlatformPlugin> Function() plugin) {
   for (var runtime in runtimes) {
-    _platformCallbacks[runtime] = getPlugin;
+    _platformCallbacks[runtime] = plugin;
   }
 }

--- a/lib/src/runner/remote_listener.dart
+++ b/lib/src/runner/remote_listener.dart
@@ -18,7 +18,6 @@ import '../backend/suite.dart';
 import '../backend/suite_platform.dart';
 import '../backend/test.dart';
 import '../util/remote_exception.dart';
-import '../utils.dart';
 import 'suite_channel_manager.dart';
 
 class RemoteListener {
@@ -44,7 +43,7 @@ class RemoteListener {
   ///
   /// If [beforeLoad] is passed, it's called before the tests have been declared
   /// for this worker.
-  static StreamChannel start(AsyncFunction getMain(),
+  static StreamChannel start(Function getMain(),
       {bool hidePrints = true, Future beforeLoad()}) {
     // This has to be synchronous to work around sdk#25745. Otherwise, there'll
     // be an asynchronous pause before a syntax error notification is sent,
@@ -84,7 +83,7 @@ class RemoteListener {
             _sendLoadException(
                 channel, "Top-level main getter is not a function.");
             return;
-          } else if (main is! AsyncFunction) {
+          } else if (main is! Function()) {
             _sendLoadException(
                 channel, "Top-level main() function takes arguments.");
             return;

--- a/lib/src/runner/runner_suite.dart
+++ b/lib/src/runner/runner_suite.dart
@@ -11,7 +11,6 @@ import '../backend/group.dart';
 import '../backend/suite.dart';
 import '../backend/suite_platform.dart';
 import '../backend/test.dart';
-import '../utils.dart';
 import 'configuration/suite.dart';
 import 'environment.dart';
 
@@ -56,7 +55,7 @@ class RunnerSuite extends Suite {
   /// debugging mode and doesn't support suite channels.
   factory RunnerSuite(Environment environment, SuiteConfiguration config,
       Group group, SuitePlatform platform,
-      {String path, AsyncFunction onClose}) {
+      {String path, Function() onClose}) {
     var controller =
         new RunnerSuiteController._local(environment, config, onClose: onClose);
     var suite = new RunnerSuite._(controller, group, path, platform);
@@ -94,7 +93,7 @@ class RunnerSuiteController {
   final MultiChannel _suiteChannel;
 
   /// The function to call when the suite is closed.
-  final AsyncFunction _onClose;
+  final Function() _onClose;
 
   /// The backing value for [suite.isDebugging].
   bool _isDebugging = false;
@@ -107,7 +106,7 @@ class RunnerSuiteController {
 
   RunnerSuiteController(this._environment, this._config, this._suiteChannel,
       Future<Group> groupFuture, SuitePlatform platform,
-      {String path, AsyncFunction onClose})
+      {String path, Function() onClose})
       : _onClose = onClose {
     _suite = groupFuture
         .then((group) => new RunnerSuite._(this, group, path, platform));
@@ -116,7 +115,7 @@ class RunnerSuiteController {
   /// Used by [new RunnerSuite] to create a runner suite that's not loaded from
   /// an external source.
   RunnerSuiteController._local(this._environment, this._config,
-      {AsyncFunction onClose})
+      {Function() onClose})
       : _suiteChannel = null,
         _onClose = onClose;
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -17,11 +17,6 @@ import 'package:term_glyph/term_glyph.dart' as glyph;
 import 'backend/invoker.dart';
 import 'backend/operating_system.dart';
 
-/// A typedef for a possibly-asynchronous function.
-///
-/// The return type should only ever by [Future] or void.
-typedef AsyncFunction();
-
 /// A transformer that decodes bytes using UTF-8 and splits them on newlines.
 final lineSplitter = new StreamTransformer<List<int>, String>(
     (stream, cancelOnError) => stream


### PR DESCRIPTION
The typedef was misused to mean either `Function` or `Function()` in
various places and worked because the difference was not checked. The
doc comment was also incorrect because there were places it was used
where a return value was explicitly necessary. Replace with an inline
function type definition using the appropriate choice for the location.

Where possible also replace with Function types that flow through the
required return types.