### PR TITLE
Remove unnecessary DelegatingStreamSink wrapping

### DIFF
--- a/pkgs/test/lib/src/runner/node/platform.dart
+++ b/pkgs/test/lib/src/runner/node/platform.dart
@@ -109,10 +109,7 @@ class NodePlatform extends PlatformPlugin
       process.stderr.transform(lineSplitter).listen(print);
 
       var socket = await server.first;
-      // TODO(nweiz): Remove the DelegatingStreamSink wrapper when sdk#31504 is
-      // fixed.
-      var channel = StreamChannel(
-              socket.cast<List<int>>(), DelegatingStreamSink(socket))
+      var channel = StreamChannel(socket.cast<List<int>>(), socket)
           .transform(StreamChannelTransformer.fromCodec(utf8))
           .transform(chunksToLines)
           .transform(jsonDocument)


### PR DESCRIPTION
This was added in https://github.com/dart-lang/test/pull/729 when the
`Socket` class was missing a method in an interface it declared it had -
this caused a problem when some code tried to tear if off.

According to https://github.com/dart-lang/sdk/issues/31504 that method
now exists and can be torn off - calling that method would still throw,
but that would also be true with a `DelegatignStreamSink` wrapper.