### PR TITLE
Fix newly enforced package:pedantic lints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v2.1.0
+# Created with package:mono_repo v2.3.0
 language: dart
 
 # Custom configuration
@@ -13,43 +13,51 @@ after_failure:
 jobs:
   include:
     - stage: analyze_and_format
-      name: "SDK: dev; PKGS: pkgs/test, pkgs/test_api, pkgs/test_core; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
-      dart: dev
-      env: PKGS="pkgs/test pkgs/test_api pkgs/test_core"
-      script: ./tool/travis.sh dartfmt dartanalyzer_0
-    - stage: analyze_and_format
-      name: "SDK: 2.2.0; PKG: pkgs/test, pkgs/test_api, pkgs/test_core; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.2.0"
+      name: "SDK: 2.3.0; PKGS: pkgs/test, pkgs/test_api, pkgs/test_core; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: "2.3.0"
+      os: linux
       env: PKGS="pkgs/test pkgs/test_api pkgs/test_core"
       script: ./tool/travis.sh dartanalyzer_1
+    - stage: analyze_and_format
+      name: "SDK: dev; PKGS: pkgs/test, pkgs/test_api, pkgs/test_core; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
+      dart: dev
+      os: linux
+      env: PKGS="pkgs/test pkgs/test_api pkgs/test_core"
+      script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: unit_test
       name: "SDK: dev; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0`"
       dart: dev
+      os: linux
       env: PKGS="pkgs/test"
       script: ./tool/travis.sh command_0
     - stage: unit_test
       name: "SDK: dev; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 1`"
       dart: dev
+      os: linux
       env: PKGS="pkgs/test"
       script: ./tool/travis.sh command_1
     - stage: unit_test
       name: "SDK: dev; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2`"
       dart: dev
+      os: linux
       env: PKGS="pkgs/test"
       script: ./tool/travis.sh command_2
     - stage: unit_test
       name: "SDK: dev; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3`"
       dart: dev
+      os: linux
       env: PKGS="pkgs/test"
       script: ./tool/travis.sh command_3
     - stage: unit_test
       name: "SDK: dev; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4`"
       dart: dev
+      os: linux
       env: PKGS="pkgs/test"
       script: ./tool/travis.sh command_4
     - stage: unit_test
       name: "SDK: dev; PKG: pkgs/test_api; TASKS: `pub run test --preset travis`"
       dart: dev
+      os: linux
       env: PKGS="pkgs/test_api"
       script: ./tool/travis.sh test
 

--- a/pkgs/test/lib/src/bootstrap/browser.dart
+++ b/pkgs/test/lib/src/bootstrap/browser.dart
@@ -8,7 +8,7 @@ import 'package:test_core/src/runner/plugin/remote_platform_helpers.dart'; // ig
 import '../runner/browser/post_message_channel.dart';
 
 /// Bootstraps a browser test to communicate with the test runner.
