### PR TITLE
Drop changelog for unpublished version

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -3,10 +3,6 @@
 * Add `customHtmlTemplateFile` configuration option to allow sharing an
   html template between tests
 
-## 1.9.5
-
-* Internal cleanup.
-
 ## 1.9.4
 
 * Extend the timeout for synthetic tests, e.g. `tearDownAll`.


### PR DESCRIPTION
We never published `1.9.5` so don't need any entry for it. The changes
don't need to be mentioned since they aren't the only thing and they
aren't user facing.