### PR TITLE
Remove Travis hack

### DIFF
--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -188,12 +188,6 @@ transformers:
   } finally {
     await close();
   }
-
-  // TODO(grouma) - figure out why the executable can hang in the travis
-  // environment. https://github.com/dart-lang/test/issues/599
-  if (Platform.environment["FORCE_TEST_EXIT"] == "true") {
-    exit(exitCode);
-  }
 }
 
 /// Print usage information for this command.


### PR DESCRIPTION
Towards https://github.com/dart-lang/test/issues/599

-  Remove odd browser kill logic. The hypothesis is that it puts Chrome in an odd state that results in the exitCode future never completing.
- Add a timeout to the browser close function and throw if it does not complete.