### PR TITLE
Tweak pubspec constraint styles

### DIFF
--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   analyzer: ">=0.26.4 <0.37.0"
-  async: ^1.0.0
+  async: ^2.0.0
   boolean_selector: ^1.0.0
   http_multi_server: ^2.0.0
   io: ^0.3.0

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -5,42 +5,42 @@ description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
-  analyzer: '>=0.26.4 <0.37.0'
-  async: '>=1.13.0 <3.0.0'
-  boolean_selector: '^1.0.0'
-  http_multi_server: '>=1.0.0 <3.0.0'
-  io: '^0.3.0'
-  js: '^0.6.0'
-  multi_server_socket: '^1.0.0'
-  node_preamble: '^1.3.0'
-  package_resolver: '^1.0.0'
-  path: '^1.2.0'
-  pedantic: '^1.1.0'
-  pool: '^1.3.0'
-  pub_semver: '^1.0.0'
-  shelf: '>=0.6.5 <0.8.0'
-  shelf_packages_handler: '^1.0.0'
-  shelf_static: '^0.2.6'
-  shelf_web_socket: '^0.2.0'
-  source_span: '^1.4.0'
-  stack_trace: '^1.9.0'
-  stream_channel: '>=1.7.0 <3.0.0'
-  typed_data: '^1.0.0'
-  vm_service_client: '^0.2.3'
-  web_socket_channel: '^1.0.0'
-  yaml: '^2.0.0'
+  analyzer: ">=0.26.4 <0.37.0"
+  async: ^1.0.0
+  boolean_selector: ^1.0.0
+  http_multi_server: ^2.0.0
+  io: ^0.3.0
+  js: ^0.6.0
+  multi_server_socket: ^1.0.0
+  node_preamble: ^1.3.0
+  package_resolver: ^1.0.0
+  path: ^1.2.0
+  pedantic: ^1.1.0
+  pool: ^1.3.0
+  pub_semver: ^1.0.0
+  shelf: ^0.7.0
+  shelf_packages_handler: ^1.0.0
+  shelf_static: ^0.2.6
+  shelf_web_socket: ^0.2.0
+  source_span: ^1.4.0
+  stack_trace: ^1.9.0
+  stream_channel: ">=1.7.0 <3.0.0"
+  typed_data: ^1.0.0
+  vm_service_client: ^0.2.3
+  web_socket_channel: ^1.0.0
+  yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: '0.2.4'
-  test_core: '0.2.3'
+  test_api: 0.2.4
+  test_core: 0.2.3
 
 dev_dependencies:
-  fake_async: '>=0.1.2 <2.0.0'
-  shelf_test_handler: '^1.0.0'
-  test_descriptor: '^1.0.0'
-  test_process: '^1.0.0'
+  fake_async: ^1.0.0
+  shelf_test_handler: ^1.0.0
+  test_descriptor: ^1.0.0
+  test_process: ^1.0.0
 
 dependency_overrides:
   test_api:

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -5,31 +5,31 @@ description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
-  async: '>=1.13.0 <3.0.0'
-  boolean_selector: '^1.0.0'
-  collection: '^1.8.0'
-  meta: '^1.1.5'
-  path: '^1.2.0'
-  pedantic: '^1.0.0'
-  source_span: '^1.4.0'
-  stack_trace: '^1.9.0'
-  stream_channel: '>=1.7.0 <3.0.0'
-  string_scanner: '>=0.1.1 <2.0.0'
-  term_glyph: '^1.0.0'
+  async: ^2.0.0
+  boolean_selector: ^1.0.0
+  collection: ^1.8.0
+  meta: ^1.1.5
+  path: ^1.2.0
+  pedantic: ^1.0.0
+  source_span: ^1.4.0
+  stack_trace: ^1.9.0
+  stream_channel: ">=1.7.0 <3.0.0"
+  string_scanner: ^1.0.0
+  term_glyph: ^1.0.0
 
   # Use a tight version constraint to ensure that a constraint on matcher
   # properly constrains all features it provides.
-  matcher: '>=0.12.5 <0.12.6'
+  matcher: ">=0.12.5 <0.12.6"
 
 dev_dependencies:
-  fake_async: '>=0.1.2 <2.0.0'
-  test_descriptor: '^1.0.0'
-  test_process: '^1.0.0'
-  test: '>=0.1.0 <2.0.0'
-  test_core: '>=0.1.0 <2.0.0'
+  fake_async: ^1.0.0
+  test_descriptor: ^1.0.0
+  test_process: ^1.0.0
+  test: any
+  test_core: any
 
 dependency_overrides:
   test:

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   analyzer: ">=0.35.3 <0.37.0"
-  async: ^1.0.0
+  async: ^2.0.0
   args: ^1.4.0
   boolean_selector: ^1.0.0
   collection: ^1.8.0

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -5,34 +5,34 @@ description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
-  analyzer: '>=0.35.3 <0.37.0'
-  async: '>=1.13.0 <3.0.0'
-  args: '>=1.4.0 <2.0.0'
-  boolean_selector: '^1.0.0'
-  collection: '^1.8.0'
-  glob: '^1.0.0'
-  io: '^0.3.0'
-  meta: '^1.1.5'
-  package_resolver: '^1.0.0'
-  path: '^1.2.0'
+  analyzer: ">=0.35.3 <0.37.0"
+  async: ^1.0.0
+  args: ^1.4.0
+  boolean_selector: ^1.0.0
+  collection: ^1.8.0
+  glob: ^1.0.0
+  io: ^0.3.0
+  meta: ^1.1.5
+  package_resolver: ^1.0.0
+  path: ^1.2.0
   pedantic: ^1.0.0
-  pool: '^1.3.0'
-  pub_semver: '^1.0.0'
-  source_map_stack_trace: '^1.1.4'
-  source_maps: '^0.10.2'
-  source_span: '^1.4.0'
-  stack_trace: '^1.9.0'
-  stream_channel: '>=1.7.0 <3.0.0'
-  vm_service_client: '^0.2.3'
-  yaml: '^2.0.0'
+  pool: ^1.3.0
+  pub_semver: ^1.0.0
+  source_map_stack_trace: ^1.1.4
+  source_maps: ^0.10.2
+  source_span: ^1.4.0
+  stack_trace: ^1.9.0
+  stream_channel: ">=1.7.0 <3.0.0"
+  vm_service_client: ^0.2.3
+  yaml: ^2.0.0
   # Use a tight version constraint to ensure that a constraint on matcher
   # properly constrains all features it provides.
-  matcher: '>=0.12.5 <0.12.6'
+  matcher: ">=0.12.5 <0.12.6"
   # Use an exact version until the test_api package is stable.
-  test_api: '0.2.4'
+  test_api: 0.2.4
 
 dependency_overrides:
   test_api:


### PR DESCRIPTION
- Don't surround versions with quotes unless they have a space.
- Remove the unnecessary lower bound for packages where the current
  lower bound is not resolvable due to SDK constraints.
- Change single quotes to double quotes since they are preferred in
  yaml.
- Remove version constraints from `test_api` to `test` and `test_core`
  since we will always have path overrides to those packages.