### PR TITLE
Always pass a function to BooleanSelector.evaluate

### DIFF
--- a/pkgs/test_api/lib/src/backend/metadata.dart
+++ b/pkgs/test_api/lib/src/backend/metadata.dart
@@ -172,7 +172,7 @@ class Metadata {
     // doing it for every test individually.
     var empty = Metadata._();
     var merged = forTag.keys.toList().fold(empty, (Metadata merged, selector) {
-      if (!selector.evaluate(tags)) return merged;
+      if (!selector.evaluate(tags.contains)) return merged;
       return merged.merge(forTag.remove(selector));
     });
 

--- a/pkgs/test_core/lib/src/runner.dart
+++ b/pkgs/test_core/lib/src/runner.dart
@@ -261,12 +261,12 @@ class Runner {
           }
 
           // If the user provided tags, skip tests that don't match all of them.
-          if (!suite.config.includeTags.evaluate(test.metadata.tags)) {
+          if (!suite.config.includeTags.evaluate(test.metadata.tags.contains)) {
             return false;
           }
 
           // Skip tests that do match any tags the user wants to exclude.
-          if (suite.config.excludeTags.evaluate(test.metadata.tags)) {
+          if (suite.config.excludeTags.evaluate(test.metadata.tags.contains)) {
             return false;
           }
 

--- a/pkgs/test_core/lib/src/runner/loader.dart
+++ b/pkgs/test_core/lib/src/runner/loader.dart
@@ -179,7 +179,8 @@ class Loader {
       return;
     }
 
-    if (_config.suiteDefaults.excludeTags.evaluate(suiteConfig.metadata.tags)) {
+    if (_config.suiteDefaults.excludeTags
+        .evaluate(suiteConfig.metadata.tags.contains)) {
       return;
     }
 

--- a/pkgs/test_core/lib/src/runner/suite.dart
+++ b/pkgs/test_core/lib/src/runner/suite.dart
@@ -364,7 +364,7 @@ class SuiteConfiguration {
     // Otherwise, resolve the tag-specific components.
     var newTags = Map<BooleanSelector, SuiteConfiguration>.from(tags);
     var merged = tags.keys.fold(empty, (SuiteConfiguration merged, selector) {
-      if (!selector.evaluate(_metadata.tags)) return merged;
+      if (!selector.evaluate(_metadata.tags.contains)) return merged;
       return merged.merge(newTags.remove(selector));
     });
 


### PR DESCRIPTION
Prepare for a potential breaking change in `package:boolean_selector`.
Currently the `evaluate` method takes an argument which is either an
`Iterable<String>` or a `bool Function(String)` which matches the
`.toSet()contains` tearoff on that Iterable. We might tighten that to
always take a `bool Function(String)` since the tearoff is easy to
handle at the calling side.