### PR TITLE
Don't deserialize to IsolateSpawnException

### DIFF
--- a/pkgs/test/test/runner/hybrid_test.dart
+++ b/pkgs/test/test/runner/hybrid_test.dart
@@ -582,6 +582,6 @@ void _spawnHybridUriTests([Iterable<String> arguments]) {
   test("emits an error from the stream channel if the isolate fails to load",
       () {
     expect(spawnHybridUri("non existent file").stream.first,
-        throwsA(TypeMatcher<IsolateSpawnException>()));
+        throwsA(TypeMatcher<Exception>()));
   });
 }

--- a/pkgs/test_api/lib/src/util/remote_exception.dart
+++ b/pkgs/test_api/lib/src/util/remote_exception.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:isolate';
 
 import 'package:stack_trace/stack_trace.dart';
 
@@ -42,15 +41,7 @@ class RemoteException implements Exception {
       }
     }
 
-    // It's possible (although unlikely) for a user-defined class to have
-    // multiple of these supertypes. That's fine, though, since we only care
-    // about core-library-raised IsolateSpawnExceptions anyway.
-    String supertype;
-    if (error is TestFailure) {
-      supertype = 'TestFailure';
-    } else if (error is IsolateSpawnException) {
-      supertype = 'IsolateSpawnException';
-    }
+    final supertype = (error is TestFailure) ? 'TestFailure' : null;
 
     return {
       'message': message,
@@ -79,8 +70,6 @@ class RemoteException implements Exception {
     switch (serialized['supertype'] as String) {
       case 'TestFailure':
         return _RemoteTestFailure(message, type, toString);
-      case 'IsolateSpawnException':
-        return _RemoteIsolateSpawnException(message, type, toString);
       default:
         return RemoteException._(message, type, toString);
     }
@@ -97,12 +86,5 @@ class RemoteException implements Exception {
 /// results depending on whether an exception was a failure or an error.
 class _RemoteTestFailure extends RemoteException implements TestFailure {
   _RemoteTestFailure(String message, String type, String toString)
-      : super._(message, type, toString);
-}
-
-/// A subclass of [RemoteException] that implements [IsolateSpawnException].
-class _RemoteIsolateSpawnException extends RemoteException
-    implements IsolateSpawnException {
-  _RemoteIsolateSpawnException(String message, String type, String toString)
       : super._(message, type, toString);
 }


### PR DESCRIPTION
We have removed most of the special handling around
`IsolateSpawnException` so it shouldn't matter if the exposed exception
implements that interface. On the web, for the `spawnHybridUri` or
`spawnHybridCode` case the web code shouldn't be able to see the type to
test for it anyway.