### PR TITLE
Fix constants on legacy `unittest` branch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+##0.11.8
+
+* Make this branch Dart 2 compatible by using new constant names.
+  The code is no longer Dart 1 compatible, so this version should only be used
+  to run tests that have not yet been converted to using the `test` package.
+
 ##0.11.7
 
 * Add separate methods for `expectAysnc` based on number of callback arguments 

--- a/lib/html_config.dart
+++ b/lib/html_config.dart
@@ -84,13 +84,13 @@ String _toHtml(TestCase testCase) {
               ${testCase.description}
             </a>.
           </p>
-          <pre>${HTML_ESCAPE.convert(testCase.message)}</pre>
+          <pre>${htmlEscape.convert(testCase.message)}</pre>
         </td>
       </tr>''';
 
   if (testCase.stackTrace != null) {
     html = '$html<tr><td></td><td colspan="2"><pre>' +
-        HTML_ESCAPE.convert(testCase.stackTrace.toString()) +
+        htmlEscape.convert(testCase.stackTrace.toString()) +
         '</pre></td></tr>';
   }
 

--- a/lib/html_enhanced_config.dart
+++ b/lib/html_enhanced_config.dart
@@ -248,11 +248,11 @@ class HtmlEnhancedConfiguration extends SimpleConfiguration {
     }
 
     addRowElement('${test_.id}', '${test_.result.toUpperCase()}',
-        '${test_.description}. ${HTML_ESCAPE.convert(test_.message)}');
+        '${test_.description}. ${htmlEscape.convert(test_.message)}');
 
     if (test_.stackTrace != null) {
       addRowElement('', '',
-          '<pre>${HTML_ESCAPE.convert(test_.stackTrace.toString())}</pre>');
+          '<pre>${htmlEscape.convert(test_.stackTrace.toString())}</pre>');
     }
   }
 

--- a/lib/src/matcher/core_matchers.dart
+++ b/lib/src/matcher/core_matchers.dart
@@ -74,13 +74,13 @@ const Matcher isNotNaN = const _IsNotNaN();
 
 class _IsNaN extends Matcher {
   const _IsNaN();
-  bool matches(item, Map matchState) => double.NAN.compareTo(item) == 0;
+  bool matches(item, Map matchState) => double.nan.compareTo(item) == 0;
   Description describe(Description description) => description.add('NaN');
 }
 
 class _IsNotNaN extends Matcher {
   const _IsNotNaN();
-  bool matches(item, Map matchState) => double.NAN.compareTo(item) != 0;
+  bool matches(item, Map matchState) => double.nan.compareTo(item) != 0;
   Description describe(Description description) => description.add('not NaN');
 }
 

--- a/lib/vm_config.dart
+++ b/lib/vm_config.dart
@@ -20,7 +20,7 @@ class VMConfiguration extends SimpleConfiguration {
   bool useColor;
 
   VMConfiguration()
-      : useColor = stdioType(stdout) == StdioType.TERMINAL,
+      : useColor = stdioType(stdout) == StdioType.terminal,
         super();
 
   String formatResult(TestCase testCase) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: unittest
-version: 0.11.7
+version: 0.11.8
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/old_unittest
 environment:
-  sdk: '>=1.0.0 <2.0.0'
+  sdk: '>=2.0.0-dev.61.0 <3.0.0'
 dependencies:
   stack_trace: '>=0.9.0 <2.0.0'
 dev_dependencies:

--- a/test/core_matchers_test.dart
+++ b/test/core_matchers_test.dart
@@ -33,13 +33,13 @@ void main() {
   });
 
   test('isNaN', () {
-    shouldPass(double.NAN, isNaN);
+    shouldPass(double.nan, isNaN);
     shouldFail(3.1, isNaN, "Expected: NaN Actual: <3.1>");
   });
 
   test('isNotNaN', () {
     shouldPass(3.1, isNotNaN);
-    shouldFail(double.NAN, isNotNaN, "Expected: not NaN Actual: <NaN>");
+    shouldFail(double.nan, isNotNaN, "Expected: not NaN Actual: <NaN>");
   });
 
   test('same', () {


### PR DESCRIPTION
We still have a lot of tests in the SDK repository using `unittest`.

We need either a version of `unittest` that will run when we remove the old-style constants, or to disable all those tests (rewriting is an option, just an expensive one).