### PR TITLE
Make the FORCE_TEST_EXIT env global

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ language: dart
 sudo: required
 addons:
   chrome: stable
-env: FORCE_TEST_EXIT=true
+env:
+  global: FORCE_TEST_EXIT=true
 
 jobs:
   include:

--- a/mono_repo.yaml
+++ b/mono_repo.yaml
@@ -3,7 +3,8 @@ travis:
   sudo: required
   addons:
     chrome: stable
-  env: FORCE_TEST_EXIT=true
+  env:
+    global: FORCE_TEST_EXIT=true
 
 merge_stages:
 - analyze_and_format

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -674,7 +674,8 @@ void main(List<String> args) async {
   test.completeShutdown();
 }""").create();
       var test = await runDart(["runner.dart", "--no-color", "--", "test.dart"],
-          description: 'dart runner.dart -- test.dart');
+          description: 'dart runner.dart -- test.dart',
+          environment: {'FORCE_TEST_EXIT': 'false'});
       expect(
           test.stdout,
           emitsThrough(containsInOrder([


### PR DESCRIPTION
We have had flakes on travis because this environment does not appear to be taking effect. This is probably because it's being overridden by the individual environments in each job.