### PR TITLE
Don't ignore packages folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* No longer ignore test files found in a `packages` directory.
+
 ## 1.0.0
 
 * No change from `0.12.42`. We are simply signalling to users that this is a

--- a/lib/src/runner/loader.dart
+++ b/lib/src/runner/loader.dart
@@ -173,10 +173,6 @@ class Loader {
         return new Stream.fromIterable([]);
       }
 
-      if (p.split(entry.path).contains('packages')) {
-        return new Stream.fromIterable([]);
-      }
-
       return loadFile(entry.path, suiteConfig);
     }));
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.0.0 
+version: 1.0.1-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test

--- a/test/runner/loader_test.dart
+++ b/test/runner/loader_test.dart
@@ -89,12 +89,6 @@ void main() {
           completion(isEmpty));
     });
 
-    test("ignores files in packages/ directories", () async {
-      await d.dir('packages', [d.file('a_test.dart', _tests)]).create();
-      expect(_loader.loadDir(d.sandbox, SuiteConfiguration.empty).toList(),
-          completion(isEmpty));
-    });
-
     test("ignores files that don't end in _test.dart", () async {
       await d.file('test.dart', _tests).create();
       expect(_loader.loadDir(d.sandbox, SuiteConfiguration.empty).toList(),


### PR DESCRIPTION
For historical reasons we used to ignore files under a `packages` directory. This is no longer necessary.

Closes: https://github.com/dart-lang/test/issues/885