### PR TITLE
Remove explicit checks for syntax errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.1
+
+* Handle parsing annotations which omit `const` on collection literals.
+
 ## 1.3.0
 
 * When using `--precompiled`, the test runner now allows symlinks to reach

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.3.0
+version: 1.3.1-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test

--- a/test/runner/parse_metadata_test.dart
+++ b/test/runner/parse_metadata_test.dart
@@ -185,8 +185,8 @@ library foo;
 
     group("throws an error for", () {
       test("multiple @Tags", () {
-        new File(_path).writeAsStringSync(
-            "@Tags(['a'])\n@Tags(['b'])\nlibrary foo;");
+        new File(_path)
+            .writeAsStringSync("@Tags(['a'])\n@Tags(['b'])\nlibrary foo;");
         expect(() => parseMetadata(_path, new Set()), throwsFormatException);
       });
     });

--- a/test/runner/parse_metadata_test.dart
+++ b/test/runner/parse_metadata_test.dart
@@ -95,6 +95,28 @@ library foo;
               microseconds: 5)));
     });
 
+    test("parses a valid duration annotation omitting const", () {
+      new File(_path).writeAsStringSync("""
+@Timeout(Duration(
+    hours: 1,
+    minutes: 2,
+    seconds: 3,
+    milliseconds: 4,
+    microseconds: 5))
+
+library foo;
+""");
+      var metadata = parseMetadata(_path, new Set());
+      expect(
+          metadata.timeout.duration,
+          equals(new Duration(
+              hours: 1,
+              minutes: 2,
+              seconds: 3,
+              milliseconds: 4,
+              microseconds: 5)));
+    }, skip: 'https://github.com/dart-lang/test/issues/915');
+
     test("parses a valid int factor annotation", () {
       new File(_path).writeAsStringSync("""
 @Timeout.factor(1)

--- a/test/runner/parse_metadata_test.dart
+++ b/test/runner/parse_metadata_test.dart
@@ -64,38 +64,6 @@ void main() {
     });
 
     group("throws an error for", () {
-      test("a named constructor", () {
-        new File(_path).writeAsStringSync("@TestOn.name('foo')\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("no argument list", () {
-        new File(_path).writeAsStringSync("@TestOn\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("an empty argument list", () {
-        new File(_path).writeAsStringSync("@TestOn()\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("a named argument", () {
-        new File(_path)
-            .writeAsStringSync("@TestOn(expression: 'foo')\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("multiple arguments", () {
-        new File(_path)
-            .writeAsStringSync("@TestOn('foo', 'bar')\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("a non-string argument", () {
-        new File(_path).writeAsStringSync("@TestOn(123)\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
       test("multiple @TestOns", () {
         new File(_path)
             .writeAsStringSync("@TestOn('foo')\n@TestOn('bar')\nlibrary foo;");
@@ -164,85 +132,10 @@ library foo;
     });
 
     group("throws an error for", () {
-      test("an unknown named constructor", () {
-        new File(_path).writeAsStringSync("@Timeout.name('foo')\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("no argument list", () {
-        new File(_path).writeAsStringSync("@Timeout\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("an empty argument list", () {
-        new File(_path).writeAsStringSync("@Timeout()\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("an argument list for Timeout.none", () {
-        new File(_path).writeAsStringSync("@Timeout.none()\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("a named argument", () {
-        new File(_path).writeAsStringSync(
-            "@Timeout(duration: const Duration(seconds: 1))\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("multiple arguments", () {
-        new File(_path)
-            .writeAsStringSync("@Timeout.factor(1, 2)\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("a non-Duration argument", () {
-        new File(_path).writeAsStringSync("@Timeout(10)\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("a non-num argument", () {
-        new File(_path)
-            .writeAsStringSync("@Timeout.factor('foo')\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
       test("multiple @Timeouts", () {
         new File(_path).writeAsStringSync(
             "@Timeout.factor(1)\n@Timeout.factor(2)\nlibrary foo;");
         expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      group("a Duration with", () {
-        test("a non-const constructor", () {
-          new File(_path)
-              .writeAsStringSync("@Timeout(new Duration(1))\nlibrary foo;");
-          expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-        });
-
-        test("a named constructor", () {
-          new File(_path).writeAsStringSync(
-              "@Timeout(const Duration.name(seconds: 1))\nlibrary foo;");
-          expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-        });
-
-        test("a positional argument", () {
-          new File(_path)
-              .writeAsStringSync("@Timeout(const Duration(1))\nlibrary foo;");
-          expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-        });
-
-        test("an unknown named argument", () {
-          new File(_path).writeAsStringSync(
-              "@Timeout(const Duration(name: 1))\nlibrary foo;");
-          expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-        });
-
-        test("a duplicate named argument", () {
-          new File(_path).writeAsStringSync(
-              "@Timeout(const Duration(seconds: 1, seconds: 1))\nlibrary foo;");
-          expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-        });
       });
     });
   });
@@ -269,31 +162,6 @@ library foo;
     });
 
     group("throws an error for", () {
-      test("a named constructor", () {
-        new File(_path).writeAsStringSync("@Skip.name('foo')\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("no argument list", () {
-        new File(_path).writeAsStringSync("@Skip\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("a named argument", () {
-        new File(_path).writeAsStringSync("@Skip(reason: 'foo')\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("multiple arguments", () {
-        new File(_path).writeAsStringSync("@Skip('foo', 'bar')\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("a non-string argument", () {
-        new File(_path).writeAsStringSync("@Skip(123)\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
       test("multiple @Skips", () {
         new File(_path)
             .writeAsStringSync("@Skip('foo')\n@Skip('bar')\nlibrary foo;");
@@ -304,48 +172,21 @@ library foo;
 
   group("@Tags:", () {
     test("parses a valid annotation", () {
-      new File(_path).writeAsStringSync("@Tags(const ['a'])\nlibrary foo;");
+      new File(_path).writeAsStringSync("@Tags(['a'])\nlibrary foo;");
       var metadata = parseMetadata(_path, new Set());
       expect(metadata.tags, equals(["a"]));
     });
 
     test("ignores a constructor named Tags", () {
-      new File(_path).writeAsStringSync("@foo.Tags(const ['a'])\nlibrary foo;");
+      new File(_path).writeAsStringSync("@foo.Tags(['a'])\nlibrary foo;");
       var metadata = parseMetadata(_path, new Set());
       expect(metadata.tags, isEmpty);
     });
 
     group("throws an error for", () {
-      test("a named constructor", () {
-        new File(_path)
-            .writeAsStringSync("@Tags.name(const ['a'])\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("no argument list", () {
-        new File(_path).writeAsStringSync("@Tags\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("a named argument", () {
-        new File(_path).writeAsStringSync("@Tags(tags: ['a'])\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("multiple arguments", () {
-        new File(_path)
-            .writeAsStringSync("@Tags(const ['a'], ['b'])\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("a non-list argument", () {
-        new File(_path).writeAsStringSync("@Tags('a')\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
       test("multiple @Tags", () {
         new File(_path).writeAsStringSync(
-            "@Tags(const ['a'])\n@Tags(const ['b'])\nlibrary foo;");
+            "@Tags(['a'])\n@Tags(['b'])\nlibrary foo;");
         expect(() => parseMetadata(_path, new Set()), throwsFormatException);
       });
     });
@@ -354,9 +195,9 @@ library foo;
   group("@OnPlatform:", () {
     test("parses a valid annotation", () {
       new File(_path).writeAsStringSync("""
-@OnPlatform(const {
+@OnPlatform({
   'chrome': const Timeout.factor(2),
-  'vm': const [const Skip(), const Timeout.factor(3)]
+  'vm': [const Skip(), const Timeout.factor(3)]
 })
 library foo;""");
       var metadata = parseMetadata(_path, new Set());
@@ -382,72 +223,27 @@ library foo;""");
     });
 
     group("throws an error for", () {
-      test("a named constructor", () {
-        new File(_path)
-            .writeAsStringSync("@OnPlatform.name(const {})\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("no argument list", () {
-        new File(_path).writeAsStringSync("@OnPlatform\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("an empty argument list", () {
-        new File(_path).writeAsStringSync("@OnPlatform()\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("a named argument", () {
-        new File(_path)
-            .writeAsStringSync("@OnPlatform(map: const {})\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("multiple arguments", () {
-        new File(_path)
-            .writeAsStringSync("@OnPlatform(const {}, const {})\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("a non-map argument", () {
-        new File(_path)
-            .writeAsStringSync("@OnPlatform(const Skip())\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("a non-const map", () {
-        new File(_path).writeAsStringSync("@OnPlatform({})\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
-      test("a map with a non-String key", () {
-        new File(_path).writeAsStringSync(
-            "@OnPlatform(const {1: const Skip()})\nlibrary foo;");
-        expect(() => parseMetadata(_path, new Set()), throwsFormatException);
-      });
-
       test("a map with a unparseable key", () {
         new File(_path).writeAsStringSync(
-            "@OnPlatform(const {'invalid': const Skip()})\nlibrary foo;");
+            "@OnPlatform({'invalid': Skip()})\nlibrary foo;");
         expect(() => parseMetadata(_path, new Set()), throwsFormatException);
       });
 
       test("a map with an invalid value", () {
         new File(_path).writeAsStringSync(
-            "@OnPlatform(const {'vm': const TestOn('vm')})\nlibrary foo;");
+            "@OnPlatform({'vm': const TestOn('vm')})\nlibrary foo;");
         expect(() => parseMetadata(_path, new Set()), throwsFormatException);
       });
 
       test("a map with an invalid value in a list", () {
         new File(_path).writeAsStringSync(
-            "@OnPlatform(const {'vm': [const TestOn('vm')]})\nlibrary foo;");
+            "@OnPlatform({'vm': [const TestOn('vm')]})\nlibrary foo;");
         expect(() => parseMetadata(_path, new Set()), throwsFormatException);
       });
 
       test("multiple @OnPlatforms", () {
         new File(_path).writeAsStringSync(
-            "@OnPlatform(const {})\n@OnPlatform(const {})\nlibrary foo;");
+            "@OnPlatform({})\n@OnPlatform({})\nlibrary foo;");
         expect(() => parseMetadata(_path, new Set()), throwsFormatException);
       });
     });

--- a/test/runner/runner_test.dart
+++ b/test/runner/runner_test.dart
@@ -244,22 +244,6 @@ $_usage""");
       await test.shouldExit(1);
     });
 
-    test("an annotation's structure is invalid", () async {
-      await d.file("test.dart", "@TestOn()\nlibrary foo;").create();
-      var test = await runTest(["test.dart"]);
-
-      expect(
-          test.stdout,
-          containsInOrder([
-            '-1: loading test.dart [E]',
-            'Failed to load "test.dart":',
-            "Error on line 1, column 8: TestOn takes 1 argument.",
-            "@TestOn()",
-            "       ^^"
-          ]));
-      await test.shouldExit(1);
-    });
-
     test("an annotation's contents are invalid", () async {
       await d.file("test.dart", "@TestOn('zim')\nlibrary foo;").create();
       var test = await runTest(["test.dart"]);


### PR DESCRIPTION
Towards #915

The CFE will already reject this code if it is incorrect, we don't need
to also check for syntax errors.

- Remove the explict checks for `const`
- Remove the explicit checks for using valid constructor names and
  argument types.
- Update test to remove most of the `const` in examples. Retain const
  constructor calls since we can't yet parse the resulting expression if
  it is omitted.
- Remove tests for the removed explicit checks.