### PR TITLE
Clean up test utils

### DIFF
--- a/test/runner/runner_test.dart
+++ b/test/runner/runner_test.dart
@@ -159,26 +159,14 @@ $_usage""");
       await d.file("test.dart", "invalid Dart file").create();
       var test = await runTest(["test.dart"]);
 
-      if (isDart2) {
-        expect(
-            test.stdout,
-            containsInOrder([
-              'Failed to load "test.dart":',
-              "Unable to spawn isolate: test.dart:1:9: Error: "
-                  "Expected ';' after this.",
-              'invalid Dart file'
-            ]));
-      } else {
-        expect(
-            test.stdout,
-            containsInOrder([
-              '-1: loading test.dart [E]',
-              'Failed to load "test.dart":',
-              "line 1 pos 1: unexpected token 'invalid'",
-              "invalid Dart file",
-              "^"
-            ]));
-      }
+      expect(
+          test.stdout,
+          containsInOrder([
+            'Failed to load "test.dart":',
+            "Unable to spawn isolate: test.dart:1:9: Error: "
+                "Expected ';' after this.",
+            'invalid Dart file'
+          ]));
 
       await test.shouldExit(1);
     });
@@ -189,26 +177,14 @@ $_usage""");
       await d.file("test.dart", "void main() {foo}").create();
       var test = await runTest(["test.dart"]);
 
-      if (isDart2) {
-        expect(
-            test.stdout,
-            containsInOrder([
-              '-1: loading test.dart [E]',
-              'Failed to load "test.dart":',
-              "Unable to spawn isolate: test.dart:1:14: "
-                  "Error: Expected ';' after this"
-            ]));
-      } else {
-        expect(
-            test.stdout,
-            containsInOrder([
-              '-1: loading test.dart [E]',
-              'Failed to load "test.dart":',
-              'line 1 pos 17: semicolon expected',
-              'void main() {foo}',
-              '                ^'
-            ]));
-      }
+      expect(
+          test.stdout,
+          containsInOrder([
+            '-1: loading test.dart [E]',
+            'Failed to load "test.dart":',
+            "Unable to spawn isolate: test.dart:1:14: "
+                "Error: Expected ';' after this"
+          ]));
 
       await test.shouldExit(1);
     });
@@ -219,27 +195,15 @@ $_usage""");
       await d.file("test.dart", "@TestOn)").create();
       var test = await runTest(["test.dart"]);
 
-      if (isDart2) {
-        expect(
-            test.stdout,
-            containsInOrder([
-              '-1: loading test.dart [E]',
-              'Failed to load "test.dart":',
-              "Unable to spawn isolate: test.dart:1:8: Error: "
-                  "Expected a declaration, but got ')'",
-              '@TestOn)',
-            ]));
-      } else {
-        expect(
-            test.stdout,
-            containsInOrder([
-              '-1: loading test.dart [E]',
-              'Failed to load "test.dart":',
-              "line 1 pos 8: unexpected token ')'",
-              "@TestOn)",
-              "       ^"
-            ]));
-      }
+      expect(
+          test.stdout,
+          containsInOrder([
+            '-1: loading test.dart [E]',
+            'Failed to load "test.dart":',
+            "Unable to spawn isolate: test.dart:1:8: Error: "
+                "Expected a declaration, but got ')'",
+            '@TestOn)',
+          ]));
 
       await test.shouldExit(1);
     });
@@ -277,21 +241,12 @@ $_usage""");
       await d.file("test.dart", "void foo() {}").create();
       var test = await runTest(["test.dart"]);
 
-      if (isDart2) {
-        expect(
-            test.stdout,
-            containsInOrder([
-              '-1: loading test.dart [E]',
-              "Error: Getter not found: 'main'",
-            ]));
-      } else {
-        expect(
-            test.stdout,
-            containsInOrder([
-              '-1: loading test.dart [E]',
-              'Failed to load "test.dart": No top-level main() function defined.'
-            ]));
-      }
+      expect(
+          test.stdout,
+          containsInOrder([
+            '-1: loading test.dart [E]',
+            "Error: Getter not found: 'main'",
+          ]));
 
       await test.shouldExit(1);
     });
