### PR TITLE
Add types to a bunch of uninitalized variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ if a test fails, to ensure that it has a chance to clean up after itself.
 import "package:test/test.dart";
 
 void main() {
-  var server;
-  var url;
+  HttepServer server;
+  Uri url;
   setUp(() async {
     server = await HttpServer.bind('localhost', 0);
     url = Uri.parse("http://${server.address.host}:${server.port}");

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -5,6 +5,7 @@
 // TODO(nweiz): This is under lib so that it can be used by the unittest dummy
 // package. Once that package is no longer being updated, move this back into
 // bin.
+import 'dart:async';
 import 'dart:io';
 
 import 'package:async/async.dart';
@@ -38,7 +39,7 @@ bool get _usesTransformer {
   if (!new File('pubspec.yaml').existsSync()) return false;
   var contents = new File('pubspec.yaml').readAsStringSync();
 
-  var yaml;
+  dynamic yaml;
   try {
     yaml = loadYaml(contents);
   } on FormatException {
@@ -155,7 +156,7 @@ transformers:
   }
 
   Runner runner;
-  var signalSubscription;
+  StreamSubscription signalSubscription;
   close() async {
     if (signalSubscription == null) return;
     signalSubscription.cancel();

--- a/lib/src/runner.dart
+++ b/lib/src/runner.dart
@@ -89,7 +89,7 @@ class Runner {
 
         var suites = _loadSuites();
 
-        var success;
+        bool success;
         if (_config.pauseAfterLoad) {
           success = await _loadThenPause(suites);
         } else {
@@ -100,7 +100,7 @@ class Runner {
                 .then((_) => _engine.suiteSink.close()),
             _engine.run()
           ], eagerError: true);
-          success = results.last;
+          success = results.last as bool;
         }
 
         if (_closed) return false;
@@ -180,7 +180,7 @@ class Runner {
   /// currently-running VM tests, in case they have stuff to clean up on the
   /// filesystem.
   Future close() => _closeMemo.runOnce(() async {
-        var timer;
+        Timer timer;
         if (!_engine.isIdle) {
           // Wait a bit to print this message, since printing it eagerly looks weird
           // if the tests then finish immediately.

--- a/lib/src/runner/debugger.dart
+++ b/lib/src/runner/debugger.dart
@@ -26,7 +26,7 @@ import 'runner_suite.dart';
 /// any resources it allocated.
 CancelableOperation debug(
     Engine engine, Reporter reporter, LoadSuite loadSuite) {
-  var debugger;
+  _Debugger debugger;
   var canceled = false;
   return new CancelableOperation.fromFuture(() async {
     // Make the underlying suite null so that the engine doesn't start running

--- a/lib/src/runner/hybrid_listener.dart
+++ b/lib/src/runner/hybrid_listener.dart
@@ -38,7 +38,7 @@ void listen(Function getMain(), List data) {
 
   Chain.capture(() {
     runZoned(() {
-      var main;
+      dynamic /*Function*/ main;
       try {
         main = getMain();
       } on NoSuchMethodError catch (_) {

--- a/lib/src/runner/parse_metadata.dart
+++ b/lib/src/runner/parse_metadata.dart
@@ -65,7 +65,7 @@ class _Parser {
   Metadata parse() {
     Timeout timeout;
     PlatformSelector testOn;
-    var skip;
+    dynamic /*String|bool*/ skip;
     Map<PlatformSelector, Metadata> onPlatform;
     Set<String> tags;
     int retry;

--- a/lib/src/runner/version.dart
+++ b/lib/src/runner/version.dart
@@ -11,7 +11,7 @@ import 'package:yaml/yaml.dart';
 /// This is a semantic version, optionally followed by a space and additional
 /// data about its source.
 final String testVersion = (() {
-  var lockfile;
+  dynamic lockfile;
   try {
     lockfile = loadYaml(new File("pubspec.lock").readAsStringSync());
   } on FormatException catch (_) {

--- a/lib/src/runner/vm/platform.dart
+++ b/lib/src/runner/vm/platform.dart
@@ -25,7 +25,7 @@ class VMPlatform extends PlatformPlugin {
   StreamChannel loadChannel(String path, SuitePlatform platform) {
     assert(platform.runtime == Runtime.vm);
 
-    var isolate;
+    Isolate isolate;
     var channel = StreamChannelCompleter.fromFuture(() async {
       var receivePort = new ReceivePort();
 
@@ -42,7 +42,7 @@ class VMPlatform extends PlatformPlugin {
     // Once the connection is closed by either end, kill the isolate.
     return channel
         .transformStream(new StreamTransformer.fromHandlers(handleDone: (sink) {
-      if (isolate != null) isolate.kill();
+      isolate?.kill();
       sink.close();
     }));
   }

--- a/lib/src/util/remote_exception.dart
+++ b/lib/src/util/remote_exception.dart
@@ -31,7 +31,7 @@ class RemoteException implements Exception {
   /// Other than JSON- and isolate-safety, no guarantees are made about the
   /// serialized format.
   static serialize(error, StackTrace stackTrace) {
-    var message;
+    String message;
     if (error is String) {
       message = error;
     } else {
@@ -45,7 +45,7 @@ class RemoteException implements Exception {
     // It's possible (although unlikely) for a user-defined class to have
     // multiple of these supertypes. That's fine, though, since we only care
     // about core-library-raised IsolateSpawnExceptions anyway.
-    var supertype;
+    String supertype;
     if (error is TestFailure) {
       supertype = 'TestFailure';
     } else if (error is IsolateSpawnException) {

--- a/test/backend/declarer_test.dart
+++ b/test/backend/declarer_test.dart
@@ -136,7 +136,7 @@ void main() {
 
   group(".tearDown()", () {
     test("is run after all tests", () async {
-      var tearDownRun;
+      bool tearDownRun;
       var tests = declare(() {
         setUp(() => tearDownRun = false);
         tearDown(() => tearDownRun = true);
@@ -161,7 +161,7 @@ void main() {
     });
 
     test("is run after an out-of-band failure", () async {
-      var tearDownRun;
+      bool tearDownRun;
       var tests = declare(() {
         setUp(() => tearDownRun = false);
         tearDown(() => tearDownRun = true);
@@ -512,7 +512,7 @@ void main() {
 
     group(".tearDown()", () {
       test("is scoped to the group", () async {
-        var tearDownRun;
+        bool tearDownRun;
         var entries = declare(() {
           setUp(() => tearDownRun = false);
 

--- a/test/backend/invoker_test.dart
+++ b/test/backend/invoker_test.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:fake_async/fake_async.dart';
 import 'package:test/src/backend/group.dart';
 import 'package:test/src/backend/invoker.dart';
+import 'package:test/src/backend/live_test.dart';
 import 'package:test/src/backend/message.dart';
 import 'package:test/src/backend/metadata.dart';
 import 'package:test/src/backend/state.dart';
@@ -29,7 +30,7 @@ void main() {
     });
 
     test("returns the current invoker in a test body", () async {
-      var invoker;
+      Invoker invoker;
       var liveTest = _localTest(() {
         invoker = Invoker.current;
       }).load(suite);
@@ -41,7 +42,7 @@ void main() {
 
     test("returns the current invoker in a test body after the test completes",
         () async {
-      var status;
+      Status status;
       var completer = new Completer();
       var liveTest = _localTest(() {
         // Use [new Future] in particular to wait longer than a microtask for
@@ -62,8 +63,8 @@ void main() {
 
   group("in a successful test,", () {
     test("the state changes from pending to running to complete", () async {
-      var stateInTest;
-      var liveTest;
+      State stateInTest;
+      LiveTest liveTest;
       liveTest = _localTest(() {
         stateInTest = liveTest.state;
       }).load(suite);

--- a/test/frontend/expect_async_test.dart
+++ b/test/frontend/expect_async_test.dart
@@ -307,7 +307,7 @@ void main() {
     });
 
     test("swallows them and returns null", () async {
-      var returnValue;
+      Function returnValue;
       var caughtError = false;
       var liveTest = await runTestBody(() {
         try {

--- a/test/runner/compact_reporter_test.dart
+++ b/test/runner/compact_reporter_test.dart
@@ -432,7 +432,7 @@ $tests
 
   // Skip the first CR, remove excess trailing whitespace, and trim off
   // timestamps.
-  var lastLine;
+  String lastLine;
   var actual = stdoutLines.skip(1).map((line) {
     if (line.startsWith("  ") || line.isEmpty) return line.trimRight();
 

--- a/test/util/one_off_handler_test.dart
+++ b/test/util/one_off_handler_test.dart
@@ -9,10 +9,11 @@ import 'package:test/src/util/one_off_handler.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var handler;
+  OneOffHandler handler;
   setUp(() => handler = new OneOffHandler());
 
-  _handle(request) => new Future.sync(() => handler.handler(request));
+  _handle(shelf.Request request) =>
+      new Future.sync(() => handler.handler(request));
 
   test("returns a 404 for a root URL", () async {
     var request = new shelf.Request("GET", Uri.parse("http://localhost/"));

--- a/test/util/path_handler_test.dart
+++ b/test/util/path_handler_test.dart
@@ -9,10 +9,11 @@ import 'package:test/src/util/path_handler.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var handler;
+  PathHandler handler;
   setUp(() => handler = new PathHandler());
 
-  _handle(request) => new Future.sync(() => handler.handler(request));
+  _handle(shelf.Request request) =>
+      new Future.sync(() => handler.handler(request));
 
   test("returns a 404 for a root URL", () async {
     var request = new shelf.Request("GET", Uri.parse("http://localhost/"));


### PR DESCRIPTION
Searched for lines matching `var \w+;`. This is a much weaker version of
no-implicit-dynamic. This catches a bunch of places where we otherwise
had dynamic calls and tightens up types a bit. Where we are relying on
being able to parse to multiple types and then throw a specific
excpetion or return null on bad types I added an explicit `dynamic`.