### PR TITLE
Update imports to allow stream_channel 2.0.0

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.1
+
+* Allow `stream_channel` version `2.0.0`.
+
 ## 1.6.0
 
 * Allow `analyzer` version `0.36.x`.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.6.0
+version: 1.6.1
 author: Dart Team <misc@dartlang.org>
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -27,14 +27,14 @@ dependencies:
   shelf_web_socket: '^0.2.0'
   source_span: '^1.4.0'
   stack_trace: '^1.9.0'
-  stream_channel: '^1.6.0'
+  stream_channel: '>=1.7.0 <3.0.0'
   typed_data: '^1.0.0'
   vm_service_client: '^0.2.3'
   web_socket_channel: '^1.0.0'
   yaml: '^2.0.0'
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: '0.2.3'
-  test_core: '0.2.2'
+  test_api: '0.2.4'
+  test_core: '0.2.3'
 
 dev_dependencies:
   fake_async: '>=0.1.2 <2.0.0'

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.4
+
+* Allow `stream_channel` version `2.0.0`.
+
 ## 0.2.3
 
 * Update to matcher version `0.12.5`.

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.2.3
+version: 0.2.4
 author: Dart Team <misc@dartlang.org>
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
@@ -16,7 +16,7 @@ dependencies:
   pedantic: '^1.0.0'
   source_span: '^1.4.0'
   stack_trace: '^1.9.0'
-  stream_channel: '^1.6.0'
+  stream_channel: '>=1.7.0 <3.0.0'
   string_scanner: '>=0.1.1 <2.0.0'
   term_glyph: '^1.0.0'
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3
+
+* Switch import for `IsolateChannel` for forwards compatibility with `2.0.0`.
+
 ## 0.2.2
 
 * Allow `analyzer` version `0.36.x`.

--- a/pkgs/test_core/lib/src/bootstrap/vm.dart
+++ b/pkgs/test_core/lib/src/bootstrap/vm.dart
@@ -4,7 +4,7 @@
 
 import "dart:isolate";
 
-import "package:stream_channel/stream_channel.dart";
+import "package:stream_channel/isolate_channel.dart";
 
 import "package:test_core/src/runner/plugin/remote_platform_helpers.dart";
 

--- a/pkgs/test_core/lib/src/runner/hybrid_listener.dart
+++ b/pkgs/test_core/lib/src/runner/hybrid_listener.dart
@@ -7,6 +7,7 @@ import "dart:isolate";
 
 import "package:async/async.dart";
 import "package:stack_trace/stack_trace.dart";
+import "package:stream_channel/isolate_channel.dart";
 import "package:stream_channel/stream_channel.dart";
 import "package:test_api/src/util/remote_exception.dart"; // ignore: implementation_imports
 import 'package:test_api/src/utils.dart'; // ignore: implementation_imports

--- a/pkgs/test_core/lib/src/runner/spawn_hybrid.dart
+++ b/pkgs/test_core/lib/src/runner/spawn_hybrid.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:isolate';
 
 import 'package:async/async.dart';
+import 'package:stream_channel/isolate_channel.dart';
 import 'package:stream_channel/stream_channel.dart';
 
 import '../util/dart.dart' as dart;

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:path/path.dart' as p;
+import 'package:stream_channel/isolate_channel.dart';
 import 'package:stream_channel/stream_channel.dart';
 
 import 'package:vm_service_client/vm_service_client.dart';

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -113,7 +113,7 @@ Future<Isolate> _spawnDataIsolate(String path, SendPort message) async {
   return await dart.runInIsolate('''
     import "dart:isolate";
 
-    import "package:stream_channel/stream_channel.dart";
+    import "package:stream_channel/isolate_channel.dart";
 
     import "package:test_core/src/runner/plugin/remote_platform_helpers.dart";
 
@@ -121,7 +121,7 @@ Future<Isolate> _spawnDataIsolate(String path, SendPort message) async {
 
     void main(_, SendPort message) {
       var channel = serializeSuite(() => test.main);
-      new IsolateChannel.connectSend(message).pipe(channel);
+      IsolateChannel.connectSend(message).pipe(channel);
     }
   ''', message, checked: true);
 }

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.2.2
+version: 0.2.3
 author: Dart Team <misc@dartlang.org>
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
@@ -25,14 +25,14 @@ dependencies:
   source_maps: '^0.10.2'
   source_span: '^1.4.0'
   stack_trace: '^1.9.0'
-  stream_channel: '^1.6.0'
+  stream_channel: '>=1.7.0 <3.0.0'
   vm_service_client: '^0.2.3'
   yaml: '^2.0.0'
   # Use a tight version constraint to ensure that a constraint on matcher
   # properly constrains all features it provides.
   matcher: '>=0.12.5 <0.12.6'
   # Use an exact version until the test_api package is stable.
-  test_api: '0.2.3'
+  test_api: '0.2.4'
 
 dependency_overrides:
   test_api:


### PR DESCRIPTION
Version `1.7.0` adds the import so it's the minimum version required.
Allow versions through `2.x` since the breaking change will be to change
the import which will now be satisfied.