### PR TITLE
Fix travis - analyzer and source_span updates

### DIFF
--- a/pkgs/test/test/runner/configuration/custom_platform_test.dart
+++ b/pkgs/test/test/runner/configuration/custom_platform_test.dart
@@ -557,7 +557,7 @@ void main() {
         expect(
             test.stderr,
             containsInOrder(
-                ['Missing required field "name".', "^^^^^^^^^^^^^^^"]));
+                ['Missing required field "name".', 'extends: chrome']));
         await test.shouldExit(exit_codes.data);
       });
 
@@ -587,7 +587,7 @@ void main() {
         expect(
             test.stderr,
             containsInOrder(
-                ['Missing required field "extends".', "^^^^^^^^^^^^^^"]));
+                ['Missing required field "extends".', 'name: Chromium']));
         await test.shouldExit(exit_codes.data);
       });
 
@@ -638,7 +638,7 @@ void main() {
         expect(
             test.stderr,
             containsInOrder(
-                ['Missing required field "settings".', "^^^^^^^^^^^^^^"]));
+                ['Missing required field "settings".', 'name: Chromium']));
         await test.shouldExit(exit_codes.data);
       });
 

--- a/pkgs/test_api/lib/src/util/remote_exception.dart
+++ b/pkgs/test_api/lib/src/util/remote_exception.dart
@@ -72,9 +72,9 @@ class RemoteException implements Exception {
 
   /// Deserializes the exception portion of [serialized].
   static RemoteException _deserializeException(serialized) {
-    String message = serialized['message'];
-    String type = serialized['type'];
-    String toString = serialized['toString'];
+    final message = serialized['message'] as String;
+    final type = serialized['type'] as String;
+    final toString = serialized['toString'] as String;
 
     switch (serialized['supertype'] as String) {
       case 'TestFailure':

--- a/pkgs/test_api/test/backend/declarer_test.dart
+++ b/pkgs/test_api/test/backend/declarer_test.dart
@@ -649,10 +649,11 @@ void main() {
 Future _runTest(Test test, {bool shouldFail = false}) {
   var liveTest = test.load(_suite);
 
-  Function(AsyncError) errorCallback = shouldFail
-      ? expectAsync1((_) {})
-      : (error) => registerException(error.error, error.stackTrace);
-  liveTest.onError.listen(errorCallback);
+  if (shouldFail) {
+    liveTest.onError.listen(expectAsync1((_) {}));
+  } else {
+    liveTest.onError.listen((e) => registerException(e.error, e.stackTrace));
+  }
 
   return liveTest.run();
 }


### PR DESCRIPTION
In version `1.5.0` of `source_span` the output for multi-line spans was
updated to output the content and highlight a section with lines on the
left instead of the old `^^^^^` format. Update the expectations
accordingly to expect that a bit of the multi-line content is printed.