### PR TITLE
Prep for analyzer changes to support the "UI as code" feature.

### DIFF
--- a/pkgs/test_core/lib/src/runner/parse_metadata.dart
+++ b/pkgs/test_core/lib/src/runner/parse_metadata.dart
@@ -437,14 +437,19 @@ class _Parser {
     key ??= (expression) => expression as K;
     value ??= (expression) => expression as V;
 
-    if (expression is! MapLiteral) {
+    if (expression is! SetOrMapLiteral) {
       throw SourceSpanFormatException('Expected a Map.', _spanFor(expression));
     }
 
-    var map = expression as MapLiteral;
-
-    return Map.fromIterables(map.entries.map((e) => key(e.key)),
-        map.entries.map((e) => value(e.value)));
+    var map = <K, V>{};
+    for (var element in (expression as SetOrMapLiteral).elements2) {
+      if (element is MapLiteralEntry) {
+        map[key(element.key)] = value(element.value);
+      } else {
+        throw SourceSpanFormatException('Expected a map entry.', _spanFor(element));
+      }
+    }
+    return map;
   }
 
   /// Parses a List literal.
@@ -455,8 +460,7 @@ class _Parser {
 
     var list = expression as ListLiteral;
 
-    // ignore: deprecated_member_use
-    return list.elements;
+    return list.elements2.cast<Expression>();
   }
 
   /// Parses a constant number literal.

--- a/pkgs/test_core/lib/src/runner/parse_metadata.dart
+++ b/pkgs/test_core/lib/src/runner/parse_metadata.dart
@@ -461,7 +461,13 @@ class _Parser {
 
     var list = expression as ListLiteral;
 
-    return list.elements2.cast<Expression>();
+    return list.elements2.map((e) {
+      if (e is! Expression) {
+        throw SourceSpanFormatException(
+            'Expected only literal elements.', _spanFor(e));
+      }
+      return e as Expression;
+    }).toList();
   }
 
   /// Parses a constant number literal.

--- a/pkgs/test_core/lib/src/runner/parse_metadata.dart
+++ b/pkgs/test_core/lib/src/runner/parse_metadata.dart
@@ -446,7 +446,8 @@ class _Parser {
       if (element is MapLiteralEntry) {
         map[key(element.key)] = value(element.value);
       } else {
-        throw SourceSpanFormatException('Expected a map entry.', _spanFor(element));
+        throw SourceSpanFormatException(
+            'Expected a map entry.', _spanFor(element));
       }
     }
     return map;

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.26.4 <0.36.0'
+  analyzer: '>=0.35.3 <0.36.0'
   async: '>=1.13.0 <3.0.0'
   args: '>=1.4.0 <2.0.0'
   boolean_selector: '^1.0.0'


### PR DESCRIPTION
As part of implementing the "UI as code" feature
(https://github.com/dart-lang/language/blob/master/accepted/future-releases/unified-collections/feature-specification.md)
the analyzer is deprecating the following classes and methods:

- ForStatement and ForEachStatement (ForStatement2 is now used for
  both kinds of loops)

- ListLiteral.elements (use elements2, which has a more general return
  type)

- AstVisitor.visitForEachStatement and AstVisitor.visitForStatement
  (visitForStatement2 is now used for both kinds of loops)

- AstVisitor.visitMapLiteral and AstVisitor.visitSetLiteral
  (visitSetOrMapLiteral is now used for both kinds of literals).

See deprecation CL: https://dart-review.googlesource.com/c/sdk/+/95665/