### PR TITLE
expose the parseMetadata function and all required classes to use it

### DIFF
--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.5
+
+* Expose the  `Metadata`, `PlatformSelector`, `Runtime`, and `SuitePlatform`
+  classes publicly.
+
 ## 0.2.4
 
 * Allow `stream_channel` version `2.0.0`.
@@ -12,16 +17,16 @@
 
 ## 0.2.1
 
-* Add `remote_listener.dart` and `suite_channel_manager.dart`. 
+* Add `remote_listener.dart` and `suite_channel_manager.dart`.
 
 ## 0.2.0
 
-* Remove "runner" extensions. 
+* Remove "runner" extensions.
 
 
 ## 0.1.1
 
-* Update `stack_trace_formatter` to fold `test_api` frames by default. 
+* Update `stack_trace_formatter` to fold `test_api` frames by default.
 
 
 ## 0.1.0

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.2.5
 
 * Expose the  `Metadata`, `PlatformSelector`, `Runtime`, and `SuitePlatform`
-  classes publicly.
+  classes publicly through a new `backend.dart` import.
 
 ## 0.2.4
 

--- a/pkgs/test_api/lib/backend.dart
+++ b/pkgs/test_api/lib/backend.dart
@@ -1,0 +1,8 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export 'src/backend/metadata.dart' show Metadata;
+export 'src/backend/platform_selector.dart' show PlatformSelector;
+export 'src/backend/runtime.dart' show Runtime;
+export 'src/backend/suite_platform.dart' show SuitePlatform;

--- a/pkgs/test_api/lib/test_api.dart
+++ b/pkgs/test_api/lib/test_api.dart
@@ -12,11 +12,6 @@ import 'src/frontend/timeout.dart';
 
 export 'package:matcher/matcher.dart';
 
-export 'src/backend/metadata.dart' show Metadata;
-export 'src/backend/platform_selector.dart' show PlatformSelector;
-export 'src/backend/runtime.dart' show Runtime;
-export 'src/backend/suite_platform.dart' show SuitePlatform;
-
 export 'src/frontend/expect.dart' hide formatFailure;
 export 'src/frontend/expect_async.dart';
 export 'src/frontend/future_matchers.dart';

--- a/pkgs/test_api/lib/test_api.dart
+++ b/pkgs/test_api/lib/test_api.dart
@@ -12,6 +12,11 @@ import 'src/frontend/timeout.dart';
 
 export 'package:matcher/matcher.dart';
 
+export 'src/backend/metadata.dart' show Metadata;
+export 'src/backend/platform_selector.dart' show PlatformSelector;
+export 'src/backend/runtime.dart' show Runtime;
+export 'src/backend/suite_platform.dart' show SuitePlatform;
+
 export 'src/frontend/expect.dart' hide formatFailure;
 export 'src/frontend/expect_async.dart';
 export 'src/frontend/future_matchers.dart';

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.2.4
+version: 0.2.5
 author: Dart Team <misc@dartlang.org>
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.4
 
-* Expose the `parseMetadata` function publicly.
+* Expose the `parseMetadata` function publicly through a new `backend.dart`
+  import, as well as re-exporting `package:test_api/backend.dart`.
 
 ## 0.2.3
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.4
+
+* Expose the `parseMetadata` function publicly.
+
 ## 0.2.3
 
 * Switch import for `IsolateChannel` for forwards compatibility with `2.0.0`.

--- a/pkgs/test_core/lib/backend.dart
+++ b/pkgs/test_core/lib/backend.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export 'package:test_api/src/backend/metadata.dart' show Metadata;
+export 'package:test_api/src/backend/platform_selector.dart'
+    show PlatformSelector;
+export 'package:test_api/src/backend/runtime.dart' show Runtime;
+export 'package:test_api/src/backend/suite_platform.dart' show SuitePlatform;
+
+export 'src/runner/parse_metadata.dart' show parseMetadata;

--- a/pkgs/test_core/lib/backend.dart
+++ b/pkgs/test_core/lib/backend.dart
@@ -2,10 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'package:test_api/src/backend/metadata.dart' show Metadata;
-export 'package:test_api/src/backend/platform_selector.dart'
-    show PlatformSelector;
-export 'package:test_api/src/backend/runtime.dart' show Runtime;
-export 'package:test_api/src/backend/suite_platform.dart' show SuitePlatform;
+export 'package:test_api/backend.dart'
+    show Metadata, PlatformSelector, Runtime, SuitePlatform;
 
 export 'src/runner/parse_metadata.dart' show parseMetadata;

--- a/pkgs/test_core/lib/test_core.dart
+++ b/pkgs/test_core/lib/test_core.dart
@@ -29,6 +29,8 @@ import 'src/runner/suite.dart';
 export 'package:test_api/test_api.dart'
     hide test, group, setUp, setUpAll, tearDown, tearDownAll;
 
+export 'src/runner/parse_metadata.dart' show parseMetadata;
+
 /// The global declarer.
 ///
 /// This is used if a test file is run directly, rather than through the runner.

--- a/pkgs/test_core/lib/test_core.dart
+++ b/pkgs/test_core/lib/test_core.dart
@@ -10,9 +10,8 @@ export 'package:matcher/matcher.dart';
 import 'package:path/path.dart' as p;
 import 'package:pedantic/pedantic.dart';
 
+import 'package:test_api/backend.dart';
 import 'package:test_api/src/backend/invoker.dart'; // ignore: implementation_imports
-import 'package:test_api/src/backend/runtime.dart'; // ignore: implementation_imports
-import 'package:test_api/src/backend/suite_platform.dart'; // ignore: implementation_imports
 import 'package:test_api/src/frontend/timeout.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/declarer.dart'; // ignore: implementation_imports
 import 'package:test_api/src/utils.dart'; // ignore: implementation_imports

--- a/pkgs/test_core/lib/test_core.dart
+++ b/pkgs/test_core/lib/test_core.dart
@@ -29,8 +29,6 @@ import 'src/runner/suite.dart';
 export 'package:test_api/test_api.dart'
     hide test, group, setUp, setUpAll, tearDown, tearDownAll;
 
-export 'src/runner/parse_metadata.dart' show parseMetadata;
-
 /// The global declarer.
 ///
 /// This is used if a test file is run directly, rather than through the runner.

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.2.3
+version: 0.2.4
 author: Dart Team <misc@dartlang.org>
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
@@ -32,7 +32,7 @@ dependencies:
   # properly constrains all features it provides.
   matcher: ">=0.12.5 <0.12.6"
   # Use an exact version until the test_api package is stable.
-  test_api: 0.2.4
+  test_api: 0.2.5
 
 dependency_overrides:
   test_api:


### PR DESCRIPTION
Towards https://github.com/dart-lang/build/issues/1554 (makes that a trivial change in build_test)