### PR TITLE
Add unnecessary new/const lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -18,5 +18,5 @@ linter:
     - await_only_futures
     - implementation_imports
     - prefer_typing_uninitialized_variables
-    - unnecessary_new
     - unnecessary_const
+    - unnecessary_new

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -18,3 +18,5 @@ linter:
     - await_only_futures
     - implementation_imports
     - prefer_typing_uninitialized_variables
+    - unnecessary_new
+    - unnecessary_const

--- a/test/runner/browser/chrome_test.dart
+++ b/test/runner/browser/chrome_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn("vm")
-@Tags(const ["chrome"])
+@Tags(["chrome"])
 
 import 'package:test_descriptor/test_descriptor.dart' as d;
 

--- a/test/runner/browser/firefox_test.dart
+++ b/test/runner/browser/firefox_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn("vm")
-@Tags(const ["firefox"])
+@Tags(["firefox"])
 
 import 'package:test_descriptor/test_descriptor.dart' as d;
 

--- a/test/runner/browser/internet_explorer_test.dart
+++ b/test/runner/browser/internet_explorer_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn("vm")
-@Tags(const ["ie"])
+@Tags(["ie"])
 
 import 'package:test_descriptor/test_descriptor.dart' as d;
 

--- a/test/runner/browser/loader_test.dart
+++ b/test/runner/browser/loader_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn("vm")
-@Tags(const ["chrome"])
+@Tags(["chrome"])
 import 'dart:io';
 
 import 'package:path/path.dart' as p;

--- a/test/runner/browser/phantom_js_test.dart
+++ b/test/runner/browser/phantom_js_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn("vm")
-@Tags(const ["phantomjs"])
+@Tags(["phantomjs"])
 
 import 'package:test_descriptor/test_descriptor.dart' as d;
 

--- a/test/runner/browser/safari_test.dart
+++ b/test/runner/browser/safari_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn("vm")
-@Tags(const ["safari"])
+@Tags(["safari"])
 
 import 'package:test_descriptor/test_descriptor.dart' as d;
 

--- a/test/runner/node/runner_test.dart
+++ b/test/runner/node/runner_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn("vm")
-@Tags(const ["node"])
+@Tags(["node"])
 
 import 'package:test_descriptor/test_descriptor.dart' as d;
 

--- a/test/runner/pub_serve_test.dart
+++ b/test/runner/pub_serve_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn("vm")
-@Tags(const ["pub"])
+@Tags(["pub"])
 @Skip('https://github.com/dart-lang/test/issues/821')
 
 import 'dart:io';


### PR DESCRIPTION
Clean up a few violations that weren't corrected by dartfmt --fix.
Dartfmt would eventually fix these but a new version of the tool needs
to be published.