### PR TITLE
Prepare for release

### DIFF
--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.0.1
+version: 0.1.0
 author: Dart Team <misc@dartlang.org>
 description: A library for writing dart unit tests.
 homepage: https://github.com/dart-lang/test


### PR DESCRIPTION
I will publish `test_api` as `0.1.0` then clean up `package:test` so that all the tests properly run with the published version.