### PR TITLE
Enable check for implicit casts

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,14 +1,17 @@
 analyzer:
-  strong-mode: true
-# Upgrade lints to errors that will break Google3
-errors:
-  unused_element: error
-  unused_import: error
-  unused_local_variable: error
-  dead_code: error
-  ### Useful to uncomment during development to remove the noise of the many
-  ### deprecated APIs.
-  # deprecated_member_use: ignore
+  strong-mode:
+    implicit-casts: false
+  errors:
+    # Remove noise from workspace diagnostics lists
+    todo: ignore
+    # Upgrade lints to errors that will break Google3
+    unused_element: error
+    unused_import: error
+    unused_local_variable: error
+    dead_code: error
+    ### Useful to uncomment during development to remove the noise of the many
+    ### deprecated APIs.
+    # deprecated_member_use: ignore
 linter:
   rules:
     - await_only_futures

--- a/test/backend/declarer_test.dart
+++ b/test/backend/declarer_test.dart
@@ -32,7 +32,7 @@ void main() {
       expect(tests, hasLength(1));
       expect(tests.single.name, equals("description"));
 
-      await _runTest(tests[0]);
+      await _runTest(tests[0] as Test);
       expect(bodyRun, isTrue);
     });
 
@@ -79,8 +79,8 @@ void main() {
             }, max: 1));
       });
 
-      await _runTest(tests[0]);
-      await _runTest(tests[1]);
+      await _runTest(tests[0] as Test);
+      await _runTest(tests[1] as Test);
     });
 
     test("can return a Future", () {
@@ -97,7 +97,7 @@ void main() {
             }, max: 1));
       });
 
-      return _runTest(tests.single);
+      return _runTest(tests.single as Test);
     });
 
     test("runs in call order within a group", () async {
@@ -130,7 +130,7 @@ void main() {
         }));
       });
 
-      await _runTest(tests.single);
+      await _runTest(tests.single as Test);
     });
   });
 
@@ -154,9 +154,9 @@ void main() {
             }, max: 1));
       });
 
-      await _runTest(tests[0]);
+      await _runTest(tests[0] as Test);
       expect(tearDownRun, isTrue);
-      await _runTest(tests[1]);
+      await _runTest(tests[1] as Test);
       expect(tearDownRun, isTrue);
     });
 
@@ -174,7 +174,7 @@ void main() {
             }, max: 1));
       });
 
-      await _runTest(tests.single, shouldFail: true);
+      await _runTest(tests.single as Test, shouldFail: true);
       expect(tearDownRun, isTrue);
     });
 
@@ -192,7 +192,7 @@ void main() {
             }, max: 1));
       });
 
-      await _runTest(tests.single);
+      await _runTest(tests.single as Test);
       expect(tearDownRun, isTrue);
     });
 
@@ -213,7 +213,7 @@ void main() {
         });
       });
 
-      await _runTest(tests.single);
+      await _runTest(tests.single as Test);
       expect(outstandingCallbackRemovedBeforeTeardown, isTrue);
     });
 
@@ -231,7 +231,7 @@ void main() {
         test("description", () {});
       });
 
-      await _runTest(tests.single);
+      await _runTest(tests.single as Test);
       expect(outstandingCallbackRemoved, isTrue);
     });
 
@@ -267,7 +267,7 @@ void main() {
             }, max: 1));
       });
 
-      await _runTest(tests.single);
+      await _runTest(tests.single as Test);
     });
 
     test("runs further tearDowns in a group even if one fails", () async {
@@ -281,7 +281,7 @@ void main() {
         test("description", expectAsync0(() {}));
       });
 
-      await _runTest(tests.single, shouldFail: true);
+      await _runTest(tests.single as Test, shouldFail: true);
     });
 
     test("runs in the same error zone as the test", () {
@@ -410,8 +410,8 @@ void main() {
               }, max: 1));
         });
 
