### PR TITLE
Add support for loading precompiled kernel files for vm tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.2.0
+
+* Added support for using precompiled kernel files when running vm tests.
+  * When using the `--precompiled` flag we will now first check for a
+    `<original-test-path>.vm_test.vm.app.dill` file, and if present load that
+    directly in the isolate. Otherwise the `<original-test-path>.vm_test.dart`
+    file will be used.
+
 ## 1.1.0
 
 * Added a new `pid` field to the StartEvent in the json runner containing the
@@ -18,7 +26,7 @@
 
   - Many improvements to `TypeMatcher`
     - Can now be used directly as `const TypeMatcher<MyType>()`.
-    - Added a type parameter to specify the target `Type`. 
+    - Added a type parameter to specify the target `Type`.
       - Made the `name` constructor parameter optional and marked it deprecated.
         It's redundant to the type parameter.
     - Migrated all `isType` matchers to `TypeMatcher`.

--- a/lib/src/runner/vm/platform.dart
+++ b/lib/src/runner/vm/platform.dart
@@ -130,8 +130,13 @@ Future<Isolate> _spawnDataIsolate(String path, SendPort message) async {
 
 Future<Isolate> _spawnPrecompiledIsolate(
     String testPath, SendPort message, String precompiledPath) async {
-  testPath = p.join(precompiledPath, testPath) + '.vm_test.dart';
-  return await Isolate.spawnUri(p.toUri(p.absolute(testPath)), [], message,
+  testPath = p.absolute(p.join(precompiledPath, testPath) + '.vm_test.dart');
+  var dillTestpath =
+      testPath.substring(0, testPath.length - '.dart'.length) + '.vm.app.dill';
+  if (await new File(dillTestpath).exists()) {
+    testPath = dillTestpath;
+  }
+  return await Isolate.spawnUri(p.toUri(testPath), [], message,
       packageConfig: p.toUri(p.join(precompiledPath, '.packages')),
       checked: true);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.1.0
+version: 1.2.0
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
When using the `--precompiled` flag we will now first check for an `<original-test-path>.vm_test.vm.app.dill` file, and if present load that directly in the isolate. Otherwise the `<original-test-path>.vm_test.dart` file will be used.