### PR TITLE
Strengthen UTF-8 decoding.

### DIFF
--- a/lib/src/runner/compiler_pool.dart
+++ b/lib/src/runner/compiler_pool.dart
@@ -90,8 +90,8 @@ class CompilerPool {
         var buffer = new StringBuffer();
 
         await Future.wait([
-          process.stdout.map(utf8.decode).listen(buffer.write).asFuture(),
-          process.stderr.map(utf8.decode).listen(buffer.write).asFuture(),
+          process.stdout.transform(utf8.decoder).forEach(buffer.write),
+          process.stderr.transform(utf8.decoder).forEach(buffer.write),
         ]);
 
         var exitCode = await process.exitCode;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.3.0
+version: 1.3.1-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
Decoding input bytes by doing `.map(utf8.decode)` assumes that input byte chunks are split at encoded code-unit boundaries.
It's safer to use `.transform(utf8.decoder)` which allows encodings to be split accross input chunks.

Also changed `.listen(f).asFuture()` to the equivalent `.forEach(f)`.