-void internalBootstrapBrowserTest(Function getMain()) {
+void internalBootstrapBrowserTest(Function Function() getMain) {
   var channel =
       serializeSuite(getMain, hidePrints: false, beforeLoad: () async {
     var serialized =

--- a/pkgs/test/lib/src/bootstrap/node.dart
+++ b/pkgs/test/lib/src/bootstrap/node.dart
@@ -8,7 +8,7 @@ import 'package:test_core/src/runner/plugin/remote_platform_helpers.dart'; // ig
 import 'package:test_core/src/util/stack_trace_mapper.dart'; // ignore: implementation_imports
 
 /// Bootstraps a browser test to communicate with the test runner.
-void internalBootstrapNodeTest(Function getMain()) {
+void internalBootstrapNodeTest(Function Function() getMain) {
   var channel = serializeSuite(getMain, beforeLoad: () async {
     var serialized = await suiteChannel('test.node.mapper').stream.first;
     if (serialized == null || serialized is! Map) return;

--- a/pkgs/test/lib/src/executable.dart
+++ b/pkgs/test/lib/src/executable.dart
@@ -9,7 +9,7 @@ import 'package:test_api/src/backend/runtime.dart'; // ignore: implementation_im
 import 'runner/node/platform.dart';
 import 'runner/browser/platform.dart';
 
-main(List<String> args) async {
+void main(List<String> args) async {
   registerPlatformPlugin([Runtime.nodeJS], () => NodePlatform());
   registerPlatformPlugin([
     Runtime.chrome,
@@ -19,5 +19,6 @@ main(List<String> args) async {
     Runtime.internetExplorer
   ], () => BrowserPlatform.start());
 
-  await executable.main(args);
+  // TODO figure out if this await is necessary
+  await (executable.main(args) as dynamic);
 }

--- a/pkgs/test/lib/src/runner/browser/browser.dart
+++ b/pkgs/test/lib/src/runner/browser/browser.dart
@@ -61,7 +61,7 @@ abstract class Browser {
   /// which asynchronously returns the browser process. Any errors in
   /// [startBrowser] (even those raised asynchronously after it returns) are
   /// piped to [onExit] and will cause the browser to be killed.
-  Browser(Future<Process> startBrowser()) {
+  Browser(Future<Process> Function() startBrowser) {
     // Don't return a Future here because there's no need for the caller to wait
     // for the process to actually start. They should just wait for the HTTP
     // request instead.
@@ -70,7 +70,7 @@ abstract class Browser {
       _processCompleter.complete(process);
 
       var output = Uint8Buffer();
-      drainOutput(Stream<List<int>> stream) {
+      void drainOutput(Stream<List<int>> stream) {
         try {
           _ioSubscriptions
               .add(stream.listen(output.addAll, cancelOnError: true));
@@ -115,7 +115,7 @@ abstract class Browser {
       // Make sure the process dies even if the error wasn't fatal.
       _process.then((process) => process.kill());
 
-      if (stackTrace == null) stackTrace = Trace.current();
+      stackTrace ??= Trace.current();
       if (_onExitCompleter.isCompleted) return;
       _onExitCompleter.completeError(
           ApplicationException(

--- a/pkgs/test/lib/src/runner/browser/browser_manager.dart
+++ b/pkgs/test/lib/src/runner/browser/browser_manager.dart
@@ -80,7 +80,7 @@ class BrowserManager {
   ///
   /// These are used to mark suites as debugging or not based on the browser's
   /// pings.
-  final _controllers = Set<RunnerSuiteController>();
+  final _controllers = <RunnerSuiteController>{};
 
   // A timer that's reset whenever we receive a message from the browser.
   //
@@ -213,7 +213,7 @@ class BrowserManager {
 
     var suiteID = _suiteID++;
     RunnerSuiteController controller;
-    closeIframe() {
+    void closeIframe() {
       if (_closed) return;
       _controllers.remove(controller);
       _channel.sink.add({'command': 'closeSuite', 'id': suiteID});
@@ -310,16 +310,21 @@ class BrowserManager {
 class _BrowserEnvironment implements Environment {
   final BrowserManager _manager;
 
+  @override
   final supportsDebugging = true;
 
+  @override
   final Uri observatoryUrl;
 
+  @override
   final Uri remoteDebuggerUrl;
 
+  @override
   final Stream onRestart;
 
   _BrowserEnvironment(this._manager, this.observatoryUrl,
       this.remoteDebuggerUrl, this.onRestart);
 
+  @override
   CancelableOperation displayPause() => _manager._displayPause();
 }

--- a/pkgs/test/lib/src/runner/browser/chrome.dart
+++ b/pkgs/test/lib/src/runner/browser/chrome.dart
@@ -22,8 +22,10 @@ import 'default_settings.dart';
 ///
 /// Any errors starting or running the process are reported through [onExit].
 class Chrome extends Browser {
+  @override
   final name = 'Chrome';
 
+  @override
   final Future<Uri> remoteDebuggerUrl;
 
   /// Starts a new instance of Chrome open to the given [url], which may be a
@@ -86,6 +88,6 @@ class Chrome extends Browser {
     }, remoteDebuggerCompleter.future);
   }
 
-  Chrome._(Future<Process> startBrowser(), this.remoteDebuggerUrl)
+  Chrome._(Future<Process> Function() startBrowser, this.remoteDebuggerUrl)
       : super(startBrowser);
 }

--- a/pkgs/test/lib/src/runner/browser/firefox.dart
+++ b/pkgs/test/lib/src/runner/browser/firefox.dart
@@ -29,6 +29,7 @@ user_pref("dom.max_script_run_time", 0);
 ///
 /// Any errors starting or running the process are reported through [onExit].
 class Firefox extends Browser {
+  @override
   final name = 'Firefox';
 
   Firefox(url, {ExecutableSettings settings})
@@ -41,11 +42,15 @@ class Firefox extends Browser {
     var dir = createTempDir();
     File(p.join(dir, 'prefs.js')).writeAsStringSync(_preferences);
 
-    var process = await Process.start(
-        settings.executable,
-        ['--profile', '$dir', url.toString(), '--no-remote']
-          ..addAll(settings.arguments),
-        environment: {'MOZ_CRASHREPORTER_DISABLE': '1'});
+    var process = await Process.start(settings.executable, [
+      '--profile',
+      '$dir',
+      url.toString(),
+      '--no-remote',
+      ...settings.arguments,
+    ], environment: {
+      'MOZ_CRASHREPORTER_DISABLE': '1'
+    });
 
     unawaited(process.exitCode
         .then((_) => Directory(dir).deleteSync(recursive: true)));

--- a/pkgs/test/lib/src/runner/browser/internet_explorer.dart
+++ b/pkgs/test/lib/src/runner/browser/internet_explorer.dart
@@ -14,6 +14,7 @@ import '../executable_settings.dart';
 ///
 /// Any errors starting or running the process are reported through [onExit].
 class InternetExplorer extends Browser {
+  @override
   final name = 'Internet Explorer';
 
   InternetExplorer(url, {ExecutableSettings settings})
@@ -24,7 +25,10 @@ class InternetExplorer extends Browser {
   static Future<Process> _startBrowser(url, ExecutableSettings settings) {
     settings ??= defaultSettings[Runtime.internetExplorer];
 
-    return Process.start(settings.executable,
-        ['-extoff', url.toString()]..addAll(settings.arguments));
+    return Process.start(settings.executable, [
+      '-extoff',
+      '$url',
+      ...settings.arguments,
+    ]);
   }
 }

--- a/pkgs/test/lib/src/runner/browser/phantom_js.dart
+++ b/pkgs/test/lib/src/runner/browser/phantom_js.dart
@@ -42,8 +42,10 @@ page.open(system.args[1], function(status) {
 ///
 /// Any errors starting or running the process are reported through [onExit].
 class PhantomJS extends Browser {
+  @override
   final name = 'PhantomJS';
 
+  @override
   final Future<Uri> remoteDebuggerUrl;
 
   factory PhantomJS(url, {ExecutableSettings settings, bool debug = false}) {
@@ -88,6 +90,6 @@ class PhantomJS extends Browser {
     }, remoteDebuggerCompleter.future);
   }
 
-  PhantomJS._(Future<Process> startBrowser(), this.remoteDebuggerUrl)
+  PhantomJS._(Future<Process> Function() startBrowser, this.remoteDebuggerUrl)
       : super(startBrowser);
 }

--- a/pkgs/test/lib/src/runner/browser/safari.dart
+++ b/pkgs/test/lib/src/runner/browser/safari.dart
@@ -20,6 +20,7 @@ import '../executable_settings.dart';
 ///
 /// Any errors starting or running the process are reported through [onExit].
 class Safari extends Browser {
+  @override
   final name = 'Safari';
 
   Safari(url, {ExecutableSettings settings})

--- a/pkgs/test/lib/src/runner/node/platform.dart
+++ b/pkgs/test/lib/src/runner/node/platform.dart
@@ -62,22 +62,27 @@ class NodePlatform extends PlatformPlugin
       : _config = Configuration.current,
         _http = Configuration.current.pubServeUrl == null ? null : HttpClient();
 
+  @override
   ExecutableSettings parsePlatformSettings(YamlMap settings) =>
       ExecutableSettings.parse(settings);
 
+  @override
   ExecutableSettings mergePlatformSettings(
           ExecutableSettings settings1, ExecutableSettings settings2) =>
       settings1.merge(settings2);
 
+  @override
   void customizePlatform(Runtime runtime, ExecutableSettings settings) {
     var oldSettings = _settings[runtime] ?? _settings[runtime.root];
     if (oldSettings != null) settings = oldSettings.merge(settings);
     _settings[runtime] = settings;
   }
 
+  @override
   StreamChannel loadChannel(String path, SuitePlatform platform) =>
       throw UnimplementedError();
 
+  @override
   Future<RunnerSuite> load(String path, SuitePlatform platform,
       SuiteConfiguration suiteConfig, Object message) async {
     var pair = await _loadChannel(path, platform.runtime, suiteConfig);
@@ -279,6 +284,7 @@ class NodePlatform extends PlatformPlugin
     }
   }
 
+  @override
   Future close() => _closeMemo.runOnce(() async {
         await _compilers.close();
 

--- a/pkgs/test/lib/src/runner/node/socket_channel.dart
+++ b/pkgs/test/lib/src/runner/node/socket_channel.dart
@@ -22,9 +22,9 @@ class _Net {
 
 @JS()
 class _Socket {
-  external setEncoding(String encoding);
-  external on(String event, void callback(String chunk));
-  external write(String data);
+  external void setEncoding(String encoding);
+  external void on(String event, void Function(String chunk) callback);
+  external void write(String data);
 }
 
 /// Returns a [StreamChannel] of JSON-encodable objects that communicates over a

--- a/pkgs/test/lib/src/util/one_off_handler.dart
+++ b/pkgs/test/lib/src/util/one_off_handler.dart
@@ -12,7 +12,7 @@ import 'package:shelf/shelf.dart' as shelf;
 /// invalid and don't need to have a persistent URL.
 class OneOffHandler {
   /// A map from URL paths to handlers.
-  final _handlers = Map<String, shelf.Handler>();
+  final _handlers = <String, shelf.Handler>{};
 
   /// The counter of handlers that have been activated.
   var _counter = 0;

--- a/pkgs/test/lib/src/util/path_handler.dart
+++ b/pkgs/test/lib/src/util/path_handler.dart
@@ -58,5 +58,5 @@ class PathHandler {
 /// A trie node.
 class _Node {
   shelf.Handler handler;
-  final children = Map<String, _Node>();
+  final children = <String, _Node>{};
 }

--- a/pkgs/test/mono_pkg.yaml
+++ b/pkgs/test/mono_pkg.yaml
@@ -9,7 +9,7 @@ stages:
         dart: dev
       - group:
         - dartanalyzer: --fatal-warnings .
-        dart: 2.2.0
+        dart: 2.3.0
     - unit_test:
       - command: xvfb-run -s "-screen 0 1024x768x24" pub run test --preset travis --total-shards 5 --shard-index 0
       - command: xvfb-run -s "-screen 0 1024x768x24" pub run test --preset travis --total-shards 5 --shard-index 1

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -5,7 +5,7 @@ description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
   analyzer: ">=0.36.0 <0.40.0"

--- a/pkgs/test/test/common.dart
+++ b/pkgs/test/test/common.dart
@@ -1,3 +1,3 @@
 import 'package:test/test.dart';
 
-myTest(String name, Function() testFn) => test(name, testFn);
+dynamic myTest(String name, Function() testFn) => test(name, testFn);

--- a/pkgs/test/test/io.dart
+++ b/pkgs/test/test/io.dart
@@ -76,7 +76,7 @@ Future<TestProcess> runTest(Iterable<String> args,
   if (reporter != null) allArgs.add('--reporter=$reporter');
   allArgs.addAll(args);
 
-  if (environment == null) environment = {};
+  environment ??= {};
   environment.putIfAbsent('_DART_TEST_TESTING', () => 'true');
 
   return await runDart(allArgs,
@@ -90,11 +90,12 @@ Future<TestProcess> runDart(Iterable<String> args,
     {Map<String, String> environment,
     String description,
     bool forwardStdio = false}) async {
-  var allArgs = <String>[]
-    ..addAll(Platform.executableArguments.where((arg) =>
-        !arg.startsWith('--package-root=') && !arg.startsWith('--packages=')))
-    ..add(await PackageResolver.current.processArgument)
-    ..addAll(args);
+  var allArgs = <String>[
+    ...Platform.executableArguments.where((arg) =>
+        !arg.startsWith('--package-root=') && !arg.startsWith('--packages=')),
+    await PackageResolver.current.processArgument,
+    ...args
+  ];
 
   return await TestProcess.start(
       p.absolute(Platform.resolvedExecutable), allArgs,

--- a/pkgs/test/test/runner/compact_reporter_test.dart
+++ b/pkgs/test/test/runner/compact_reporter_test.dart
@@ -424,8 +424,8 @@ $tests
     }
   ''').create();
 
-  var test =
-      await runTest(['test.dart']..addAll(args ?? []), reporter: 'compact');
+  var test = await runTest(['test.dart', if (args != null) ...args],
+      reporter: 'compact');
   await test.shouldExit();
 
   var stdoutLines = await test.stdout.rest.toList();

--- a/pkgs/test/test/runner/expanded_reporter_test.dart
+++ b/pkgs/test/test/runner/expanded_reporter_test.dart
@@ -327,7 +327,7 @@ $tests
     }
   ''').create();
 
-  var test = await runTest(['test.dart']..addAll(args ?? []));
+  var test = await runTest(['test.dart', if (args != null) ...args]);
   await test.shouldExit();
 
   var stdoutLines = await test.stdoutStream().toList();

--- a/pkgs/test/test/runner/hybrid_test.dart
+++ b/pkgs/test/test/runner/hybrid_test.dart
@@ -425,7 +425,7 @@ void _spawnHybridUriTests([Iterable<String> arguments]) {
         }
       ''').create();
 
-    var test = await runTest(['test.dart']..addAll(arguments));
+    var test = await runTest(['test.dart', ...arguments]);
     expect(test.stdout,
         containsInOrder(['+0: hybrid emits numbers', '+1: All tests passed!']));
     await test.shouldExit(0);
@@ -452,7 +452,7 @@ void _spawnHybridUriTests([Iterable<String> arguments]) {
         '''),
     ]).create();
 
-    var test = await runTest(['test/dir/subdir/test.dart']..addAll(arguments));
+    var test = await runTest(['test/dir/subdir/test.dart', ...arguments]);
     expect(test.stdout,
         containsInOrder(['+0: hybrid emits numbers', '+1: All tests passed!']));
     await test.shouldExit(0);
@@ -481,7 +481,7 @@ void _spawnHybridUriTests([Iterable<String> arguments]) {
         '''),
     ]).create();
 
-    var test = await runTest(['test/dir/subdir/test.dart']..addAll(arguments));
+    var test = await runTest(['test/dir/subdir/test.dart', ...arguments]);
     expect(test.stdout,
         containsInOrder(['+0: hybrid emits numbers', '+1: All tests passed!']));
     await test.shouldExit(0);
@@ -508,7 +508,7 @@ void _spawnHybridUriTests([Iterable<String> arguments]) {
         }
       ''').create();
 
-    var test = await runTest(['test.dart']..addAll(arguments));
+    var test = await runTest(['test.dart', ...arguments]);
     expect(test.stdout,
         containsInOrder(['+0: hybrid emits numbers', '+1: All tests passed!']));
     await test.shouldExit(0);
@@ -534,7 +534,7 @@ void _spawnHybridUriTests([Iterable<String> arguments]) {
         }
       ''').create();
 
-    var test = await runTest(['test.dart']..addAll(arguments));
+    var test = await runTest(['test.dart', ...arguments]);
     expect(test.stdout,
         containsInOrder(['+0: hybrid emits numbers', '+1: All tests passed!']));
     await test.shouldExit(0);
@@ -571,7 +571,7 @@ void _spawnHybridUriTests([Iterable<String> arguments]) {
         }
       ''').create();
 
-    var test = await runTest(['test.dart']..addAll(arguments));
+    var test = await runTest(['test.dart',...arguments]);
     expect(
         test.stdout,
         containsInOrder(

--- a/pkgs/test/test/runner/hybrid_test.dart
+++ b/pkgs/test/test/runner/hybrid_test.dart
@@ -571,7 +571,7 @@ void _spawnHybridUriTests([Iterable<String> arguments]) {
         }
       ''').create();
 
-    var test = await runTest(['test.dart',...arguments]);
+    var test = await runTest(['test.dart', ...arguments]);
     expect(
         test.stdout,
         containsInOrder(

--- a/pkgs/test/test/runner/json_reporter_test.dart
+++ b/pkgs/test/test/runner/json_reporter_test.dart
@@ -594,7 +594,7 @@ import 'package:test/test.dart';
 
   await d.file('test.dart', testContent.toString()).create();
 
-  var test = await runTest(['test.dart']..addAll(args), reporter: 'json');
+  var test = await runTest(['test.dart', ...args], reporter: 'json');
   await test.shouldExit();
 
   var stdoutLines = await test.stdoutStream().toList();
@@ -605,8 +605,8 @@ import 'package:test/test.dart';
 
   // TODO(nweiz): validate each event against the JSON schema when
   // patefacio/json_schema#4 is merged.
-
-  decodeLine(String l) => jsonDecode(l)..remove('time')..remove('stackTrace');
+  dynamic decodeLine(String l) =>
+      jsonDecode(l)..remove('time')..remove('stackTrace');
 
   // Should contain all suites message.
   expect(stdoutLines.map(decodeLine), containsAll([_allSuites()]));

--- a/pkgs/test/test/runner/parse_metadata_test.dart
+++ b/pkgs/test/test/runner/parse_metadata_test.dart
@@ -59,9 +59,7 @@ void main() {
 
   group('@Timeout:', () {
     test('parses a valid duration annotation', () {
-      var metadata = parseMetadata(
-          _path,
-          '''
+      var metadata = parseMetadata(_path, '''
 @Timeout(const Duration(
     hours: 1,
     minutes: 2,
@@ -70,8 +68,7 @@ void main() {
     microseconds: 5))
 
 library foo;
-''',
-{});
+''', {});
       expect(
           metadata.timeout.duration,
           equals(Duration(
@@ -83,9 +80,7 @@ library foo;
     });
 
     test('parses a valid duration omitting const', () {
-      var metadata = parseMetadata(
-          _path,
-          '''
+      var metadata = parseMetadata(_path, '''
 @Timeout(Duration(
     hours: 1,
     minutes: 2,
@@ -94,8 +89,7 @@ library foo;
     microseconds: 5))
 
 library foo;
-''',
-{});
+''', {});
       expect(
           metadata.timeout.duration,
           equals(Duration(
@@ -107,9 +101,7 @@ library foo;
     });
 
     test('parses a valid duration with an import prefix', () {
-      var metadata = parseMetadata(
-          _path,
-          '''
+      var metadata = parseMetadata(_path, '''
 @Timeout(core.Duration(
     hours: 1,
     minutes: 2,
@@ -117,8 +109,7 @@ library foo;
     milliseconds: 4,
     microseconds: 5))
 import 'dart:core' as core;
-''',
-{});
+''', {});
       expect(
           metadata.timeout.duration,
           equals(Duration(
@@ -130,49 +121,37 @@ import 'dart:core' as core;
     });
 
     test('parses a valid int factor annotation', () {
-      var metadata = parseMetadata(
-          _path,
-          '''
+      var metadata = parseMetadata(_path, '''
 @Timeout.factor(1)
 
 library foo;
-''',
-{});
+''', {});
       expect(metadata.timeout.scaleFactor, equals(1));
     });
 
     test('parses a valid int factor annotation with an import prefix', () {
-      var metadata = parseMetadata(
-          _path,
-          '''
+      var metadata = parseMetadata(_path, '''
 @test.Timeout.factor(1)
 import 'package:test/test.dart' as test;
-''',
-{});
+''', {});
       expect(metadata.timeout.scaleFactor, equals(1));
     });
 
     test('parses a valid double factor annotation', () {
-      var metadata = parseMetadata(
-          _path,
-          '''
+      var metadata = parseMetadata(_path, '''
 @Timeout.factor(0.5)
 
 library foo;
-''',
-{});
+''', {});
       expect(metadata.timeout.scaleFactor, equals(0.5));
     });
 
     test('parses a valid Timeout.none annotation', () {
-      var metadata = parseMetadata(
-          _path,
-          '''
+      var metadata = parseMetadata(_path, '''
 @Timeout.none
 
 library foo;
-''',
-{});
+''', {});
       expect(metadata.timeout, same(Timeout.none));
     });
 
@@ -200,15 +179,13 @@ library foo;
     });
 
     test('parses a valid annotation with a reason', () {
-      var metadata =
-          parseMetadata(_path, "@Skip('reason')\nlibrary foo;", {});
+      var metadata = parseMetadata(_path, "@Skip('reason')\nlibrary foo;", {});
       expect(metadata.skip, isTrue);
       expect(metadata.skipReason, equals('reason'));
     });
 
     test('ignores a constructor named Skip', () {
-      var metadata =
-          parseMetadata(_path, "@foo.Skip('foo')\nlibrary foo;", {});
+      var metadata = parseMetadata(_path, "@foo.Skip('foo')\nlibrary foo;", {});
       expect(metadata.skip, isFalse);
     });
 
@@ -229,8 +206,7 @@ library foo;
     });
 
     test('ignores a constructor named Tags', () {
-      var metadata =
-          parseMetadata(_path, "@foo.Tags(['a'])\nlibrary foo;", {});
+      var metadata = parseMetadata(_path, "@foo.Tags(['a'])\nlibrary foo;", {});
       expect(metadata.tags, isEmpty);
     });
 
@@ -253,15 +229,12 @@ library foo;
 
   group('@OnPlatform:', () {
     test('parses a valid annotation', () {
-      var metadata = parseMetadata(
-          _path,
-          '''
+      var metadata = parseMetadata(_path, '''
 @OnPlatform({
   'chrome': Timeout.factor(2),
   'vm': [Skip(), Timeout.factor(3)]
 })
-library foo;''',
-{});
+library foo;''', {});
 
       var key = metadata.onPlatform.keys.first;
       expect(key.evaluate(SuitePlatform(Runtime.chrome)), isTrue);
@@ -278,16 +251,13 @@ library foo;''',
     });
 
     test('parses a valid annotation with an import prefix', () {
-      var metadata = parseMetadata(
-          _path,
-          '''
+      var metadata = parseMetadata(_path, '''
 @test.OnPlatform({
   'chrome': test.Timeout.factor(2),
   'vm': [test.Skip(), test.Timeout.factor(3)]
 })
 import 'package:test/test.dart' as test;
-''',
-{});
+''', {});
 
       var key = metadata.onPlatform.keys.first;
       expect(key.evaluate(SuitePlatform(Runtime.chrome)), isTrue);
@@ -326,10 +296,8 @@ import 'package:test/test.dart' as test;
 
       test('a map with an invalid value in a list', () {
         expect(
-            () => parseMetadata(
-                _path,
-                "@OnPlatform({'vm': [const TestOn('vm')]})\nlibrary foo;",
-                {}),
+            () => parseMetadata(_path,
+                "@OnPlatform({'vm': [const TestOn('vm')]})\nlibrary foo;", {}),
             throwsFormatException);
       });
 

--- a/pkgs/test/test/runner/parse_metadata_test.dart
+++ b/pkgs/test/test/runner/parse_metadata_test.dart
@@ -13,14 +13,14 @@ final _path = 'test.dart';
 
 void main() {
   test('returns empty metadata for an empty file', () {
-    var metadata = parseMetadata(_path, '', Set());
+    var metadata = parseMetadata(_path, '', {});
     expect(metadata.testOn, equals(PlatformSelector.all));
     expect(metadata.timeout.scaleFactor, equals(1));
   });
 
   test('ignores irrelevant annotations', () {
     var metadata =
-        parseMetadata(_path, '@Fblthp\n@Fblthp.foo\nlibrary foo;', Set());
+        parseMetadata(_path, '@Fblthp\n@Fblthp.foo\nlibrary foo;', {});
     expect(metadata.testOn, equals(PlatformSelector.all));
   });
 
@@ -29,21 +29,21 @@ void main() {
         _path,
         "@foo.TestOn('vm')\n"
         "import 'package:test/test.dart' as foo;",
-        Set());
+        {});
     expect(metadata.testOn.evaluate(SuitePlatform(Runtime.vm)), isTrue);
     expect(metadata.testOn.evaluate(SuitePlatform(Runtime.chrome)), isFalse);
   });
 
   group('@TestOn:', () {
     test('parses a valid annotation', () {
-      var metadata = parseMetadata(_path, "@TestOn('vm')\nlibrary foo;", Set());
+      var metadata = parseMetadata(_path, "@TestOn('vm')\nlibrary foo;", {});
       expect(metadata.testOn.evaluate(SuitePlatform(Runtime.vm)), isTrue);
       expect(metadata.testOn.evaluate(SuitePlatform(Runtime.chrome)), isFalse);
     });
 
     test('ignores a constructor named TestOn', () {
       var metadata =
-          parseMetadata(_path, "@foo.TestOn('foo')\nlibrary foo;", Set());
+          parseMetadata(_path, "@foo.TestOn('foo')\nlibrary foo;", {});
       expect(metadata.testOn, equals(PlatformSelector.all));
     });
 
@@ -51,7 +51,7 @@ void main() {
       test('multiple @TestOns', () {
         expect(
             () => parseMetadata(
-                _path, "@TestOn('foo')\n@TestOn('bar')\nlibrary foo;", Set()),
+                _path, "@TestOn('foo')\n@TestOn('bar')\nlibrary foo;", {}),
             throwsFormatException);
       });
     });
@@ -71,7 +71,7 @@ void main() {
 
 library foo;
 ''',
-          Set());
+{});
       expect(
           metadata.timeout.duration,
           equals(Duration(
@@ -95,7 +95,7 @@ library foo;
 
 library foo;
 ''',
-          Set());
+{});
       expect(
           metadata.timeout.duration,
           equals(Duration(
@@ -118,7 +118,7 @@ library foo;
     microseconds: 5))
 import 'dart:core' as core;
 ''',
-          Set());
+{});
       expect(
           metadata.timeout.duration,
           equals(Duration(
@@ -137,7 +137,7 @@ import 'dart:core' as core;
 
 library foo;
 ''',
-          Set());
+{});
       expect(metadata.timeout.scaleFactor, equals(1));
     });
 
@@ -148,7 +148,7 @@ library foo;
 @test.Timeout.factor(1)
 import 'package:test/test.dart' as test;
 ''',
-          Set());
+{});
       expect(metadata.timeout.scaleFactor, equals(1));
     });
 
@@ -160,7 +160,7 @@ import 'package:test/test.dart' as test;
 
 library foo;
 ''',
-          Set());
+{});
       expect(metadata.timeout.scaleFactor, equals(0.5));
     });
 
@@ -172,13 +172,13 @@ library foo;
 
 library foo;
 ''',
-          Set());
+{});
       expect(metadata.timeout, same(Timeout.none));
     });
 
     test('ignores a constructor named Timeout', () {
       var metadata =
-          parseMetadata(_path, "@foo.Timeout('foo')\nlibrary foo;", Set());
+          parseMetadata(_path, "@foo.Timeout('foo')\nlibrary foo;", {});
       expect(metadata.timeout.scaleFactor, equals(1));
     });
 
@@ -186,7 +186,7 @@ library foo;
       test('multiple @Timeouts', () {
         expect(
             () => parseMetadata(_path,
-                '@Timeout.factor(1)\n@Timeout.factor(2)\nlibrary foo;', Set()),
+                '@Timeout.factor(1)\n@Timeout.factor(2)\nlibrary foo;', {}),
             throwsFormatException);
       });
     });
@@ -194,21 +194,21 @@ library foo;
 
   group('@Skip:', () {
     test('parses a valid annotation', () {
-      var metadata = parseMetadata(_path, '@Skip()\nlibrary foo;', Set());
+      var metadata = parseMetadata(_path, '@Skip()\nlibrary foo;', {});
       expect(metadata.skip, isTrue);
       expect(metadata.skipReason, isNull);
     });
 
     test('parses a valid annotation with a reason', () {
       var metadata =
-          parseMetadata(_path, "@Skip('reason')\nlibrary foo;", Set());
+          parseMetadata(_path, "@Skip('reason')\nlibrary foo;", {});
       expect(metadata.skip, isTrue);
       expect(metadata.skipReason, equals('reason'));
     });
 
     test('ignores a constructor named Skip', () {
       var metadata =
-          parseMetadata(_path, "@foo.Skip('foo')\nlibrary foo;", Set());
+          parseMetadata(_path, "@foo.Skip('foo')\nlibrary foo;", {});
       expect(metadata.skip, isFalse);
     });
 
@@ -216,7 +216,7 @@ library foo;
       test('multiple @Skips', () {
         expect(
             () => parseMetadata(
-                _path, "@Skip('foo')\n@Skip('bar')\nlibrary foo;", Set()),
+                _path, "@Skip('foo')\n@Skip('bar')\nlibrary foo;", {}),
             throwsFormatException);
       });
     });
@@ -224,13 +224,13 @@ library foo;
 
   group('@Tags:', () {
     test('parses a valid annotation', () {
-      var metadata = parseMetadata(_path, "@Tags(['a'])\nlibrary foo;", Set());
+      var metadata = parseMetadata(_path, "@Tags(['a'])\nlibrary foo;", {});
       expect(metadata.tags, equals(['a']));
     });
 
     test('ignores a constructor named Tags', () {
       var metadata =
-          parseMetadata(_path, "@foo.Tags(['a'])\nlibrary foo;", Set());
+          parseMetadata(_path, "@foo.Tags(['a'])\nlibrary foo;", {});
       expect(metadata.tags, isEmpty);
     });
 
@@ -238,14 +238,14 @@ library foo;
       test('multiple @Tags', () {
         expect(
             () => parseMetadata(
-                _path, "@Tags(['a'])\n@Tags(['b'])\nlibrary foo;", Set()),
+                _path, "@Tags(['a'])\n@Tags(['b'])\nlibrary foo;", {}),
             throwsFormatException);
       });
 
       test('String interpolation', () {
         expect(
             () => parseMetadata(
-                _path, "@Tags(['\$a'])\nlibrary foo;\nconst a = 'a';", Set()),
+                _path, "@Tags(['\$a'])\nlibrary foo;\nconst a = 'a';", {}),
             throwsFormatException);
       });
     });
@@ -261,7 +261,7 @@ library foo;
   'vm': [Skip(), Timeout.factor(3)]
 })
 library foo;''',
-          Set());
+{});
 
       var key = metadata.onPlatform.keys.first;
       expect(key.evaluate(SuitePlatform(Runtime.chrome)), isTrue);
@@ -287,7 +287,7 @@ library foo;''',
 })
 import 'package:test/test.dart' as test;
 ''',
-          Set());
+{});
 
       var key = metadata.onPlatform.keys.first;
       expect(key.evaluate(SuitePlatform(Runtime.chrome)), isTrue);
@@ -305,7 +305,7 @@ import 'package:test/test.dart' as test;
 
     test('ignores a constructor named OnPlatform', () {
       var metadata =
-          parseMetadata(_path, "@foo.OnPlatform('foo')\nlibrary foo;", Set());
+          parseMetadata(_path, "@foo.OnPlatform('foo')\nlibrary foo;", {});
       expect(metadata.testOn, equals(PlatformSelector.all));
     });
 
@@ -313,14 +313,14 @@ import 'package:test/test.dart' as test;
       test('a map with a unparseable key', () {
         expect(
             () => parseMetadata(
-                _path, "@OnPlatform({'invalid': Skip()})\nlibrary foo;", Set()),
+                _path, "@OnPlatform({'invalid': Skip()})\nlibrary foo;", {}),
             throwsFormatException);
       });
 
       test('a map with an invalid value', () {
         expect(
             () => parseMetadata(_path,
-                "@OnPlatform({'vm': const TestOn('vm')})\nlibrary foo;", Set()),
+                "@OnPlatform({'vm': const TestOn('vm')})\nlibrary foo;", {}),
             throwsFormatException);
       });
 
@@ -329,14 +329,14 @@ import 'package:test/test.dart' as test;
             () => parseMetadata(
                 _path,
                 "@OnPlatform({'vm': [const TestOn('vm')]})\nlibrary foo;",
-                Set()),
+                {}),
             throwsFormatException);
       });
 
       test('multiple @OnPlatforms', () {
         expect(
             () => parseMetadata(
-                _path, '@OnPlatform({})\n@OnPlatform({})\nlibrary foo;', Set()),
+                _path, '@OnPlatform({})\n@OnPlatform({})\nlibrary foo;', {}),
             throwsFormatException);
       });
     });

--- a/pkgs/test/test/runner/pub_serve_test.dart
+++ b/pkgs/test/test/runner/pub_serve_test.dart
@@ -125,7 +125,7 @@ void main() {
       testWithCompiler('when run on Chrome', (compilerArgs) async {
         await d.dir('web').create();
 
-        var pub = await runPubServe(args: ['web']..addAll(compilerArgs));
+        var pub = await runPubServe(args: ['web', ...compilerArgs]);
         var test = await runTest([_pubServeArg, '-p', 'chrome']);
         expect(
             test.stdout,
@@ -343,7 +343,9 @@ final Iterable<String> _compilers = ['dart2js', 'dartdevc'];
 /// Runs the test described by [testFn] once for each supported compiler on the
 /// current [Platform.version], passing the relevant compiler args for pub serve
 /// as the first argument.
-void testWithCompiler(String name, testFn(List<String> compilerArgs), {tags}) {
+void testWithCompiler(
+    String name, dynamic Function(List<String> compilerArgs) testFn,
+    {tags}) {
   for (var compiler in _compilers) {
     var compilerArgs = ['--web-compiler', compiler];
     test('$name with $compiler', () => testFn(compilerArgs), tags: tags);

--- a/pkgs/test/test/runner/test_chain_test.dart
+++ b/pkgs/test/test/runner/test_chain_test.dart
@@ -77,5 +77,5 @@ void main() {
     var test = await runTest(['test.dart']);
     expect(test.stdoutStream(), emitsThrough(contains('package:test')));
     await test.shouldExit(1);
-  });
+  }, skip: 'https://github.com/dart-lang/test/issues/1120');
 }

--- a/pkgs/test/test/util/one_off_handler_test.dart
+++ b/pkgs/test/test/util/one_off_handler_test.dart
@@ -12,7 +12,8 @@ void main() {
   OneOffHandler handler;
   setUp(() => handler = OneOffHandler());
 
-  _handle(shelf.Request request) => Future.sync(() => handler.handler(request));
+  Future<shelf.Response> _handle(shelf.Request request) =>
+      Future.sync(() => handler.handler(request));
 
   test('returns a 404 for a root URL', () async {
     var request = shelf.Request('GET', Uri.parse('http://localhost/'));

--- a/pkgs/test/test/util/path_handler_test.dart
+++ b/pkgs/test/test/util/path_handler_test.dart
@@ -12,7 +12,8 @@ void main() {
   PathHandler handler;
   setUp(() => handler = PathHandler());
 
-  _handle(shelf.Request request) => Future.sync(() => handler.handler(request));
+  Future<shelf.Response> _handle(shelf.Request request) =>
+      Future.sync(() => handler.handler(request));
 
   test('returns a 404 for a root URL', () async {
     var request = shelf.Request('GET', Uri.parse('http://localhost/'));

--- a/pkgs/test/test/utils.dart
+++ b/pkgs/test/test/utils.dart
@@ -99,7 +99,7 @@ Matcher isApplicationException(message) =>
         .having((e) => e.message, 'message', message);
 
 /// Returns a local [LiveTest] that runs [body].
-LiveTest createTest(body()) {
+LiveTest createTest(dynamic Function() body) {
   var test = LocalTest('test', Metadata(), body);
   var suite = Suite(Group.root([test]), suitePlatform);
   return test.load(suite);
@@ -108,7 +108,7 @@ LiveTest createTest(body()) {
 /// Runs [body] as a test.
 ///
 /// Once it completes, returns the [LiveTest] used to run it.
-Future<LiveTest> runTestBody(body()) async {
+Future<LiveTest> runTestBody(dynamic Function() body) async {
   var liveTest = createTest(body);
   await liveTest.run();
   return liveTest;
@@ -144,7 +144,8 @@ void expectTestFailed(LiveTest liveTest, message) {
 /// is called at some later time.
 ///
 /// [stopBlocking] is passed the return value of [test].
-Future expectTestBlocks(test(), stopBlocking(value)) async {
+Future expectTestBlocks(
+    dynamic Function() test, dynamic Function(dynamic) stopBlocking) async {
   LiveTest liveTest;
   Future future;
   liveTest = createTest(() {
@@ -167,7 +168,7 @@ Future expectTestBlocks(test(), stopBlocking(value)) async {
 ///
 /// This is typically used to run multiple tests where later tests make
 /// assertions about the results of previous ones.
-Future expectTestsPass(void body()) async {
+Future expectTestsPass(void Function() body) async {
   var engine = declareEngine(body);
   var success = await engine.run();
 
@@ -179,13 +180,14 @@ Future expectTestsPass(void body()) async {
 }
 
 /// Runs [body] with a declarer and returns the declared entries.
-List<GroupEntry> declare(void body()) {
+List<GroupEntry> declare(void Function() body) {
   var declarer = Declarer()..declare(body);
   return declarer.build().entries;
 }
 
 /// Runs [body] with a declarer and returns an engine that runs those tests.
-Engine declareEngine(void body(), {bool runSkipped = false, String coverage}) {
+Engine declareEngine(void Function() body,
+    {bool runSkipped = false, String coverage}) {
   var declarer = Declarer()..declare(body);
   return Engine.withSuites([
     RunnerSuite(

--- a/pkgs/test/tool/host.dart
+++ b/pkgs/test/tool/host.dart
@@ -38,7 +38,8 @@ class _JSApi {
   /// running.
   external Function get restartCurrent;
 
-  external factory _JSApi({void resume(), void restartCurrent()});
+  external factory _JSApi(
+      {void Function() resume, void Function() restartCurrent});
 }
 
 /// Sets the top-level `dartTest` object so that it's visible to JS.
@@ -46,10 +47,10 @@ class _JSApi {
 external set _jsApi(_JSApi api);
 
 /// The iframes created for each loaded test suite, indexed by the suite id.
-final _iframes = Map<int, IFrameElement>();
+final _iframes = <int, IFrameElement>{};
 
 /// Subscriptions created for each loaded test suite, indexed by the suite id.
-final _subscriptions = Map<int, List<StreamSubscription>>();
+final _subscriptions = <int, List<StreamSubscription>>{};
 
 /// The URL for the current page.
 final _currentUrl = Uri.parse(window.location.href);

--- a/pkgs/test_api/lib/src/backend/closed_exception.dart
+++ b/pkgs/test_api/lib/src/backend/closed_exception.dart
@@ -7,5 +7,6 @@
 class ClosedException implements Exception {
   ClosedException();
 
+  @override
   String toString() => 'This test has been closed.';
 }

--- a/pkgs/test_api/lib/src/backend/declarer.dart
+++ b/pkgs/test_api/lib/src/backend/declarer.dart
@@ -250,7 +250,8 @@ class Declarer {
 
   /// Like [tearDownAll], but called from within a running [setUpAll] test to
   /// dynamically add a [tearDownAll].
-  void addTearDownAll(dynamic Function() callback) => _tearDownAlls.add(callback);
+  void addTearDownAll(dynamic Function() callback) =>
+      _tearDownAlls.add(callback);
 
   /// Finalizes and returns the group being declared.
   ///

--- a/pkgs/test_api/lib/src/backend/declarer.dart
+++ b/pkgs/test_api/lib/src/backend/declarer.dart
@@ -50,13 +50,13 @@ class Declarer {
   final bool _noRetry;
 
   /// The set-up functions to run for each test in this group.
-  final _setUps = List<Function()>();
+  final _setUps = <dynamic Function()>[];
 
   /// The tear-down functions to run for each test in this group.
-  final _tearDowns = List<Function()>();
+  final _tearDowns = <dynamic Function()>[];
 
   /// The set-up functions to run once for this group.
-  final _setUpAlls = List<Function()>();
+  final _setUpAlls = <dynamic Function()>[];
 
   /// The default timeout for synthetic tests.
   final _timeout = Timeout(Duration(minutes: 12));
@@ -69,7 +69,7 @@ class Declarer {
   Trace _setUpAllTrace;
 
   /// The tear-down functions to run once for this group.
-  final _tearDownAlls = List<Function()>();
+  final _tearDownAlls = <Function()>[];
 
   /// The trace for the first call to [tearDownAll].
   ///
@@ -78,13 +78,13 @@ class Declarer {
   Trace _tearDownAllTrace;
 
   /// The children of this group, either tests or sub-groups.
-  final _entries = List<GroupEntry>();
+  final _entries = <GroupEntry>[];
 
   /// Whether [build] has been called for this declarer.
   bool _built = false;
 
   /// The tests and/or groups that have been flagged as solo.
-  final _soloEntries = Set<GroupEntry>();
+  final _soloEntries = <GroupEntry>[];
 
   /// Whether any tests and/or groups have been flagged as solo.
   bool get _solo => _soloEntries.isNotEmpty;
@@ -127,10 +127,11 @@ class Declarer {
   /// Runs [body] with this declarer as [Declarer.current].
   ///
   /// Returns the return value of [body].
-  declare(body()) => runZoned(body, zoneValues: {#test.declarer: this});
+  void declare(void Function() body) =>
+      runZoned(body, zoneValues: {#test.declarer: this});
 
   /// Defines a test case with the given name and body.
-  void test(String name, body(),
+  void test(String name, dynamic Function() body,
       {String testOn,
       Timeout timeout,
       skip,
@@ -181,7 +182,7 @@ class Declarer {
   }
 
   /// Creates a group of tests.
-  void group(String name, void body(),
+  void group(String name, void Function() body,
       {String testOn,
       Timeout timeout,
       skip,
@@ -222,26 +223,26 @@ class Declarer {
   String _prefix(String name) => _name == null ? name : '$_name $name';
 
   /// Registers a function to be run before each test in this group.
-  void setUp(callback()) {
+  void setUp(dynamic Function() callback) {
     _checkNotBuilt('setUp');
     _setUps.add(callback);
   }
 
   /// Registers a function to be run after each test in this group.
-  void tearDown(callback()) {
+  void tearDown(dynamic Function() callback) {
     _checkNotBuilt('tearDown');
     _tearDowns.add(callback);
   }
 
   /// Registers a function to be run once before all tests.
-  void setUpAll(callback()) {
+  void setUpAll(dynamic Function() callback) {
     _checkNotBuilt('setUpAll');
     if (_collectTraces) _setUpAllTrace ??= Trace.current(2);
     _setUpAlls.add(callback);
   }
 
   /// Registers a function to be run once after all tests.
-  void tearDownAll(callback()) {
+  void tearDownAll(dynamic Function() callback) {
     _checkNotBuilt('tearDownAll');
     if (_collectTraces) _tearDownAllTrace ??= Trace.current(2);
     _tearDownAlls.add(callback);
@@ -249,7 +250,7 @@ class Declarer {
 
   /// Like [tearDownAll], but called from within a running [setUpAll] test to
   /// dynamically add a [tearDownAll].
-  void addTearDownAll(callback()) => _tearDownAlls.add(callback);
+  void addTearDownAll(dynamic Function() callback) => _tearDownAlls.add(callback);
 
   /// Finalizes and returns the group being declared.
   ///

--- a/pkgs/test_api/lib/src/backend/group.dart
+++ b/pkgs/test_api/lib/src/backend/group.dart
@@ -13,10 +13,13 @@ import 'test.dart';
 ///
 /// It includes metadata that applies to all contained tests.
 class Group implements GroupEntry {
+  @override
   final String name;
 
+  @override
   final Metadata metadata;
 
+  @override
   final Trace trace;
 
   /// The children of this group.
@@ -49,8 +52,9 @@ class Group implements GroupEntry {
   Group(this.name, Iterable<GroupEntry> entries,
       {Metadata metadata, this.trace, this.setUpAll, this.tearDownAll})
       : entries = List<GroupEntry>.unmodifiable(entries),
-        metadata = metadata == null ? Metadata() : metadata;
+        metadata = metadata ?? Metadata();
 
+  @override
   Group forPlatform(SuitePlatform platform) {
     if (!metadata.testOn.evaluate(platform)) return null;
     var newMetadata = metadata.forPlatform(platform);
@@ -63,7 +67,8 @@ class Group implements GroupEntry {
         tearDownAll: tearDownAll);
   }
 
-  Group filter(bool callback(Test test)) {
+  @override
+  Group filter(bool Function(Test) callback) {
     var filtered = _map((entry) => entry.filter(callback));
     if (filtered.isEmpty && entries.isNotEmpty) return null;
     return Group(name, filtered,
@@ -76,7 +81,7 @@ class Group implements GroupEntry {
   /// Returns the entries of this group mapped using [callback].
   ///
   /// Any `null` values returned by [callback] will be removed.
-  List<GroupEntry> _map(GroupEntry callback(GroupEntry entry)) {
+  List<GroupEntry> _map(GroupEntry Function(GroupEntry) callback) {
     return entries
         .map((entry) => callback(entry))
         .where((entry) => entry != null)

--- a/pkgs/test_api/lib/src/backend/group_entry.dart
+++ b/pkgs/test_api/lib/src/backend/group_entry.dart
@@ -35,5 +35,5 @@ abstract class GroupEntry {
   ///
   /// Returns `null` if this is a test that doesn't match [callback] or a group
   /// where no child tests match [callback].
-  GroupEntry filter(bool callback(Test test));
+  GroupEntry filter(bool Function(Test) callback);
 }

--- a/pkgs/test_api/lib/src/backend/invoker.dart
+++ b/pkgs/test_api/lib/src/backend/invoker.dart
@@ -24,8 +24,11 @@ import 'test.dart';
 
 /// A test in this isolate.
 class LocalTest extends Test {
+  @override
   final String name;
+  @override
   final Metadata metadata;
+  @override
   final Trace trace;
 
   /// Whether this is a test defined using `setUpAll()` or `tearDownAll()`.
@@ -51,11 +54,13 @@ class LocalTest extends Test {
       this.isScaffoldAll);
 
   /// Loads a single runnable instance of this test.
+  @override
   LiveTest load(Suite suite, {Iterable<Group> groups}) {
     var invoker = Invoker._(suite, this, groups: groups, guarded: _guarded);
     return invoker.liveTest;
   }
 
+  @override
   Test forPlatform(SuitePlatform platform) {
     if (!metadata.testOn.evaluate(platform)) return null;
     return LocalTest._(name, metadata.forPlatform(platform), _body, trace,
@@ -140,7 +145,7 @@ class Invoker {
 
   /// Runs [callback] in a zone where unhandled errors from [LiveTest]s are
   /// caught and dispatched to the appropriate [Invoker].
-  static T guard<T>(T callback()) =>
+  static T guard<T>(T Function() callback) =>
       runZoned(callback, zoneSpecification: ZoneSpecification(
           // Use [handleUncaughtError] rather than [onError] so we can
           // capture [zone] and with it the outstanding callback counter for
@@ -183,7 +188,7 @@ class Invoker {
   ///
   /// The [callback] may return a [Future]. Like all tear-downs, callbacks are
   /// run in the reverse of the order they're declared.
-  void addTearDown(callback()) {
+  void addTearDown(dynamic Function() callback) {
     if (closed) throw ClosedException();
 
     if (_test.isScaffoldAll) {

--- a/pkgs/test_api/lib/src/backend/live_test_controller.dart
+++ b/pkgs/test_api/lib/src/backend/live_test_controller.dart
@@ -18,27 +18,38 @@ import 'test.dart';
 class _LiveTest extends LiveTest {
   final LiveTestController _controller;
 
+  @override
   Suite get suite => _controller._suite;
 
+  @override
   List<Group> get groups => _controller._groups;
 
+  @override
   Test get test => _controller._test;
 
+  @override
   State get state => _controller._state;
 
+  @override
   Stream<State> get onStateChange =>
       _controller._onStateChangeController.stream;
 
+  @override
   List<AsyncError> get errors => UnmodifiableListView(_controller._errors);
 
+  @override
   Stream<AsyncError> get onError => _controller._onErrorController.stream;
 
+  @override
   Stream<Message> get onMessage => _controller._onMessageController.stream;
 
+  @override
   Future<void> get onComplete => _controller.onComplete;
 
+  @override
   Future<void> run() => _controller._run();
 
+  @override
   Future<void> close() => _controller._close();
 
   _LiveTest(this._controller);
@@ -76,7 +87,7 @@ class LiveTestController {
   final Function _onClose;
 
   /// The list of errors caught by the test.
-  final _errors = List<AsyncError>();
+  final _errors = <AsyncError>[];
 
   /// The current state of the test.
   var _state = const State(Status.pending, Result.success);
@@ -125,7 +136,8 @@ class LiveTestController {
   ///
   /// If [groups] is passed, it's used to populate the list of groups that
   /// contain this test. Otherwise, `suite.group` is used.
-  LiveTestController(Suite suite, this._test, void onRun(), void onClose(),
+  LiveTestController(
+      Suite suite, this._test, void Function() onRun, void Function() onClose,
       {Iterable<Group> groups})
       : _suite = suite,
         _onRun = onRun,

--- a/pkgs/test_api/lib/src/backend/message.dart
+++ b/pkgs/test_api/lib/src/backend/message.dart
@@ -41,5 +41,6 @@ class MessageType {
 
   const MessageType._(this.name);
 
+  @override
   String toString() => name;
 }

--- a/pkgs/test_api/lib/src/backend/operating_system.dart
+++ b/pkgs/test_api/lib/src/backend/operating_system.dart
@@ -77,5 +77,6 @@ class OperatingSystem {
 
   const OperatingSystem._(this.name, this.identifier);
 
+  @override
   String toString() => name;
 }

--- a/pkgs/test_api/lib/src/backend/platform_selector.dart
+++ b/pkgs/test_api/lib/src/backend/platform_selector.dart
@@ -10,10 +10,16 @@ import 'runtime.dart';
 import 'suite_platform.dart';
 
 /// The set of variable names that are valid for all platform selectors.
-final _universalValidVariables =
-    Set<String>.from(['posix', 'dart-vm', 'browser', 'js', 'blink', 'google'])
-      ..addAll(Runtime.builtIn.map((runtime) => runtime.identifier))
-      ..addAll(OperatingSystem.all.map((os) => os.identifier));
+final _universalValidVariables = {
+  'posix',
+  'dart-vm',
+  'browser',
+  'js',
+  'blink',
+  'google',
+  for (var runtime in Runtime.builtIn) runtime.identifier,
+  for (var os in OperatingSystem.all) os.identifier,
+};
 
 /// An expression for selecting certain platforms, including operating systems
 /// and browsers.
@@ -46,7 +52,7 @@ class PlatformSelector {
   /// [SourceSpanFormatException] using [span].
   ///
   /// If [span] is `null`, runs [body] as-is.
-  static T _wrapFormatException<T>(T body(), SourceSpan span) {
+  static T _wrapFormatException<T>(T Function() body, SourceSpan span) {
     if (span == null) return body();
 
     try {
@@ -103,10 +109,13 @@ class PlatformSelector {
     return PlatformSelector._(_inner.intersection(other._inner));
   }
 
+  @override
   String toString() => _inner.toString();
 
+  @override
   bool operator ==(other) =>
       other is PlatformSelector && _inner == other._inner;
 
+  @override
   int get hashCode => _inner.hashCode;
 }

--- a/pkgs/test_api/lib/src/backend/runtime.dart
+++ b/pkgs/test_api/lib/src/backend/runtime.dart
@@ -153,5 +153,6 @@ class Runtime {
     throw StateError('A child platform may not be extended.');
   }
 
+  @override
   String toString() => name;
 }

--- a/pkgs/test_api/lib/src/backend/stack_trace_formatter.dart
+++ b/pkgs/test_api/lib/src/backend/stack_trace_formatter.dart
@@ -22,12 +22,12 @@ class StackTraceFormatter {
   /// as-is.
   StackTraceMapper _mapper;
 
-  /// The list of packages to fold when producing terse [Chain]s.
-  var _except = Set<String>.from(['test', 'stream_channel', 'test_api']);
+  /// The set of packages to fold when producing terse [Chain]s.
+  var _except = {'test', 'stream_channel', 'test_api'};
 
   /// If non-empty, all packages not in this list will be folded when producing
   /// terse [Chain]s.
-  var _only = Set<String>();
+  var _only = <String>{};
 
   /// Returns the current manager, or `null` if this isn't called within a call
   /// to [asCurrent].
@@ -38,7 +38,8 @@ class StackTraceFormatter {
   ///
   /// This is zone-scoped, so [this] will be the current configuration in any
   /// asynchronous callbacks transitively created by [body].
-  T asCurrent<T>(T body()) => runZoned(body, zoneValues: {_currentKey: this});
+  T asCurrent<T>(T Function() body) =>
+      runZoned(body, zoneValues: {_currentKey: this});
 
   /// Configure how stack traces are formatted.
   ///

--- a/pkgs/test_api/lib/src/backend/state.dart
+++ b/pkgs/test_api/lib/src/backend/state.dart
@@ -27,11 +27,14 @@ class State {
 
   const State(this.status, this.result);
 
+  @override
   bool operator ==(other) =>
       other is State && status == other.status && result == other.result;
 
+  @override
   int get hashCode => status.hashCode ^ (7 * result.hashCode);
 
+  @override
   String toString() {
     if (status == Status.pending) return 'pending';
     if (status == Status.complete) return result.toString();
@@ -75,6 +78,7 @@ class Status {
 
   const Status._(this.name);
 
+  @override
   String toString() => name;
 }
 
@@ -134,5 +138,6 @@ class Result {
 
   const Result._(this.name);
 
+  @override
   String toString() => name;
 }

--- a/pkgs/test_api/lib/src/backend/suite.dart
+++ b/pkgs/test_api/lib/src/backend/suite.dart
@@ -48,9 +48,9 @@ class Suite {
   ///
   /// Unlike [GroupEntry.filter], this never returns `null`. If all entries are
   /// filtered out, it returns an empty suite.
-  Suite filter(bool callback(Test test)) {
+  Suite filter(bool Function(Test) callback) {
     var filtered = group.filter(callback);
-    if (filtered == null) filtered = Group.root([], metadata: metadata);
+    filtered ??= Group.root([], metadata: metadata);
     return Suite(filtered, platform, path: path);
   }
 

--- a/pkgs/test_api/lib/src/backend/test.dart
+++ b/pkgs/test_api/lib/src/backend/test.dart
@@ -17,10 +17,13 @@ import 'suite_platform.dart';
 /// directly. To run one, load a live version using [Test.load] and run it using
 /// [LiveTest.run].
 abstract class Test implements GroupEntry {
+  @override
   String get name;
 
+  @override
   Metadata get metadata;
 
+  @override
   Trace get trace;
 
   /// Loads a live version of this test, which can be used to run it a single
@@ -31,7 +34,9 @@ abstract class Test implements GroupEntry {
   /// defaults to just containing `suite.group`.
   LiveTest load(Suite suite, {Iterable<Group> groups});
 
+  @override
   Test forPlatform(SuitePlatform platform);
 
-  Test filter(bool callback(Test test)) => callback(this) ? this : null;
+  @override
+  Test filter(bool Function(Test) callback) => callback(this) ? this : null;
 }

--- a/pkgs/test_api/lib/src/frontend/async_matcher.dart
+++ b/pkgs/test_api/lib/src/frontend/async_matcher.dart
@@ -27,8 +27,9 @@ abstract class AsyncMatcher extends Matcher {
   ///
   /// If this returns a [String] synchronously, [expect] will synchronously
   /// throw a [TestFailure] and [matches] will synchronusly return `false`.
-  /*FutureOr<String>*/ matchAsync(item);
+  dynamic/*FutureOr<String>*/ matchAsync(item);
 
+  @override
   bool matches(item, Map matchState) {
     var result = matchAsync(item);
     expect(result,
@@ -51,6 +52,7 @@ abstract class AsyncMatcher extends Matcher {
     return true;
   }
 
+  @override
   Description describeMismatch(
           item, Description description, Map matchState, bool verbose) =>
       StringDescription(matchState[this] as String);

--- a/pkgs/test_api/lib/src/frontend/async_matcher.dart
+++ b/pkgs/test_api/lib/src/frontend/async_matcher.dart
@@ -27,7 +27,7 @@ abstract class AsyncMatcher extends Matcher {
   ///
   /// If this returns a [String] synchronously, [expect] will synchronously
   /// throw a [TestFailure] and [matches] will synchronusly return `false`.
-  dynamic/*FutureOr<String>*/ matchAsync(item);
+  dynamic /*FutureOr<String>*/ matchAsync(item);
 
   @override
   bool matches(item, Map matchState) {

--- a/pkgs/test_api/lib/src/frontend/expect.dart
+++ b/pkgs/test_api/lib/src/frontend/expect.dart
@@ -18,6 +18,7 @@ class TestFailure {
 
   TestFailure(this.message);
 
+  @override
   String toString() => message;
 }
 

--- a/pkgs/test_api/lib/src/frontend/expect_async.dart
+++ b/pkgs/test_api/lib/src/frontend/expect_async.dart
@@ -91,15 +91,15 @@ class _ExpectedFunction<T> {
   /// as a reason it's expected to be called. If [isDone] is passed, the test
   /// won't be allowed to complete until it returns `true`.
   _ExpectedFunction(Function callback, int minExpected, int maxExpected,
-      {String id, String reason, bool isDone()})
-      : this._callback = callback,
+      {String id, String reason, bool Function() isDone})
+      : _callback = callback,
         _minExpectedCalls = minExpected,
         _maxExpectedCalls =
             (maxExpected == 0 && minExpected > 0) ? minExpected : maxExpected,
-        this._isDone = isDone,
-        this._reason = reason == null ? '' : '\n$reason',
-        this._zone = Zone.current,
-        this._id = _makeCallbackId(id, callback) {
+        _isDone = isDone,
+        _reason = reason == null ? '' : '\n$reason',
+        _zone = Zone.current,
+        _id = _makeCallbackId(id, callback) {
     if (_invoker == null) {
       throw StateError('[expectAsync] was called outside of a test.');
     } else if (maxExpected > 0 && minExpected > maxExpected) {
@@ -258,7 +258,7 @@ Function expectAsync(Function callback,
 /// This method takes callbacks with zero arguments. See also
 /// [expectAsync1], [expectAsync2], [expectAsync3], [expectAsync4],
 /// [expectAsync5], and [expectAsync6] for callbacks with different arity.
-Func0<T> expectAsync0<T>(T callback(),
+Func0<T> expectAsync0<T>(T Function() callback,
     {int count = 1, int max = 0, String id, String reason}) {
   if (Invoker.current == null) {
     throw StateError('expectAsync0() may only be called within a test.');
@@ -289,7 +289,7 @@ Func0<T> expectAsync0<T>(T callback(),
 /// This method takes callbacks with one argument. See also
 /// [expectAsync0], [expectAsync2], [expectAsync3], [expectAsync4],
 /// [expectAsync5], and [expectAsync6] for callbacks with different arity.
-Func1<T, A> expectAsync1<T, A>(T callback(A a),
+Func1<T, A> expectAsync1<T, A>(T Function(A) callback,
     {int count = 1, int max = 0, String id, String reason}) {
   if (Invoker.current == null) {
     throw StateError('expectAsync1() may only be called within a test.');
@@ -320,7 +320,7 @@ Func1<T, A> expectAsync1<T, A>(T callback(A a),
 /// This method takes callbacks with two arguments. See also
 /// [expectAsync0], [expectAsync1], [expectAsync3], [expectAsync4],
 /// [expectAsync5], and [expectAsync6] for callbacks with different arity.
-Func2<T, A, B> expectAsync2<T, A, B>(T callback(A a, B b),
+Func2<T, A, B> expectAsync2<T, A, B>(T Function(A, B) callback,
     {int count = 1, int max = 0, String id, String reason}) {
   if (Invoker.current == null) {
     throw StateError('expectAsync2() may only be called within a test.');
@@ -351,7 +351,7 @@ Func2<T, A, B> expectAsync2<T, A, B>(T callback(A a, B b),
 /// This method takes callbacks with three arguments. See also
 /// [expectAsync0], [expectAsync1], [expectAsync2], [expectAsync4],
 /// [expectAsync5], and [expectAsync6] for callbacks with different arity.
-Func3<T, A, B, C> expectAsync3<T, A, B, C>(T callback(A a, B b, C c),
+Func3<T, A, B, C> expectAsync3<T, A, B, C>(T Function(A, B, C) callback,
     {int count = 1, int max = 0, String id, String reason}) {
   if (Invoker.current == null) {
     throw StateError('expectAsync3() may only be called within a test.');
@@ -382,8 +382,12 @@ Func3<T, A, B, C> expectAsync3<T, A, B, C>(T callback(A a, B b, C c),
 /// This method takes callbacks with four arguments. See also
 /// [expectAsync0], [expectAsync1], [expectAsync2], [expectAsync3],
 /// [expectAsync5], and [expectAsync6] for callbacks with different arity.
-Func4<T, A, B, C, D> expectAsync4<T, A, B, C, D>(T callback(A a, B b, C c, D d),
-    {int count = 1, int max = 0, String id, String reason}) {
+Func4<T, A, B, C, D> expectAsync4<T, A, B, C, D>(
+    T Function(A, B, C, D) callback,
+    {int count = 1,
+    int max = 0,
+    String id,
+    String reason}) {
   if (Invoker.current == null) {
     throw StateError('expectAsync4() may only be called within a test.');
   }
@@ -414,7 +418,7 @@ Func4<T, A, B, C, D> expectAsync4<T, A, B, C, D>(T callback(A a, B b, C c, D d),
 /// [expectAsync0], [expectAsync1], [expectAsync2], [expectAsync3],
 /// [expectAsync4], and [expectAsync6] for callbacks with different arity.
 Func5<T, A, B, C, D, E> expectAsync5<T, A, B, C, D, E>(
-    T callback(A a, B b, C c, D d, E e),
+    T Function(A, B, C, D, E) callback,
     {int count = 1,
     int max = 0,
     String id,
@@ -449,7 +453,7 @@ Func5<T, A, B, C, D, E> expectAsync5<T, A, B, C, D, E>(
 /// [expectAsync0], [expectAsync1], [expectAsync2], [expectAsync3],
 /// [expectAsync4], and [expectAsync5] for callbacks with different arity.
 Func6<T, A, B, C, D, E, F> expectAsync6<T, A, B, C, D, E, F>(
-    T callback(A a, B b, C c, D d, E e, F f),
+    T Function(A, B, C, D, E, F) callback,
     {int count = 1,
     int max = 0,
     String id,
@@ -467,7 +471,7 @@ Func6<T, A, B, C, D, E, F> expectAsync6<T, A, B, C, D, E, F>(
 /// [expectAsyncUntil2], [expectAsyncUntil3], [expectAsyncUntil4],
 /// [expectAsyncUntil5], or [expectAsyncUntil6] instead.
 @Deprecated('Will be removed in 0.13.0')
-Function expectAsyncUntil(Function callback, bool isDone(),
+Function expectAsyncUntil(Function callback, bool Function() isDone,
     {String id, String reason}) {
   if (Invoker.current == null) {
     throw StateError('expectAsyncUntil() may only be called within a test.');
@@ -495,7 +499,7 @@ Function expectAsyncUntil(Function callback, bool isDone(),
 /// [expectAsyncUntil1], [expectAsyncUntil2], [expectAsyncUntil3],
 /// [expectAsyncUntil4], [expectAsyncUntil5], and [expectAsyncUntil6] for
 /// callbacks with different arity.
-Func0<T> expectAsyncUntil0<T>(T callback(), bool isDone(),
+Func0<T> expectAsyncUntil0<T>(T Function() callback, bool Function() isDone,
     {String id, String reason}) {
   if (Invoker.current == null) {
     throw StateError('expectAsyncUntil0() may only be called within a test.');
@@ -523,7 +527,8 @@ Func0<T> expectAsyncUntil0<T>(T callback(), bool isDone(),
 /// [expectAsyncUntil0], [expectAsyncUntil2], [expectAsyncUntil3],
 /// [expectAsyncUntil4], [expectAsyncUntil5], and [expectAsyncUntil6] for
 /// callbacks with different arity.
-Func1<T, A> expectAsyncUntil1<T, A>(T callback(A a), bool isDone(),
+Func1<T, A> expectAsyncUntil1<T, A>(
+    T Function(A) callback, bool Function() isDone,
     {String id, String reason}) {
   if (Invoker.current == null) {
     throw StateError('expectAsyncUntil1() may only be called within a test.');
@@ -551,7 +556,8 @@ Func1<T, A> expectAsyncUntil1<T, A>(T callback(A a), bool isDone(),
 /// [expectAsyncUntil0], [expectAsyncUntil1], [expectAsyncUntil3],
 /// [expectAsyncUntil4], [expectAsyncUntil5], and [expectAsyncUntil6] for
 /// callbacks with different arity.
-Func2<T, A, B> expectAsyncUntil2<T, A, B>(T callback(A a, B b), bool isDone(),
+Func2<T, A, B> expectAsyncUntil2<T, A, B>(
+    T Function(A, B) callback, bool Function() isDone,
     {String id, String reason}) {
   if (Invoker.current == null) {
     throw StateError('expectAsyncUntil2() may only be called within a test.');
@@ -580,7 +586,7 @@ Func2<T, A, B> expectAsyncUntil2<T, A, B>(T callback(A a, B b), bool isDone(),
 /// [expectAsyncUntil4], [expectAsyncUntil5], and [expectAsyncUntil6] for
 /// callbacks with different arity.
 Func3<T, A, B, C> expectAsyncUntil3<T, A, B, C>(
-    T callback(A a, B b, C c), bool isDone(),
+    T Function(A, B, C) callback, bool Function() isDone,
     {String id, String reason}) {
   if (Invoker.current == null) {
     throw StateError('expectAsyncUntil3() may only be called within a test.');
@@ -609,7 +615,7 @@ Func3<T, A, B, C> expectAsyncUntil3<T, A, B, C>(
 /// [expectAsyncUntil3], [expectAsyncUntil5], and [expectAsyncUntil6] for
 /// callbacks with different arity.
 Func4<T, A, B, C, D> expectAsyncUntil4<T, A, B, C, D>(
-    T callback(A a, B b, C c, D d), bool isDone(),
+    T Function(A, B, C, D) callback, bool Function() isDone,
     {String id, String reason}) {
   if (Invoker.current == null) {
     throw StateError('expectAsyncUntil4() may only be called within a test.');
@@ -638,7 +644,7 @@ Func4<T, A, B, C, D> expectAsyncUntil4<T, A, B, C, D>(
 /// [expectAsyncUntil3], [expectAsyncUntil4], and [expectAsyncUntil6] for
 /// callbacks with different arity.
 Func5<T, A, B, C, D, E> expectAsyncUntil5<T, A, B, C, D, E>(
-    T callback(A a, B b, C c, D d, E e), bool isDone(),
+    T Function(A, B, C, D, E) callback, bool Function() isDone,
     {String id, String reason}) {
   if (Invoker.current == null) {
     throw StateError('expectAsyncUntil5() may only be called within a test.');
@@ -667,7 +673,7 @@ Func5<T, A, B, C, D, E> expectAsyncUntil5<T, A, B, C, D, E>(
 /// [expectAsyncUntil3], [expectAsyncUntil4], and [expectAsyncUntil5] for
 /// callbacks with different arity.
 Func6<T, A, B, C, D, E, F> expectAsyncUntil6<T, A, B, C, D, E, F>(
-    T callback(A a, B b, C c, D d, E e, F f), bool isDone(),
+    T Function(A, B, C, D, E, F) callback, bool Function() isDone,
     {String id, String reason}) {
   if (Invoker.current == null) {
     throw StateError('expectAsyncUntil() may only be called within a test.');

--- a/pkgs/test_api/lib/src/frontend/future_matchers.dart
+++ b/pkgs/test_api/lib/src/frontend/future_matchers.dart
@@ -45,7 +45,8 @@ class _Completes extends AsyncMatcher {
   const _Completes(this._matcher);
 
   // Avoid async/await so we synchronously start listening to [item].
-  /*FutureOr<String>*/ matchAsync(item) {
+  @override
+  dynamic /*FutureOr<String>*/ matchAsync(item) {
     if (item is! Future) return 'was not a Future';
 
     return item.then((value) async {
@@ -70,6 +71,7 @@ class _Completes extends AsyncMatcher {
     });
   }
 
+  @override
   Description describe(Description description) {
     if (_matcher == null) {
       description.add('completes successfully');
@@ -90,11 +92,13 @@ final Matcher doesNotComplete = const _DoesNotComplete();
 class _DoesNotComplete extends Matcher {
   const _DoesNotComplete();
 
+  @override
   Description describe(Description description) {
     description.add('does not complete');
     return description;
   }
 
+  @override
   bool matches(item, Map matchState) {
     if (item is! Future) return false;
     item.then((value) {
@@ -105,6 +109,7 @@ class _DoesNotComplete extends Matcher {
     return true;
   }
 
+  @override
   Description describeMismatch(
       item, Description description, Map matchState, bool verbose) {
     if (item is! Future) return description.add('$item is not a Future');

--- a/pkgs/test_api/lib/src/frontend/prints_matcher.dart
+++ b/pkgs/test_api/lib/src/frontend/prints_matcher.dart
@@ -30,7 +30,8 @@ class _Prints extends AsyncMatcher {
 
   // Avoid async/await so we synchronously fail if the function is
   // synchronous.
-  /*FutureOr<String>*/ matchAsync(item) {
+  @override
+  dynamic/*FutureOr<String>*/ matchAsync(item) {
     if (item is! Function()) return 'was not a unary Function';
 
     var buffer = StringBuffer();
@@ -44,6 +45,7 @@ class _Prints extends AsyncMatcher {
         : _check(buffer.toString());
   }
 
+  @override
   Description describe(Description description) =>
       description.add('prints ').addDescriptionOf(_matcher);
 

--- a/pkgs/test_api/lib/src/frontend/prints_matcher.dart
+++ b/pkgs/test_api/lib/src/frontend/prints_matcher.dart
@@ -31,7 +31,7 @@ class _Prints extends AsyncMatcher {
   // Avoid async/await so we synchronously fail if the function is
   // synchronous.
   @override
-  dynamic/*FutureOr<String>*/ matchAsync(item) {
+  dynamic /*FutureOr<String>*/ matchAsync(item) {
     if (item is! Function()) return 'was not a unary Function';
 
     var buffer = StringBuffer();

--- a/pkgs/test_api/lib/src/frontend/stream_matcher.dart
+++ b/pkgs/test_api/lib/src/frontend/stream_matcher.dart
@@ -89,7 +89,7 @@ abstract class StreamMatcher extends Matcher {
   /// should be grammatically valid when used after the word "should". For
   /// example, it might be "emit the right events".
   factory StreamMatcher(
-          Future<String> matchQueue(StreamQueue queue), String description) =
+          Future<String> Function(StreamQueue) matchQueue, String description) =
       _StreamMatcher;
 
   /// Tries to match events emitted by [queue].
@@ -116,6 +116,7 @@ abstract class StreamMatcher extends Matcher {
 /// This is separate from the original type to hide the private [AsyncMatcher]
 /// interface.
 class _StreamMatcher extends AsyncMatcher implements StreamMatcher {
+  @override
   final String description;
 
   /// The callback used to implement [matchQueue].
@@ -123,9 +124,11 @@ class _StreamMatcher extends AsyncMatcher implements StreamMatcher {
 
   _StreamMatcher(this._matchQueue, this.description);
 
+  @override
   Future<String> matchQueue(StreamQueue queue) => _matchQueue(queue);
 
-  /*FutureOr<String>*/ matchAsync(item) {
+  @override
+  dynamic/*FutureOr<String>*/ matchAsync(item) {
     StreamQueue queue;
     if (item is StreamQueue) {
       queue = item;
@@ -185,6 +188,7 @@ class _StreamMatcher extends AsyncMatcher implements StreamMatcher {
     });
   }
 
+  @override
   Description describe(Description description) =>
       description.add('should ').add(this.description);
 }

--- a/pkgs/test_api/lib/src/frontend/stream_matcher.dart
+++ b/pkgs/test_api/lib/src/frontend/stream_matcher.dart
@@ -128,7 +128,7 @@ class _StreamMatcher extends AsyncMatcher implements StreamMatcher {
   Future<String> matchQueue(StreamQueue queue) => _matchQueue(queue);
 
   @override
-  dynamic/*FutureOr<String>*/ matchAsync(item) {
+  dynamic /*FutureOr<String>*/ matchAsync(item) {
     StreamQueue queue;
     if (item is StreamQueue) {
       queue = item;

--- a/pkgs/test_api/lib/src/frontend/stream_matchers.dart
+++ b/pkgs/test_api/lib/src/frontend/stream_matchers.dart
@@ -199,7 +199,7 @@ StreamMatcher emitsThrough(matcher) {
   return StreamMatcher((queue) async {
     var failures = <String>[];
 
-    tryHere() => queue.withTransaction((copy) async {
+    Future<bool> tryHere() => queue.withTransaction((copy) async {
           var result = await streamMatcher.matchQueue(copy);
           if (result == null) return true;
           failures.add(result);

--- a/pkgs/test_api/lib/src/frontend/throws_matcher.dart
+++ b/pkgs/test_api/lib/src/frontend/throws_matcher.dart
@@ -42,11 +42,12 @@ Matcher throwsA(matcher) => Throws(wrapMatcher(matcher));
 class Throws extends AsyncMatcher {
   final Matcher _matcher;
 
-  const Throws([Matcher matcher]) : this._matcher = matcher;
+  const Throws([Matcher matcher]) : _matcher = matcher;
 
   // Avoid async/await so we synchronously fail if we match a synchronous
   // function.
-  /*FutureOr<String>*/ matchAsync(item) {
+  @override
+  dynamic/*FutureOr<String>*/ matchAsync(item) {
     if (item is! Function && item is! Future) {
       return 'was not a Function or Future';
     }
@@ -71,6 +72,7 @@ class Throws extends AsyncMatcher {
     }
   }
 
+  @override
   Description describe(Description description) {
     if (_matcher == null) {
       return description.add('throws');

--- a/pkgs/test_api/lib/src/frontend/throws_matcher.dart
+++ b/pkgs/test_api/lib/src/frontend/throws_matcher.dart
@@ -47,7 +47,7 @@ class Throws extends AsyncMatcher {
   // Avoid async/await so we synchronously fail if we match a synchronous
   // function.
   @override
-  dynamic/*FutureOr<String>*/ matchAsync(item) {
+  dynamic /*FutureOr<String>*/ matchAsync(item) {
     if (item is! Function && item is! Future) {
       return 'was not a Function or Future';
     }

--- a/pkgs/test_api/lib/src/frontend/timeout.dart
+++ b/pkgs/test_api/lib/src/frontend/timeout.dart
@@ -141,16 +141,19 @@ class Timeout {
   /// If this is [none], returns `null`.
   Duration apply(Duration base) {
     if (this == none) return null;
-    return duration == null ? base * scaleFactor : duration;
+    return duration ?? base * scaleFactor;
   }
 
+  @override
   int get hashCode => duration.hashCode ^ 5 * scaleFactor.hashCode;
 
+  @override
   bool operator ==(other) =>
       other is Timeout &&
       other.duration == duration &&
       other.scaleFactor == scaleFactor;
 
+  @override
   String toString() {
     if (duration != null) return duration.toString();
     if (scaleFactor != null) return '${scaleFactor}x';

--- a/pkgs/test_api/lib/src/remote_listener.dart
+++ b/pkgs/test_api/lib/src/remote_listener.dart
@@ -44,8 +44,8 @@ class RemoteListener {
   ///
   /// If [beforeLoad] is passed, it's called before the tests have been declared
   /// for this worker.
-  static StreamChannel start(Function getMain(),
-      {bool hidePrints = true, Future beforeLoad()}) {
+  static StreamChannel start(Function Function() getMain,
+      {bool hidePrints = true, Future Function() beforeLoad}) {
     // This has to be synchronous to work around sdk#25745. Otherwise, there'll
     // be an asynchronous pause before a syntax error notification is sent,
     // which will cause the send to fail entirely.
@@ -121,7 +121,8 @@ class RemoteListener {
 
           if (beforeLoad != null) await beforeLoad();
 
-          await declarer.declare(main as Function());
+          // TODO - is this await necessary?
+          await (declarer.declare(main as Function()) as dynamic);
 
           var suite = Suite(
               declarer.build(), SuitePlatform.deserialize(message['platform']),

--- a/pkgs/test_api/lib/src/suite_channel_manager.dart
+++ b/pkgs/test_api/lib/src/suite_channel_manager.dart
@@ -31,7 +31,8 @@ class SuiteChannelManager {
   ///
   /// This is zone-scoped, so [this] will be the current configuration in any
   /// asynchronous callbacks transitively created by [body].
-  T asCurrent<T>(T Function() body) => runZoned(body, zoneValues: {_currentKey: this});
+  T asCurrent<T>(T Function() body) =>
+      runZoned(body, zoneValues: {_currentKey: this});
 
   /// Creates a connection to the test runnner's channel with the given [name].
   StreamChannel connectOut(String name) {

--- a/pkgs/test_api/lib/src/suite_channel_manager.dart
+++ b/pkgs/test_api/lib/src/suite_channel_manager.dart
@@ -20,7 +20,7 @@ class SuiteChannelManager {
   final _outgoingConnections = <String, StreamChannelCompleter>{};
 
   /// The channel names that have already been used.
-  final _names = Set<String>();
+  final _names = <String>{};
 
   /// Returns the current manager, or `null` if this isn't called within a call
   /// to [asCurrent].
@@ -31,7 +31,7 @@ class SuiteChannelManager {
   ///
   /// This is zone-scoped, so [this] will be the current configuration in any
   /// asynchronous callbacks transitively created by [body].
-  T asCurrent<T>(T body()) => runZoned(body, zoneValues: {_currentKey: this});
+  T asCurrent<T>(T Function() body) => runZoned(body, zoneValues: {_currentKey: this});
 
   /// Creates a connection to the test runnner's channel with the given [name].
   StreamChannel connectOut(String name) {

--- a/pkgs/test_api/lib/src/util/iterable_set.dart
+++ b/pkgs/test_api/lib/src/util/iterable_set.dart
@@ -19,17 +19,22 @@ class IterableSet<E> extends SetMixin<E> with UnmodifiableSetMixin<E> {
   /// The base iterable that set operations forward to.
   final Iterable<E> _base;
 
+  @override
   int get length => _base.length;
 
+  @override
   Iterator<E> get iterator => _base.iterator;
 
   /// Creates a [Set] view of [base].
   IterableSet(this._base);
 
+  @override
   bool contains(Object element) => _base.contains(element);
 
+  @override
   E lookup(Object needle) =>
       _base.firstWhere((element) => element == needle, orElse: () => null);
 
+  @override
   Set<E> toSet() => _base.toSet();
 }

--- a/pkgs/test_api/lib/src/util/remote_exception.dart
+++ b/pkgs/test_api/lib/src/util/remote_exception.dart
@@ -29,7 +29,7 @@ class RemoteException implements Exception {
   ///
   /// Other than JSON- and isolate-safety, no guarantees are made about the
   /// serialized format.
-  static serialize(error, StackTrace stackTrace) {
+  static Map<String, dynamic> serialize(error, StackTrace stackTrace) {
     String message;
     if (error is String) {
       message = error;
@@ -77,6 +77,7 @@ class RemoteException implements Exception {
 
   RemoteException._(this.message, this.type, this._toString);
 
+  @override
   String toString() => _toString;
 }
 

--- a/pkgs/test_api/lib/src/util/test.dart
+++ b/pkgs/test_api/lib/src/util/test.dart
@@ -13,7 +13,7 @@ import '../backend/invoker.dart';
 /// callbacks registered outside of [body].
 ///
 /// This may only be called within a test.
-Future errorsDontStopTest(body()) {
+Future errorsDontStopTest(dynamic Function() body) {
   var completer = Completer();
 
   Invoker.current.addOutstandingCallback();

--- a/pkgs/test_api/lib/src/utils.dart
+++ b/pkgs/test_api/lib/src/utils.dart
@@ -43,8 +43,13 @@ final _vowel = RegExp('[aeiou]');
 /// Directories that are specific to OS X.
 ///
 /// This is used to try to distinguish OS X and Linux in [currentOSGuess].
-final _macOSDirectories = Set<String>.from(
-    ['/Applications', '/Library', '/Network', '/System', '/Users']);
+final _macOSDirectories = {
+  '/Applications',
+  '/Library',
+  '/Network',
+  '/System',
+  '/Users',
+};
 
 /// Returns the best guess for the current operating system without using
 /// `dart:io`.
@@ -77,13 +82,16 @@ class Pair<E, F> {
 
   Pair(this.first, this.last);
 
+  @override
   String toString() => '($first, $last)';
 
+  @override
   bool operator ==(other) {
     if (other is! Pair) return false;
     return other.first == first && other.last == last;
   }
 
+  @override
   int get hashCode => first.hashCode ^ last.hashCode;
 }
 
@@ -141,7 +149,7 @@ String withoutColors(String str) => str.replaceAll(_colorCode, '');
 ///
 /// The return value *may or may not* be unmodifiable.
 Map<K, V> mergeUnmodifiableMaps<K, V>(Map<K, V> map1, Map<K, V> map2,
-    {V value(V value1, V value2)}) {
+    {V Function(V, V) value}) {
   if (map1.isEmpty) return map2;
   if (map2.isEmpty) return map1;
   return mergeMaps(map1, map2, value: value);
@@ -237,7 +245,7 @@ Stream<T> inCompletionOrder<T>(Iterable<CancelableOperation<T>> operations) {
 ///
 /// This is useful for making a block of code async without forcing the
 /// containing method to return a future.
-void invoke(fn()) {
+void invoke(void Function() fn) {
   fn();
 }
 

--- a/pkgs/test_api/lib/test_api.dart
+++ b/pkgs/test_api/lib/test_api.dart
@@ -94,7 +94,7 @@ Declarer get _declarer => Zone.current[#test.declarer] as Declarer;
 /// avoid this flag if possible and instead use the test runner flag `-n` to
 /// filter tests by name.
 @isTest
-void test(description, body(),
+void test(description, dynamic Function() body,
     {String testOn,
     Timeout timeout,
     skip,
@@ -172,7 +172,7 @@ void test(description, body(),
 /// avoid this flag if possible, and instead use the test runner flag `-n` to
 /// filter tests by name.
 @isTestGroup
-void group(description, body(),
+void group(description, dynamic Function() body,
     {String testOn,
     Timeout timeout,
     skip,
@@ -207,7 +207,7 @@ void group(description, body(),
 ///
 /// Each callback at the top level or in a given group will be run in the order
 /// they were declared.
-void setUp(callback()) => _declarer.setUp(callback);
+void setUp(dynamic Function() callback) => _declarer.setUp(callback);
 
 /// Registers a function to be run after tests.
 ///
@@ -222,7 +222,7 @@ void setUp(callback()) => _declarer.setUp(callback);
 /// reverse of the order they were declared.
 ///
 /// See also [addTearDown], which adds tear-downs to a running test.
-void tearDown(callback()) => _declarer.tearDown(callback);
+void tearDown(dynamic Function() callback) => _declarer.tearDown(callback);
 
 /// Registers a function to be run after the current test.
 ///
@@ -235,7 +235,7 @@ void tearDown(callback()) => _declarer.tearDown(callback);
 ///
 /// If this is called from within a [setUpAll] or [tearDownAll] callback, it
 /// instead runs the function after *all* tests in the current test suite.
-void addTearDown(callback()) {
+void addTearDown(dynamic Function() callback) {
   if (Invoker.current == null) {
     throw StateError('addTearDown() may only be called within a test.');
   }
@@ -256,7 +256,7 @@ void addTearDown(callback()) {
 /// dependencies between tests that should be isolated. In general, you should
 /// prefer [setUp], and only use [setUpAll] if the callback is prohibitively
 /// slow.
-void setUpAll(callback()) => _declarer.setUpAll(callback);
+void setUpAll(dynamic Function() callback) => _declarer.setUpAll(callback);
 
 /// Registers a function to be run once after all tests.
 ///
@@ -269,7 +269,7 @@ void setUpAll(callback()) => _declarer.setUpAll(callback);
 /// dependencies between tests that should be isolated. In general, you should
 /// prefer [tearDown], and only use [tearDownAll] if the callback is
 /// prohibitively slow.
-void tearDownAll(callback()) => _declarer.tearDownAll(callback);
+void tearDownAll(dynamic Function() callback) => _declarer.tearDownAll(callback);
 
 /// Registers an exception that was caught for the current test.
 void registerException(error, [StackTrace stackTrace]) {

--- a/pkgs/test_api/lib/test_api.dart
+++ b/pkgs/test_api/lib/test_api.dart
@@ -269,7 +269,8 @@ void setUpAll(dynamic Function() callback) => _declarer.setUpAll(callback);
 /// dependencies between tests that should be isolated. In general, you should
 /// prefer [tearDown], and only use [tearDownAll] if the callback is
 /// prohibitively slow.
-void tearDownAll(dynamic Function() callback) => _declarer.tearDownAll(callback);
+void tearDownAll(dynamic Function() callback) =>
+    _declarer.tearDownAll(callback);
 
 /// Registers an exception that was caught for the current test.
 void registerException(error, [StackTrace stackTrace]) {

--- a/pkgs/test_api/mono_pkg.yaml
+++ b/pkgs/test_api/mono_pkg.yaml
@@ -6,7 +6,7 @@ stages:
         dart: dev
       - group:
         - dartanalyzer: --fatal-warnings .
-        dart: 2.1.0
+        dart: 2.3.0
     - unit_test:
       - group:
         - test: --preset travis

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -5,7 +5,7 @@ description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 
 environment:
-  sdk: ">=2.2.0 <3.0.0"
+  sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
   async: ^2.0.0

--- a/pkgs/test_api/test/backend/invoker_test.dart
+++ b/pkgs/test_api/test/backend/invoker_test.dart
@@ -615,7 +615,7 @@ void main() {
   });
 }
 
-LocalTest _localTest(body(), {Metadata metadata}) {
-  if (metadata == null) metadata = Metadata();
+LocalTest _localTest(dynamic Function() body, {Metadata metadata}) {
+  metadata ??= Metadata();
   return LocalTest('test', metadata, body);
 }

--- a/pkgs/test_api/test/backend/metadata_test.dart
+++ b/pkgs/test_api/test/backend/metadata_test.dart
@@ -196,25 +196,23 @@ void main() {
   group('validatePlatformSelectors', () {
     test('succeeds if onPlatform uses valid platforms', () {
       Metadata.parse(onPlatform: {'vm || browser': Skip()})
-          .validatePlatformSelectors(Set.from(['vm']));
+          .validatePlatformSelectors({'vm'});
     });
 
     test('succeeds if testOn uses valid platforms', () {
-      Metadata.parse(testOn: 'vm || browser')
-          .validatePlatformSelectors(Set.from(['vm']));
+      Metadata.parse(testOn: 'vm || browser').validatePlatformSelectors({'vm'});
     });
 
     test('fails if onPlatform uses an invalid platform', () {
       expect(() {
         Metadata.parse(onPlatform: {'unknown': Skip()})
-            .validatePlatformSelectors(Set.from(['vm']));
+            .validatePlatformSelectors({'vm'});
       }, throwsFormatException);
     });
 
     test('fails if testOn uses an invalid platform', () {
       expect(() {
-        Metadata.parse(testOn: 'unknown')
-            .validatePlatformSelectors(Set.from(['vm']));
+        Metadata.parse(testOn: 'unknown').validatePlatformSelectors({'vm'});
       }, throwsFormatException);
     });
   });

--- a/pkgs/test_api/test/utils.dart
+++ b/pkgs/test_api/test/utils.dart
@@ -99,7 +99,7 @@ Matcher isApplicationException(message) =>
         .having((e) => e.message, 'message', message);
 
 /// Returns a local [LiveTest] that runs [body].
-LiveTest createTest(body()) {
+LiveTest createTest(dynamic Function() body) {
   var test = LocalTest('test', Metadata(), body);
   var suite = Suite(Group.root([test]), suitePlatform);
   return test.load(suite);
@@ -108,7 +108,7 @@ LiveTest createTest(body()) {
 /// Runs [body] as a test.
 ///
 /// Once it completes, returns the [LiveTest] used to run it.
-Future<LiveTest> runTestBody(body()) async {
+Future<LiveTest> runTestBody(dynamic Function() body) async {
   var liveTest = createTest(body);
   await liveTest.run();
   return liveTest;
@@ -144,7 +144,8 @@ void expectTestFailed(LiveTest liveTest, message) {
 /// is called at some later time.
 ///
 /// [stopBlocking] is passed the return value of [test].
-Future expectTestBlocks(test(), stopBlocking(value)) async {
+Future expectTestBlocks(
+    dynamic Function() test, dynamic Function(dynamic) stopBlocking) async {
   LiveTest liveTest;
   Future future;
   liveTest = createTest(() {
@@ -167,7 +168,7 @@ Future expectTestBlocks(test(), stopBlocking(value)) async {
 ///
 /// This is typically used to run multiple tests where later tests make
 /// assertions about the results of previous ones.
-Future expectTestsPass(void body()) async {
+Future expectTestsPass(void Function() body) async {
   var engine = declareEngine(body);
   var success = await engine.run();
 
@@ -179,13 +180,13 @@ Future expectTestsPass(void body()) async {
 }
 
 /// Runs [body] with a declarer and returns the declared entries.
-List<GroupEntry> declare(void body()) {
+List<GroupEntry> declare(void Function() body) {
   var declarer = Declarer()..declare(body);
   return declarer.build().entries;
 }
 
 /// Runs [body] with a declarer and returns an engine that runs those tests.
-Engine declareEngine(void body(), {bool runSkipped = false}) {
+Engine declareEngine(void Function() body, {bool runSkipped = false}) {
   var declarer = Declarer()..declare(body);
   return Engine.withSuites([
     RunnerSuite(

--- a/pkgs/test_core/lib/src/bootstrap/vm.dart
+++ b/pkgs/test_core/lib/src/bootstrap/vm.dart
@@ -9,7 +9,7 @@ import 'package:stream_channel/isolate_channel.dart';
 import 'package:test_core/src/runner/plugin/remote_platform_helpers.dart';
 
 /// Bootstraps a vm test to communicate with the test runner.
-void internalBootstrapVmTest(Function getMain(), SendPort sendPort) {
+void internalBootstrapVmTest(Function Function() getMain, SendPort sendPort) {
   var channel = serializeSuite(getMain);
   IsolateChannel.connectSend(sendPort).pipe(channel);
 }

--- a/pkgs/test_core/lib/src/executable.dart
+++ b/pkgs/test_core/lib/src/executable.dart
@@ -36,7 +36,7 @@ final String _globalConfigPath = () {
   }
 }();
 
-main(List<String> args) async {
+void main(List<String> args) async {
   await _execute(args);
   completeShutdown();
 }

--- a/pkgs/test_core/lib/src/runner.dart
+++ b/pkgs/test_core/lib/src/runner.dart
@@ -58,7 +58,7 @@ class Runner {
   ///
   /// This is used to avoid printing duplicate warnings when a suite is loaded
   /// on multiple platforms.
-  final _tagWarningSuites = Set<String>();
+  final _tagWarningSuites = <String>{};
 
   /// The current debug operation, if any.
   ///
@@ -320,10 +320,10 @@ class Runner {
   /// This returns a map from tag names to lists of entries that use those tags.
   Map<String, List<GroupEntry>> _collectUnknownTags(Suite suite) {
     var unknownTags = <String, List<GroupEntry>>{};
-    var currentTags = Set<String>();
+    var currentTags = <String>{};
 
-    collect(GroupEntry entry) {
-      var newTags = Set<String>();
+    void collect(GroupEntry entry) {
+      var newTags = <String>{};
       for (var unknownTag
           in entry.metadata.tags.difference(_config.knownTags)) {
         if (currentTags.contains(unknownTag)) continue;

--- a/pkgs/test_core/lib/src/runner/application_exception.dart
+++ b/pkgs/test_core/lib/src/runner/application_exception.dart
@@ -8,5 +8,6 @@ class ApplicationException implements Exception {
 
   ApplicationException(this.message);
 
+  @override
   String toString() => message;
 }

--- a/pkgs/test_core/lib/src/runner/compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/compiler_pool.dart
@@ -30,7 +30,7 @@ class CompilerPool {
   final Pool _pool;
 
   /// The currently-active dart2js processes.
-  final _processes = Set<Process>();
+  final _processes = <Process>{};
 
   /// Whether [close] has been called.
   bool get _closed => _closeMemo.hasRun;
@@ -67,10 +67,10 @@ class CompilerPool {
           '--enable-asserts',
           wrapperPath,
           '--out=$jsPath',
-          await PackageResolver.current.processArgument
-        ]
-          ..addAll(_extraArgs)
-          ..addAll(suiteConfig.dart2jsArgs);
+          await PackageResolver.current.processArgument,
+          ..._extraArgs,
+          ...suiteConfig.dart2jsArgs
+        ];
 
         if (_config.color) args.add('--enable-diagnostic-colors');
 

--- a/pkgs/test_core/lib/src/runner/configuration.dart
+++ b/pkgs/test_core/lib/src/runner/configuration.dart
@@ -420,7 +420,8 @@ class Configuration {
   ///
   /// This is zone-scoped, so [this] will be the current configuration in any
   /// asynchronous callbacks transitively created by [body].
-  T asCurrent<T>(T Function() body) => runZoned(body, zoneValues: {_currentKey: this});
+  T asCurrent<T>(T Function() body) =>
+      runZoned(body, zoneValues: {_currentKey: this});
 
   /// Throws a [FormatException] if [this] refers to any undefined runtimes.
   void validateRuntimes(List<Runtime> allRuntimes) {
@@ -619,8 +620,8 @@ class Configuration {
 
     // Make sure the configuration knows about presets that were selected and
     // thus removed from [newPresets].
-    result._knownPresets = UnmodifiableSetView(
-        result.knownPresets.toSet()..addAll(presets.keys));
+    result._knownPresets =
+        UnmodifiableSetView(result.knownPresets.toSet()..addAll(presets.keys));
 
     return result;
   }

--- a/pkgs/test_core/lib/src/runner/configuration.dart
+++ b/pkgs/test_core/lib/src/runner/configuration.dart
@@ -112,12 +112,12 @@ class Configuration {
   final int totalShards;
 
   /// The list of packages to fold when producing [StackTrace]s.
-  Set<String> get foldTraceExcept => _foldTraceExcept ?? Set();
+  Set<String> get foldTraceExcept => _foldTraceExcept ?? {};
   final Set<String> _foldTraceExcept;
 
   /// If non-empty, all packages not in this list will be folded when producing
   /// [StackTrace]s.
-  Set<String> get foldTraceOnly => _foldTraceOnly ?? Set();
+  Set<String> get foldTraceOnly => _foldTraceOnly ?? {};
   final Set<String> _foldTraceOnly;
 
   /// The paths from which to load tests.
@@ -362,7 +362,7 @@ class Configuration {
         _foldTraceExcept = _set(foldTraceExcept),
         _foldTraceOnly = _set(foldTraceOnly),
         _filename = filename,
-        chosenPresets = UnmodifiableSetView(chosenPresets?.toSet() ?? Set()),
+        chosenPresets = UnmodifiableSetView(chosenPresets?.toSet() ?? {}),
         presets = _map(presets),
         overrideRuntimes = _map(overrideRuntimes),
         defineRuntimes = _map(defineRuntimes),
@@ -420,7 +420,7 @@ class Configuration {
   ///
   /// This is zone-scoped, so [this] will be the current configuration in any
   /// asynchronous callbacks transitively created by [body].
-  T asCurrent<T>(T body()) => runZoned(body, zoneValues: {_currentKey: this});
+  T asCurrent<T>(T Function() body) => runZoned(body, zoneValues: {_currentKey: this});
 
   /// Throws a [FormatException] if [this] refers to any undefined runtimes.
   void validateRuntimes(List<Runtime> allRuntimes) {
@@ -615,12 +615,12 @@ class Configuration {
             merged.merge(newPresets.remove(preset) ?? Configuration.empty));
 
     if (merged == empty) return this;
-    var result = this.change(presets: newPresets).merge(merged);
+    var result = change(presets: newPresets).merge(merged);
 
     // Make sure the configuration knows about presets that were selected and
     // thus removed from [newPresets].
     result._knownPresets = UnmodifiableSetView(
-        result.knownPresets.toSet()..addAll(this.presets.keys));
+        result.knownPresets.toSet()..addAll(presets.keys));
 
     return result;
   }

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -264,7 +264,7 @@ class _Parser {
 
   /// Runs [parse] on the value of the option [name], and wraps any
   /// [FormatException] it throws with additional information.
-  T _parseOption<T>(String name, T parse(String value)) {
+  T _parseOption<T>(String name, T Function(String) parse) {
     if (!_options.wasParsed(name)) return null;
 
     var value = _options[name];
@@ -275,7 +275,7 @@ class _Parser {
 
   /// Runs [parse], and wraps any [FormatException] it throws with additional
   /// information.
-  T _wrapFormatException<T>(String name, T parse()) {
+  T _wrapFormatException<T>(String name, T Function() parse) {
     try {
       return parse();
     } on FormatException catch (error) {

--- a/pkgs/test_core/lib/src/runner/console.dart
+++ b/pkgs/test_core/lib/src/runner/console.dart
@@ -49,7 +49,8 @@ class Console {
   /// The [description] should be a one-line description of the command to print
   /// in the help output. The [body] callback will be called when the user types
   /// the command, and may return a [Future].
-  void registerCommand(String name, String description, body()) {
+  void registerCommand(
+      String name, String description, dynamic Function() body) {
     if (_commands.containsKey(name)) {
       throw ArgumentError('The console already has a command named "$name".');
     }

--- a/pkgs/test_core/lib/src/runner/coverage.dart
+++ b/pkgs/test_core/lib/src/runner/coverage.dart
@@ -9,25 +9,24 @@ import 'package:coverage/coverage.dart';
 import 'package:path/path.dart' as p;
 
 import 'live_suite_controller.dart';
-import 'runner_suite.dart';
 
 /// Collects coverage and outputs to the [coverage] path.
 Future<void> gatherCoverage(
     String coverage, LiveSuiteController controller) async {
-  final RunnerSuite suite = controller.liveSuite.suite;
+  final suite = controller.liveSuite.suite;
 
   if (!suite.platform.runtime.isDartVM) return;
 
-  final String isolateId = Uri.parse(suite.environment.observatoryUrl.fragment)
+  final isolateId = Uri.parse(suite.environment.observatoryUrl.fragment)
       .queryParameters['isolateId'];
 
   final cov = await collect(
-      suite.environment.observatoryUrl, false, false, false, Set(),
+      suite.environment.observatoryUrl, false, false, false, {},
       isolateIds: {isolateId});
 
   final outfile = File(p.join('$coverage', '${suite.path}.vm.json'))
     ..createSync(recursive: true);
-  final IOSink out = outfile.openWrite();
+  final out = outfile.openWrite();
   out.write(json.encode(cov));
   await out.flush();
   await out.close();

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -108,7 +108,7 @@ class Engine {
   final _group = FutureGroup();
 
   /// All of the engine's stream subscriptions.
-  final _subscriptions = Set<StreamSubscription>();
+  final _subscriptions = <StreamSubscription>{};
 
   /// A sink used to pass [RunnerSuite]s in to the engine to run.
   ///
@@ -125,7 +125,7 @@ class Engine {
   /// Note that if a [LoadSuite] is added, this will only contain that suite,
   /// not the suite it loads.
   Set<RunnerSuite> get addedSuites => UnmodifiableSetView(_addedSuites);
-  final _addedSuites = Set<RunnerSuite>();
+  final _addedSuites = <RunnerSuite>{};
 
   /// A broadcast stream that emits each [RunnerSuite] as it's added to the
   /// engine via [suiteSink].
@@ -146,7 +146,7 @@ class Engine {
   /// [LoadSuite]s, both the [LoadSuite] and the suite it loads will eventually
   /// be in this set.
   Set<LiveSuite> get liveSuites => UnmodifiableSetView(_liveSuites);
-  final _liveSuites = Set<LiveSuite>();
+  final _liveSuites = <LiveSuite>{};
 
   /// A broadcast stream that emits each [LiveSuite] as it's loaded.
   ///
@@ -196,13 +196,13 @@ class Engine {
   ///
   /// This is always a subset of [active]. Once a test in here has finished
   /// running, it's run again.
-  final _restarted = Set<LiveTest>();
+  final _restarted = <LiveTest>{};
 
   /// The tests from [LoadSuite]s that are still running, in the order they
   /// began running.
   ///
   /// This is separate from [active] because load tests aren't always surfaced.
-  final _activeLoadTests = List<LiveTest>();
+  final _activeLoadTests = <LiveTest>{};
 
   /// Whether this engine is idle—that is, not currently executing a test.
   bool get isIdle => _group.isIdle;
@@ -225,7 +225,7 @@ class Engine {
     _group.future.then((_) {
       _onTestStartedGroup.close();
       _onSuiteStartedController.close();
-      if (_closedBeforeDone == null) _closedBeforeDone = false;
+      _closedBeforeDone ??= false;
     }).catchError((_) {
       // Don't top-level errors. They'll be thrown via [success] anyway.
     });

--- a/pkgs/test_core/lib/src/runner/environment.dart
+++ b/pkgs/test_core/lib/src/runner/environment.dart
@@ -36,15 +36,20 @@ abstract class Environment {
 
 /// The default environment for platform plugins.
 class PluginEnvironment implements Environment {
+  @override
   final supportsDebugging = false;
+  @override
   Stream get onRestart => StreamController.broadcast().stream;
 
   const PluginEnvironment();
 
+  @override
   Uri get observatoryUrl => null;
 
+  @override
   Uri get remoteDebuggerUrl => null;
 
+  @override
   CancelableOperation displayPause() => throw UnsupportedError(
       'PluginEnvironment.displayPause is not supported.');
 }

--- a/pkgs/test_core/lib/src/runner/hybrid_listener.dart
+++ b/pkgs/test_core/lib/src/runner/hybrid_listener.dart
@@ -32,7 +32,7 @@ final _transformer = StreamSinkTransformer<dynamic, dynamic>.fromHandlers(
 ///
 /// The [data] argument contains two values: a [SendPort] that communicates with
 /// the main isolate, and a message to pass to `hybridMain()`.
-void listen(Function getMain(), List data) {
+void listen(Function Function() getMain, List data) {
   var channel = IsolateChannel.connectSend(data.first as SendPort);
   var message = data.last;
 

--- a/pkgs/test_core/lib/src/runner/live_suite.dart
+++ b/pkgs/test_core/lib/src/runner/live_suite.dart
@@ -59,11 +59,12 @@ abstract class LiveSuite {
   ///
   /// This is guaranteed to contain the same tests as the union of [passed],
   /// [skipped], [failed], and [active].
-  Set<LiveTest> get liveTests {
-    var sets = [passed, skipped, failed];
-    if (active != null) sets.add(Set.from([active]));
-    return UnionSet.from(sets);
-  }
+  Set<LiveTest> get liveTests => UnionSet.from([
+        passed,
+        skipped,
+        failed,
+        if (active != null) {active}
+      ]);
 
   /// A stream that emits each [LiveTest] in this suite as it's about to start
   /// running.

--- a/pkgs/test_core/lib/src/runner/live_suite_controller.dart
+++ b/pkgs/test_core/lib/src/runner/live_suite_controller.dart
@@ -18,25 +18,35 @@ import 'live_suite.dart';
 class _LiveSuite extends LiveSuite {
   final LiveSuiteController _controller;
 
+  @override
   RunnerSuite get suite => _controller._suite;
 
+  @override
   bool get isComplete => _controller._isComplete;
 
+  @override
   Future get onComplete => _controller._onCompleteGroup.future;
 
+  @override
   bool get isClosed => _controller._onCloseCompleter.isCompleted;
 
+  @override
   Future get onClose => _controller._onCloseCompleter.future;
 
+  @override
   Stream<LiveTest> get onTestStarted =>
       _controller._onTestStartedController.stream;
 
+  @override
   Set<LiveTest> get passed => UnmodifiableSetView(_controller._passed);
 
+  @override
   Set<LiveTest> get skipped => UnmodifiableSetView(_controller._skipped);
 
+  @override
   Set<LiveTest> get failed => UnmodifiableSetView(_controller._failed);
 
+  @override
   LiveTest get active => _controller._active;
 
   _LiveSuite(this._controller);
@@ -76,13 +86,13 @@ class LiveSuiteController {
       StreamController<LiveTest>.broadcast(sync: true);
 
   /// The set that backs [LiveTest.passed].
-  final _passed = Set<LiveTest>();
+  final _passed = <LiveTest>{};
 
   /// The set that backs [LiveTest.skipped].
-  final _skipped = Set<LiveTest>();
+  final _skipped = <LiveTest>{};
 
   /// The set that backs [LiveTest.failed].
-  final _failed = Set<LiveTest>();
+  final _failed = <LiveTest>{};
 
   /// The test exposed through [LiveTest.active].
   LiveTest _active;

--- a/pkgs/test_core/lib/src/runner/load_exception.dart
+++ b/pkgs/test_core/lib/src/runner/load_exception.dart
@@ -12,6 +12,7 @@ class LoadException implements Exception {
 
   LoadException(this.path, this.innerError);
 
+  @override
   String toString({bool color = false}) {
     var buffer = StringBuffer();
     if (color) buffer.write('\u001b[31m'); // red

--- a/pkgs/test_core/lib/src/runner/loader.dart
+++ b/pkgs/test_core/lib/src/runner/loader.dart
@@ -35,7 +35,7 @@ class Loader {
   final _config = Configuration.current;
 
   /// All suites that have been created by the loader.
-  final _suites = Set<RunnerSuite>();
+  final _suites = <RunnerSuite>{};
 
   /// Memoizers for platform plugins, indexed by the runtimes they support.
   final _platformPlugins = <Runtime, AsyncMemoizer<PlatformPlugin>>{};

--- a/pkgs/test_core/lib/src/runner/plugin/environment.dart
+++ b/pkgs/test_core/lib/src/runner/plugin/environment.dart
@@ -10,15 +10,20 @@ import '../environment.dart';
 
 /// The default environment for platform plugins.
 class PluginEnvironment implements Environment {
+  @override
   final supportsDebugging = false;
+  @override
   Stream get onRestart => StreamController.broadcast().stream;
 
   const PluginEnvironment();
 
+  @override
   Uri get observatoryUrl => null;
 
+  @override
   Uri get remoteDebuggerUrl => null;
 
+  @override
   CancelableOperation displayPause() => throw UnsupportedError(
       'PluginEnvironment.displayPause is not supported.');
 }

--- a/pkgs/test_core/lib/src/runner/plugin/platform_helpers.dart
+++ b/pkgs/test_core/lib/src/runner/plugin/platform_helpers.dart
@@ -60,7 +60,7 @@ RunnerSuiteController deserializeSuite(
   var completer = Completer<Group>();
 
   var loadSuiteZone = Zone.current;
-  handleError(error, StackTrace stackTrace) {
+  void handleError(error, StackTrace stackTrace) {
     disconnector.disconnect();
 
     if (completer.isCompleted) {

--- a/pkgs/test_core/lib/src/runner/plugin/remote_platform_helpers.dart
+++ b/pkgs/test_core/lib/src/runner/plugin/remote_platform_helpers.dart
@@ -30,8 +30,8 @@ import 'package:test_api/src/suite_channel_manager.dart'; // ignore: implementat
 ///
 /// If [beforeLoad] is passed, it's called before the tests have been declared
 /// for this worker.
-StreamChannel serializeSuite(Function getMain(),
-        {bool hidePrints = true, Future beforeLoad()}) =>
+StreamChannel serializeSuite(Function Function() getMain,
+        {bool hidePrints = true, Future Function() beforeLoad}) =>
     RemoteListener.start(getMain,
         hidePrints: hidePrints, beforeLoad: beforeLoad);
 

--- a/pkgs/test_core/lib/src/runner/reporter/compact.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/compact.dart
@@ -99,7 +99,7 @@ class CompactReporter implements Reporter {
   var _paused = false;
 
   /// The set of all subscriptions to various streams.
-  final _subscriptions = Set<StreamSubscription>();
+  final _subscriptions = <StreamSubscription>{};
 
   /// Watches the tests run by [engine] and prints their results to the
   /// terminal.
@@ -114,6 +114,7 @@ class CompactReporter implements Reporter {
     _subscriptions.add(_engine.success.asStream().listen(_onDone));
   }
 
+  @override
   void pause() {
     if (_paused) return;
     _paused = true;
@@ -132,6 +133,7 @@ class CompactReporter implements Reporter {
     }
   }
 
+  @override
   void resume() {
     if (!_paused) return;
     _paused = false;
@@ -143,6 +145,7 @@ class CompactReporter implements Reporter {
     }
   }
 
+  @override
   void cancel() {
     for (var subscription in _subscriptions) {
       subscription.cancel();
@@ -309,7 +312,7 @@ class CompactReporter implements Reporter {
     _lastProgressTruncated = truncate;
 
     if (suffix != null) message += suffix;
-    if (color == null) color = '';
+    color ??= '';
     var duration = _stopwatch.elapsed;
     var buffer = StringBuffer();
 

--- a/pkgs/test_core/lib/src/runner/reporter/expanded.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/expanded.dart
@@ -261,7 +261,7 @@ class ExpandedReporter implements Reporter {
     _lastProgressSuffix = suffix;
 
     if (suffix != null) message += suffix;
-     color ??= '';
+    color ??= '';
     var duration = _stopwatch.elapsed;
     var buffer = StringBuffer();
 

--- a/pkgs/test_core/lib/src/runner/reporter/expanded.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/expanded.dart
@@ -82,7 +82,7 @@ class ExpandedReporter implements Reporter {
   var _paused = false;
 
   /// The set of all subscriptions to various streams.
-  final _subscriptions = Set<StreamSubscription>();
+  final _subscriptions = <StreamSubscription>{};
 
   final StringSink _sink;
 
@@ -119,6 +119,7 @@ class ExpandedReporter implements Reporter {
     _subscriptions.add(_engine.success.asStream().listen(_onDone));
   }
 
+  @override
   void pause() {
     if (_paused) return;
     _paused = true;
@@ -130,6 +131,7 @@ class ExpandedReporter implements Reporter {
     }
   }
 
+  @override
   void resume() {
     if (!_paused) return;
     _stopwatch.start();
@@ -139,6 +141,7 @@ class ExpandedReporter implements Reporter {
     }
   }
 
+  @override
   void cancel() {
     for (var subscription in _subscriptions) {
       subscription.cancel();
@@ -258,7 +261,7 @@ class ExpandedReporter implements Reporter {
     _lastProgressSuffix = suffix;
 
     if (suffix != null) message += suffix;
-    if (color == null) color = '';
+     color ??= '';
     var duration = _stopwatch.elapsed;
     var buffer = StringBuffer();
 

--- a/pkgs/test_core/lib/src/runner/reporter/json.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/json.dart
@@ -48,16 +48,16 @@ class JsonReporter implements Reporter {
   var _paused = false;
 
   /// The set of all subscriptions to various streams.
-  final _subscriptions = Set<StreamSubscription>();
+  final _subscriptions = <StreamSubscription>{};
 
   /// An expando that associates unique IDs with [LiveTest]s.
-  final _liveTestIDs = Map<LiveTest, int>();
+  final _liveTestIDs = <LiveTest, int>{};
 
   /// An expando that associates unique IDs with [Suite]s.
-  final _suiteIDs = Map<Suite, int>();
+  final _suiteIDs = <Suite, int>{};
 
   /// An expando that associates unique IDs with [Group]s.
-  final _groupIDs = Map<Group, int>();
+  final _groupIDs = <Group, int>{};
 
   /// The next ID to associate with a [LiveTest].
   var _nextID = 0;
@@ -81,6 +81,7 @@ class JsonReporter implements Reporter {
         {'protocolVersion': '0.1.1', 'runnerVersion': testVersion, 'pid': pid});
   }
 
+  @override
   void pause() {
     if (_paused) return;
     _paused = true;
@@ -92,6 +93,7 @@ class JsonReporter implements Reporter {
     }
   }
 
+  @override
   void resume() {
     if (!_paused) return;
     _paused = false;
@@ -103,6 +105,7 @@ class JsonReporter implements Reporter {
     }
   }
 
+  @override
   void cancel() {
     for (var subscription in _subscriptions) {
       subscription.cancel();

--- a/pkgs/test_core/lib/src/runner/runner_suite.dart
+++ b/pkgs/test_core/lib/src/runner/runner_suite.dart
@@ -68,7 +68,8 @@ class RunnerSuite extends Suite {
       this._controller, Group group, String path, SuitePlatform platform)
       : super(group, platform, path: path);
 
-  RunnerSuite filter(bool callback(Test test)) {
+  @override
+  RunnerSuite filter(bool Function(Test) callback) {
     var filtered = group.filter(callback);
     filtered ??= Group.root([], metadata: metadata);
     return RunnerSuite._(_controller, filtered, path, platform);
@@ -103,7 +104,7 @@ class RunnerSuiteController {
   final _onDebuggingController = StreamController<bool>.broadcast();
 
   /// The channel names that have already been used.
-  final _channelNames = Set<String>();
+  final _channelNames = <String>{};
 
   RunnerSuiteController(this._environment, this._config, this._suiteChannel,
       Future<Group> groupFuture, SuitePlatform platform,

--- a/pkgs/test_core/lib/src/runner/runner_test.dart
+++ b/pkgs/test_core/lib/src/runner/runner_test.dart
@@ -21,8 +21,11 @@ import 'spawn_hybrid.dart';
 
 /// A test running remotely, controlled by a stream channel.
 class RunnerTest extends Test {
+  @override
   final String name;
+  @override
   final Metadata metadata;
+  @override
   final Trace trace;
 
   /// The channel used to communicate with the test's [IframeListener].
@@ -32,6 +35,7 @@ class RunnerTest extends Test {
 
   RunnerTest._(this.name, this.metadata, this.trace, this._channel);
 
+  @override
   LiveTest load(Suite suite, {Iterable<Group> groups}) {
     LiveTestController controller;
     VirtualChannel testChannel;
@@ -97,6 +101,7 @@ class RunnerTest extends Test {
     return controller.liveTest;
   }
 
+  @override
   Test forPlatform(SuitePlatform platform) {
     if (!metadata.testOn.evaluate(platform)) return null;
     return RunnerTest._(name, metadata.forPlatform(platform), trace, _channel);

--- a/pkgs/test_core/lib/src/runner/runtime_selection.dart
+++ b/pkgs/test_core/lib/src/runner/runtime_selection.dart
@@ -16,7 +16,9 @@ class RuntimeSelection {
 
   RuntimeSelection(this.name, [this.span]);
 
+  @override
   bool operator ==(other) => other is RuntimeSelection && other.name == name;
 
+  @override
   int get hashCode => name.hashCode;
 }

--- a/pkgs/test_core/lib/src/runner/suite.dart
+++ b/pkgs/test_core/lib/src/runner/suite.dart
@@ -196,7 +196,7 @@ class SuiteConfiguration {
       : _jsTrace = jsTrace,
         _runSkipped = runSkipped,
         dart2jsArgs = _list(dart2jsArgs) ?? const [],
-        patterns = UnmodifiableSetView(patterns?.toSet() ?? Set()),
+        patterns = UnmodifiableSetView(patterns?.toSet() ?? {}),
         _runtimes = _list(runtimes),
         includeTags = includeTags ?? BooleanSelector.all,
         excludeTags = excludeTags ?? BooleanSelector.none,
@@ -369,6 +369,6 @@ class SuiteConfiguration {
     });
 
     if (merged == empty) return this;
-    return this.change(tags: newTags).merge(merged);
+    return change(tags: newTags).merge(merged);
   }
 }

--- a/pkgs/test_core/lib/src/runner/vm/environment.dart
+++ b/pkgs/test_core/lib/src/runner/vm/environment.dart
@@ -10,7 +10,9 @@ import 'package:test_core/src/runner/environment.dart'; // ignore: implementatio
 
 /// The environment in which VM tests are loaded.
 class VMEnvironment implements Environment {
+  @override
   final supportsDebugging = true;
+  @override
   final Uri observatoryUrl;
 
   /// The VM service isolate object used to control this isolate.
@@ -19,10 +21,13 @@ class VMEnvironment implements Environment {
 
   VMEnvironment(this.observatoryUrl, this._isolate, this._client);
 
+  @override
   Uri get remoteDebuggerUrl => null;
 
+  @override
   Stream get onRestart => StreamController.broadcast().stream;
 
+  @override
   CancelableOperation displayPause() {
     var completer =
         CancelableCompleter(onCancel: () => _client.resume(_isolate.id));

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -33,9 +33,11 @@ class VMPlatform extends PlatformPlugin {
 
   VMPlatform();
 
+  @override
   StreamChannel loadChannel(String path, SuitePlatform platform) =>
       throw UnimplementedError();
 
+  @override
   Future<RunnerSuite> load(String path, SuitePlatform platform,
       SuiteConfiguration suiteConfig, Object message) async {
     assert(platform.runtime == Runtime.vm);

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -92,7 +92,7 @@ String createTempDir() =>
 ///
 /// Returns a future that completes to the value that the future returned from
 /// [fn] completes to.
-Future withTempDir(Future fn(String path)) {
+Future withTempDir(Future Function(String) fn) {
   return Future.sync(() {
     var tempDir = createTempDir();
     return Future.sync(() => fn(tempDir))
@@ -139,7 +139,7 @@ String wordWrap(String text) {
 /// If [print] is `true`, this prints the message using [print] to associate it
 /// with the current test. Otherwise, it prints it using [stderr].
 void warn(String message, {bool color, bool print = false}) {
-  if (color == null) color = canUseSpecialChars;
+  color ??= canUseSpecialChars;
   var header = color ? '\u001b[33mWarning:\u001b[0m' : 'Warning:';
   (print ? core.print : stderr.writeln)(wordWrap('$header $message\n'));
 }
@@ -153,7 +153,7 @@ void warn(String message, {bool color, bool print = false}) {
 ///
 /// This is necessary for ensuring that our port binding isn't flaky for
 /// applications that don't print out the bound port.
-Future<T> getUnusedPort<T>(FutureOr<T> tryPort(int port)) async {
+Future<T> getUnusedPort<T>(FutureOr<T> Function(int port) tryPort) async {
   T value;
   await Future.doWhile(() async {
     value = await tryPort(await getUnsafeUnusedPort());

--- a/pkgs/test_core/lib/src/util/stack_trace_mapper.dart
+++ b/pkgs/test_core/lib/src/util/stack_trace_mapper.dart
@@ -33,6 +33,7 @@ class JSStackTraceMapper extends StackTraceMapper {
         _sdkRoot = sdkRoot;
 
   /// Converts [trace] into a Dart stack trace.
+  @override
   StackTrace mapStackTrace(StackTrace trace) {
     _mapping ??= parseExtended(_mapContents, mapUrl: _mapUrl);
     return mapper.mapStackTrace(_mapping, trace,
@@ -40,6 +41,7 @@ class JSStackTraceMapper extends StackTraceMapper {
   }
 
   /// Returns a Map representation which is suitable for JSON serialization.
+  @override
   Map<String, dynamic> serialize() {
     return {
       'mapContents': _mapContents,
@@ -55,7 +57,7 @@ class JSStackTraceMapper extends StackTraceMapper {
   /// representation.
   static StackTraceMapper deserialize(Map serialized) {
     if (serialized == null) return null;
-    String packageRoot = serialized['packageRoot'] as String ?? '';
+    var packageRoot = serialized['packageRoot'] as String ?? '';
     return JSStackTraceMapper(serialized['mapContents'] as String,
         sdkRoot: Uri.parse(serialized['sdkRoot'] as String),
         packageResolver: packageRoot.isNotEmpty

--- a/pkgs/test_core/lib/src/util/string_literal_iterator.dart
+++ b/pkgs/test_core/lib/src/util/string_literal_iterator.dart
@@ -37,6 +37,7 @@ const _verticalTab = 0xB;
 /// In addition to exposing the values of the runes themselves, this also
 /// exposes the offset of the current rune in the Dart source file.
 class StringLiteralIterator extends Iterator<int> {
+  @override
   int get current => _current;
   int _current;
 
@@ -96,6 +97,7 @@ class StringLiteralIterator extends Iterator<int> {
     _offset = _strings.first.contentsOffset - 1;
   }
 
+  @override
   bool moveNext() {
     // If we're at beginning of a [SimpleStringLiteral], move forward until
     // there's actually text to consume.

--- a/pkgs/test_core/lib/test_core.dart
+++ b/pkgs/test_core/lib/test_core.dart
@@ -129,7 +129,7 @@ Declarer get _declarer {
 /// avoid this flag if possible and instead use the test runner flag `-n` to
 /// filter tests by name.
 @isTest
-void test(description, body(),
+void test(description, dynamic Function() body,
     {String testOn,
     Timeout timeout,
     skip,
@@ -207,7 +207,7 @@ void test(description, body(),
 /// avoid this flag if possible, and instead use the test runner flag `-n` to
 /// filter tests by name.
 @isTestGroup
-void group(description, body(),
+void group(description, dynamic Function() body,
     {String testOn,
     Timeout timeout,
     skip,
@@ -242,7 +242,7 @@ void group(description, body(),
 ///
 /// Each callback at the top level or in a given group will be run in the order
 /// they were declared.
-void setUp(callback()) => _declarer.setUp(callback);
+void setUp(dynamic Function() callback) => _declarer.setUp(callback);
 
 /// Registers a function to be run after tests.
 ///
@@ -257,7 +257,7 @@ void setUp(callback()) => _declarer.setUp(callback);
 /// reverse of the order they were declared.
 ///
 /// See also [addTearDown], which adds tear-downs to a running test.
-void tearDown(callback()) => _declarer.tearDown(callback);
+void tearDown(dynamic Function() callback) => _declarer.tearDown(callback);
 
 /// Registers a function to be run once before all tests.
 ///
@@ -272,7 +272,7 @@ void tearDown(callback()) => _declarer.tearDown(callback);
 /// dependencies between tests that should be isolated. In general, you should
 /// prefer [setUp], and only use [setUpAll] if the callback is prohibitively
 /// slow.
-void setUpAll(callback()) => _declarer.setUpAll(callback);
+void setUpAll(dynamic Function() callback) => _declarer.setUpAll(callback);
 
 /// Registers a function to be run once after all tests.
 ///
@@ -285,4 +285,5 @@ void setUpAll(callback()) => _declarer.setUpAll(callback);
 /// dependencies between tests that should be isolated. In general, you should
 /// prefer [tearDown], and only use [tearDownAll] if the callback is
 /// prohibitively slow.
-void tearDownAll(callback()) => _declarer.tearDownAll(callback);
+void tearDownAll(dynamic Function() callback) =>
+    _declarer.tearDownAll(callback);

--- a/pkgs/test_core/mono_pkg.yaml
+++ b/pkgs/test_core/mono_pkg.yaml
@@ -6,4 +6,4 @@ stages:
       dart: dev
     - group:
       - dartanalyzer: --fatal-warnings .
-      dart: 2.1.0
+      dart: 2.3.0

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -5,7 +5,7 @@ description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
 environment:
-  sdk: ">=2.2.0 <3.0.0"
+  sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
   analyzer: ">=0.36.0 <0.40.0"

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -1,5 +1,28 @@
 #!/bin/bash
-# Created with package:mono_repo v2.1.0
+# Created with package:mono_repo v2.3.0
+
+# Support built in commands on windows out of the box.
+function pub {
+       if [[ $TRAVIS_OS_NAME == "windows" ]]; then
+        command pub.bat "$@"
+    else
+        command pub "$@"
+    fi
+}
+function dartfmt {
+       if [[ $TRAVIS_OS_NAME == "windows" ]]; then
+        command dartfmt.bat "$@"
+    else
+        command dartfmt "$@"
+    fi
+}
+function dartanalyzer {
+       if [[ $TRAVIS_OS_NAME == "windows" ]]; then
+        command dartanalyzer.bat "$@"
+    else
+        command dartanalyzer "$@"
+    fi
+}
 
 if [[ -z ${PKGS} ]]; then
   echo -e '\033[31mPKGS environment variable must be set!\033[0m'
@@ -16,7 +39,16 @@ EXIT_CODE=0
 for PKG in ${PKGS}; do
   echo -e "\033[1mPKG: ${PKG}\033[22m"
   pushd "${PKG}" || exit $?
-  pub upgrade --no-precompile || exit $?
+
+  PUB_EXIT_CODE=0
+  pub upgrade --no-precompile || PUB_EXIT_CODE=$?
+
+  if [[ ${PUB_EXIT_CODE} -ne 0 ]]; then
+    EXIT_CODE=1
+    echo -e '\033[31mpub upgrade failed\033[0m'
+    popd
+    continue
+  fi
 
   for TASK in "$@"; do
     echo


### PR DESCRIPTION
- always_declare_return_types
- annotate_overrides
- await_only_futures
- omit_local_variable_types
- prefer_collection_literals
- prefer_conditional_assignment
- prefer_final_fields
- prefer_for_elements_to_map_fromiterable
- prefer_if_null_operators
- prefer_spread_collections
- unnecessary_this
- use_function_type_syntax_for_parameters

Bump min SDK to 2.3.0 everywhere to allow using spreads in collection
literals.

Skip one test failing on master to unblock Travis.
https://github.com/dart-lang/test/issues/1120