@@ -300,22 +255,13 @@ $_usage""");
       await d.file("test.dart", "int main;").create();
       var test = await runTest(["test.dart"]);
 
-      if (isDart2) {
-        expect(
-            test.stdout,
-            containsInOrder([
-              '-1: loading test.dart [E]',
-              "A value of type 'dart.core::int' can't be assigned to a "
-                  "variable of type 'dart.core::Function'",
-            ]));
-      } else {
-        expect(
-            test.stdout,
-            containsInOrder([
-              '-1: loading test.dart [E]',
-              'Failed to load "test.dart": Top-level main getter is not a function.'
-            ]));
-      }
+      expect(
+          test.stdout,
+          containsInOrder([
+            '-1: loading test.dart [E]',
+            "A value of type 'dart.core::int' can't be assigned to a "
+                "variable of type 'dart.core::Function'",
+          ]));
 
       await test.shouldExit(1);
     });
@@ -337,28 +283,14 @@ $_usage""");
       await d.file("test.dart", "invalid Dart file").create();
       var test = await runTest(["test.dart", "nonexistent.dart"]);
 
-      if (isDart2) {
-        expect(
-            test.stdout,
-            containsInOrder([
-              '-1: loading nonexistent.dart [E]',
-              'Failed to load "nonexistent.dart": Does not exist',
-              '-2: loading test.dart [E]',
-              'Failed to load "test.dart"',
-            ]));
-      } else {
-        expect(
-            test.stdout,
-            containsInOrder([
-              'loading nonexistent.dart',
-              'Failed to load "nonexistent.dart": Does not exist.',
-              'loading test.dart',
-              'Failed to load "test.dart":',
-              "line 1 pos 1: unexpected token 'invalid'",
-              "invalid Dart file",
-              "^"
-            ]));
-      }
+      expect(
+          test.stdout,
+          containsInOrder([
+            '-1: loading nonexistent.dart [E]',
+            'Failed to load "nonexistent.dart": Does not exist',
+            '-2: loading test.dart [E]',
+            'Failed to load "test.dart"',
+          ]));
 
       await test.shouldExit(1);
     });

--- a/test/runner/runner_test.dart
+++ b/test/runner/runner_test.dart
@@ -13,7 +13,6 @@ import 'package:test/src/util/exit_codes.dart' as exit_codes;
 import 'package:test/test.dart';
 
 import '../io.dart';
