### PR TITLE
Ensure that the test state transitions to complete before the test is considered complete.

### DIFF
--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.2.6
 
 * Internal cleanup - fix lints.
+* Fixed a race condition that caused tests to occasionally fail during
+  `tearDownAll` with the message `(tearDownAll) - did not complete [E]`.
 
 ## 0.2.5
 


### PR DESCRIPTION
In some environments the state change events and the "test complete" event are sent over a stream that does not guarantee ordering (e.g. as independent HTTP requests when using package:sse).
Without this change, such tests will fail intermittently, when the "test complete" event happens to be delivered before the state change event.