### PR TITLE
Implement VM coverage gathering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,9 @@ jobs:
       env: PKGS="pkgs/test pkgs/test_api pkgs/test_core"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: analyze_and_format
-      name: "SDK: 2.2.0; PKG: pkgs/test; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.2.0; PKG: pkgs/test, pkgs/test_api, pkgs/test_core; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.2.0"
-      env: PKGS="pkgs/test"
-      script: ./tool/travis.sh dartanalyzer_1
-    - stage: analyze_and_format
-      name: "SDK: 2.1.0; PKGS: pkgs/test_api, pkgs/test_core; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.1.0"
-      env: PKGS="pkgs/test_api pkgs/test_core"
+      env: PKGS="pkgs/test pkgs/test_api pkgs/test_core"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: unit_test
       name: "SDK: dev; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0`"

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.0
+
+* Implement code coverage collection for VM based tests
+
 ## 1.8.0
 
 * Expose the previously hidden sharding arguments

--- a/pkgs/test/README.md
+++ b/pkgs/test/README.md
@@ -2,6 +2,8 @@
 
 * [Writing Tests](#writing-tests)
 * [Running Tests](#running-tests)
+  * [Sharding Tests](#sharding-tests)
+  * [Collecting Code Coverage](#collecting-code-coverage)
   * [Restricting Tests to Certain Platforms](#restricting-tests-to-certain-platforms)
   * [Platform Selectors](#platform-selectors)
   * [Running Tests on Node.js](#running-tests-on-nodejs)
@@ -157,6 +159,7 @@ reported on the command line just like for VM tests. In fact, you can even run
 tests on both platforms with a single command: `pub run test -p "chrome,vm"
 path/to/test.dart`.
 
+### Sharding Tests
 Tests can also be sharded with the `--total-shards` and `--shard-index` arguments,
 allowing you to split up your test suites and run them separately. For example,
 if you wanted to run 3 shards of your test suite, you could run them as follows:
@@ -166,6 +169,20 @@ pub run test --total-shards 3 --shard-index 0 path/to/test.dart
 pub run test --total-shards 3 --shard-index 1 path/to/test.dart
 pub run test --total-shards 3 --shard-index 2 path/to/test.dart
 ```
+
+### Collecting Code Coverage
+To collect code coverage, you can run tests with the `--coverage <directory>`
+argument. The directory specified can be an absolute or relative path. 
+If a directory does not exist at the path specified, a directory will be
+created. If a directory does exist, files may be overwritten with the latest
+coverage data, if they conflict.
+
+This option will enable code coverage collection on a suite-by-suite basis,
+and the resulting coverage files will be outputted in the directory specified.
+The files can then be formatted using the `package:coverage`
+`format_coverage` executable.
+
+Coverage gathering is currently only implemented for tests run in the Dart VM.
 
 ### Restricting Tests to Certain Platforms
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.8.0
+version: 1.9.0
 author: Dart Team <misc@dartlang.org>
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -32,7 +32,7 @@ dependencies:
   yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.2.8
-  test_core: 0.2.10
+  test_core: 0.2.11
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test/test/runner/coverage_test.dart
+++ b/pkgs/test/test/runner/coverage_test.dart
@@ -2,10 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn("vm")
+
 import 'dart:convert';
 import 'dart:io';
 
-@TestOn("vm")
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
 import 'package:path/path.dart' as p;

--- a/pkgs/test/test/runner/coverage_test.dart
+++ b/pkgs/test/test/runner/coverage_test.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+@TestOn("vm")
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../io.dart';
+
+void main() {
+  group("with the --coverage flag,", () {
+    test("gathers coverage for VM tests", () async {
+      await d.file("test.dart", """
+        import 'package:test/test.dart';
+
+        void main() {
+          test("test 1", () {
+            expect(true, isTrue);
+          });
+        }
+      """).create();
+
+      final coverageDirectory =
+          Directory(p.join(Directory.current.path, "test_coverage"));
+      expect(await coverageDirectory.exists(), isFalse,
+          reason:
+              'Coverage directory exists, cannot safely run coverage tests. Delete the ${coverageDirectory.path} directory to fix.');
+
+      var test =
+          await runTest(["--coverage", coverageDirectory.path, "test.dart"]);
+      expect(test.stdout, emitsThrough(contains("+1: All tests passed!")));
+      await test.shouldExit(0);
+
+      final coverageFile =
+          File(p.join(coverageDirectory.path, "test.dart.vm.json"));
+      final coverage = await coverageFile.readAsString();
+      final jsonCoverage = json.decode(coverage);
+      expect(jsonCoverage['coverage'], isNotEmpty);
+
+      await coverageDirectory.delete(recursive: true);
+    });
+  });
+}

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -95,8 +95,7 @@ Usage: pub run test [files or directories...]
                                   Currently only supported for browser tests.
 
     --debug                       Runs the VM and Chrome tests in debug mode.
-    --coverage=<directory>        Enables coverage gathering for the Dart VM and outputs an
-                                  lcov formatted file to the specified directory.
+    --coverage=<directory>        Gathers coverage and outputs it to the specified directory.
                                   Implies --debug.
 
     --[no-]chain-stack-traces     Chained stack traces to provide greater exception details

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -95,6 +95,10 @@ Usage: pub run test [files or directories...]
                                   Currently only supported for browser tests.
 
     --debug                       Runs the VM and Chrome tests in debug mode.
+    --coverage=<directory>        Enables coverage gathering for the Dart VM and outputs an
+                                  lcov formatted file to the specified directory.
+                                  Implies --debug.
+
     --[no-]chain-stack-traces     Chained stack traces to provide greater exception details
                                   especially for asynchronous code. It may be useful to disable
                                   to provide improved test performance but at the cost of

--- a/pkgs/test/test/utils.dart
+++ b/pkgs/test/test/utils.dart
@@ -185,7 +185,7 @@ List<GroupEntry> declare(void body()) {
 }
 
 /// Runs [body] with a declarer and returns an engine that runs those tests.
-Engine declareEngine(void body(), {bool runSkipped = false}) {
+Engine declareEngine(void body(), {bool runSkipped = false, String coverage}) {
   var declarer = Declarer()..declare(body);
   return Engine.withSuites([
     RunnerSuite(
@@ -193,7 +193,7 @@ Engine declareEngine(void body(), {bool runSkipped = false}) {
         SuiteConfiguration(runSkipped: runSkipped),
         declarer.build(),
         suitePlatform)
-  ]);
+  ], coverage: coverage);
 }
 
 /// Returns a [RunnerSuite] with a default environment and configuration.

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -5,7 +5,7 @@ description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.2.0 <3.0.0"
 
 dependencies:
   async: ^2.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 0.2.11
+
+* Implement code coverage gathering for VM tests.
+
 ## 0.2.10
 
-Add a `--debug` argument for running the VM/Chrome in debug mode.
+* Add a `--debug` argument for running the VM/Chrome in debug mode.
 
 ## 0.2.9+2
 

--- a/pkgs/test_core/lib/src/runner.dart
+++ b/pkgs/test_core/lib/src/runner.dart
@@ -71,7 +71,8 @@ class Runner {
 
   /// Creates a new runner based on [configuration].
   factory Runner(Configuration config) => config.asCurrent(() {
-        var engine = Engine(concurrency: config.concurrency, coverage: config.coverage);
+        var engine =
+            Engine(concurrency: config.concurrency, coverage: config.coverage);
 
         var reporterDetails = allReporters[config.reporter];
         return Runner._(engine, reporterDetails.factory(config, engine));
@@ -107,7 +108,8 @@ class Runner {
         }
 
         if (_config.coverage != null) {
-          var directory = await Directory(_config.coverage).create(recursive: true);
+          var directory =
+              await Directory(_config.coverage).create(recursive: true);
           print('Gathering coverage and outputting to: ${directory.path}');
         }
 

--- a/pkgs/test_core/lib/src/runner.dart
+++ b/pkgs/test_core/lib/src/runner.dart
@@ -108,9 +108,7 @@ class Runner {
         }
 
         if (_config.coverage != null) {
-          var directory =
-              await Directory(_config.coverage).create(recursive: true);
-          print('Gathering coverage and outputting to: ${directory.path}');
+          await Directory(_config.coverage).create(recursive: true);
         }
 
         bool success;

--- a/pkgs/test_core/lib/src/runner.dart
+++ b/pkgs/test_core/lib/src/runner.dart
@@ -71,7 +71,7 @@ class Runner {
 
   /// Creates a new runner based on [configuration].
   factory Runner(Configuration config) => config.asCurrent(() {
-        var engine = Engine(concurrency: config.concurrency);
+        var engine = Engine(concurrency: config.concurrency, coverage: config.coverage);
 
         var reporterDetails = allReporters[config.reporter];
         return Runner._(engine, reporterDetails.factory(config, engine));
@@ -104,6 +104,11 @@ class Runner {
               'default.\nThis breaks the various reporter contracts.'
               '\nTo set the value define '
               '`DART_VM_OPTIONS=-DSILENT_OBSERVATORY=true`.');
+        }
+
+        if (_config.coverage != null) {
+          var directory = await Directory(_config.coverage).create(recursive: true);
+          print('Gathering coverage and outputting to: ${directory.path}');
         }
 
         bool success;

--- a/pkgs/test_core/lib/src/runner/configuration.dart
+++ b/pkgs/test_core/lib/src/runner/configuration.dart
@@ -52,8 +52,12 @@ class Configuration {
   final bool _pauseAfterLoad;
 
   /// Whether to run browsers in their respective debug modes
-  bool get debug => pauseAfterLoad || (_debug ?? false);
+  bool get debug => pauseAfterLoad || (_debug ?? false) || _coverage != null;
   final bool _debug;
+
+  /// The output folder for coverage gathering
+  String get coverage => _coverage;
+  final String _coverage;
 
   /// The path to the file from which to load more configuration information.
   ///
@@ -219,6 +223,7 @@ class Configuration {
       String configurationPath,
       String dart2jsPath,
       String reporter,
+      String coverage,
       int pubServePort,
       int concurrency,
       int shardIndex,
@@ -264,6 +269,7 @@ class Configuration {
         configurationPath: configurationPath,
         dart2jsPath: dart2jsPath,
         reporter: reporter,
+        coverage: coverage,
         pubServePort: pubServePort,
         concurrency: concurrency,
         shardIndex: shardIndex,
@@ -322,6 +328,7 @@ class Configuration {
       String configurationPath,
       String dart2jsPath,
       String reporter,
+      String coverage,
       int pubServePort,
       int concurrency,
       this.shardIndex,
@@ -344,6 +351,7 @@ class Configuration {
         _configurationPath = configurationPath,
         _dart2jsPath = dart2jsPath,
         _reporter = reporter,
+        _coverage = coverage,
         pubServeUrl = pubServePort == null
             ? null
             : Uri.parse("http://localhost:$pubServePort"),

--- a/pkgs/test_core/lib/src/runner/configuration.dart
+++ b/pkgs/test_core/lib/src/runner/configuration.dart
@@ -473,6 +473,7 @@ class Configuration {
         configurationPath: other._configurationPath ?? _configurationPath,
         dart2jsPath: other._dart2jsPath ?? _dart2jsPath,
         reporter: other._reporter ?? _reporter,
+        coverage: other._coverage ?? _coverage,
         pubServePort: (other.pubServeUrl ?? pubServeUrl)?.port,
         concurrency: other._concurrency ?? _concurrency,
         shardIndex: other.shardIndex ?? shardIndex,

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -92,8 +92,7 @@ final ArgParser _parser = (() {
   parser.addFlag("debug",
       help: 'Runs the VM and Chrome tests in debug mode.', negatable: false);
   parser.addOption("coverage",
-      help: 'Enables coverage gathering for the Dart VM and outputs an\n'
-          'lcov formatted file to the specified directory.\n'
+      help: 'Gathers coverage and outputs it to the specified directory.\n'
           'Implies --debug.',
       valueHelp: 'directory');
   parser.addFlag("chain-stack-traces",

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -91,6 +91,11 @@ final ArgParser _parser = (() {
       negatable: false);
   parser.addFlag("debug",
       help: 'Runs the VM and Chrome tests in debug mode.', negatable: false);
+  parser.addOption("coverage",
+      help: 'Enables coverage gathering for the Dart VM and outputs an\n'
+          'lcov formatted file to the specified directory.\n'
+          'Implies --debug.',
+      valueHelp: 'directory');
   parser.addFlag("chain-stack-traces",
       help: 'Chained stack traces to provide greater exception details\n'
           'especially for asynchronous code. It may be useful to disable\n'
@@ -214,6 +219,7 @@ class _Parser {
         dart2jsArgs: _ifParsed('dart2js-args'),
         precompiledPath: _ifParsed('precompiled'),
         reporter: _ifParsed('reporter'),
+        coverage: _ifParsed('coverage'),
         pubServePort: _parseOption('pub-serve', int.parse),
         concurrency: _parseOption('concurrency', int.parse),
         shardIndex: shardIndex,

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -21,7 +21,6 @@ import 'package:test_api/src/backend/message.dart'; // ignore: implementation_im
 import 'package:test_api/src/backend/state.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/test.dart'; // ignore: implementation_imports
 import 'package:test_api/src/util/iterable_set.dart'; // ignore: implementation_imports
-import 'package:test_core/src/runner/environment.dart';
 
 import 'runner_suite.dart';
 import 'live_suite.dart';

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -310,12 +310,10 @@ class Engine {
     if (!suite.platform.runtime.isDartVM) return;
 
     final Map<String, dynamic> cov = await collect(suite.environment.observatoryUrl, false, false, false, Set());
-    final Map<String, Map<int, int>> hitmap = createHitmap(cov['coverage'] as List);
-    final String lcov = await LcovFormatter(BazelResolver()).format(hitmap);
 
-    final outfile = File('$_coverage/${suite.path}.lcov.info')..createSync(recursive: true);
+    final outfile = File('$_coverage/${suite.path}.json')..createSync(recursive: true);
     final IOSink out = outfile.openWrite();
-    out.write(json.encode(lcov));
+    out.write(json.encode(cov));
     await out.flush();
     await out.close();
   }

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -10,7 +10,7 @@ import 'dart:io';
 import 'package:async/async.dart' hide Result;
 import 'package:collection/collection.dart';
 import 'package:coverage/coverage.dart';
-import 'package:path/path.dart';
+import 'package:path/path.dart' as p;
 import 'package:pedantic/pedantic.dart';
 import 'package:pool/pool.dart';
 
@@ -318,7 +318,7 @@ class Engine {
         suite.environment.observatoryUrl, false, false, false, Set(),
         isolateIds: {isolateId});
 
-    final outfile = File(join('$_coverage', '${suite.path}.vm.json'))
+    final outfile = File(p.join('$_coverage', '${suite.path}.vm.json'))
       ..createSync(recursive: true);
     final IOSink out = outfile.openWrite();
     out.write(json.encode(cov));

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -287,8 +287,8 @@ class Engine {
           if (_closed) return;
           await _runGroup(controller, controller.liveSuite.suite.group, []);
           controller.noMoreLiveTests();
-          loadResource.allowRelease(() => controller.close());
           await _gatherCoverage(controller);
+          loadResource.allowRelease(() => controller.close());
         });
       }());
     }, onDone: () {
@@ -308,7 +308,6 @@ class Engine {
     final RunnerSuite suite = controller.liveSuite.suite;
 
     if (!suite.platform.runtime.isDartVM) return;
-
     final Map<String, dynamic> cov = await collect(suite.environment.observatoryUrl, false, false, false, Set());
 
     final outfile = File('$_coverage/${suite.path}.json')..createSync(recursive: true);

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -10,6 +10,7 @@ import 'dart:io';
 import 'package:async/async.dart' hide Result;
 import 'package:collection/collection.dart';
 import 'package:coverage/coverage.dart';
+import 'package:path/path.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:pool/pool.dart';
 
@@ -309,16 +310,15 @@ class Engine {
 
     if (!suite.platform.runtime.isDartVM) return;
 
-    // for some reason the observatoryUrl URI doesn't have the query parameters populated
     final String isolateId =
         Uri.parse(suite.environment.observatoryUrl.fragment)
             .queryParameters['isolateId'];
 
-    final Map<String, dynamic> cov = await collect(
+    final cov = await collect(
         suite.environment.observatoryUrl, false, false, false, Set(),
         isolateIds: {isolateId});
 
-    final outfile = File('$_coverage/${suite.path}.vm.json')
+    final outfile = File(join('$_coverage', '${suite.path}.vm.json'))
       ..createSync(recursive: true);
     final IOSink out = outfile.openWrite();
     out.write(json.encode(cov));

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -314,7 +314,7 @@ class Engine {
         suite.environment.observatoryUrl.toString().split('?')[1])['isolateId'];
 
     final Map<String, dynamic> cov = await collect(
-        suite.environment.observatoryUrl, false, false, false, {},
+        suite.environment.observatoryUrl, false, false, false, Set(),
         isolateIds: {isolateId});
 
     final outfile = File('$_coverage/${suite.path}.vm.json')

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -318,7 +318,7 @@ class Engine {
         suite.environment.observatoryUrl, false, false, false, Set(),
         isolateIds: Set.from([isolateId]));
 
-    final outfile = File('$_coverage/${suite.path}.json')
+    final outfile = File('$_coverage/${suite.path}.vm.json')
       ..createSync(recursive: true);
     final IOSink out = outfile.openWrite();
     out.write(json.encode(cov));

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -69,7 +69,7 @@ class Engine {
   /// `false` if the tests finished running before close was called.
   bool _closedBeforeDone;
 
-  /// The coverage output directory
+  /// The coverage output directory.
   String _coverage;
 
   /// A pool that limits the number of test suites running concurrently.
@@ -314,8 +314,8 @@ class Engine {
         suite.environment.observatoryUrl.toString().split('?')[1])['isolateId'];
 
     final Map<String, dynamic> cov = await collect(
-        suite.environment.observatoryUrl, false, false, false, Set(),
-        isolateIds: Set.from([isolateId]));
+        suite.environment.observatoryUrl, false, false, false, {},
+        isolateIds: {isolateId});
 
     final outfile = File('$_coverage/${suite.path}.vm.json')
       ..createSync(recursive: true);

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -310,8 +310,9 @@ class Engine {
     if (!suite.platform.runtime.isDartVM) return;
 
     // for some reason the observatoryUrl URI doesn't have the query parameters populated
-    final String isolateId = Uri.splitQueryString(
-        suite.environment.observatoryUrl.toString().split('?')[1])['isolateId'];
+    final String isolateId =
+        Uri.parse(suite.environment.observatoryUrl.fragment)
+            .queryParameters['isolateId'];
 
     final Map<String, dynamic> cov = await collect(
         suite.environment.observatoryUrl, false, false, false, Set(),

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -5,7 +5,7 @@ description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.2.0 <3.0.0"
 
 dependencies:
   analyzer: ">=0.36.0 <0.39.0"

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   args: ^1.4.0
   boolean_selector: ^1.0.0
   collection: ^1.8.0
-  coverage: ^0.13.2
+  coverage: ^0.13.3
   glob: ^1.0.0
   io: ^0.3.0
   meta: ^1.1.5

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   args: ^1.4.0
   boolean_selector: ^1.0.0
   collection: ^1.8.0
+  coverage: ^0.13.2
   glob: ^1.0.0
   io: ^0.3.0
   meta: ^1.1.5

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.2.10
+version: 0.2.11
 author: Dart Team <misc@dartlang.org>
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core


### PR DESCRIPTION
Open to feedback on this. Here's how it works at the moment:

There's a new `--coverage` option that you can use to specify the output directory for your coverage. It will create a new output directory if one doesn't already exist.

The tests are run through the engine, and then get spit out to a coverage helper function. That coverage helper function:
**A)** Checks if it's a VM suite
**B)** Gathers coverage if it is
**C)** Outputs coverage to `${suite path}.vm.json`

So, for example, when I run:
```bash
pub run test --coverage hello_world test/vm/simple_repo_test.dart
```

A new file gets added at `hello_world/test/vm/simple_repo_test.dart.vm.json` with the coverage results!