### PR TITLE
Fix test_chain_test at head

### DIFF
--- a/pkgs/test/test/runner/test_chain_test.dart
+++ b/pkgs/test/test/runner/test_chain_test.dart
@@ -6,8 +6,8 @@
 
 import 'dart:convert';
 
-import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
 
 import '../io.dart';
 
@@ -70,12 +70,12 @@ void main() {
             'dart_test.yaml',
             jsonEncode({
               'fold_stack_frames': {
-                'only': ['test']
+                'only': ['test_api']
               }
             }))
         .create();
     var test = await runTest(['test.dart']);
-    expect(test.stdoutStream(), emitsThrough(contains('package:test')));
+    expect(test.stdoutStream(), emitsThrough(contains('package:test_api')));
     await test.shouldExit(1);
-  }, skip: 'https://github.com/dart-lang/test/issues/1120');
+  });
 }


### PR DESCRIPTION
With the split of `test` to `test_core` and `test_api` this test was incorrectly passing. This issue was only highlighted with the latest SDK change. Update the expectation which closes https://github.com/dart-lang/test/issues/1120