### PR TITLE
Stop using deprecated analyzer API left over from "UI as code" migration.

### DIFF
--- a/pkgs/test_core/lib/src/runner/parse_metadata.dart
+++ b/pkgs/test_core/lib/src/runner/parse_metadata.dart
@@ -443,7 +443,6 @@ class _Parser {
     }
 
     var map = <K, V>{};
-    // ignore: deprecated_member_use
     for (var element in (expression as SetOrMapLiteral).elements) {
       if (element is MapLiteralEntry) {
         map[key(element.key)] = value(element.value);
@@ -463,7 +462,6 @@ class _Parser {
 
     var list = expression as ListLiteral;
 
-    // ignore: deprecated_member_use
     return list.elements.map((e) {
       if (e is! Expression) {
         throw SourceSpanFormatException(

--- a/pkgs/test_core/lib/src/runner/parse_metadata.dart
+++ b/pkgs/test_core/lib/src/runner/parse_metadata.dart
@@ -444,7 +444,7 @@ class _Parser {
 
     var map = <K, V>{};
     // ignore: deprecated_member_use
-    for (var element in (expression as SetOrMapLiteral).elements2) {
+    for (var element in (expression as SetOrMapLiteral).elements) {
       if (element is MapLiteralEntry) {
         map[key(element.key)] = value(element.value);
       } else {
@@ -464,7 +464,7 @@ class _Parser {
     var list = expression as ListLiteral;
 
     // ignore: deprecated_member_use
-    return list.elements2.map((e) {
+    return list.elements.map((e) {
       if (e is! Expression) {
         throw SourceSpanFormatException(
             'Expected only literal elements.', _spanFor(e));

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=0.36.0 <0.37.0"
+  analyzer: ^0.36.0
   async: ^2.0.0
   args: ^1.4.0
   boolean_selector: ^1.0.0

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=0.35.3 <0.37.0"
+  analyzer: ">=0.36.0 <0.37.0"
   async: ^2.0.0
   args: ^1.4.0
   boolean_selector: ^1.0.0


### PR DESCRIPTION
Since analyzer version 0.36.0, we no longer need to use elements2.
elements is equivalent.