### PR TITLE
Add custom-html-template-path config option

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.10.0-dev
+
+* Add `customHtmlTemplateFile` configuration option to allow sharing an
+  html template between tests
+
 ## 1.9.5
 
 * Internal cleanup.

--- a/pkgs/test/README.md
+++ b/pkgs/test/README.md
@@ -528,7 +528,8 @@ If you want to share the same HTML file across all tests, you can provide a
 This file should follow the rules above, except that instead of the link tag
 add exactly one `{testScript}` in the place where you want the template processor to insert it.
 
-The template can't end with `.html` since the test loader will not able to process it and an error will be thrown.
+The template can't be named like any test file, as that would clash with using the
+custom HTML mechanics. In such a case, an error will be thrown.
 
 For example:
 

--- a/pkgs/test/README.md
+++ b/pkgs/test/README.md
@@ -526,7 +526,9 @@ the following HTML file:
 If you want to share the same HTML file across all tests, you can provide a
 `custom-html-template-path` configuration option to your configuration file.
 This file should follow the rules above, except that instead of the link tag
-add exactly one `{testScript}` in the place where you want the template processor to insert it.
+add exactly one `{{testScript}}` in the place where you want the template processor to insert it.
+
+You can also optionally use any number of `{{testName}}` placeholders which will be replaced by the test filename.
 
 The template can't be named like any test file, as that would clash with using the
 custom HTML mechanics. In such a case, an error will be thrown.
@@ -542,8 +544,8 @@ custom-html-template-path: html_template.html.tpl
 <!-- html_template.html.tpl -->
 <html>
   <head>
-    <title>Custom HTML Template</title>
-    {testScript}
+    <title>{{testName}} Test</title>
+    {{testScript}}
     <script src="packages/test/dart.js"></script>
   </head>
   <body>

