### PR TITLE
Don't reroute exceptions thrown in expectAsync

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.6.4
 
+* Don't swallow exceptions from callbacks in `expectAsync*`.
 * Internal cleanup - fix lints.
 
 ## 1.6.3

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.2.6
 
+* Don't swallow exceptions from callbacks in `expectAsync*`.
 * Internal cleanup - fix lints.
 
 ## 0.2.5

--- a/pkgs/test_api/lib/src/frontend/expect_async.dart
+++ b/pkgs/test_api/lib/src/frontend/expect_async.dart
@@ -205,9 +205,6 @@ class _ExpectedFunction<T> {
       }
 
       return Function.apply(_callback, args.toList()) as T;
-    } catch (error, stackTrace) {
-      _zone.handleUncaughtError(error, stackTrace);
-      return null;
     } finally {
       _afterRun();
     }

--- a/pkgs/test_api/test/frontend/expect_async_test.dart
+++ b/pkgs/test_api/test/frontend/expect_async_test.dart
@@ -300,30 +300,12 @@ void main() {
     });
   });
 
-  group("with errors", () {
-    test("reports them to the current test", () async {
-      var liveTest = await runTestBody(() {
-        expectAsync0(() => throw TestFailure('oh no'))();
-      });
-
-      expectTestFailed(liveTest, 'oh no');
+  test("allows errors", () async {
+    var liveTest = await runTestBody(() {
+      expect(expectAsync0(() => throw 'oh no'), throwsA('oh no'));
     });
 
-    test("swallows them and returns null", () async {
-      Function returnValue;
-      var caughtError = false;
-      var liveTest = await runTestBody(() {
-        try {
-          returnValue = expectAsync0(() => throw TestFailure('oh no'))();
-        } on TestFailure catch (_) {
-          caughtError = true;
-        }
-      });
-
-      expectTestFailed(liveTest, 'oh no');
-      expect(returnValue, isNull);
-      expect(caughtError, isFalse);
-    });
+    expectTestPassed(liveTest);
   });
 
   group("old-style expectAsync()", () {


### PR DESCRIPTION
Allows using `expectAsync*` to wrap callbacks in context where they are
called with a `try/catch` without changing visible behavior.