### PR TITLE
expectAsync0 fails within callbacks with non-zero count

### DIFF
--- a/pkgs/test_api/test/frontend/expect_async_test.dart
+++ b/pkgs/test_api/test/frontend/expect_async_test.dart
@@ -222,6 +222,14 @@ void main() {
         expectTestFailed(
             liveTest, "Callback called more times than expected (0).");
       });
+
+      test("handles being in a callback", () {
+        var callbackFn = (){
+          expectAsync0(() {}, count: 0);
+        };
+
+        callbackFn();
+      }, timeout: new Timeout(new Duration(seconds: 1)));
     });
 
     group("1,", (){
@@ -231,7 +239,7 @@ void main() {
         };
 
         callbackFn();
-      });
+      }, timeout: new Timeout(new Duration(seconds: 1)));
     });
   });
 

--- a/pkgs/test_api/test/frontend/expect_async_test.dart
+++ b/pkgs/test_api/test/frontend/expect_async_test.dart
@@ -223,6 +223,16 @@ void main() {
             liveTest, "Callback called more times than expected (0).");
       });
     });
+
+    group("1,", (){
+      test("handles being in a callback", () {
+        var callbackFn = (){
+          expectAsync0(() {}, count: 1);
+        };
+
+        callbackFn();
+      });
+    });
   });
 
   group("with max", () {


### PR DESCRIPTION
Suddenly, we started seeing unexplained test failures. I'm not sure what exactly is the problem, but I got around it with using a completer to check that my callback function is only called once. Any ideas?