### PR TITLE
Add a link to docs on changing timeout

### DIFF
--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.12-dev
+
+* Link to docs on setting timeout when a test times out with the default
+  duration.
+
 ## 0.2.11
 
 * Extend the timeout for synthetic tests, e.g. `tearDownAll`.

--- a/pkgs/test_api/lib/src/backend/invoker.dart
+++ b/pkgs/test_api/lib/src/backend/invoker.dart
@@ -267,15 +267,21 @@ class Invoker {
     if (liveTest.isComplete) return;
     if (_timeoutTimer != null) _timeoutTimer.cancel();
 
-    var timeout = liveTest.test.metadata.timeout.apply(Duration(seconds: 30));
+    const defaultTimeout = Duration(seconds: 30);
+    var timeout = liveTest.test.metadata.timeout.apply(defaultTimeout);
     if (timeout == null) return;
+    String message() {
+      var message = "Test timed out after ${niceDuration(timeout)}.";
+      if (timeout == defaultTimeout) {
+        message += " See https://pub.dev/packages/test#timeouts";
+      }
+      return message;
+    }
+
     _timeoutTimer = _invokerZone.createTimer(timeout, () {
       _outstandingCallbackZones.last.run(() {
         if (liveTest.isComplete) return;
-        _handleError(
-            Zone.current,
-            TimeoutException(
-                "Test timed out after ${niceDuration(timeout)}.", timeout));
+        _handleError(Zone.current, TimeoutException(message(), timeout));
       });
     });
   }

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.2.11
+version: 0.2.12-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api


### PR DESCRIPTION
If a test times out at the default timeout, point to the docs for
changing timeouts in the error message.