### PR TITLE
Add explicit casts for virtual channel IDs

### DIFF
--- a/lib/src/runner/plugin/platform_helpers.dart
+++ b/lib/src/runner/plugin/platform_helpers.dart
@@ -146,7 +146,7 @@ class _Deserializer {
     var metadata = new Metadata.deserialize(test['metadata']);
     var trace =
         test['trace'] == null ? null : new Trace.parse(test['trace'] as String);
-    var testChannel = _channel.virtualChannel(test['channel']);
+    var testChannel = _channel.virtualChannel(test['channel'] as int);
     return new RunnerTest(test['name'] as String, metadata, trace, testChannel);
   }
 }

--- a/lib/src/runner/remote_listener.dart
+++ b/lib/src/runner/remote_listener.dart
@@ -96,7 +96,7 @@ class RemoteListener {
           queue.rest.listen((message) {
             assert(message["type"] == "suiteChannel");
             SuiteChannelManager.current.connectIn(message['name'] as String,
-                channel.virtualChannel(message['id']));
+                channel.virtualChannel(message['id'] as int));
           });
 
           if ((message['asciiGlyphs'] as bool) ?? false) glyph.ascii = true;
@@ -207,7 +207,7 @@ class RemoteListener {
     testChannel.stream.listen((message) {
       assert(message['command'] == 'run');
       _runLiveTest(test.load(_suite, groups: groups),
-          channel.virtualChannel(message['channel']));
+          channel.virtualChannel(message['channel'] as int));
     });
 
     return {

--- a/lib/src/runner/runner_test.dart
+++ b/lib/src/runner/runner_test.dart
@@ -69,7 +69,7 @@ class RunnerTest extends Test {
             // this virtual channel and cause the spawned isolate to close as
             // well.
             spawnHybridUri(message['url'] as String, message['message'])
-                .pipe(testChannel.virtualChannel(message['channel']));
+                .pipe(testChannel.virtualChannel(message['channel'] as int));
             break;
         }
       }, onDone: () {

--- a/tool/host.dart
+++ b/tool/host.dart
@@ -118,7 +118,8 @@ void main() {
     var serverChannel = _connectToServer();
     serverChannel.stream.listen((message) {
       if (message['command'] == 'loadSuite') {
-        var suiteChannel = serverChannel.virtualChannel(message['channel']);
+        var suiteChannel =
+            serverChannel.virtualChannel(message['channel'] as int);
         var iframeChannel =
             _connectToIframe(message['url'] as String, message['id'] as int);
         suiteChannel.pipe(iframeChannel);


### PR DESCRIPTION
The latest version of `stream_channel` made the type explicit on the
method signature whereas before it was implicit with an `as` cast inside
the method. Most clients wouldn't be impacted is but this package is
because of it's use of `implicit-casts: false`.