### PR TITLE
Add pid to start event; bump protocol version to 0.1.1; package version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.1
+
+* Added a new `pid` field to the StartEvent in the json runner containing the
+  pid of the VM process running the tests.
+
 ## 1.0.0
 
 * No change from `0.12.42`. We are simply signalling to users that this is a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.1
+## 1.1.0
 
 * Added a new `pid` field to the StartEvent in the json runner containing the
   pid of the VM process running the tests.

--- a/doc/json_reporter.md
+++ b/doc/json_reporter.md
@@ -95,6 +95,9 @@ class StartEvent extends Event {
 
   // The version of the test runner being used.
   String runnerVersion;
+
+  // The pid of the VM process running the tests.
+  int pid;
 }
 ```
 

--- a/json_reporter.schema.json
+++ b/json_reporter.schema.json
@@ -98,6 +98,7 @@
       "required": ["protocolVersion", "runnerVersion"],
       "properties": {
         "type": {"enum": ["start"]},
+        "pid": {"type": "integer", "minimum": 0},
         "protocolVersion": {"type": "string", "pattern": "^0\\.1\\."},
         "runnerVersion": {
           "oneOf": [{"type": "string"}, {"type": "null"}]

--- a/lib/src/runner/reporter/json.dart
+++ b/lib/src/runner/reporter/json.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io' show pid;
 
 import 'package:path/path.dart' as p;
 
@@ -72,7 +73,8 @@ class JsonReporter implements Reporter {
       _emit("allSuites", {"count": _engine.addedSuites.length});
     }));
 
-    _emit("start", {"protocolVersion": "0.1.0", "runnerVersion": testVersion});
+    _emit("start",
+        {"protocolVersion": "0.1.1", "runnerVersion": testVersion, "pid": pid});
   }
 
   void pause() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.0.1
+version: 1.1.0
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.0.0 
+version: 1.0.1
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test

--- a/test/runner/json_reporter_test.dart
+++ b/test/runner/json_reporter_test.dart
@@ -16,13 +16,6 @@ import 'package:test/test.dart';
 
 import '../io.dart';
 
-/// The first event emitted by the JSON reporter.
-final _start = {
-  "type": "start",
-  "protocolVersion": "0.1.0",
-  "runnerVersion": testVersion
-};
-
 void main() {
   test("runs several successful tests and reports when each completes", () {
     return _expectReport("""
@@ -619,6 +612,12 @@ import 'package:test/test.dart';
   expect(stdoutLines.map(decodeLine), containsAll([_allSuites()]));
 
   // A single start event is emitted first.
+  final _start = {
+    "type": "start",
+    "protocolVersion": "0.1.1",
+    "runnerVersion": testVersion,
+    "pid": test.pid
+  };
   expect(decodeLine(stdoutLines.first), equals(_start));
 
   // A single done event is emmited last.


### PR DESCRIPTION
Fixes #889.

I bumped the protocol version since it's a change, even though it shouldn't be breaking in any way. I moved the expected start event down in the test so I can put the real `pid` in it (so it's tested to be correct, rather than just stripped out) though not sure if there's a better way to do this.

I have some test failures locally that I don't think are related to this (maybe it's Dart2?), but let me know if you disagree and I'll do some more digging:

```
dantup-macbookpro:test dantup$ pub run test
01:12 +365 -1: test/runner/configuration/custom_platform_test.dart: override_platforms can override a browser with a basename-only executable [E]              
  Expected: <0>
    Actual: <1>
  Process `dart bin/test.dart` had an unexpected exit code.
  
  package:test/src/frontend/expect.dart 165:30               fail
  package:test/src/frontend/expect.dart 159:3                _expect
  package:test/src/frontend/expect.dart 60:3                 expect
  ===== asynchronous gap ===========================
  package:test_process                                       TestProcess.shouldExit
  test/runner/configuration/custom_platform_test.dart 75:20  main.<fn>.<fn>.<fn>
  dart:async                                                 _completeOnAsyncReturn
  test/io.dart 82:3                                          runTest
  dart:async                                                 _completeOnAsyncReturn
  test/io.dart 99:3                                          runDart
  ===== asynchronous gap ===========================
  dart:async                                                 _asyncThenWrapperHelper
  test/runner/configuration/custom_platform_test.dart 62:56  main.<fn>.<fn>.<fn>
  package:test/src/backend/declarer.dart 161:27              Declarer.test.<fn>.<fn>.<fn>
  ===== asynchronous gap ===========================
  dart:async                                                 _asyncThenWrapperHelper
  package:test/src/backend/declarer.dart 159:70              Declarer.test.<fn>.<fn>.<fn>
  package:test/src/backend/invoker.dart 249:15               Invoker.waitForOutstandingCallbacks.<fn>
  ===== asynchronous gap ===========================
  dart:async                                                 new Future
  package:test/src/backend/invoker.dart 402:15               Invoker._onRun.<fn>.<fn>.<fn>
  
  Expected: should eventually emit an event that contains 'All tests passed!'
    Actual: <Instance of '_StreamQueue'>
     Which: emitted • 00:00 +0: compiling test.dart
```