### PR TITLE
Drop support for old stack trace format

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.1-dev
+
+* Internal cleanup.
+
 ## 1.10.0
 
 * Add `customHtmlTemplateFile` configuration option to allow sharing an

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.10.0
+version: 1.10.1-dev
 author: Dart Team <misc@dartlang.org>
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test

--- a/pkgs/test/test/runner/compact_reporter_test.dart
+++ b/pkgs/test/test/runner/compact_reporter_test.dart
@@ -124,19 +124,19 @@ void main() {
           first error
           test.dart 10:38  main.<fn>.<fn>
           ===== asynchronous gap ===========================
-          dart:async       Future.Future.microtask
+          dart:async       new Future.microtask
           test.dart 10:15  main.<fn>
 
           second error
           test.dart 11:38  main.<fn>.<fn>
           ===== asynchronous gap ===========================
-          dart:async       Future.Future.microtask
+          dart:async       new Future.microtask
           test.dart 11:15  main.<fn>
 
           third error
           test.dart 12:38  main.<fn>.<fn>
           ===== asynchronous gap ===========================
-          dart:async       Future.Future.microtask
+          dart:async       new Future.microtask
           test.dart 12:15  main.<fn>
 
 
@@ -452,13 +452,5 @@ $tests
     return line.substring(indentation);
   });
 
-  // In Dart 1.24, stack traces with Future constructors output as
-  // `new Future` instead of `Future.Future`.
-  // Support running tests in both old and new styles.
-  expect(
-      actual,
-      anyOf(
-          containsAllInOrder(expectedLines),
-          containsAllInOrder(expectedLines
-              .map((s) => s.replaceAll(' Future.Future.', ' new Future.')))));
+  expect(actual, containsAllInOrder(expectedLines));
 }

--- a/pkgs/test/test/runner/expanded_reporter_test.dart
+++ b/pkgs/test/test/runner/expanded_reporter_test.dart
@@ -119,19 +119,19 @@ void main() {
           first error
           test.dart 10:38  main.<fn>.<fn>
           ===== asynchronous gap ===========================
-          dart:async       Future.Future.microtask
+          dart:async       new Future.microtask
           test.dart 10:15  main.<fn>
 
           second error
           test.dart 11:38  main.<fn>.<fn>
           ===== asynchronous gap ===========================
-          dart:async       Future.Future.microtask
+          dart:async       new Future.microtask
           test.dart 11:15  main.<fn>
 
           third error
           test.dart 12:38  main.<fn>.<fn>
           ===== asynchronous gap ===========================
-          dart:async       Future.Future.microtask
+          dart:async       new Future.microtask
           test.dart 12:15  main.<fn>
 
         +0 -1: wait
@@ -345,11 +345,5 @@ $tests
     return line.substring(indentation);
   }).join('\n');
 
-  // In Dart 1.24, stack traces with Future constructors output as
-  // `new Future` instead of `Future.Future`.
-  // Support running tests in both old and new styles.
-  expect(
-      actual,
-      anyOf(equals(expected),
-          equals(expected.replaceAll(' Future.Future.', ' new Future.'))));
+  expect(actual, equals(expected));
 }


### PR DESCRIPTION
The stack trace changed in `1.24` and the tests were updated to allow
either format. Since we don't support that SDK anymore we can simplify
back to the single format that will be used.