-        await _runTest((entries[0] as Group).entries.single);
-        await _runTest(entries[1]);
+        await _runTest((entries[0] as Group).entries.single as Test);
+        await _runTest(entries[1] as Test);
       });
 
       test("runs from the outside in", () {
@@ -452,7 +452,7 @@ void main() {
 
         var middleGroup = entries.single as Group;
         var innerGroup = middleGroup.entries.single as Group;
-        return _runTest(innerGroup.entries.single);
+        return _runTest(innerGroup.entries.single as Test);
       });
 
       test("handles Futures when chained", () {
@@ -480,7 +480,7 @@ void main() {
         });
 
         var innerGroup = entries.single as Group;
-        return _runTest(innerGroup.entries.single);
+        return _runTest(innerGroup.entries.single as Test);
       });
 
       test("inherits group's tags", () {
@@ -534,9 +534,9 @@ void main() {
         });
 
         var testGroup = entries[0] as Group;
-        await _runTest(testGroup.entries.single);
+        await _runTest(testGroup.entries.single as Test);
         expect(tearDownRun, isTrue);
-        await _runTest(entries[1]);
+        await _runTest(entries[1] as Test);
         expect(tearDownRun, isFalse);
       });
 
@@ -578,7 +578,7 @@ void main() {
 
         var middleGroup = entries.single as Group;
         var innerGroup = middleGroup.entries.single as Group;
-        await _runTest(innerGroup.entries.single);
+        await _runTest(innerGroup.entries.single as Test);
         expect(innerTearDownRun, isTrue);
         expect(middleTearDownRun, isTrue);
         expect(outerTearDownRun, isTrue);
@@ -609,7 +609,7 @@ void main() {
         });
 
         var innerGroup = entries.single as Group;
-        await _runTest(innerGroup.entries.single);
+        await _runTest(innerGroup.entries.single as Test);
         expect(innerTearDownRun, isTrue);
         expect(outerTearDownRun, isTrue);
       });
@@ -635,7 +635,7 @@ void main() {
         });
 
         var innerGroup = entries.single as Group;
-        await _runTest(innerGroup.entries.single, shouldFail: true);
+        await _runTest(innerGroup.entries.single as Test, shouldFail: true);
         expect(outerTearDownRun, isTrue);
       });
     });
