### PR TITLE
Mark non-solo tests as "skipped"

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.2
+
+* Depend on the latest `package:test_api` and `package:test_core`.
+
 ## 1.9.1
 
 * Depend on latest `test_core`.

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.9.2
 
 * Depend on the latest `package:test_api` and `package:test_core`.
+* While using `solo` tests that are not run will now be reported as skipped.
 
 ## 1.9.1
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -31,8 +31,8 @@ dependencies:
   web_socket_channel: ^1.0.0
   yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.2.8
-  test_core: 0.2.12
+  test_api: 0.2.9
+  test_core: 0.2.13
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test/test/runner/solo_test.dart
+++ b/pkgs/test/test/runner/solo_test.dart
@@ -2,10 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:test/test.dart';
 @TestOn("vm")
 import 'package:test_descriptor/test_descriptor.dart' as d;
-
-import 'package:test/test.dart';
 
 import '../io.dart';
 
@@ -27,7 +26,7 @@ void main() {
           """).create();
 
     var test = await runTest(["test.dart"]);
-    expect(test.stdout, emitsThrough(contains("+1: All tests passed!")));
+    expect(test.stdout, emitsThrough(contains("+1 ~1: All tests passed!")));
     await test.shouldExit(0);
   });
 
@@ -58,7 +57,7 @@ void main() {
           """).create();
 
     var test = await runTest(["test.dart"]);
-    expect(test.stdout, emitsThrough(contains("+2: All tests passed!")));
+    expect(test.stdout, emitsThrough(contains("+2 ~1: All tests passed!")));
     await test.shouldExit(0);
   });
 }

--- a/pkgs/test/test/runner/solo_test.dart
+++ b/pkgs/test/test/runner/solo_test.dart
@@ -2,8 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:test/test.dart';
 @TestOn("vm")
+
+import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
 import '../io.dart';

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.9
+
+* Treat non-solo tests as skipped so they are properly reported.
+
 ## 0.2.8
 
 * Remove logic which accounted for a race condition in state change. The logic

--- a/pkgs/test_api/lib/src/backend/declarer.dart
+++ b/pkgs/test_api/lib/src/backend/declarer.dart
@@ -256,8 +256,16 @@ class Declarer {
     _checkNotBuilt("build");
 
     _built = true;
-    var entries = _entries.toList();
-    if (_solo) entries.removeWhere((entry) => !_soloEntries.contains(entry));
+    var entries = _entries.map((entry) {
+      if (_solo && !_soloEntries.contains(entry)) {
+        entry = LocalTest(
+            entry.name,
+            entry.metadata
+                .change(skip: true, skipReason: 'does not have "solo"'),
+            null);
+      }
+      return entry;
+    }).toList();
 
     return Group(_name, entries,
         metadata: _metadata,

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.2.8
+version: 0.2.9
 author: Dart Team <misc@dartlang.org>
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.13
+
+* Depend on the latest `package:test_api`.
+
 ## 0.2.12
 
 * Conditionally import coverage logic in `engine.dart`. This ensures the engine

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.2.12
+version: 0.2.13
 author: Dart Team <misc@dartlang.org>
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
@@ -32,7 +32,7 @@ dependencies:
   # properly constrains all features it provides.
   matcher: ">=0.12.5 <0.12.6"
   # Use an exact version until the test_api package is stable.
-  test_api: 0.2.8
+  test_api: 0.2.9
 
 dependency_overrides:
   test_api:


### PR DESCRIPTION
While using solo, mark non-solo tests as "skipped". This improves the reporting of these skipped tests.