### PR TITLE
Fix implicit casts in lib directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: dart
 sudo: required
 
 dart:
- - dev
+ - 2.0.0-dev.60.0
 
 env: FORCE_TEST_EXIT=true
 

--- a/lib/src/backend/declarer.dart
+++ b/lib/src/backend/declarer.dart
@@ -81,7 +81,7 @@ class Declarer {
   bool _built = false;
 
   /// The current zone-scoped declarer.
-  static Declarer get current => Zone.current[#test.declarer];
+  static Declarer get current => Zone.current[#test.declarer] as Declarer;
 
   /// Creates a new declarer for the root group.
   ///

--- a/lib/src/backend/invoker.dart
+++ b/lib/src/backend/invoker.dart
@@ -79,7 +79,7 @@ class Invoker {
   final bool _guarded;
 
   /// Whether the test can be closed in the current zone.
-  bool get _closable => Zone.current[_closableKey];
+  bool get _closable => Zone.current[_closableKey] as bool;
 
   /// An opaque object used as a key in the zone value map to identify
   /// [_closable].
@@ -108,7 +108,7 @@ class Invoker {
 
   /// The outstanding callback counter for the current zone.
   OutstandingCallbackCounter get _outstandingCallbacks {
-    var counter = Zone.current[_counterKey];
+    var counter = Zone.current[_counterKey] as OutstandingCallbackCounter;
     if (counter != null) return counter;
     throw new StateError("Can't add or remove outstanding callbacks outside "
         "of a test body.");
@@ -135,7 +135,7 @@ class Invoker {
   /// An invoker is only set within the zone scope of a running test.
   static Invoker get current {
     // TODO(nweiz): Use a private symbol when dart2js supports it (issue 17526).
-    return Zone.current[#test.invoker];
+    return Zone.current[#test.invoker] as Invoker;
   }
 
   /// Runs [callback] in a zone where unhandled errors from [LiveTest]s are
@@ -241,7 +241,7 @@ class Invoker {
   Future waitForOutstandingCallbacks(fn()) {
     heartbeat();
 
-    var zone;
+    Zone zone;
     var counter = new OutstandingCallbackCounter();
     runZoned(() async {
       zone = Zone.current;

--- a/lib/src/backend/platform_selector.dart
+++ b/lib/src/backend/platform_selector.dart
@@ -73,7 +73,7 @@ class PlatformSelector {
   ///
   /// [os] defaults to [OperatingSystem.none].
   bool evaluate(SuitePlatform platform) {
-    return _inner.evaluate((variable) {
+    return _inner.evaluate((String variable) {
       if (variable == platform.runtime.identifier) return true;
       if (variable == platform.runtime.parent?.identifier) return true;
       if (variable == platform.os.identifier) return true;

--- a/lib/src/backend/runtime.dart
+++ b/lib/src/backend/runtime.dart
@@ -108,16 +108,16 @@ class Runtime {
       // a separately-deserialized parent platform. This should be fine, though,
       // since we only deserialize platforms in the remote execution context
       // where they're only used to evaluate platform selectors.
-      return new Runtime._child(
-          map["name"], map["identifier"], new Runtime.deserialize(parent));
+      return new Runtime._child(map["name"] as String,
+          map["identifier"] as String, new Runtime.deserialize(parent));
     }
 
-    return new Runtime(map["name"], map["identifier"],
-        isDartVM: map["isDartVM"],
-        isBrowser: map["isBrowser"],
-        isJS: map["isJS"],
-        isBlink: map["isBlink"],
-        isHeadless: map["isHeadless"]);
+    return new Runtime(map["name"] as String, map["identifier"] as String,
+        isDartVM: map["isDartVM"] as bool,
+        isBrowser: map["isBrowser"] as bool,
+        isJS: map["isJS"] as bool,
+        isBlink: map["isBlink"] as bool,
+        isHeadless: map["isHeadless"] as bool);
   }
 
   /// Converts [this] into a JSON-safe object that can be converted back to a

--- a/lib/src/backend/suite_platform.dart
+++ b/lib/src/backend/suite_platform.dart
@@ -36,7 +36,8 @@ class SuitePlatform {
   factory SuitePlatform.deserialize(Object serialized) {
     var map = serialized as Map;
     return new SuitePlatform(new Runtime.deserialize(map['runtime']),
-        os: OperatingSystem.find(map['os']), inGoogle: map['inGoogle']);
+        os: OperatingSystem.find(map['os'] as String),
+        inGoogle: map['inGoogle'] as bool);
   }
 
   /// Converts [this] into a JSON-safe object that can be converted back to a

--- a/lib/src/bootstrap/browser.dart
+++ b/lib/src/bootstrap/browser.dart
@@ -13,7 +13,8 @@ import "../util/stack_trace_mapper.dart";
 void internalBootstrapBrowserTest(Function getMain()) {
   var channel =
       serializeSuite(getMain, hidePrints: false, beforeLoad: () async {
-    var serialized = await suiteChannel("test.browser.mapper").stream.first;
+    var serialized =
+        await suiteChannel("test.browser.mapper").stream.first as Map;
     if (serialized == null) return;
     setStackTraceMapper(StackTraceMapper.deserialize(serialized));
   });

--- a/lib/src/bootstrap/node.dart
+++ b/lib/src/bootstrap/node.dart
@@ -14,7 +14,7 @@ void internalBootstrapNodeTest(Function getMain()) {
   var channel = serializeSuite(getMain, beforeLoad: () async {
     var serialized = await suiteChannel("test.node.mapper").stream.first;
     if (serialized == null || serialized is! Map) return;
-    setStackTraceMapper(StackTraceMapper.deserialize(serialized));
+    setStackTraceMapper(StackTraceMapper.deserialize(serialized as Map));
   });
   socketChannel().pipe(channel);
 }

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -51,7 +51,7 @@ bool get _usesTransformer {
   if (transformers == null) return false;
   if (transformers is! List) return false;
 
-  return transformers.any((transformer) {
+  return (transformers as List).any((transformer) {
     if (transformer is String) return transformer == 'test/pub_serve';
     if (transformer is! Map) return false;
     if (transformer.keys.length != 1) return false;

--- a/lib/src/frontend/async_matcher.dart
+++ b/lib/src/frontend/async_matcher.dart
@@ -44,7 +44,8 @@ abstract class AsyncMatcher extends Matcher {
       Invoker.current.addOutstandingCallback();
       result.then((realResult) {
         // ignore: deprecated_member_use
-        if (realResult != null) fail(formatFailure(this, item, realResult));
+        if (realResult != null)
+          fail(formatFailure(this, item, realResult as String));
         Invoker.current.removeOutstandingCallback();
       });
     } else if (result is String) {
@@ -57,5 +58,5 @@ abstract class AsyncMatcher extends Matcher {
 
   Description describeMismatch(
           item, Description description, Map matchState, bool verbose) =>
-      new StringDescription(matchState[this]);
+      new StringDescription(matchState[this] as String);
 }

--- a/lib/src/frontend/async_matcher.dart
+++ b/lib/src/frontend/async_matcher.dart
@@ -43,9 +43,10 @@ abstract class AsyncMatcher extends Matcher {
     if (result is Future) {
       Invoker.current.addOutstandingCallback();
       result.then((realResult) {
-        // ignore: deprecated_member_use
-        if (realResult != null)
+        if (realResult != null) {
+          // ignore: deprecated_member_use
           fail(formatFailure(this, item, realResult as String));
+        }
         Invoker.current.removeOutstandingCallback();
       });
     } else if (result is String) {

--- a/lib/src/frontend/expect.dart
+++ b/lib/src/frontend/expect.dart
@@ -131,13 +131,14 @@ Future _expect(actual, matcher,
 
     if (result is String) {
       // ignore: deprecated_member_use
-      fail(formatFailure(matcher, actual, result, reason: reason));
+      fail(formatFailure(matcher as Matcher, actual, result, reason: reason));
     } else if (result is Future) {
       Invoker.current.addOutstandingCallback();
       return result.then((realResult) {
         if (realResult == null) return;
         // ignore: deprecated_member_use
-        fail(formatFailure(matcher, actual, realResult, reason: reason));
+        fail(formatFailure(matcher as Matcher, actual, realResult as String,
+            reason: reason));
       }).whenComplete(() {
         // Always remove this, in case the failure is caught and handled
         // gracefully.
@@ -150,11 +151,12 @@ Future _expect(actual, matcher,
 
   var matchState = {};
   try {
-    if (matcher.matches(actual, matchState)) return new Future.sync(() {});
+    if ((matcher as Matcher).matches(actual, matchState))
+      return new Future.sync(() {});
   } catch (e, trace) {
     reason ??= '$e at $trace';
   }
-  fail(formatter(actual, matcher, reason, matchState, verbose));
+  fail(formatter(actual, matcher as Matcher, reason, matchState, verbose));
 }
 
 /// Convenience method for throwing a new [TestFailure] with the provided

--- a/lib/src/frontend/expect_async.dart
+++ b/lib/src/frontend/expect_async.dart
@@ -76,7 +76,7 @@ class _ExpectedFunction<T> {
   int _actualCalls = 0;
 
   /// The test invoker in which this function was wrapped.
-  Invoker get _invoker => _zone[#test.invoker];
+  Invoker get _invoker => _zone[#test.invoker] as Invoker;
 
   /// The zone in which this function was wrapped.
   final Zone _zone;

--- a/lib/src/frontend/future_matchers.dart
+++ b/lib/src/frontend/future_matchers.dart
@@ -53,7 +53,7 @@ class _Completes extends AsyncMatcher {
 
       String result;
       if (_matcher is AsyncMatcher) {
-        result = await (_matcher as AsyncMatcher).matchAsync(value);
+        result = await (_matcher as AsyncMatcher).matchAsync(value) as String;
         if (result == null) return null;
       } else {
         var matchState = {};

--- a/lib/src/frontend/prints_matcher.dart
+++ b/lib/src/frontend/prints_matcher.dart
@@ -31,10 +31,10 @@ class _Prints extends AsyncMatcher {
   // Avoid async/await so we synchronously fail if the function is
   // synchronous.
   /*FutureOr<String>*/ matchAsync(item) {
-    if (item is! Function) return "was not a Function";
+    if (item is! Function()) return "was not a unary Function";
 
     var buffer = new StringBuffer();
-    var result = runZoned(item,
+    var result = runZoned(item as Function(),
         zoneSpecification: new ZoneSpecification(print: (_, __, ____, line) {
       buffer.writeln(line);
     }));

--- a/lib/src/frontend/spawn_hybrid.dart
+++ b/lib/src/frontend/spawn_hybrid.dart
@@ -23,7 +23,7 @@ import '../utils.dart';
 // TODO(grouma) - Restore the type here and correctly flow it throughout.
 final _transformer = new StreamChannelTransformer<dynamic, dynamic>(
     new StreamTransformer.fromHandlers(handleData: (message, sink) {
-  switch (message["type"]) {
+  switch (message["type"] as String) {
     case "data":
       sink.add(message["data"]);
       break;

--- a/lib/src/frontend/stream_matchers.dart
+++ b/lib/src/frontend/stream_matchers.dart
@@ -56,7 +56,7 @@ StreamMatcher emitsError(matcher) {
   var throwsMatcher = throwsA(wrapped) as AsyncMatcher;
 
   return new StreamMatcher(
-      (queue) => throwsMatcher.matchAsync(queue.next),
+      (queue) => throwsMatcher.matchAsync(queue.next) as Future<String>,
       // TODO(nweiz): add "should" once matcher#42 is fixed.
       "emit an error that $matcherDescription");
 }

--- a/lib/src/runner.dart
+++ b/lib/src/runner.dart
@@ -299,7 +299,7 @@ class Runner {
     var unknownTags = <String, List<GroupEntry>>{};
     var currentTags = new Set<String>();
 
-    collect(entry) {
+    collect(GroupEntry entry) {
       var newTags = new Set<String>();
       for (var unknownTag
           in entry.metadata.tags.difference(_config.knownTags)) {
@@ -309,9 +309,10 @@ class Runner {
       }
 
       if (entry is! Group) return;
+      var group = entry as Group;
 
       currentTags.addAll(newTags);
-      for (var child in entry.entries) {
+      for (var child in group.entries) {
         collect(child);
       }
       currentTags.removeAll(newTags);
@@ -335,7 +336,7 @@ class Runner {
   /// index. This makes the tests pretty tests across shards, and since the
   /// tests are continuous, makes us more likely to be able to re-use
   /// `setUpAll()` logic.
-  Suite _shardSuite(Suite suite) {
+  T _shardSuite<T extends Suite>(T suite) {
     if (_config.totalShards == null) return suite;
 
     var shardSize = suite.group.testCount / _config.totalShards;
@@ -348,7 +349,7 @@ class Runner {
       return count >= shardStart && count < shardEnd;
     });
 
-    return filtered;
+    return filtered as T;
   }
 
   /// Loads each suite in [suites] in order, pausing after load for runtimes
@@ -368,6 +369,6 @@ class Runner {
       _suiteSubscription.asFuture().then((_) => _engine.suiteSink.close()),
       _engine.run()
     ], eagerError: true);
-    return results.last;
+    return results.last as Future<bool>;
   }
 }

--- a/lib/src/runner.dart
+++ b/lib/src/runner.dart
@@ -369,6 +369,6 @@ class Runner {
       _suiteSubscription.asFuture().then((_) => _engine.suiteSink.close()),
       _engine.run()
     ], eagerError: true);
-    return results.last as Future<bool>;
+    return results.last as bool;
   }
 }

--- a/lib/src/runner/browser/browser.dart
+++ b/lib/src/runner/browser/browser.dart
@@ -107,7 +107,7 @@ abstract class Browser {
       }
 
       _onExitCompleter.complete();
-    }, onError: (error, stackTrace) {
+    }, onError: (error, StackTrace stackTrace) {
       // Ignore any errors after the browser has been closed.
       if (_closed) return;
 

--- a/lib/src/runner/browser/browser_manager.dart
+++ b/lib/src/runner/browser/browser_manager.dart
@@ -109,7 +109,7 @@ class BrowserManager {
     browser.onExit.then((_) {
       throw new ApplicationException(
           "${runtime.name} exited before connecting.");
-    }).catchError((error, stackTrace) {
+    }).catchError((error, StackTrace stackTrace) {
       if (completer.isCompleted) return;
       completer.completeError(error, stackTrace);
     });
@@ -117,7 +117,7 @@ class BrowserManager {
     future.then((webSocket) {
       if (completer.isCompleted) return;
       completer.complete(new BrowserManager._(browser, runtime, webSocket));
-    }).catchError((error, stackTrace) {
+    }).catchError((error, StackTrace stackTrace) {
       browser.close();
       if (completer.isCompleted) return;
       completer.completeError(error, stackTrace);
@@ -183,7 +183,8 @@ class BrowserManager {
     }));
 
     _environment = _loadBrowserEnvironment();
-    _channel.stream.listen((message) => _onMessage(message), onDone: close);
+    _channel.stream
+        .listen((message) => _onMessage(message as Map), onDone: close);
   }
 
   /// Loads [_BrowserEnvironment].
@@ -210,7 +211,7 @@ class BrowserManager {
     })));
 
     var suiteID = _suiteID++;
-    var controller;
+    RunnerSuiteController controller;
     closeIframe() {
       if (_closed) return;
       _controllers.remove(controller);
@@ -270,7 +271,7 @@ class BrowserManager {
 
   /// The callback for handling messages received from the host page.
   void _onMessage(Map message) {
-    switch (message["command"]) {
+    switch (message["command"] as String) {
       case "ping":
         break;
 

--- a/lib/src/runner/browser/platform.dart
+++ b/lib/src/runner/browser/platform.dart
@@ -232,7 +232,7 @@ class BrowserPlatform extends PlatformPlugin
           '</script>.');
     }
 
-    var suiteUrl;
+    Uri suiteUrl;
     if (_config.pubServeUrl != null) {
       var suitePrefix = p
           .toUri(

--- a/lib/src/runner/compiler_pool.dart
+++ b/lib/src/runner/compiler_pool.dart
@@ -113,9 +113,9 @@ class CompilerPool {
   /// URIs that are resolvable by the browser.
   void _fixSourceMap(String mapPath) {
     var map = jsonDecode(new File(mapPath).readAsStringSync());
-    var root = map['sourceRoot'];
+    var root = map['sourceRoot'] as String;
 
-    map['sources'] = map['sources'].map((source) {
+    map['sources'] = map['sources'].map((String source) {
       var url = Uri.parse(root + source);
       if (url.scheme != '' && url.scheme != 'file') return source;
       if (url.path.endsWith("/runInBrowser.dart")) return "";

--- a/lib/src/runner/configuration.dart
+++ b/lib/src/runner/configuration.dart
@@ -188,7 +188,7 @@ class Configuration {
   ///
   /// The current configuration is set using [asCurrent].
   static Configuration get current =>
-      Zone.current[_currentKey] ?? new Configuration();
+      Zone.current[_currentKey] as Configuration ?? new Configuration();
 
   /// Parses the configuration from [args].
   ///
@@ -294,12 +294,13 @@ class Configuration {
     return configuration._resolvePresets();
   }
 
-  static Map<Object, Configuration> _withChosenPresets(
-      Map<Object, Configuration> map, Set<String> chosenPresets) {
+  static Map<String, Configuration> _withChosenPresets(
+      Map<String, Configuration> map, Set<String> chosenPresets) {
     if (map == null || chosenPresets == null) return map;
-    return mapMap(map,
-        value: (_, config) => config.change(
-            chosenPresets: config.chosenPresets.union(chosenPresets)));
+    return map.map((key, config) => new MapEntry(
+        key,
+        config.change(
+            chosenPresets: config.chosenPresets.union(chosenPresets))));
   }
 
   /// Creates new Configuration.
@@ -589,7 +590,7 @@ class Configuration {
     var newPresets = new Map<String, Configuration>.from(presets);
     var merged = chosenPresets.fold(
         empty,
-        (merged, preset) =>
+        (Configuration merged, preset) =>
             merged.merge(newPresets.remove(preset) ?? Configuration.empty));
 
     if (merged == empty) return this;

--- a/lib/src/runner/configuration/args.dart
+++ b/lib/src/runner/configuration/args.dart
@@ -168,19 +168,21 @@ class _Parser {
         .toList()
           ..addAll(_options['plain-name'] as List<String>);
 
-    var includeTagSet = new Set.from(_options['tags'] ?? [])
-      ..addAll(_options['tag'] ?? []);
+    var includeTagSet = new Set.from(_options['tags'] as Iterable ?? [])
+      ..addAll(_options['tag'] as Iterable ?? []);
 
-    var includeTags = includeTagSet.fold(BooleanSelector.all, (selector, tag) {
-      var tagSelector = new BooleanSelector.parse(tag);
+    var includeTags = includeTagSet.fold(BooleanSelector.all,
+        (BooleanSelector selector, tag) {
+      var tagSelector = new BooleanSelector.parse(tag as String);
       return selector.intersection(tagSelector);
     });
 
-    var excludeTagSet = new Set.from(_options['exclude-tags'] ?? [])
-      ..addAll(_options['exclude-tag'] ?? []);
+    var excludeTagSet = new Set.from(_options['exclude-tags'] as Iterable ?? [])
+      ..addAll(_options['exclude-tag'] as Iterable ?? []);
 
-    var excludeTags = excludeTagSet.fold(BooleanSelector.none, (selector, tag) {
-      var tagSelector = new BooleanSelector.parse(tag);
+    var excludeTags = excludeTagSet.fold(BooleanSelector.none,
+        (BooleanSelector selector, tag) {
+      var tagSelector = new BooleanSelector.parse(tag as String);
       return selector.union(tagSelector);
     });
 
@@ -208,7 +210,7 @@ class _Parser {
         color: _ifParsed('color'),
         configurationPath: _ifParsed('configuration'),
         dart2jsPath: _ifParsed('dart2js-path'),
-        dart2jsArgs: _ifParsed('dart2js-args') as List<String>,
+        dart2jsArgs: _ifParsed('dart2js-args'),
         precompiledPath: _ifParsed('precompiled'),
         reporter: _ifParsed('reporter'),
         pubServePort: _parseOption('pub-serve', int.parse),
@@ -217,11 +219,11 @@ class _Parser {
         totalShards: totalShards,
         timeout: _parseOption('timeout', (value) => new Timeout.parse(value)),
         patterns: patterns,
-        runtimes: (_ifParsed('platform') as List<String>)
+        runtimes: _ifParsed<List<String>>('platform')
             ?.map((runtime) => new RuntimeSelection(runtime))
             ?.toList(),
         runSkipped: _ifParsed('run-skipped'),
-        chosenPresets: _ifParsed('preset') as List<String>,
+        chosenPresets: _ifParsed('preset'),
         paths: _options.rest.isEmpty ? null : _options.rest,
         includeTags: includeTags,
         excludeTags: excludeTags,
@@ -233,7 +235,8 @@ class _Parser {
   /// If the user hasn't explicitly chosen a value, we want to pass null values
   /// to [new Configuration] so that it considers those fields unset when
   /// merging with configuration from the config file.
-  _ifParsed(String name) => _options.wasParsed(name) ? _options[name] : null;
+  T _ifParsed<T>(String name) =>
+      _options.wasParsed(name) ? _options[name] as T : null;
 
   /// Runs [parse] on the value of the option [name], and wraps any
   /// [FormatException] it throws with additional information.

--- a/lib/src/runner/configuration/suite.dart
+++ b/lib/src/runner/configuration/suite.dart
@@ -288,7 +288,7 @@ class SuiteConfiguration {
             retry: retry,
             skipReason: skipReason,
             testOn: testOn,
-            tags: addTags.toSet()));
+            tags: addTags?.toSet()));
     return config._resolveTags();
   }
 

--- a/lib/src/runner/configuration/suite.dart
+++ b/lib/src/runner/configuration/suite.dart
@@ -87,8 +87,9 @@ class SuiteConfiguration {
   Metadata get metadata {
     if (tags.isEmpty && onPlatform.isEmpty) return _metadata;
     return _metadata.change(
-        forTag: mapMap(tags, value: (_, config) => config.metadata),
-        onPlatform: mapMap(onPlatform, value: (_, config) => config.metadata));
+        forTag: tags.map((key, config) => new MapEntry(key, config.metadata)),
+        onPlatform: onPlatform
+            .map((key, config) => new MapEntry(key, config.metadata)));
   }
 
   final Metadata _metadata;
@@ -197,10 +198,10 @@ class SuiteConfiguration {
   /// [metadata].
   factory SuiteConfiguration.fromMetadata(Metadata metadata) =>
       new SuiteConfiguration._(
-          tags: mapMap(metadata.forTag,
-              value: (_, child) => new SuiteConfiguration.fromMetadata(child)),
-          onPlatform: mapMap(metadata.onPlatform,
-              value: (_, child) => new SuiteConfiguration.fromMetadata(child)),
+          tags: metadata.forTag.map((key, child) =>
+              new MapEntry(key, new SuiteConfiguration.fromMetadata(child))),
+          onPlatform: metadata.onPlatform.map((key, child) =>
+              new MapEntry(key, new SuiteConfiguration.fromMetadata(child))),
           metadata: metadata.change(forTag: {}, onPlatform: {}));
 
   /// Returns an unmodifiable copy of [input].
@@ -287,7 +288,7 @@ class SuiteConfiguration {
             retry: retry,
             skipReason: skipReason,
             testOn: testOn,
-            tags: addTags));
+            tags: addTags.toSet()));
     return config._resolveTags();
   }
 
@@ -346,7 +347,7 @@ class SuiteConfiguration {
 
     // Otherwise, resolve the tag-specific components.
     var newTags = new Map<BooleanSelector, SuiteConfiguration>.from(tags);
-    var merged = tags.keys.fold(empty, (merged, selector) {
+    var merged = tags.keys.fold(empty, (SuiteConfiguration merged, selector) {
       if (!selector.evaluate(_metadata.tags)) return merged;
       return merged.merge(newTags.remove(selector));
     });

--- a/lib/src/runner/engine.dart
+++ b/lib/src/runner/engine.dart
@@ -62,7 +62,7 @@ class Engine {
   /// This is `null` if close hasn't been called and the tests are still
   /// running, `true` if close was called before the tests finished running, and
   /// `false` if the tests finished running before close was called.
-  var _closedBeforeDone;
+  bool _closedBeforeDone;
 
   /// A pool that limits the number of test suites running concurrently.
   final Pool _runPool;
@@ -255,7 +255,7 @@ class Engine {
       _group.add(() async {
         var loadResource = await _loadPool.request();
 
-        var controller;
+        LiveSuiteController controller;
         if (suite is LoadSuite) {
           await _onUnpaused;
           controller = await _addLoadSuite(suite);
@@ -314,7 +314,7 @@ class Engine {
           if (entry is Group) {
             await _runGroup(suiteController, entry, parents);
           } else if (!suiteConfig.runSkipped && entry.metadata.skip) {
-            await _runSkippedTest(suiteController, entry, parents);
+            await _runSkippedTest(suiteController, entry as Test, parents);
           } else {
             var test = entry as Test;
             await _runLiveTest(suiteController,
@@ -390,7 +390,7 @@ class Engine {
     var skipped =
         new LocalTest(test.name, test.metadata, () {}, trace: test.trace);
 
-    var controller;
+    LiveTestController controller;
     controller =
         new LiveTestController(suiteController.liveSuite.suite, skipped, () {
       controller.setState(const State(Status.running, Result.success));

--- a/lib/src/runner/executable_settings.dart
+++ b/lib/src/runner/executable_settings.dart
@@ -74,9 +74,10 @@ class ExecutableSettings {
     List<String> arguments;
     var argumentsNode = settings.nodes["arguments"];
     if (argumentsNode != null) {
-      if (argumentsNode.value is String) {
+      var value = argumentsNode.value;
+      if (value is String) {
         try {
-          arguments = shellSplit(argumentsNode.value);
+          arguments = shellSplit(value);
         } on FormatException catch (error) {
           throw new SourceSpanFormatException(
               error.message, argumentsNode.span);
@@ -92,14 +93,16 @@ class ExecutableSettings {
     String windowsExecutable;
     var executableNode = settings.nodes["executable"];
     if (executableNode != null) {
-      if (executableNode.value is String) {
+      var value = executableNode.value;
+      if (value is String) {
         // Don't check this on Windows because people may want to set relative
         // paths in their global config.
-        if (!Platform.isWindows) _assertNotRelative(executableNode);
+        if (!Platform.isWindows)
+          _assertNotRelative(executableNode as YamlScalar);
 
-        linuxExecutable = executableNode.value;
-        macOSExecutable = executableNode.value;
-        windowsExecutable = executableNode.value;
+        linuxExecutable = value;
+        macOSExecutable = value;
+        windowsExecutable = value;
       } else if (executableNode is YamlMap) {
         linuxExecutable = _getExecutable(executableNode.nodes["linux"]);
         macOSExecutable = _getExecutable(executableNode.nodes["mac_os"]);
@@ -114,8 +117,9 @@ class ExecutableSettings {
     var headless = true;
     var headlessNode = settings.nodes["headless"];
     if (headlessNode != null) {
-      if (headlessNode.value is bool) {
-        headless = headlessNode.value;
+      var value = headlessNode.value;
+      if (value is bool) {
+        headless = value;
       } else {
         throw new SourceSpanFormatException(
             "Must be a boolean.", headlessNode.span);
@@ -141,8 +145,8 @@ class ExecutableSettings {
       throw new SourceSpanFormatException(
           "Must be a string.", executableNode.span);
     }
-    if (!allowRelative) _assertNotRelative(executableNode);
-    return executableNode.value;
+    if (!allowRelative) _assertNotRelative(executableNode as YamlScalar);
+    return executableNode.value as String;
   }
 
   /// Throws a [SourceSpanFormatException] if [executableNode]'s value is a

--- a/lib/src/runner/load_exception.dart
+++ b/lib/src/runner/load_exception.dart
@@ -54,8 +54,9 @@ class LoadException implements Exception {
       innerString = innerString.split("Stack Trace:\n").first.trim();
     }
     if (innerError is SourceSpanException) {
-      innerString =
-          innerError.toString(color: color).replaceFirst(" of $path", "");
+      innerString = (innerError as SourceSpanException)
+          .toString(color: color)
+          .replaceFirst(" of $path", "");
     }
 
     buffer.write(innerString.contains("\n") ? "\n" : " ");

--- a/lib/src/runner/load_suite.dart
+++ b/lib/src/runner/load_suite.dart
@@ -167,7 +167,7 @@ class LoadSuite extends Suite implements RunnerSuite {
       if (pair == null) return null;
 
       var zone = pair.last;
-      var newSuite;
+      RunnerSuite newSuite;
       zone.runGuarded(() {
         newSuite = change(pair.first);
       });

--- a/lib/src/runner/remote_listener.dart
+++ b/lib/src/runner/remote_listener.dart
@@ -68,7 +68,7 @@ class RemoteListener {
     new SuiteChannelManager().asCurrent(() {
       new StackTraceFormatter().asCurrent(() {
         runZoned(() async {
-          var main;
+          dynamic main;
           try {
             main = getMain();
           } on NoSuchMethodError catch (_) {
@@ -96,30 +96,31 @@ class RemoteListener {
 
           queue.rest.listen((message) {
             assert(message["type"] == "suiteChannel");
-            SuiteChannelManager.current.connectIn(
-                message['name'], channel.virtualChannel(message['id']));
+            SuiteChannelManager.current.connectIn(message['name'] as String,
+                channel.virtualChannel(message['id']));
           });
 
-          if (message['asciiGlyphs'] ?? false) glyph.ascii = true;
+          if ((message['asciiGlyphs'] as bool) ?? false) glyph.ascii = true;
           var metadata = new Metadata.deserialize(message['metadata']);
           verboseChain = metadata.verboseTrace;
           var declarer = new Declarer(
               metadata: metadata,
-              platformVariables: new Set.from(message['platformVariables']),
-              collectTraces: message['collectTraces'],
-              noRetry: message['noRetry']);
+              platformVariables:
+                  new Set.from(message['platformVariables'] as Iterable),
+              collectTraces: message['collectTraces'] as bool,
+              noRetry: message['noRetry'] as bool);
 
           StackTraceFormatter.current.configure(
-              except: _deserializeSet(message['foldTraceExcept']),
-              only: _deserializeSet(message['foldTraceOnly']));
+              except: _deserializeSet(message['foldTraceExcept'] as List),
+              only: _deserializeSet(message['foldTraceOnly'] as List));
 
           if (beforeLoad != null) await beforeLoad();
 
-          await declarer.declare(main);
+          await declarer.declare(main as Function());
 
           var suite = new Suite(declarer.build(),
               new SuitePlatform.deserialize(message['platform']),
-              path: message['path']);
+              path: message['path'] as String);
 
           runZoned(() {
             Invoker.guard(
@@ -129,7 +130,7 @@ class RemoteListener {
               // useful errors when calling `test()` and `group()` within a test,
               // and so they can add to the declarer's `tearDownAll()` list.
               zoneValues: {#test.declarer: declarer});
-        }, onError: (error, stackTrace) {
+        }, onError: (error, StackTrace stackTrace) {
           _sendError(channel, error, stackTrace, verboseChain);
         }, zoneSpecification: spec);
       });
@@ -191,7 +192,7 @@ class RemoteListener {
       "entries": group.entries.map((entry) {
         return entry is Group
             ? _serializeGroup(channel, entry, parents)
-            : _serializeTest(channel, entry, parents);
+            : _serializeTest(channel, entry as Test, parents);
       }).toList()
     };
   }

--- a/lib/src/runner/reporter/compact.dart
+++ b/lib/src/runner/reporter/compact.dart
@@ -212,7 +212,8 @@ class CompactReporter implements Reporter {
       return;
     }
 
-    print(indent(error.toString(color: _config.color)));
+    // TODO - what type is this?
+    print(indent(error.toString(color: _config.color) as String));
 
     // Only print stack traces for load errors that come from the user's code.
     if (error.innerError is! IOException &&

--- a/lib/src/runner/reporter/expanded.dart
+++ b/lib/src/runner/reporter/expanded.dart
@@ -200,7 +200,8 @@ class ExpandedReporter implements Reporter {
       return;
     }
 
-    print(indent(error.toString(color: _color)));
+    // TODO - what type is this?
+    print(indent((error as dynamic).toString(color: _color) as String));
 
     // Only print stack traces for load errors that come from the user's code.
     if (error.innerError is! IsolateSpawnException &&

--- a/lib/src/runner/runner_test.dart
+++ b/lib/src/runner/runner_test.dart
@@ -32,8 +32,8 @@ class RunnerTest extends Test {
   RunnerTest._(this.name, this.metadata, this.trace, this._channel);
 
   LiveTest load(Suite suite, {Iterable<Group> groups}) {
-    var controller;
-    var testChannel;
+    LiveTestController controller;
+    VirtualChannel testChannel;
     controller = new LiveTestController(suite, this, () {
       controller.setState(const State(Status.running, Result.success));
 
@@ -41,7 +41,7 @@ class RunnerTest extends Test {
       _channel.sink.add({'command': 'run', 'channel': testChannel.id});
 
       testChannel.stream.listen((message) {
-        switch (message['type']) {
+        switch (message['type'] as String) {
           case 'error':
             var asyncError = RemoteException.deserialize(message['error']);
             var stackTrace = asyncError.stackTrace;
@@ -49,14 +49,15 @@ class RunnerTest extends Test {
             break;
 
           case 'state-change':
-            controller.setState(new State(new Status.parse(message['status']),
-                new Result.parse(message['result'])));
+            controller.setState(new State(
+                new Status.parse(message['status'] as String),
+                new Result.parse(message['result'] as String)));
             break;
 
           case 'message':
             controller.message(new Message(
-                new MessageType.parse(message['message-type']),
-                message['text']));
+                new MessageType.parse(message['message-type'] as String),
+                message['text'] as String));
             break;
 
           case 'complete':
@@ -67,7 +68,7 @@ class RunnerTest extends Test {
             // When we kill the isolate that the test lives in, that will close
             // this virtual channel and cause the spawned isolate to close as
             // well.
-            spawnHybridUri(message['url'], message['message'])
+            spawnHybridUri(message['url'] as String, message['message'])
                 .pipe(testChannel.virtualChannel(message['channel']));
             break;
         }

--- a/lib/src/runner/version.dart
+++ b/lib/src/runner/version.dart
@@ -29,7 +29,7 @@ final String testVersion = (() {
   var source = package["source"];
   if (source is! String) return null;
 
-  switch (source) {
+  switch (source as String) {
     case "hosted":
       var version = package["version"];
       if (version is! String) return null;

--- a/lib/src/runner/vm/catch_isolate_errors.dart
+++ b/lib/src/runner/vm/catch_isolate_errors.dart
@@ -17,9 +17,10 @@ void catchIsolateErrors() {
   errorPort.listen((message) {
     // Masquerade as an IsolateSpawnException because that's what this would
     // be if the error had been detected statically.
-    var error = new IsolateSpawnException(message[0]);
-    var stackTrace =
-        message[1] == null ? new Trace([]) : new Trace.parse(message[1]);
+    var error = new IsolateSpawnException(message[0] as String);
+    var stackTrace = message[1] == null
+        ? new Trace([])
+        : new Trace.parse(message[1] as String);
     Zone.current.handleUncaughtError(error, stackTrace);
   });
 }

--- a/lib/src/util/remote_exception.dart
+++ b/lib/src/util/remote_exception.dart
@@ -67,16 +67,16 @@ class RemoteException implements Exception {
   /// error and a [Chain] as its stack trace.
   static AsyncError deserialize(serialized) {
     return new AsyncError(_deserializeException(serialized),
-        new Chain.parse(serialized['stackChain']));
+        new Chain.parse(serialized['stackChain'] as String));
   }
 
   /// Deserializes the exception portion of [serialized].
   static RemoteException _deserializeException(serialized) {
-    var message = serialized['message'];
-    var type = serialized['type'];
-    var toString = serialized['toString'];
+    String message = serialized['message'];
+    String type = serialized['type'];
+    String toString = serialized['toString'];
 
-    switch (serialized['supertype']) {
+    switch (serialized['supertype'] as String) {
       case 'TestFailure':
         return new _RemoteTestFailure(message, type, toString);
       case 'IsolateSpawnException':

--- a/lib/src/util/stack_trace_mapper.dart
+++ b/lib/src/util/stack_trace_mapper.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:collection/collection.dart';
 import 'package:package_resolver/package_resolver.dart';
 import 'package:source_map_stack_trace/source_map_stack_trace.dart' as mapper;
 import 'package:source_maps/source_maps.dart';
@@ -56,13 +55,15 @@ class StackTraceMapper {
   static StackTraceMapper deserialize(Map serialized) {
     if (serialized == null) return null;
     String packageRoot = serialized['packageRoot'] as String ?? '';
-    return new StackTraceMapper(serialized['mapContents'],
-        sdkRoot: Uri.parse(serialized['sdkRoot']),
+    return new StackTraceMapper(serialized['mapContents'] as String,
+        sdkRoot: Uri.parse(serialized['sdkRoot'] as String),
         packageResolver: packageRoot.isNotEmpty
-            ? new SyncPackageResolver.root(Uri.parse(serialized['packageRoot']))
+            ? new SyncPackageResolver.root(
+                Uri.parse(serialized['packageRoot'] as String))
             : new SyncPackageResolver.config(_deserializePackageConfigMap(
-                serialized['packageConfigMap'].cast<String, String>())),
-        mapUrl: Uri.parse(serialized['mapUrl']));
+                (serialized['packageConfigMap'] as Map)
+                    .cast<String, String>())),
+        mapUrl: Uri.parse(serialized['mapUrl'] as String));
   }
 
   /// Converts a [packageConfigMap] into a format suitable for JSON
@@ -70,7 +71,7 @@ class StackTraceMapper {
   static Map<String, String> _serializePackageConfigMap(
       Map<String, Uri> packageConfigMap) {
     if (packageConfigMap == null) return null;
-    return mapMap(packageConfigMap, value: (_, value) => '$value');
+    return packageConfigMap.map((key, value) => new MapEntry(key, '$value'));
   }
 
   /// Converts a serialized package config map into a format suitable for
@@ -78,6 +79,6 @@ class StackTraceMapper {
   static Map<String, Uri> _deserializePackageConfigMap(
       Map<String, String> serialized) {
     if (serialized == null) return null;
-    return mapMap(serialized, value: (_, value) => Uri.parse(value));
+    return serialized.map((key, value) => new MapEntry(key, Uri.parse(value)));
   }
 }

--- a/lib/src/util/string_literal_iterator.dart
+++ b/lib/src/util/string_literal_iterator.dart
@@ -89,8 +89,7 @@ class StringLiteralIterator extends Iterator<int> {
         if (string is StringInterpolation) {
           throw new ArgumentError("Can't iterate over an interpolated string.");
         }
-        assert(string is SimpleStringLiteral);
-        _strings.add(string);
+        _strings.add(string as SimpleStringLiteral);
       }
     }
 

--- a/test/frontend/matcher/prints_test.dart
+++ b/test/frontend/matcher/prints_test.dart
@@ -90,7 +90,7 @@ void main() {
           liveTest,
           "Expected: prints contains 'Goodbye'\n"
           "  Actual: <10>\n"
-          "   Which: was not a Function\n");
+          "   Which: was not a unary Function\n");
     });
   });
 


### PR DESCRIPTION
There are still errors in tests which may be harder to fix so we can't
check in the change to analysis options.

This should make it easier to diagnose Dart 2 semantic issues as more of
the places where there can be failures are explicit.

Most of the changes are just adding explicit `as` statements and keeping
the semantics that already existed. In a few places an uninitialized
`var` is given a type, and in others a reused variable name with
different types is split into multiple variables.

The changes in the frontend code are the most risky, since some users
might still be using that code in a non Dart 2 runtime and relying on
looseness which is lost with an explicit cast.