### PR TITLE
Fixes for latest SDK (dev.61 - default sync-async)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: dart
 sudo: required
 
 dart:
- - 2.0.0-dev.60.0
+ - dev
 
 env: FORCE_TEST_EXIT=true
 

--- a/lib/src/runner/configuration.dart
+++ b/lib/src/runner/configuration.dart
@@ -294,8 +294,8 @@ class Configuration {
     return configuration._resolvePresets();
   }
 
-  static Map<Object, Configuration> _withChosenPresets(
-      Map<Object, Configuration> map, Set<String> chosenPresets) {
+  static Map<String, Configuration> _withChosenPresets(
+      Map<String, Configuration> map, Set<String> chosenPresets) {
     if (map == null || chosenPresets == null) return map;
     return mapMap(map,
         value: (_, config) => config.change(

--- a/lib/src/runner/engine.dart
+++ b/lib/src/runner/engine.dart
@@ -528,7 +528,7 @@ class Engine {
   /// the engine indicates that no more output should be emitted.
   Future close() async {
     // TODO(grouma) - Remove this unecessary await.
-    await null;
+    await new Future(() {});
     _closed = true;
     if (_closedBeforeDone != null) _closedBeforeDone = true;
     _onSuiteAddedController.close();

--- a/lib/src/runner/engine.dart
+++ b/lib/src/runner/engine.dart
@@ -527,6 +527,8 @@ class Engine {
   /// Closing [suiteSink] indicates that no more input will be provided, closing
   /// the engine indicates that no more output should be emitted.
   Future close() async {
+    // TODO(grouma) - Remove this unecessary await.
+    await null;
     _closed = true;
     if (_closedBeforeDone != null) _closedBeforeDone = true;
     _onSuiteAddedController.close();

--- a/test/runner/compact_reporter_test.dart
+++ b/test/runner/compact_reporter_test.dart
@@ -76,7 +76,7 @@ void main() {
 
     var test =
         await runTest(["--verbose-trace", "test.dart"], reporter: "compact");
-    expect(test.stdout, emitsThrough(contains("dart:isolate-patch")));
+    expect(test.stdout, emitsThrough(contains("dart:async")));
     await test.shouldExit(1);
   });
 

--- a/test/runner/configuration/top_level_test.dart
+++ b/test/runner/configuration/top_level_test.dart
@@ -129,7 +129,7 @@ void main() {
     """).create();
 
     var test = await runTest(["test.dart"]);
-    expect(test.stdout, emitsThrough(contains("dart:isolate-patch")));
+    expect(test.stdout, emitsThrough(contains("dart:async")));
     await test.shouldExit(1);
   });
 

--- a/test/runner/expanded_reporter_test.dart
+++ b/test/runner/expanded_reporter_test.dart
@@ -67,7 +67,7 @@ void main() {
 """).create();
 
     var test = await runTest(["--verbose-trace", "test.dart"]);
-    expect(test.stdout, emitsThrough(contains("dart:isolate-patch")));
+    expect(test.stdout, emitsThrough(contains("dart:async")));
     await test.shouldExit(1);
   });
 


### PR DESCRIPTION
More towards https://github.com/dart-lang/test/issues/842

- The SDK has changed the stack traces so look for another identifier on verbose traces
- sync-async is now on by default so add in an additional await to make some tests pass. Why this is necessary should be investigated. Tracking with: https://github.com/dart-lang/test/issues/865