### PR TITLE
Fix root_url/root_line/root_column for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.3.1
 
 * Handle parsing annotations which omit `const` on collection literals.
+* Fix an issue where `root_line`, `root_column`, and `root_url` may not be
+  populated correctly on Windows.
 
 ## 1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 1.3.1
 
 * Handle parsing annotations which omit `const` on collection literals.
-* Fix an issue where `root_line`, `root_column`, and `root_url` may not be
-  populated correctly on Windows.
+* Fix an issue where `root_line`, `root_column`, and `root_url` in the
+  JSON reported may not be populated correctly on Windows.
 
 ## 1.3.0
 

--- a/lib/src/runner/reporter/json.dart
+++ b/lib/src/runner/reporter/json.dart
@@ -297,7 +297,7 @@ class JsonReporter implements Reporter {
       String suitePath) {
     var frame = entry.trace?.frames?.first;
     var rootFrame = entry.trace?.frames?.firstWhere(
-        (frame) => frame.uri.path == p.absolute(suitePath),
+        (frame) => frame.uri.toFilePath() == p.absolute(suitePath),
         orElse: () => null);
     if (suiteConfig.jsTrace && runtime.isJS) {
       frame = null;


### PR DESCRIPTION
This should fix #918 (I've run the test on Windows and macOS and it passed on both; before this fix it failed on Windows). I believe calling `.path` on a `Uru` is not safe for file URIs, since it'll return a path in a URI format.

(~~this may mean the tests aren't running on any Windows bots~~ Looks like tests run on Travis but no Windows - I don't know if it'd be tricky to set up?)