### PR TITLE
Prepare to publish version 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.2
+
+* Widen the constraints on the analyzer package.
+
 ## 1.3.1
 
 * Handle parsing annotations which omit `const` on collection literals.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: test
-version: 1.3.1
+version: 1.3.2
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test
 environment:
   sdk: '>=2.0.0-dev.54.0 <3.0.0'
 dependencies:
-  analyzer: '>=0.26.4 <0.33.0'
+  analyzer: '>=0.26.4 <0.34.0'
   args: '>=1.4.0 <2.0.0'
   async: '>=1.13.0 <3.0.0'
   boolean_selector: '^1.0.0'


### PR DESCRIPTION
This is necessary to allow packages that depend on test to pull in the latest version of analyzer, which includes support for the 2.1 features.