### PR TITLE
Use supported --server-mode flag for dart2js

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.6
+
+* Pass `--server-mode` to dart2js instead of `--categories=Server` to fix a
+  warning about the flag deprecation.
+
 ## 1.6.5
 
 * Depend on the latest `test_core`.

--- a/pkgs/test/README.md
+++ b/pkgs/test/README.md
@@ -263,8 +263,7 @@ The test runner looks for an executable named `node` (on Mac OS or Linux) or
 `node.exe` (on Windows) on your system path. When compiling Node.js tests, it
 passes `-Dnode=true`, so tests can determine whether they're running on Node
 using [`const bool.fromEnvironment("node")`][bool.fromEnvironment]. It also sets
-`--categories=Server`, which will tell the compiler that `dart:html` is not
-available.
+`--server-mode`, which will tell the compiler that `dart:html` is not available.
 
 [bool.fromEnvironment]: https://api.dartlang.org/stable/1.24.2/dart-core/bool/bool.fromEnvironment.html
 

--- a/pkgs/test/lib/src/runner/node/platform.dart
+++ b/pkgs/test/lib/src/runner/node/platform.dart
@@ -10,7 +10,6 @@ import 'package:async/async.dart';
 import 'package:multi_server_socket/multi_server_socket.dart';
 import 'package:node_preamble/preamble.dart' as preamble;
 import 'package:pedantic/pedantic.dart';
-import 'package:pub_semver/pub_semver.dart';
 import 'package:package_resolver/package_resolver.dart';
 import 'package:path/path.dart' as p;
 import 'package:stream_channel/stream_channel.dart';
@@ -35,10 +34,6 @@ import 'package:test_core/src/runner/plugin/platform_helpers.dart'; // ignore: i
 
 import '../executable_settings.dart';
 
-/// The first Dart SDK version where `--categories=Server` disables `dart:html`
-/// rather than disabling all JS-specific libraries.
-final _firstServerSdk = Version.parse("2.0.0-dev.42.0");
-
 /// A platform that loads tests in Node.js processes.
 class NodePlatform extends PlatformPlugin
     implements CustomizablePlatform<ExecutableSettings> {
@@ -46,11 +41,7 @@ class NodePlatform extends PlatformPlugin
   final Configuration _config;
 
   /// The [CompilerPool] managing active instances of `dart2js`.
-  final _compilers = () {
-    var arguments = ["-Dnode=true"];
-    if (sdkVersion >= _firstServerSdk) arguments.add("--categories=Server");
-    return CompilerPool(arguments);
-  }();
+  final _compilers = CompilerPool(["-Dnode=true", "--server-mode"]);
 
   /// The temporary directory in which compiled JS is emitted.
   final _compiledDir = createTempDir();

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.6.5
+version: 1.6.6-dev
 author: Dart Team <misc@dartlang.org>
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test


### PR DESCRIPTION
The old flag, `--categories=Server`, is deprecated and emits a warning
when used. The new flag is supported since at least 2.1.1

Since our pubspec already limits us to at least 2.2.0, remove the SDK
version check for using the flag.