### PR TITLE
Remove uses of "invoke" utility

### DIFF
--- a/pkgs/test_core/lib/src/runner/console.dart
+++ b/pkgs/test_core/lib/src/runner/console.dart
@@ -6,8 +6,7 @@ import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:async/async.dart';
-
-import 'package:test_api/src/utils.dart'; // ignore: implementation_imports
+import 'package:pedantic/pedantic.dart';
 
 import '../util/io.dart';
 
@@ -62,7 +61,7 @@ class Console {
   /// This prints the initial prompt and loops while waiting for user input.
   void start() {
     _running = true;
-    invoke(() async {
+    unawaited(() async {
       while (_running) {
         stdout.write('> ');
         _nextLine = stdinLines.cancelable((queue) => queue.next);
@@ -78,7 +77,7 @@ class Console {
           await command.body();
         }
       }
-    });
+    }());
   }
 
   /// Stops the console running.

--- a/pkgs/test_core/lib/src/runner/load_suite.dart
+++ b/pkgs/test_core/lib/src/runner/load_suite.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:pedantic/pedantic.dart';
 import 'package:stack_trace/stack_trace.dart';
 import 'package:stream_channel/stream_channel.dart';
 
@@ -94,7 +95,7 @@ class LoadSuite extends Suite implements RunnerSuite {
       var invoker = Invoker.current;
       invoker.addOutstandingCallback();
 
-      invoke(() async {
+      unawaited(() async {
         var suite = await body();
         if (completer.isCompleted) {
           // If the load test has already been closed, close the suite it
@@ -105,7 +106,7 @@ class LoadSuite extends Suite implements RunnerSuite {
 
         completer.complete(suite == null ? null : Pair(suite, Zone.current));
         invoker.removeOutstandingCallback();
-      });
+      }());
 
       // If the test completes before the body callback, either an out-of-band
       // error occurred or the test was canceled. Either way, we return a `null`

--- a/pkgs/test_core/lib/src/runner/runner_test.dart
+++ b/pkgs/test_core/lib/src/runner/runner_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:pedantic/pedantic.dart';
 import 'package:stack_trace/stack_trace.dart';
 import 'package:stream_channel/stream_channel.dart';
 
@@ -15,7 +16,6 @@ import 'package:test_api/src/backend/suite.dart'; // ignore: implementation_impo
 import 'package:test_api/src/backend/suite_platform.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/test.dart'; // ignore: implementation_imports
 import 'package:test_api/src/util/remote_exception.dart'; // ignore: implementation_imports
-import 'package:test_api/src/utils.dart'; // ignore: implementation_imports
 
 import 'spawn_hybrid.dart';
 
@@ -85,14 +85,14 @@ class RunnerTest extends Test {
         return;
       }
 
-      invoke(() async {
+      unawaited(() async {
         // If the test is still running, send it a message telling it to shut
         // down ASAP. This causes the [Invoker] to eagerly throw exceptions
         // whenever the test touches it.
         testChannel.sink.add({'command': 'close'});
         await controller.completer.future;
         await testChannel.sink.close();
-      });
+      }());
     }, groups: groups);
     return controller.liveTest;
   }


### PR DESCRIPTION
This has the same intended purpose as `unawaited` so it can be easily
replaced. Technically even the `unawaited` is not necessary here since
none of the surrounding functions are `async`, but it is fine to use it
for documentation purposed.

Leave the utility in place for now since it will take some version bump
gymnastics to roll out.