--- a/pkgs/test/README.md
+++ b/pkgs/test/README.md
@@ -10,6 +10,7 @@
 * [Asynchronous Tests](#asynchronous-tests)
   * [Stream Matchers](#stream-matchers)
 * [Running Tests With Custom HTML](#running-tests-with-custom-html)
+  * [Providing a custom HTML template](#providing-a-custom-html-template)
 * [Configuring Tests](#configuring-tests)
   * [Skipping Tests](#skipping-tests)
   * [Timeouts](#timeouts)
@@ -493,7 +494,9 @@ By default, the test runner will generate its own empty HTML file for browser
 tests. However, tests that need custom HTML can create their own files. These
 files have three requirements:
 
-* They must have the same name as the test, with `.dart` replaced by `.html`.
+* They must have the same name as the test, with `.dart` replaced by `.html`. You can also
+  provide a configuration path to an html file if you want it to be reused across all tests.
+  See [Providing a custom HTML template](#providing-a-custom-html-template) below.
 
 * They must contain a `link` tag with `rel="x-dart-test"` and an `href`
   attribute pointing to the test script.
@@ -517,6 +520,37 @@ the following HTML file:
   </body>
 </html>
 ```
+
+### Providing a custom HTML template
+
+If you want to share the same HTML file across all tests, you can provide a
+`custom-html-template-path` configuration option to your configuration file.
+This file should follow the rules above, except that instead of the link tag
+add exactly one `{testScript}` in the place where you want the template processor to insert it.
+
+The template can't end with `.html` since the test loader will not able to process it and an error will be thrown.
+
+For example:
+
+```yaml
+custom-html-template-path: html_template.html.tpl
+```
+
+```html
+<!doctype html>
+<!-- html_template.html.tpl -->
+<html>
+  <head>
+    <title>Custom HTML Template</title>
+    {testScript}
+    <script src="packages/test/dart.js"></script>
+  </head>
+  <body>
+    // ...
+  </body>
+</html>
+```
+
 
 ## Configuring Tests
 

--- a/pkgs/test/doc/configuration.md
+++ b/pkgs/test/doc/configuration.md
@@ -468,7 +468,6 @@ test/sample_test.dart 5:27  main.<fn>
 
 This field specifies the path of the HTML template file to be used for tests run in an HTML environment.
 Any HTML file that is named the same as the test and in the same directory will take precedence over the template.
-The template file can't end with `.html` - any other extension will do, like `.html.tpl`. Otherwise an error will be thrown.
 For more information about the usage of this option see [Providing a custom HTML template](https://github.com/dart-lang/test/blob/master/README.md#providing-a-custom-html-template)
 
 ## Configuring Tags

--- a/pkgs/test/doc/configuration.md
+++ b/pkgs/test/doc/configuration.md
@@ -47,6 +47,7 @@ tags:
   * [`pub_serve`](#pub_serve)
   * [`reporter`](#reporter)
   * [`fold_stack_frames`](#fold_stack_frames)
+  * [`custom_html_template_path`](#custom_html_template_path)
 * [Configuring Tags](#configuring-tags)
   * [`tags`](#tags)
   * [`add_tags`](#add_tags)
@@ -463,6 +464,12 @@ dart:async                  _asyncThenWrapperHelper
 test/sample_test.dart 5:27  main.<fn>
 ```
 
+### `custom_html_template_path`
+
+This field specifies the path of the HTML template file to be used for tests run in an HTML environment.
+Any HTML file that is named the same as the test and in the same directory will take precedence over the template.
+The template file can't end with `.html` - any other extension will do, like `.html.tpl`. Otherwise an error will be thrown.
+For more information about the usage of this option see [Providing a custom HTML template](https://github.com/dart-lang/test/blob/master/README.md#providing-a-custom-html-template)
 
 ## Configuring Tags
 

--- a/pkgs/test/lib/src/runner/browser/platform.dart
+++ b/pkgs/test/lib/src/runner/browser/platform.dart
@@ -191,7 +191,7 @@ class BrowserPlatform extends PlatformPlugin
       var template = _config.customHtmlTemplatePath ?? _defaultTemplatePath;
       var contents = File(template).readAsStringSync();
       var processedContents = contents
-          .replaceFirst('{testScript}', link)
+          .replaceFirst('{{testScript}}', link)
           .replaceAll('{{testName}}', testName);
       return shelf.Response.ok(processedContents,
           headers: {'Content-Type': 'text/html'});
@@ -242,9 +242,9 @@ class BrowserPlatform extends PlatformPlugin
       }
 
       final templateFileContents = File(htmlTemplatePath).readAsStringSync();
-      if ('\{testScript\}'.allMatches(templateFileContents).length != 1) {
+      if ('{{testScript}}'.allMatches(templateFileContents).length != 1) {
         throw LoadException(path,
-            '"${htmlTemplatePath}" must contain exactly one {testScript} placeholder');
+            '"${htmlTemplatePath}" must contain exactly one {{testScript}} placeholder');
       }
       checkHtmlCorrectness(htmlTemplatePath, path);
     }

--- a/pkgs/test/lib/src/runner/browser/platform.dart
+++ b/pkgs/test/lib/src/runner/browser/platform.dart
@@ -191,6 +191,7 @@ class BrowserPlatform extends PlatformPlugin
       var template = _config.customHtmlTemplatePath ?? _defaultTemplatePath;
       var contents = File(template).readAsStringSync();
       var processedContents = contents
+          // Checked during loading phase that there is only one {{testScript}} placeholder
           .replaceFirst('{{testScript}}', link)
           .replaceAll('{{testName}}', testName);
       return shelf.Response.ok(processedContents,
@@ -233,7 +234,7 @@ class BrowserPlatform extends PlatformPlugin
 
     var htmlPathFromTestPath = p.withoutExtension(path) + '.html';
     if (File(htmlPathFromTestPath).existsSync()) {
-      checkHtmlCorrectness(htmlPathFromTestPath, path);
+      _checkHtmlCorrectness(htmlPathFromTestPath, path);
     } else if (_config.customHtmlTemplatePath != null) {
       var htmlTemplatePath = _config.customHtmlTemplatePath;
       if (!File(htmlTemplatePath).existsSync()) {
@@ -246,7 +247,7 @@ class BrowserPlatform extends PlatformPlugin
         throw LoadException(path,
             '"${htmlTemplatePath}" must contain exactly one {{testScript}} placeholder');
       }
-      checkHtmlCorrectness(htmlTemplatePath, path);
+      _checkHtmlCorrectness(htmlTemplatePath, path);
     }
 
     Uri suiteUrl;
@@ -285,7 +286,7 @@ class BrowserPlatform extends PlatformPlugin
     return suite;
   }
 
-  void checkHtmlCorrectness(String htmlPath, String path) {
+  void _checkHtmlCorrectness(String htmlPath, String path) {
     if (!File(htmlPath).readAsStringSync().contains('packages/test/dart.js')) {
       throw LoadException(
           path,

--- a/pkgs/test/lib/src/runner/browser/platform.dart
+++ b/pkgs/test/lib/src/runner/browser/platform.dart
@@ -239,9 +239,9 @@ class BrowserPlatform extends PlatformPlugin
     }
 
     var htmlPathFromTestPath = p.withoutExtension(path) + '.html';
-    var htmlPathFromTestPathExists = File(htmlPathFromTestPath).existsSync();
-
-    if (!htmlPathFromTestPathExists && _config.customHtmlTemplatePath != null) {
+    if (File(htmlPathFromTestPath).existsSync()) {
+      checkHtmlCorrectness(htmlPathFromTestPath, path);
+    } else if (_config.customHtmlTemplatePath != null) {
       var htmlTemplatePath = _config.customHtmlTemplatePath;
       if (!File(htmlTemplatePath).existsSync()) {
         throw LoadException(
@@ -254,8 +254,6 @@ class BrowserPlatform extends PlatformPlugin
             '"${htmlTemplatePath}" must contain exactly one {testScript} placeholder');
       }
       checkHtmlCorrectness(htmlTemplatePath, path);
-    } else if (htmlPathFromTestPathExists) {
-      checkHtmlCorrectness(htmlPathFromTestPath, path);
     }
 
     Uri suiteUrl;

--- a/pkgs/test/lib/src/runner/browser/platform.dart
+++ b/pkgs/test/lib/src/runner/browser/platform.dart
@@ -239,8 +239,8 @@ class BrowserPlatform extends PlatformPlugin
               p.basename(_config.customHtmlTemplatePath)) {
         throw LoadException(
             path,
-            'template file ${p.basename(_config.customHtmlTemplatePath)} cannot be named '
-            'like the test file ${p.basename(path)}');
+            'template file "${p.basename(_config.customHtmlTemplatePath)}" cannot be named '
+            'like the test file.');
       }
       _checkHtmlCorrectness(htmlPathFromTestPath, path);
     } else if (_config.customHtmlTemplatePath != null) {

--- a/pkgs/test/lib/src/runner/browser/platform.dart
+++ b/pkgs/test/lib/src/runner/browser/platform.dart
@@ -128,7 +128,7 @@ class BrowserPlatform extends PlatformPlugin
   /// Mappers for Dartifying stack traces, indexed by test path.
   final _mappers = <String, StackTraceMapper>{};
 
-  /// The default template for html tests
+  /// The default template for html tests.
   final String _defaultTemplatePath;
 
   BrowserPlatform._(this._server, Configuration config, String faviconPath,
@@ -191,7 +191,7 @@ class BrowserPlatform extends PlatformPlugin
       var template = _config.customHtmlTemplatePath ?? _defaultTemplatePath;
       var contents = File(template).readAsStringSync();
       var processedContents = contents
-          // Checked during loading phase that there is only one {{testScript}} placeholder
+          // Checked during loading phase that there is only one {{testScript}} placeholder.
           .replaceFirst('{{testScript}}', link)
           .replaceAll('{{testName}}', testName);
       return shelf.Response.ok(processedContents,

--- a/pkgs/test/lib/src/runner/browser/platform.dart
+++ b/pkgs/test/lib/src/runner/browser/platform.dart
@@ -234,6 +234,14 @@ class BrowserPlatform extends PlatformPlugin
 
     var htmlPathFromTestPath = p.withoutExtension(path) + '.html';
     if (File(htmlPathFromTestPath).existsSync()) {
+      if (_config.customHtmlTemplatePath != null &&
+          p.basename(htmlPathFromTestPath) ==
+              p.basename(_config.customHtmlTemplatePath)) {
+        throw LoadException(
+            path,
+            'template file ${p.basename(_config.customHtmlTemplatePath)} cannot be named '
+            'like the test file ${p.basename(path)}');
+      }
       _checkHtmlCorrectness(htmlPathFromTestPath, path);
     } else if (_config.customHtmlTemplatePath != null) {
       var htmlTemplatePath = _config.customHtmlTemplatePath;

--- a/pkgs/test/lib/src/runner/browser/static/default.html.tpl
+++ b/pkgs/test/lib/src/runner/browser/static/default.html.tpl
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>{{testName}}</title>
+    <title>{{testName}} Test</title>
     {{testScript}}
     <script src="packages/test/dart.js"></script>
   </head>

--- a/pkgs/test/lib/src/runner/browser/static/default.html.tpl
+++ b/pkgs/test/lib/src/runner/browser/static/default.html.tpl
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{{testName}}</title>
+    {testScript}
+    <script src="packages/test/dart.js"></script>
+  </head>
+</html>

--- a/pkgs/test/lib/src/runner/browser/static/default.html.tpl
+++ b/pkgs/test/lib/src/runner/browser/static/default.html.tpl
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>{{testName}}</title>
-    {testScript}
+    {{testScript}}
     <script src="packages/test/dart.js"></script>
   </head>
 </html>

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.9.5-dev
+version: 1.10.0-dev
 author: Dart Team <misc@dartlang.org>
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test

--- a/pkgs/test/test/runner/browser/runner_test.dart
+++ b/pkgs/test/test/runner/browser/runner_test.dart
@@ -343,6 +343,32 @@ void main() {
             ]));
         await test.shouldExit(1);
       }, tags: 'chrome');
+
+      test('that is named like the test file', () async {
+        await d.file('test.html', '''
+<html>
+<head>
+  {{testScript}}
+  <script src="packages/test/dart.js"></script>
+</head>
+</html>
+''').create();
+
+        await d
+            .file('global_test_2.yaml',
+                jsonEncode({'custom_html_template_path': 'test.html'}))
+            .create();
+        var test = await runTest(['-p', 'chrome', 'test.dart'],
+            environment: {'DART_TEST_CONFIG': 'global_test_2.yaml'});
+        expect(
+            test.stdout,
+            containsInOrder([
+              '-1: compiling test.dart [E]',
+              'Failed to load "test.dart": template file test.html cannot be named '
+                  'like the test file test.dart'
+            ]));
+        await test.shouldExit(1);
+      });
     });
   });
 

--- a/pkgs/test/test/runner/browser/runner_test.dart
+++ b/pkgs/test/test/runner/browser/runner_test.dart
@@ -231,7 +231,7 @@ void main() {
       await d.file('html_template.html.tpl', '''
 <html>
 <head>
-  {testScript}
+  {{testScript}}
   <script src="packages/test/dart.js"></script>
 </head>
 <body>
@@ -278,7 +278,7 @@ void main() {
         await test.shouldExit(1);
       }, tags: 'chrome');
 
-      test("that doesn't contain the {testScript} tag", () async {
+      test("that doesn't contain the {{testScript}} tag", () async {
         await d.file('html_template.html.tpl', '''
 <html>
 <head>
@@ -296,17 +296,17 @@ void main() {
             test.stdout,
             containsInOrder([
               '-1: compiling test.dart [E]',
-              'Failed to load "test.dart": "html_template.html.tpl" must contain exactly one {testScript} placeholder'
+              'Failed to load "test.dart": "html_template.html.tpl" must contain exactly one {{testScript}} placeholder'
             ]));
         await test.shouldExit(1);
       }, tags: 'chrome');
 
-      test('that contains more than one {testScript} tag', () async {
+      test('that contains more than one {{testScript}} tag', () async {
         await d.file('html_template.html.tpl', '''
 <html>
 <head>
-  {testScript}
-  {testScript}
+  {{testScript}}
+  {{testScript}}
   <script src="packages/test/dart.js"></script>
 </head>
 <body>
@@ -321,7 +321,7 @@ void main() {
             test.stdout,
             containsInOrder([
               '-1: compiling test.dart [E]',
-              'Failed to load "test.dart": "html_template.html.tpl" must contain exactly one {testScript} placeholder'
+              'Failed to load "test.dart": "html_template.html.tpl" must contain exactly one {{testScript}} placeholder'
             ]));
         await test.shouldExit(1);
       }, tags: 'chrome');
@@ -330,7 +330,7 @@ void main() {
         await d.file('html_template.html.tpl', '''
 <html>
 <head>
-  {testScript}
+  {{testScript}}
 </head>
 </html>
 ''').create();
@@ -413,7 +413,7 @@ void main() {
           await d.file('html_template.html.tpl', '''
   <html>
   <head>
-    {testScript}
+    {{testScript}}
     <script src="packages/test/dart.js"></script>
   </head>
   <body>
@@ -455,7 +455,7 @@ void main() {
   <html>
   <head>
     <title>{{testName}}</title>
-    {testScript}
+    {{testScript}}
     <script src="packages/test/dart.js"></script>
   </head>
   <body>
@@ -553,7 +553,7 @@ void main() {
         await d.file('html_template.html.tpl', '''
 <html>
 <head>
-  {testScript}
+  {{testScript}}
   <script src="packages/test/dart.js"></script>
 </head>
 <body>

--- a/pkgs/test/test/runner/browser/runner_test.dart
+++ b/pkgs/test/test/runner/browser/runner_test.dart
@@ -2,9 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn('vm')
 import 'dart:convert';
 
-@TestOn('vm')
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
 import 'package:test/test.dart';
@@ -251,9 +251,6 @@ void main() {
           ]));
       await test.shouldExit(1);
     }, tags: 'chrome');
-
-    // TODO(nweiz): test what happens when a test file is unreadable once issue
-    // 15078 is fixed.
 
     group('with a custom HTML template', () {
       setUp(() async {

--- a/pkgs/test/test/runner/browser/runner_test.dart
+++ b/pkgs/test/test/runner/browser/runner_test.dart
@@ -364,8 +364,8 @@ void main() {
             test.stdout,
             containsInOrder([
               '-1: compiling test.dart [E]',
-              'Failed to load "test.dart": template file test.html cannot be named '
-                  'like the test file test.dart'
+              'Failed to load "test.dart": template file "test.html" cannot be named '
+                  'like the test file.'
             ]));
         await test.shouldExit(1);
       });

--- a/pkgs/test/test/runner/browser/runner_test.dart
+++ b/pkgs/test/test/runner/browser/runner_test.dart
@@ -2,8 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@TestOn('vm')
+import 'dart:convert';
 
+@TestOn('vm')
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
 import 'package:test/test.dart';
@@ -207,8 +208,145 @@ void main() {
       await test.shouldExit(1);
     }, tags: 'chrome');
 
+    test(
+        'still errors even with a custom HTML template set since it will take precedence',
+        () async {
+      await d.file('test.dart', 'void main() {}').create();
+
+      await d.file('test.html', '''
+<html>
+<head>
+  <link rel="x-dart-test" href="test.dart">
+</head>
+</html>
+''').create();
+
+      await d
+          .file(
+              'global_test.yaml',
+              jsonEncode(
+                  {'custom_html_template_path': 'html_template.html.tpl'}))
+          .create();
+
+      await d.file('html_template.html.tpl', '''
+<html>
+<head>
+  {testScript}
+  <script src="packages/test/dart.js"></script>
+</head>
+<body>
+  <div id="foo"></div>
+</body>
+</html>
+''').create();
+
+      var test = await runTest(['-p', 'chrome', 'test.dart'],
+          environment: {'DART_TEST_CONFIG': 'global_test.yaml'});
+      expect(
+          test.stdout,
+          containsInOrder([
+            '-1: compiling test.dart [E]',
+            'Failed to load "test.dart": "test.html" must contain '
+                '<script src="packages/test/dart.js"></script>.'
+          ]));
+      await test.shouldExit(1);
+    }, tags: 'chrome');
+
     // TODO(nweiz): test what happens when a test file is unreadable once issue
     // 15078 is fixed.
+
+    group('with a custom HTML template', () {
+      setUp(() async {
+        await d.file('test.dart', _success).create();
+        await d
+            .file(
+                'global_test.yaml',
+                jsonEncode(
+                    {'custom_html_template_path': 'html_template.html.tpl'}))
+            .create();
+      });
+
+      test('that does not exist', () async {
+        var test = await runTest(['-p', 'chrome', 'test.dart'],
+            environment: {'DART_TEST_CONFIG': 'global_test.yaml'});
+        expect(
+            test.stdout,
+            containsInOrder([
+              '-1: compiling test.dart [E]',
+              'Failed to load "test.dart": "html_template.html.tpl" does not exist or is not readable'
+            ]));
+        await test.shouldExit(1);
+      }, tags: 'chrome');
+
+      test("that doesn't contain the {testScript} tag", () async {
+        await d.file('html_template.html.tpl', '''
+<html>
+<head>
+  <script src="packages/test/dart.js"></script>
+</head>
+<body>
+  <div id="foo"></div>
+</body>
+</html>
+''').create();
+
+        var test = await runTest(['-p', 'chrome', 'test.dart'],
+            environment: {'DART_TEST_CONFIG': 'global_test.yaml'});
+        expect(
+            test.stdout,
+            containsInOrder([
+              '-1: compiling test.dart [E]',
+              'Failed to load "test.dart": "html_template.html.tpl" must contain exactly one {testScript} placeholder'
+            ]));
+        await test.shouldExit(1);
+      }, tags: 'chrome');
+
+      test('that contains more than one {testScript} tag', () async {
+        await d.file('html_template.html.tpl', '''
+<html>
+<head>
+  {testScript}
+  {testScript}
+  <script src="packages/test/dart.js"></script>
+</head>
+<body>
+  <div id="foo"></div>
+</body>
+</html>
+''').create();
+
+        var test = await runTest(['-p', 'chrome', 'test.dart'],
+            environment: {'DART_TEST_CONFIG': 'global_test.yaml'});
+        expect(
+            test.stdout,
+            containsInOrder([
+              '-1: compiling test.dart [E]',
+              'Failed to load "test.dart": "html_template.html.tpl" must contain exactly one {testScript} placeholder'
+            ]));
+        await test.shouldExit(1);
+      }, tags: 'chrome');
+
+      test('that has no script tag', () async {
+        await d.file('html_template.html.tpl', '''
+<html>
+<head>
+  {testScript}
+</head>
+</html>
+''').create();
+
+        var test = await runTest(['-p', 'chrome', 'test.dart'],
+            environment: {'DART_TEST_CONFIG': 'global_test.yaml'});
+        expect(
+            test.stdout,
+            containsInOrder([
+              '-1: compiling test.dart [E]',
+              'Failed to load "test.dart": "html_template.html.tpl" must contain '
+                  '<script src="packages/test/dart.js"></script>.'
+            ]));
+        await test.shouldExit(1);
+      }, tags: 'chrome');
+    });
   });
 
   group('runs successful tests', () {
@@ -263,6 +401,47 @@ void main() {
       await test.shouldExit(0);
     }, tags: 'chrome');
 
+    group('with a custom HTML template file', () {
+      setUp(() async {
+        await d
+            .file(
+                'global_test.yaml',
+                jsonEncode(
+                    {'custom_html_template_path': 'html_template.html.tpl'}))
+            .create();
+        await d.file('html_template.html.tpl', '''
+<html>
+<head>
+  {testScript}
+  <script src="packages/test/dart.js"></script>
+</head>
+<body>
+  <div id="foo"></div>
+</body>
+</html>
+''').create();
+
+        await d.file('test.dart', '''
+import 'dart:html';
+
+import 'package:test/test.dart';
+
+void main() {
+  test("success", () {
+    expect(document.querySelector('#foo'), isNotNull);
+  });
+}
+''').create();
+      });
+
+      test('on Chrome', () async {
+        var test = await runTest(['-p', 'chrome', 'test.dart'],
+            environment: {'DART_TEST_CONFIG': 'global_test.yaml'});
+        expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
+        await test.shouldExit(0);
+      }, tags: 'chrome');
+    });
+
     group('with a custom HTML file', () {
       setUp(() async {
         await d.file('test.dart', '''
@@ -313,6 +492,31 @@ void main() {
 ''').create();
 
         var test = await runTest(['-p', 'chrome', 'test.dart']);
+        expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
+        await test.shouldExit(0);
+      }, tags: 'chrome');
+
+      test('takes precedence over provided HTML template', () async {
+        await d
+            .file(
+                'global_test.yaml',
+                jsonEncode(
+                    {'custom_html_template_path': 'html_template.html.tpl'}))
+            .create();
+        await d.file('html_template.html.tpl', '''
+<html>
+<head>
+  {testScript}
+  <script src="packages/test/dart.js"></script>
+</head>
+<body>
+  <div id="not-foo"></div>
+</body>
+</html>
+''').create();
+
+        var test = await runTest(['-p', 'chrome', 'test.dart'],
+            environment: {'DART_TEST_CONFIG': 'global_test.yaml'});
         expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
         await test.shouldExit(0);
       }, tags: 'chrome');

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.2.16-dev
 
 * Internal cleanup.
+* Add `customHtmlTemplateFile` configuration option to allow sharing an
+  html template between tests
 
 ## 0.2.15
 

--- a/pkgs/test_core/lib/src/runner/configuration.dart
+++ b/pkgs/test_core/lib/src/runner/configuration.dart
@@ -44,8 +44,7 @@ class Configuration {
   final bool _help;
 
   /// Custom HTML template file
-  String get customHtmlTemplatePath => _customHtmlTemplatePath;
-  final String _customHtmlTemplatePath;
+  final String customHtmlTemplatePath;
 
   /// Whether `--version` was passed.
   bool get version => _version ?? false;
@@ -353,7 +352,7 @@ class Configuration {
       bool noRetry,
       SuiteConfiguration suiteDefaults})
       : _help = help,
-        _customHtmlTemplatePath = customHtmlTemplatePath,
+        customHtmlTemplatePath = customHtmlTemplatePath,
         _version = version,
         _pauseAfterLoad = pauseAfterLoad,
         _debug = debug,
@@ -479,7 +478,7 @@ class Configuration {
     var result = Configuration._(
         help: other._help ?? _help,
         customHtmlTemplatePath:
-            other._customHtmlTemplatePath ?? _customHtmlTemplatePath,
+            other.customHtmlTemplatePath ?? customHtmlTemplatePath,
         version: other._version ?? _version,
         pauseAfterLoad: other._pauseAfterLoad ?? _pauseAfterLoad,
         color: other._color ?? _color,
@@ -566,7 +565,7 @@ class Configuration {
     var config = Configuration._(
         help: help ?? _help,
         customHtmlTemplatePath:
-            customHtmlTemplatePath ?? _customHtmlTemplatePath,
+            customHtmlTemplatePath ?? this.customHtmlTemplatePath,
         version: version ?? _version,
         pauseAfterLoad: pauseAfterLoad ?? _pauseAfterLoad,
         color: color ?? _color,

--- a/pkgs/test_core/lib/src/runner/configuration.dart
+++ b/pkgs/test_core/lib/src/runner/configuration.dart
@@ -43,7 +43,7 @@ class Configuration {
   bool get help => _help ?? false;
   final bool _help;
 
-  /// Custom HTML template file
+  /// Custom HTML template file.
   final String customHtmlTemplatePath;
 
   /// Whether `--version` was passed.

--- a/pkgs/test_core/lib/src/runner/configuration.dart
+++ b/pkgs/test_core/lib/src/runner/configuration.dart
@@ -43,6 +43,10 @@ class Configuration {
   bool get help => _help ?? false;
   final bool _help;
 
+  /// Custom HTML template file
+  String get customHtmlTemplatePath => _customHtmlTemplatePath;
+  final String _customHtmlTemplatePath;
+
   /// Whether `--version` was passed.
   bool get version => _version ?? false;
   final bool _version;
@@ -216,6 +220,7 @@ class Configuration {
 
   factory Configuration(
       {bool help,
+      String customHtmlTemplatePath,
       bool version,
       bool pauseAfterLoad,
       bool debug,
@@ -263,6 +268,7 @@ class Configuration {
     var chosenPresetSet = chosenPresets?.toSet();
     var configuration = Configuration._(
         help: help,
+        customHtmlTemplatePath: customHtmlTemplatePath,
         version: version,
         pauseAfterLoad: pauseAfterLoad,
         debug: debug,
@@ -323,6 +329,7 @@ class Configuration {
   /// Unlike [new Configuration], this assumes [presets] is already resolved.
   Configuration._(
       {bool help,
+      String customHtmlTemplatePath,
       bool version,
       bool pauseAfterLoad,
       bool debug,
@@ -346,6 +353,7 @@ class Configuration {
       bool noRetry,
       SuiteConfiguration suiteDefaults})
       : _help = help,
+        _customHtmlTemplatePath = customHtmlTemplatePath,
         _version = version,
         _pauseAfterLoad = pauseAfterLoad,
         _debug = debug,
@@ -470,6 +478,8 @@ class Configuration {
 
     var result = Configuration._(
         help: other._help ?? _help,
+        customHtmlTemplatePath:
+            other._customHtmlTemplatePath ?? _customHtmlTemplatePath,
         version: other._version ?? _version,
         pauseAfterLoad: other._pauseAfterLoad ?? _pauseAfterLoad,
         color: other._color ?? _color,
@@ -511,6 +521,7 @@ class Configuration {
   /// always replaced by the new one.
   Configuration change(
       {bool help,
+      String customHtmlTemplatePath,
       bool version,
       bool pauseAfterLoad,
       bool color,
@@ -554,6 +565,8 @@ class Configuration {
       Iterable<String> addTags}) {
     var config = Configuration._(
         help: help ?? _help,
+        customHtmlTemplatePath:
+            customHtmlTemplatePath ?? _customHtmlTemplatePath,
         version: version ?? _version,
         pauseAfterLoad: pauseAfterLoad ?? _pauseAfterLoad,
         color: color ?? _color,

--- a/pkgs/test_core/lib/src/runner/configuration/load.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/load.dart
@@ -252,12 +252,6 @@ class _ConfigurationLoader {
     var overrideRuntimes = _loadOverrideRuntimes();
 
     var customHtmlTemplatePath = _getString('custom_html_template_path');
-    if (customHtmlTemplatePath != null &&
-        customHtmlTemplatePath.endsWith('.html')) {
-      _error(
-          'customHtmlTemplatePath cannot have .html extension: "$customHtmlTemplatePath',
-          'custom_html_template_path');
-    }
 
     return Configuration(
         pauseAfterLoad: pauseAfterLoad,

--- a/pkgs/test_core/lib/src/runner/configuration/load.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/load.dart
@@ -251,8 +251,17 @@ class _ConfigurationLoader {
 
     var overrideRuntimes = _loadOverrideRuntimes();
 
+    var customHtmlTemplatePath = _getString('custom_html_template_path');
+    if (customHtmlTemplatePath != null &&
+        customHtmlTemplatePath.endsWith('.html')) {
+      _error(
+          'customHtmlTemplatePath cannot have .html extension: "$customHtmlTemplatePath',
+          'custom_html_template_path');
+    }
+
     return Configuration(
         pauseAfterLoad: pauseAfterLoad,
+        customHtmlTemplatePath: customHtmlTemplatePath,
         runSkipped: runSkipped,
         reporter: reporter,
         concurrency: concurrency,


### PR DESCRIPTION
This allows for reusing one template file across all tests in use cases
where external scripts or html elements are required for all tests. The
possibility to still use local html files per test file is retained.

Fixes https://github.com/dart-lang/test/issues/39