### PR TITLE
Drop --checked arg to dart2js

### DIFF
--- a/lib/src/runner/compiler_pool.dart
+++ b/lib/src/runner/compiler_pool.dart
@@ -64,6 +64,7 @@ class CompilerPool {
         if (Platform.isWindows) dart2jsPath += '.bat';
 
         var args = [
+          "--enable-asserts",
           wrapperPath,
           "--out=$jsPath",
           await PackageResolver.current.processArgument

--- a/lib/src/runner/compiler_pool.dart
+++ b/lib/src/runner/compiler_pool.dart
@@ -64,7 +64,6 @@ class CompilerPool {
         if (Platform.isWindows) dart2jsPath += '.bat';
 
         var args = [
-          "--checked",
           wrapperPath,
           "--out=$jsPath",
           await PackageResolver.current.processArgument


### PR DESCRIPTION
We'll stop getting messages like "Option '--enable-checked-mode' is not
needed in Dart 2.0."