### PR TITLE
Let test_core depend on latest test_api

### DIFF
--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   # properly constrains all features it provides.
   matcher: '>=0.12.3 <0.12.4'
   # Use an exact version until the test_api package is stable.
-  test_api: '0.2.0'
+  test_api: '0.2.1'
 dev_dependencies:
   fake_async: '>=0.1.2 <2.0.0'
   pedantic: '1.1.0'


### PR DESCRIPTION
I should really pay more attention before opening PRs...