### PR TITLE
Fix tests against the latest SDK

### DIFF
--- a/test/runner/browser/runner_test.dart
+++ b/test/runner/browser/runner_test.dart
@@ -66,7 +66,7 @@ void main() {
             'Failed to load "test.dart": No top-level main() function defined.'
           ]));
       await test.shouldExit(1);
-    }, tags: 'chrome');
+    }, tags: 'chrome', skip: 'https://github.com/dart-lang/test/issues/894');
 
     test("a test file has a non-function main", () async {
       await d.file("test.dart", "int main;").create();
@@ -79,7 +79,7 @@ void main() {
             'Failed to load "test.dart": Top-level main getter is not a function.'
           ]));
       await test.shouldExit(1);
-    }, tags: 'chrome');
+    }, tags: 'chrome', skip: 'https://github.com/dart-lang/test/issues/894');
 
     test("a test file has a main with arguments", () async {
       await d.file("test.dart", "void main(arg) {}").create();
@@ -397,7 +397,7 @@ void main() {
     await d.file("test.dart", "{").create();
 
     var test = await runTest(["--color", "-p", "chrome", "test.dart"]);
-    expect(test.stdout, emitsThrough(contains('\u001b[35m')));
+    expect(test.stdout, emitsThrough(contains('\u001b[31m')));
     await test.shouldExit(1);
   }, tags: 'chrome');
 

--- a/test/runner/node/runner_test.dart
+++ b/test/runner/node/runner_test.dart
@@ -68,7 +68,7 @@ void main() {
             'Failed to load "test.dart": No top-level main() function defined.'
           ]));
       await test.shouldExit(1);
-    });
+    }, skip: 'https://github.com/dart-lang/test/issues/894');
 
     test("a test file has a non-function main", () async {
       await d.file("test.dart", "int main;").create();
@@ -81,7 +81,7 @@ void main() {
             'Failed to load "test.dart": Top-level main getter is not a function.'
           ]));
       await test.shouldExit(1);
-    });
+    }, skip: 'https://github.com/dart-lang/test/issues/894');
 
     test("a test file has a main with arguments", () async {
       await d.file("test.dart", "void main(arg) {}").create();


### PR DESCRIPTION
- Update expecation now that dart2js produces different color output.
- Skip tests against a graceful fallback for invalid code that can no
  longer parse.