### PR TITLE
test_core: migrate to pkg:vm_service

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.8
+
+* Depend on `vm_service` instead of `vm_service_lib`.
+
 ## 0.2.7
 
 * Depend on `vm_service_lib` instead of `vm_service_client`.

--- a/pkgs/test_core/lib/src/runner/vm/environment.dart
+++ b/pkgs/test_core/lib/src/runner/vm/environment.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 
 import 'package:async/async.dart';
-import 'package:vm_service_lib/vm_service_lib.dart';
+import 'package:vm_service/vm_service.dart';
 import 'package:test_core/src/runner/environment.dart'; // ignore: implementation_imports
 
 /// The environment in which VM tests are loaded.

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -21,8 +21,8 @@ import 'package:test_core/src/runner/runner_suite.dart'; // ignore: implementati
 import 'package:test_core/src/runner/suite.dart'; // ignore: implementation_imports
 import 'package:test_core/src/util/dart.dart' // ignore: implementation_imports
     as dart;
-import 'package:vm_service_lib/vm_service_lib.dart' hide Isolate;
-import 'package:vm_service_lib/vm_service_lib_io.dart';
+import 'package:vm_service/vm_service.dart' hide Isolate;
+import 'package:vm_service/vm_service_io.dart';
 
 import 'environment.dart';
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.2.7
+version: 0.2.8-dev
 author: Dart Team <misc@dartlang.org>
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
@@ -26,7 +26,7 @@ dependencies:
   source_span: ^1.4.0
   stack_trace: ^1.9.0
   stream_channel: ">=1.7.0 <3.0.0"
-  vm_service_lib: ^3.21.0
+  vm_service: ^1.0.0
   yaml: ^2.0.0
   # Use a tight version constraint to ensure that a constraint on matcher
   # properly constrains all features it provides.


### PR DESCRIPTION
pkg:vm_service_lib is discontinued

Related to https://github.com/dart-lang/vm_service_drivers/issues/257