-import '../utils.dart';
 
 final _success = """
 import 'dart:async';

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -18,16 +18,9 @@ import 'package:test/src/backend/suite_platform.dart';
 import 'package:test/src/runner/application_exception.dart';
 import 'package:test/src/runner/configuration/suite.dart';
 import 'package:test/src/runner/engine.dart';
-import 'package:test/src/runner/load_exception.dart';
 import 'package:test/src/runner/plugin/environment.dart';
 import 'package:test/src/runner/runner_suite.dart';
-import 'package:test/src/util/remote_exception.dart';
 import 'package:test/test.dart';
-
-/// The string representation of an untyped closure with no arguments.
-///
-/// This differs between dart2js and the VM.
-final String closureString = (() {}).toString();
 
 /// A dummy suite platform to use for testing suites.
 final suitePlatform = SuitePlatform(Runtime.vm);
@@ -94,138 +87,16 @@ Matcher throwsTestFailure(message) => throwsA(isTestFailure(message));
 /// Returns a matcher that matches a [TestFailure] with the given [message].
 ///
 /// [message] can be a string or a [Matcher].
-Matcher isTestFailure(message) => _IsTestFailure(wrapMatcher(message));
-
-class _IsTestFailure extends Matcher {
-  final Matcher _message;
-
-  _IsTestFailure(this._message);
-
-  bool matches(item, Map matchState) =>
-      item is TestFailure && _message.matches(item.message, matchState);
-
-  Description describe(Description description) =>
-      description.add('a TestFailure with message ').addDescriptionOf(_message);
-
-  Description describeMismatch(
-      item, Description mismatchDescription, Map matchState, bool verbose) {
-    if (item is! TestFailure) {
-      return mismatchDescription
-          .addDescriptionOf(item)
-          .add('is not a TestFailure');
-    } else {
-      return mismatchDescription
-          .add('message ')
-          .addDescriptionOf(item.message)
-          .add(' is not ')
-          .addDescriptionOf(_message);
-    }
-  }
-}
-
-/// Returns a matcher that matches a [RemoteException] with the given [message].
-///
-/// [message] can be a string or a [Matcher].
-Matcher isRemoteException(message) => _IsRemoteException(wrapMatcher(message));
-
-class _IsRemoteException extends Matcher {
-  final Matcher _message;
-
-  _IsRemoteException(this._message);
-
-  bool matches(item, Map matchState) =>
-      item is RemoteException && _message.matches(item.message, matchState);
-
-  Description describe(Description description) => description
-      .add('a RemoteException with message ')
-      .addDescriptionOf(_message);
-
-  Description describeMismatch(
-      item, Description mismatchDescription, Map matchState, bool verbose) {
-    if (item is! RemoteException) {
-      return mismatchDescription
-          .addDescriptionOf(item)
-          .add('is not a RemoteException');
-    } else {
-      return mismatchDescription
-          .add('message ')
-          .addDescriptionOf(item)
-          .add(' is not ')
-          .addDescriptionOf(_message);
-    }
-  }
-}
-
-/// Returns a matcher that matches a [LoadException] with the given
-/// [innerError].
-///
-/// [innerError] can be a string or a [Matcher].
-Matcher isLoadException(innerError) =>
-    _IsLoadException(wrapMatcher(innerError));
-
-class _IsLoadException extends Matcher {
-  final Matcher _innerError;
-
-  _IsLoadException(this._innerError);
-
-  bool matches(item, Map matchState) =>
-      item is LoadException && _innerError.matches(item.innerError, matchState);
-
-  Description describe(Description description) => description
-      .add('a LoadException with message ')
-      .addDescriptionOf(_innerError);
-
-  Description describeMismatch(
-      item, Description mismatchDescription, Map matchState, bool verbose) {
-    if (item is! LoadException) {
-      return mismatchDescription
-          .addDescriptionOf(item)
-          .add('is not a LoadException');
-    } else {
-      return mismatchDescription
-          .add('inner error ')
-          .addDescriptionOf(item)
-          .add(' is not ')
-          .addDescriptionOf(_innerError);
-    }
-  }
-}
+Matcher isTestFailure(message) => const TypeMatcher<TestFailure>()
+    .having((e) => e.message, 'message', message);
 
 /// Returns a matcher that matches a [ApplicationException] with the given
 /// [message].
 ///
 /// [message] can be a string or a [Matcher].
 Matcher isApplicationException(message) =>
-    _IsApplicationException(wrapMatcher(message));
-
-class _IsApplicationException extends Matcher {
-  final Matcher _message;
-
-  _IsApplicationException(this._message);
-
-  bool matches(item, Map matchState) =>
-      item is ApplicationException &&
-      _message.matches(item.message, matchState);
-
-  Description describe(Description description) => description
-      .add('a ApplicationException with message ')
-      .addDescriptionOf(_message);
-
-  Description describeMismatch(
-      item, Description mismatchDescription, Map matchState, bool verbose) {
-    if (item is! ApplicationException) {
-      return mismatchDescription
-          .addDescriptionOf(item)
-          .add('is not a ApplicationException');
-    } else {
-      return mismatchDescription
-          .add('message ')
-          .addDescriptionOf(item)
-          .add(' is not ')
-          .addDescriptionOf(_message);
-    }
-  }
-}
+    const TypeMatcher<ApplicationException>()
+        .having((e) => e.message, 'message', message);
 
 /// Returns a local [LiveTest] that runs [body].
 LiveTest createTest(body()) {
@@ -328,9 +199,3 @@ Engine declareEngine(void body(), {bool runSkipped = false}) {
 /// Returns a [RunnerSuite] with a default environment and configuration.
 RunnerSuite runnerSuite(Group root) => RunnerSuite(
     const PluginEnvironment(), SuiteConfiguration.empty, root, suitePlatform);
-
-/// Whether Pub is running with Dart 2 runtime semantics.
-final bool isDart2 = () {
-  Type checkType<T>() => T;
-  return checkType<String>() == String;
-}();


### PR DESCRIPTION
- Remove APIs that are no longer used.
- Switch to `TypeMatcher` instead of manual implementation for exception
  matchers.
- Drop `isDart2` since we only run in Dart 2 mode everywhere.