### PR TITLE
Disallow non-literal strings in annotations

### DIFF
--- a/pkgs/test/test/runner/parse_metadata_test.dart
+++ b/pkgs/test/test/runner/parse_metadata_test.dart
@@ -240,6 +240,12 @@ library foo;
             .writeAsStringSync("@Tags(['a'])\n@Tags(['b'])\nlibrary foo;");
         expect(() => parseMetadata(_path, Set()), throwsFormatException);
       });
+
+      test('String interpolation', () {
+        File(_path)
+            .writeAsStringSync("@Tags(['\$a'])\nlibrary foo;\nconst a = 'a';");
+        expect(() => parseMetadata(_path, Set()), throwsFormatException);
+      });
     });
   });
 

--- a/pkgs/test_core/lib/src/runner/parse_metadata.dart
+++ b/pkgs/test_core/lib/src/runner/parse_metadata.dart
@@ -475,8 +475,11 @@ class _Parser {
 
   /// Parses a constant String literal.
   StringLiteral _parseString(Expression expression) {
-    if (expression is StringLiteral) return expression;
-    throw SourceSpanFormatException('Expected a String.', _spanFor(expression));
+    if (expression is StringLiteral && expression.stringValue != null) {
+      return expression;
+    }
+    throw SourceSpanFormatException(
+        'Expected a String literal.', _spanFor(expression));
   }
 
   /// Creates a [SourceSpan] for [node].


### PR DESCRIPTION
Gives an actionable error in a case where we'd otherwise get a stack
trace.