### PR TITLE
Remove state change race condition logic

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.11
+
+* Depend on the latest `test_core` and `test_api`.
+
 ## 1.6.10
 
 * Depend on the latest `test_core`.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -31,8 +31,8 @@ dependencies:
   web_socket_channel: ^1.0.0
   yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.2.7
-  test_core: 0.2.9+1
+  test_api: 0.2.8
+  test_core: 0.2.9+2
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.8
+
+* Remove logic which accounted for a race condition in state change. The logic
+  was required because `package:sse` used to not guarantee order. This is no
+  longer the case.
+
 ## 0.2.7
 
 * Prepare for upcoming `Stream<List<int>>` changes in the Dart SDK.

--- a/pkgs/test_api/lib/src/backend/live_test_controller.dart
+++ b/pkgs/test_api/lib/src/backend/live_test_controller.dart
@@ -109,8 +109,6 @@ class LiveTestController {
   /// Whether [close] has been called.
   bool get _isClosed => _onErrorController.isClosed;
 
-  final _stateChangedToComplete = Completer<void>();
-
   /// Creates a new controller for a [LiveTest].
   ///
   /// [test] is the test being run; [suite] is the suite that contains it.
@@ -160,11 +158,6 @@ class LiveTestController {
 
     _state = newState;
     _onStateChangeController.add(newState);
-
-    if (newState.status == Status.complete &&
-        !_stateChangedToComplete.isCompleted) {
-      _stateChangedToComplete.complete();
-    }
   }
 
   /// Emits message over [LiveTest.onMessage].
@@ -196,8 +189,7 @@ class LiveTestController {
   /// Returns a future that completes when the test is complete.
   ///
   /// We also wait for the state to transition to Status.complete.
-  Future<void> get onComplete =>
-      Future.wait([completer.future, _stateChangedToComplete.future]);
+  Future<void> get onComplete => completer.future;
 
   /// A wrapper for [_onClose] that ensures that all controllers are closed.
   Future<void> _close() {
@@ -210,10 +202,6 @@ class LiveTestController {
       _onClose();
     } else {
       completer.complete();
-    }
-
-    if (!_stateChangedToComplete.isCompleted) {
-      _stateChangedToComplete.complete();
     }
 
     return onComplete;

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.2.7
+version: 0.2.8
 author: Dart Team <misc@dartlang.org>
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.9+2
+
+* Depend on the latest `test_api`.
+
 ## 0.2.9+1
 
 * Allow the latest `package:vm_service`.

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.2.9+1
+version: 0.2.9+2
 author: Dart Team <misc@dartlang.org>
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
@@ -31,7 +31,7 @@ dependencies:
   # properly constrains all features it provides.
   matcher: ">=0.12.5 <0.12.6"
   # Use an exact version until the test_api package is stable.
-  test_api: 0.2.7
+  test_api: 0.2.8
 
 dependency_overrides:
   test_api:


### PR DESCRIPTION
Externally there is no race condition as event order is guaranteed as we are using a websocket for the remote connection. Internally we make use of `package:sse`. As of  https://github.com/dart-lang/sse/pull/11 order is also guaranteed.