### PR TITLE
Non-completed tests should cause failures

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.3
+
+* Depend on latests `package:test_core`.
+  * This fixes an issue where non-completed tests were considered passing.
+
 ## 1.6.2
 
 * Avoid `dart:isolate` imports on code loaded in tests.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.6.2
+version: 1.6.3
 author: Dart Team <misc@dartlang.org>
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -34,7 +34,7 @@ dependencies:
   yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.2.5
-  test_core: 0.2.4
+  test_core: 0.2.5
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test/test/runner/engine_test.dart
+++ b/pkgs/test/test/runner/engine_test.dart
@@ -59,7 +59,7 @@ void main() {
     engine.suiteSink.close();
   });
 
-  test("returns failure all tests do not complete", () async {
+  test("returns failure if all tests do not complete", () async {
     var engine = declareEngine(() {
       for (var i = 0; i < 3; i++) {
         test("test ${i + 1}", () async {

--- a/pkgs/test/test/runner/engine_test.dart
+++ b/pkgs/test/test/runner/engine_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:pedantic/pedantic.dart';
 import 'package:test_api/src/backend/group.dart';
 import 'package:test_api/src/backend/state.dart';
 import 'package:test_core/src/runner/engine.dart';
@@ -56,6 +57,19 @@ void main() {
 
     engine.suiteSink.add(runnerSuite(Group.root(tests)));
     engine.suiteSink.close();
+  });
+
+  test("returns failure all tests do not complete", () async {
+    var engine = declareEngine(() {
+      for (var i = 0; i < 3; i++) {
+        test("test ${i + 1}", () async {
+          await Future.delayed(Duration(seconds: 5));
+        });
+      }
+    });
+
+    unawaited(expectLater(engine.run(), completion(isFalse)));
+    await engine.close();
   });
 
   test(

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.5
+
+* Fix an issue where non-completed tests were considered passing.
+* Updated `compact` and `expanded` reporters to display non-completed tests.
+
 ## 0.2.4
 
 * Avoid `dart:isolate` imports on code loaded in tests.

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -95,7 +95,9 @@ class Engine {
     await Future.wait(<Future>[_group.future, _loadPool.done],
         eagerError: true);
     if (_closedBeforeDone) return null;
-    return liveTests.every((liveTest) => liveTest.state.result.isPassing);
+    return liveTests.every((liveTest) =>
+        liveTest.state.result.isPassing &&
+        liveTest.state.status == Status.complete);
   }
 
   /// A group of futures for each test suite.

--- a/pkgs/test_core/lib/src/runner/reporter/compact.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/compact.dart
@@ -10,7 +10,6 @@ import 'package:test_api/src/backend/live_test.dart'; // ignore: implementation_
 import 'package:test_api/src/backend/message.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/state.dart'; // ignore: implementation_imports
 import 'package:test_api/src/utils.dart'; // ignore: implementation_imports
-// ignore: implementation_imports
 import 'package:test_api/src/utils.dart' as utils;
 
 import '../../util/io.dart';
@@ -253,6 +252,12 @@ class CompactReporter implements Reporter {
       if (!_printedNewline) stdout.write(" " * (lineLength - message.length));
       stdout.writeln();
     } else if (!success) {
+      for (var liveTest in _engine.active) {
+        _progressLine(_description(liveTest),
+            truncate: false,
+            suffix: " - did not complete $_bold$_red[E]$_noColor");
+        print('');
+      }
       _progressLine('Some tests failed.', color: _red);
       print('');
     } else if (_engine.passed.isEmpty) {

--- a/pkgs/test_core/lib/src/runner/reporter/compact.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/compact.dart
@@ -10,6 +10,7 @@ import 'package:test_api/src/backend/live_test.dart'; // ignore: implementation_
 import 'package:test_api/src/backend/message.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/state.dart'; // ignore: implementation_imports
 import 'package:test_api/src/utils.dart'; // ignore: implementation_imports
+// ignore: implementation_imports
 import 'package:test_api/src/utils.dart' as utils;
 
 import '../../util/io.dart';

--- a/pkgs/test_core/lib/src/runner/reporter/expanded.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/expanded.dart
@@ -222,6 +222,10 @@ class ExpandedReporter implements Reporter {
     if (_engine.liveTests.isEmpty) {
       print("No tests ran.");
     } else if (!success) {
+      for (var liveTest in _engine.active) {
+        _progressLine(_description(liveTest),
+            suffix: " - did not complete $_bold$_red[E]$_noColor");
+      }
       _progressLine('Some tests failed.', color: _red);
     } else if (_engine.passed.isEmpty) {
       _progressLine("All tests skipped.");

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.2.4
+version: 0.2.5
 author: Dart Team <misc@dartlang.org>
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core


### PR DESCRIPTION
- Update engine to consider non-completed tests as a failure run
- Update `compact` and `expanded` reporters to list the non-completed tests
- Add corresponding test
- Rev version numbers

Closes https://github.com/dart-lang/test/issues/1003