### PR TITLE
Ignore a new deprecation from analyzer package

### DIFF
--- a/pkgs/test_core/lib/src/runner/parse_metadata.dart
+++ b/pkgs/test_core/lib/src/runner/parse_metadata.dart
@@ -455,6 +455,7 @@ class _Parser {
 
     var list = expression as ListLiteral;
 
+    // ignore: deprecated_member_use
     return list.elements;
   }
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.2.1+1
+version: 0.2.2-dev
 author: Dart Team <misc@dartlang.org>
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core


### PR DESCRIPTION
I will separetly look in to the migration, this is to get travis
unblocked for other commits.