### PR TITLE
Updated VM platform to accept custom `PackageResolver Function(path)` that can be used in spawning isolated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.1
+
+* Updated VM platform to accept custom `PackageResolver Function(path)` 
+  that can be used in spawning isolated.
+
 ## 1.3.0
 
 * When using `--precompiled`, the test runner now allows symlinks to reach

--- a/lib/src/runner/vm/platform.dart
+++ b/lib/src/runner/vm/platform.dart
@@ -30,7 +30,7 @@ class VMPlatform extends PlatformPlugin {
   /// The test runner configuration.
   final _config = Configuration.current;
 
-  /// A function that returns a [PackageResovler] that is used in spawning
+  /// A function that returns a [PackageResolver] that is used in spawning
   /// isolates based on the current test path.
   final PackageResolver Function(String path) _packageResolver;
 
@@ -114,7 +114,7 @@ class VMPlatform extends PlatformPlugin {
 }
 
 Future<Isolate> _spawnDataIsolate(String path, SendPort message,
-    {PackageResolver resolver}) async {
+    PackageResolver resolver) async {
   return await dart.runInIsolate('''
     import "dart:isolate";
 

--- a/lib/src/runner/vm/platform.dart
+++ b/lib/src/runner/vm/platform.dart
@@ -31,7 +31,7 @@ class VMPlatform extends PlatformPlugin {
   final _config = Configuration.current;
 
   /// A function that returns a [PackageResolver] that is used in spawning
-  /// isolates based on the current test path.
+  /// isolates based on the current test suite path.
   final PackageResolver Function(String path) _packageResolver;
 
   VMPlatform({PackageResolver Function(String path) packageResolver})

--- a/lib/src/runner/vm/platform.dart
+++ b/lib/src/runner/vm/platform.dart
@@ -30,7 +30,12 @@ class VMPlatform extends PlatformPlugin {
   /// The test runner configuration.
   final _config = Configuration.current;
 
-  VMPlatform();
+  /// A function that returns a [PackageResovler] that is used in spawning
+  /// isolates based on the current test path.
+  final PackageResolver Function(String path) _packageResolver;
+
+  VMPlatform({PackageResolver Function(String path) packageResolver})
+      : _packageResolver = packageResolver ?? ((_) => PackageResolver.current);
 
   StreamChannel loadChannel(String path, SuitePlatform platform) =>
       throw new UnimplementedError();
@@ -103,14 +108,9 @@ class VMPlatform extends PlatformPlugin {
     } else if (_config.pubServeUrl != null) {
       return _spawnPubServeIsolate(path, message, _config.pubServeUrl);
     } else {
-      return _spawnDataIsolate(path, message,
-          resolver: resolverForDataIsolate(path));
+      return _spawnDataIsolate(path, message, _packageResolver(path));
     }
   }
-
-  /// What [PackageResolver] should be used for data isolate by given a [path].
-  PackageResolver resolverForDataIsolate(String path) =>
-      PackageResolver.current;
 }
 
 Future<Isolate> _spawnDataIsolate(String path, SendPort message,

--- a/lib/src/runner/vm/platform.dart
+++ b/lib/src/runner/vm/platform.dart
@@ -113,8 +113,8 @@ class VMPlatform extends PlatformPlugin {
   }
 }
 
-Future<Isolate> _spawnDataIsolate(String path, SendPort message,
-    PackageResolver resolver) async {
+Future<Isolate> _spawnDataIsolate(
+    String path, SendPort message, PackageResolver resolver) async {
   return await dart.runInIsolate('''
     import "dart:isolate";
 

--- a/test/runner/runner_test.dart
+++ b/test/runner/runner_test.dart
@@ -164,8 +164,8 @@ $_usage""");
             test.stdout,
             containsInOrder([
               'Failed to load "test.dart":',
-              "Unable to spawn isolate: test.dart:1:14: Error: "
-                  "Expected ';' before this.",
+              "Unable to spawn isolate: test.dart:1:9: Error: "
+                  "Expected ';' after this.",
               'invalid Dart file'
             ]));
       } else {
@@ -195,8 +195,8 @@ $_usage""");
             containsInOrder([
               '-1: loading test.dart [E]',
               'Failed to load "test.dart":',
-              "Unable to spawn isolate: test.dart:1:17: "
-                  "Error: Expected ';' before this"
+              "Unable to spawn isolate: test.dart:1:14: "
+                  "Error: Expected ';' after this"
             ]));
       } else {
         expect(


### PR DESCRIPTION
Add resolverForDataIsolate(path) API to vm platform.dart to allow children to override which package resolver to use when spawning DataIsolate.