### PR TITLE
Drop dependency on pub_semver

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Pass `--server-mode` to dart2js instead of `--categories=Server` to fix a
   warning about the flag deprecation.
+* Drop dependency on `pub_semver`.
 
 ## 1.6.5
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -20,7 +20,6 @@ dependencies:
   path: ^1.2.0
   pedantic: ^1.1.0
   pool: ^1.3.0
-  pub_semver: ^1.0.0
   shelf: ^0.7.0
   shelf_packages_handler: ^1.0.0
   shelf_static: ^0.2.6

--- a/pkgs/test/test/runner/pub_serve_test.dart
+++ b/pkgs/test/test/runner/pub_serve_test.dart
@@ -9,10 +9,8 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
-import 'package:pub_semver/pub_semver.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
-import 'package:test_core/src/util/io.dart';
 import 'package:test/test.dart';
 
 import '../io.dart';
@@ -340,23 +338,14 @@ void main() {
 }
 
 /// The list of supported compilers for the current [Platform.version].
-final Iterable<String> _compilers = () {
-  var compilers = ['dart2js'];
-  if (_sdkSupportsDartDevc) compilers.add('dartdevc');
-  return compilers;
-}();
-
-/// Whether or not the dartdevc compiler is supported on the current
-/// [Platform.version].
-final bool _sdkSupportsDartDevc = sdkVersion >= Version(1, 24, 0);
+final Iterable<String> _compilers = ['dart2js', 'dartdevc'];
 
 /// Runs the test described by [testFn] once for each supported compiler on the
 /// current [Platform.version], passing the relevant compiler args for pub serve
 /// as the first argument.
 void testWithCompiler(String name, testFn(List<String> compilerArgs), {tags}) {
   for (var compiler in _compilers) {
-    var compilerArgs =
-        _sdkSupportsDartDevc ? ['--web-compiler', compiler] : <String>[];
+    var compilerArgs = ['--web-compiler', compiler];
     test("$name with $compiler", () => testFn(compilerArgs), tags: tags);
   }
 }

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.8
 
 * Depend on `vm_service` instead of `vm_service_lib`.
+* Drop dependency on `pub_semver`.
 
 ## 0.2.7
 

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -10,7 +10,6 @@ import 'dart:io';
 
 import 'package:async/async.dart';
 import 'package:path/path.dart' as p;
-import 'package:pub_semver/pub_semver.dart';
 
 import 'package:test_api/src/backend/operating_system.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/runtime.dart'; // ignore: implementation_imports
@@ -39,9 +38,6 @@ final int lineLength = () {
 
 /// The root directory of the Dart SDK.
 final String sdkDir = p.dirname(p.dirname(Platform.resolvedExecutable));
-
-/// The version of the Dart SDK on which test is running.
-final sdkVersion = Version.parse(Platform.version.split(' ').first);
 
 /// Returns the current operating system.
 final OperatingSystem currentOS = (() {

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -20,7 +20,6 @@ dependencies:
   path: ^1.2.0
   pedantic: ^1.0.0
   pool: ^1.3.0
-  pub_semver: ^1.0.0
   source_map_stack_trace: ^1.1.4
   source_maps: ^0.10.2
   source_span: ^1.4.0


### PR DESCRIPTION
This had been used to detect feature support so that the package could
have a wider SDK constraint and have enhanced features for newer SDKs.
Drop the dependency and code checking the SDK version because:

- We now typically bump the SDK constraint rather than support multiple
  code paths.
- The remaining usage was for checking for DDC support in `pub serve`
  which doesn't exist anymore - we haven't yet deleted the tests or
  migrated them to use `build_runner serve`. This test and references to
  the old approach with both compilers is retained to make it clear what
  should be tested when we get around to migrating it.