### PR TITLE
Remove imports of `dart:io` from `test.dart` unless its available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.3
+
+* Add conditional imports so that `dart:io` is not imported from the main
+  `test.dart` entrypoint unless it is available.
+
 ## 1.3.2
 
 * Widen the constraints on the analyzer package.

--- a/lib/src/backend/declarer.dart
+++ b/lib/src/backend/declarer.dart
@@ -8,7 +8,7 @@ import 'package:collection/collection.dart';
 import 'package:stack_trace/stack_trace.dart';
 
 import '../frontend/timeout.dart';
-import '../utils.dart';
+import '../util/test.dart';
 import 'group.dart';
 import 'group_entry.dart';
 import 'invoker.dart';

--- a/lib/src/backend/invoker.dart
+++ b/lib/src/backend/invoker.dart
@@ -8,6 +8,7 @@ import 'package:stack_trace/stack_trace.dart';
 
 import '../frontend/expect.dart';
 import '../runner/load_suite.dart';
+import '../util/test.dart';
 import '../utils.dart';
 import 'closed_exception.dart';
 import 'declarer.dart';

--- a/lib/src/runner/load_suite.dart
+++ b/lib/src/runner/load_suite.dart
@@ -15,7 +15,10 @@ import '../backend/suite.dart';
 import '../backend/suite_platform.dart';
 import '../backend/test.dart';
 import '../backend/runtime.dart';
-import '../util/io.dart';
+// ignore: uri_does_not_exist
+import '../util/io_stub.dart'
+    // ignore: uri_does_not_exist
+    if (dart.library.io) '../util/io.dart';
 import '../utils.dart';
 import 'configuration/suite.dart';
 import 'load_exception.dart';

--- a/lib/src/util/io_stub.dart
+++ b/lib/src/util/io_stub.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import '../backend/runtime.dart';
 import '../backend/suite_platform.dart';
 

--- a/lib/src/util/io_stub.dart
+++ b/lib/src/util/io_stub.dart
@@ -1,0 +1,5 @@
+import '../backend/runtime.dart';
+import '../backend/suite_platform.dart';
+
+SuitePlatform currentPlatform(Runtime runtime) => throw UnsupportedError(
+    'Getting the current platform is only supported where dart:io exists');

--- a/lib/src/util/test.dart
+++ b/lib/src/util/test.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import '../backend/invoker.dart';
+
+/// Runs [body] with special error-handling behavior.
+///
+/// Errors emitted [body] will still cause the current test to fail, but they
+/// won't cause it to *stop*. In particular, they won't remove any outstanding
+/// callbacks registered outside of [body].
+///
+/// This may only be called within a test.
+Future errorsDontStopTest(body()) {
+  var completer = new Completer();
+
+  Invoker.current.addOutstandingCallback();
+  Invoker.current.waitForOutstandingCallbacks(() {
+    new Future.sync(body).whenComplete(completer.complete);
+  }).then((_) => Invoker.current.removeOutstandingCallback());
+
+  return completer.future;
+}

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -14,7 +14,6 @@ import 'package:path/path.dart' as p;
 import 'package:stream_channel/stream_channel.dart';
 import 'package:term_glyph/term_glyph.dart' as glyph;
 
-import 'backend/invoker.dart';
 import 'backend/operating_system.dart';
 
 /// A transformer that decodes bytes using UTF-8 and splits them on newlines.
@@ -240,24 +239,6 @@ Stream<T> inCompletionOrder<T>(Iterable<CancelableOperation<T>> operations) {
 /// containing method to return a future.
 void invoke(fn()) {
   fn();
-}
-
-/// Runs [body] with special error-handling behavior.
-///
-/// Errors emitted [body] will still cause the current test to fail, but they
-/// won't cause it to *stop*. In particular, they won't remove any outstanding
-/// callbacks registered outside of [body].
-///
-/// This may only be called within a test.
-Future errorsDontStopTest(body()) {
-  var completer = new Completer();
-
-  Invoker.current.addOutstandingCallback();
-  Invoker.current.waitForOutstandingCallbacks(() {
-    new Future.sync(body).whenComplete(completer.complete);
-  }).then((_) => Invoker.current.removeOutstandingCallback());
-
-  return completer.future;
 }
 
 /// Returns a random base64 string containing [bytes] bytes of data.

--- a/lib/test.dart
+++ b/lib/test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
 
 import 'src/backend/declarer.dart';
 import 'src/backend/invoker.dart';
@@ -37,8 +38,6 @@ export 'src/frontend/throws_matcher.dart';
 export 'src/frontend/throws_matchers.dart';
 export 'src/frontend/timeout.dart';
 export 'src/frontend/utils.dart';
-
-import 'package:path/path.dart' as p;
 
 /// The global declarer.
 ///

--- a/lib/test.dart
+++ b/lib/test.dart
@@ -75,7 +75,7 @@ Declarer get _declarer {
         color: true, printPath: false, printPlatform: false);
 
     var success = await runZoned(() => Invoker.guard(engine.run),
-        zoneValues: {#test.declarer: declarer});
+        zoneValues: {#test.declarer: _globalDeclarer});
     // TODO(nweiz): Set the exit code on the VM when issue 6943 is fixed.
     if (success) return null;
     print('');

--- a/lib/test.dart
+++ b/lib/test.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
-import 'package:path/path.dart' as p;
 
 import 'src/backend/declarer.dart';
 import 'src/backend/invoker.dart';
@@ -38,6 +37,8 @@ export 'src/frontend/throws_matcher.dart';
 export 'src/frontend/throws_matchers.dart';
 export 'src/frontend/timeout.dart';
 export 'src/frontend/utils.dart';
+
+import 'package:path/path.dart' as p;
 
 /// The global declarer.
 ///
@@ -74,7 +75,7 @@ Declarer get _declarer {
         color: true, printPath: false, printPlatform: false);
 
     var success = await runZoned(() => Invoker.guard(engine.run),
-        zoneValues: {#test.declarer: _globalDeclarer});
+        zoneValues: {#test.declarer: declarer});
     // TODO(nweiz): Set the exit code on the VM when issue 6943 is fixed.
     if (success) return null;
     print('');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.3.2
+version: 1.3.3
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
Adds conditional imports and moves some code around to eliminate non-conditional imports of `dart:io` from `test.dart`.