### PR TITLE
Add support for setting the reporter via env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.12.41
+
+* The default reporter can now be overriden by setting the `DART_TEST_REPORTER`
+  environment variable. This enables using the `json` reporter when running test
+  scripts directly via the Dart VM where the `-reporter` flag is not available.
+
 ## 0.12.40
 
 * Added some new optional fields to the json reporter, `root_line`,

--- a/doc/json_reporter.md
+++ b/doc/json_reporter.md
@@ -19,6 +19,11 @@ JSON reporter.
 
     pub run test --reporter json <path-to-test-file>
 
+If running tests directly through Dart the `--reporter` flag is not available.
+Instead, you can set the `DART_TEST_REPORTER` environment variable:
+
+    DART_TEST_REPORTER=json dart <path-to-test-file>
+
 The JSON stream will be emitted via standard output. It will be a stream of JSON
 objects, separated by newlines.
 

--- a/lib/src/runner/configuration/reporters.dart
+++ b/lib/src/runner/configuration/reporters.dart
@@ -43,8 +43,8 @@ final _allReporters = <String, ReporterDetails>{
       (_, engine) => JsonReporter.watch(engine)),
 };
 
-final defaultReporter =
-    inTestTests ? 'expanded' : canUseSpecialChars ? 'compact' : 'expanded';
+final defaultReporter = environmentReporter ??
+    (inTestTests ? 'expanded' : canUseSpecialChars ? 'compact' : 'expanded');
 
 /// **Do not call this function without express permission from the test package
 /// authors**.

--- a/lib/src/util/io.dart
+++ b/lib/src/util/io.dart
@@ -69,6 +69,9 @@ final stdinLines = new StreamQueue(lineSplitter.bind(stdin));
 /// Whether this is being run as a subprocess in the test package's own tests.
 bool inTestTests = Platform.environment["_DART_TEST_TESTING"] == "true";
 
+/// The default reporter defined in the DART_TEST_REPORTER environment variable.
+String environmentReporter = Platform.environment["DART_TEST_REPORTER"];
+
 /// The root directory below which to nest temporary directories created by the
 /// test runner.
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 0.12.40
+version: 0.12.41
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
This is to fix #838.

I added a flag to suppress passing `-reporter json` in the tests and pass it (along with an env var) from a new simple test that just ensures we're using the JSON reporter.

The json reporter tests all pass for my locally, however running the whole suite has some failures (before this change; things like not being able to launch Firefox) so I'm not totally confident this doesn't break anything and hope this'll run some builds when I open the PR (if not, I can work through the issues and get them all working locally).

Happy to revise as required!