@@ -649,9 +649,10 @@ void main() {
 Future _runTest(Test test, {bool shouldFail = false}) {
   var liveTest = test.load(_suite);
 
-  liveTest.onError.listen(shouldFail
+  Function(AsyncError) errorCallback = shouldFail
       ? expectAsync1((_) {})
-      : (error) => registerException(error.error, error.stackTrace));
+      : (error) => registerException(error.error, error.stackTrace);
+  liveTest.onError.listen(errorCallback);
 
   return liveTest.run();
 }

--- a/test/backend/invoker_test.dart
+++ b/test/backend/invoker_test.dart
@@ -16,7 +16,7 @@ import 'package:test/test.dart';
 import '../utils.dart';
 
 void main() {
-  var suite;
+  Suite suite;
   setUp(() {
     lastState = null;
     suite = new Suite(new Group.root([]), suitePlatform);

--- a/test/common.dart
+++ b/test/common.dart
@@ -1,3 +1,3 @@
 import 'package:test/test.dart';
 
-myTest(String name, Function testFn) => test(name, testFn);
+myTest(String name, Function() testFn) => test(name, testFn);

--- a/test/frontend/expect_async_test.dart
+++ b/test/frontend/expect_async_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
+import 'package:test/src/backend/live_test.dart';
 import 'package:test/src/backend/state.dart';
 import 'package:test/test.dart';
 
@@ -165,8 +168,8 @@ void main() {
     test(
         "won't allow the test to complete until it's called at least that "
         "many times", () async {
-      var liveTest;
-      var future;
+      LiveTest liveTest;
+      Future future;
       liveTest = createTest(() {
         var callback = expectAsync0(() {}, count: 3);
 
@@ -264,8 +267,8 @@ void main() {
   group("expectAsyncUntil()", () {
     test("won't allow the test to complete until isDone returns true",
         () async {
-      var liveTest;
-      var future;
+      LiveTest liveTest;
+      Future future;
       liveTest = createTest(() {
         var done = false;
         var callback = expectAsyncUntil0(() {}, () => done);

--- a/test/runner/browser/loader_test.dart
+++ b/test/runner/browser/loader_test.dart
@@ -15,6 +15,8 @@ import 'package:test/src/backend/test.dart';
 import 'package:test/src/runner/configuration/runtime_selection.dart';
 import 'package:test/src/runner/configuration/suite.dart';
 import 'package:test/src/runner/loader.dart';
+import 'package:test/src/runner/runner_suite.dart';
+import 'package:test/src/runner/runner_test.dart';
 import 'package:test/test.dart';
 
 import '../../utils.dart';
@@ -45,7 +47,7 @@ void main() {
   tearDown(() => _loader.close());
 
   group(".loadFile()", () {
-    var suite;
+    RunnerSuite suite;
     setUp(() async {
       var suites = await _loader
           .loadFile(p.join(d.sandbox, 'a_test.dart'), _chrome)
@@ -69,7 +71,7 @@ void main() {
     });
 
     test("can load and run a successful test", () {
-      var liveTest = suite.group.entries[0].load(suite);
+      var liveTest = (suite.group.entries[0] as RunnerTest).load(suite);
 
       expectStates(liveTest, [
         const State(Status.running, Result.success),
@@ -81,7 +83,7 @@ void main() {
     });
 
     test("can load and run a failing test", () {
-      var liveTest = suite.group.entries[1].load(suite);
+      var liveTest = (suite.group.entries[1] as RunnerTest).load(suite);
       expectSingleFailure(liveTest);
       return liveTest.run().whenComplete(() => liveTest.close());
     });

--- a/test/runner/hybrid_test.dart
+++ b/test/runner/hybrid_test.dart
@@ -268,7 +268,7 @@ void main() {
 
       // Expect that the socket disconnects at some point (presumably when the
       // isolate closes).
-      var port = await channel.stream.first;
+      var port = await channel.stream.first as int;
       var socket = await Socket.connect("localhost", port);
       expect(socket.listen(null).asFuture(), completes);
 
@@ -294,7 +294,7 @@ void main() {
 
       // Expect that the socket disconnects at some point (presumably when the
       // isolate closes).
-      var port = await channel.stream.first;
+      var port = await channel.stream.first as int;
       var socket = await Socket.connect("localhost", port);
       expect(socket.listen(null).asFuture(), completes);
       channel.sink.add(null);

--- a/test/runner/json_reporter_test.dart
+++ b/test/runner/json_reporter_test.dart
@@ -610,7 +610,7 @@ import 'package:test/test.dart';
   // TODO(nweiz): validate each event against the JSON schema when
   // patefacio/json_schema#4 is merged.
 
-  decodeLine(l) => jsonDecode(l)..remove("time")..remove("stackTrace");
+  decodeLine(String l) => jsonDecode(l)..remove("time")..remove("stackTrace");
 
   // Should contain all suites message.
   expect(stdoutLines.map(decodeLine), containsAll([_allSuites()]));

--- a/test/runner/load_suite_test.dart
+++ b/test/runner/load_suite_test.dart
@@ -18,7 +18,7 @@ import 'package:test/test.dart';
 import '../utils.dart';
 
 void main() {
-  var innerSuite;
+  RunnerSuite innerSuite;
   setUp(() {
     innerSuite = runnerSuite(new Group.root([]));
   });

--- a/test/runner/loader_test.dart
+++ b/test/runner/loader_test.dart
@@ -7,11 +7,13 @@
 import 'package:path/path.dart' as p;
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
+import 'package:test/src/backend/runtime.dart';
 import 'package:test/src/backend/state.dart';
 import 'package:test/src/backend/test.dart';
-import 'package:test/src/backend/runtime.dart';
 import 'package:test/src/runner/configuration/suite.dart';
 import 'package:test/src/runner/loader.dart';
+import 'package:test/src/runner/runner_suite.dart';
+import 'package:test/src/runner/runner_test.dart';
 import 'package:test/test.dart';
 
 import '../utils.dart';
@@ -38,7 +40,7 @@ void main() {
   tearDown(() => _loader.close());
 
   group(".loadFile()", () {
-    var suite;
+    RunnerSuite suite;
     setUp(() async {
       await d.file('a_test.dart', _tests).create();
       var suites = await _loader
@@ -62,7 +64,7 @@ void main() {
     });
 
     test("can load and run a successful test", () {
-      var liveTest = suite.group.entries[0].load(suite);
+      var liveTest = (suite.group.entries[0] as RunnerTest).load(suite);
 
       expectStates(liveTest, [
         const State(Status.running, Result.success),
@@ -74,7 +76,7 @@ void main() {
     });
 
     test("can load and run a failing test", () {
-      var liveTest = suite.group.entries[1].load(suite);
+      var liveTest = (suite.group.entries[1] as RunnerTest).load(suite);
       expectSingleFailure(liveTest);
       return liveTest.run().whenComplete(() => liveTest.close());
     });
@@ -100,7 +102,7 @@ void main() {
     });
 
     group("with suites loaded from a directory", () {
-      var suites;
+      List<RunnerSuite> suites;
       setUp(() async {
         await d.file('a_test.dart', _tests).create();
         await d.file('another_test.dart', _tests).create();
@@ -124,7 +126,7 @@ void main() {
 
       test("can run tests in those suites", () {
         var suite = suites.firstWhere((suite) => suite.path.contains("a_test"));
-        var liveTest = suite.group.entries[1].load(suite);
+        var liveTest = (suite.group.entries[1] as RunnerTest).load(suite);
         expectSingleFailure(liveTest);
         return liveTest.run().whenComplete(() => liveTest.close());
       });

--- a/test/runner/pub_serve_test.dart
+++ b/test/runner/pub_serve_test.dart
@@ -381,7 +381,8 @@ final bool _sdkSupportsDartDevc = sdkVersion >= new Version(1, 24, 0);
 /// as the first argument.
 void testWithCompiler(String name, testFn(List<String> compilerArgs), {tags}) {
   for (var compiler in _compilers) {
-    var compilerArgs = _sdkSupportsDartDevc ? ['--web-compiler', compiler] : [];
+    var compilerArgs =
+        _sdkSupportsDartDevc ? ['--web-compiler', compiler] : <String>[];
     test("$name with $compiler", () => testFn(compilerArgs), tags: tags);
   }
 }

--- a/test/util/string_literal_iterator_test.dart
+++ b/test/util/string_literal_iterator_test.dart
@@ -242,5 +242,5 @@ StringLiteralIterator _parse(String dart) {
       .declarations
       .single as TopLevelVariableDeclaration;
   var literal = declaration.variables.variables.single.initializer;
-  return new StringLiteralIterator(literal);
+  return new StringLiteralIterator(literal as StringLiteral);
 }

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -275,8 +275,8 @@ void expectTestFailed(LiveTest liveTest, message) {
 ///
 /// [stopBlocking] is passed the return value of [test].
 Future expectTestBlocks(test(), stopBlocking(value)) async {
-  var liveTest;
-  var future;
+  LiveTest liveTest;
+  Future future;
   liveTest = createTest(() {
     var value = test();
     future = pumpEventQueue().then((_) {

--- a/tool/host.dart
+++ b/tool/host.dart
@@ -119,7 +119,8 @@ void main() {
     serverChannel.stream.listen((message) {
       if (message['command'] == 'loadSuite') {
         var suiteChannel = serverChannel.virtualChannel(message['channel']);
-        var iframeChannel = _connectToIframe(message['url'], message['id']);
+        var iframeChannel =
+            _connectToIframe(message['url'] as String, message['id'] as int);
         suiteChannel.pipe(iframeChannel);
       } else if (message['command'] == 'displayPause') {
         document.body.classes.add('paused');
@@ -152,7 +153,7 @@ void main() {
     }), restartCurrent: allowInterop(() {
       serverChannel.sink.add({"command": "restart"});
     }));
-  }, onError: (error, stackTrace) {
+  }, onError: (error, StackTrace stackTrace) {
     print("$error\n${new Trace.from(stackTrace).terse}");
   });
 }
@@ -166,7 +167,7 @@ MultiChannel _connectToServer() {
 
   var controller = new StreamChannelController(sync: true);
   webSocket.onMessage.listen((message) {
-    controller.local.sink.add(jsonDecode(message.data));
+    controller.local.sink.add(jsonDecode(message.data as String));
   });
 
   controller.local.stream


### PR DESCRIPTION
- Fix syntax for upgrading errors in the analysis options
- Ignore todo hints since they are very noisy
- Enable check for implicit casts
- Fix a bunch of implicit casts in the test directory