### PR TITLE
Drop optional new from code in strings

### DIFF
--- a/pkgs/test/README.md
+++ b/pkgs/test/README.md
@@ -33,17 +33,17 @@ are made using [`expect()`]:
 [`expect()`]: https://pub.dev/documentation/test_api/latest/test_api/expect.html
 
 ```dart
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
 void main() {
-  test("String.split() splits the string on the delimiter", () {
-    var string = "foo,bar,baz";
-    expect(string.split(","), equals(["foo", "bar", "baz"]));
+  test('String.split() splits the string on the delimiter', () {
+    var string = 'foo,bar,baz';
+    expect(string.split(','), equals(['foo', 'bar', 'baz']));
   });
 
-  test("String.trim() removes surrounding whitespace", () {
-    var string = "  foo ";
-    expect(string.trim(), equals("foo"));
+  test('String.trim() removes surrounding whitespace', () {
+    var string = '  foo ';
+    expect(string.trim(), equals('foo'));
   });
 }
 ```
@@ -54,28 +54,28 @@ description is added to the beginning of its test's descriptions.
 [`group()`]: https://pub.dev/documentation/test_api/latest/test_api/group.html
 
 ```dart
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
 void main() {
-  group("String", () {
-    test(".split() splits the string on the delimiter", () {
-      var string = "foo,bar,baz";
-      expect(string.split(","), equals(["foo", "bar", "baz"]));
+  group('String', () {
+    test('.split() splits the string on the delimiter', () {
+      var string = 'foo,bar,baz';
+      expect(string.split(','), equals(['foo', 'bar', 'baz']));
     });
 
-    test(".trim() removes surrounding whitespace", () {
-      var string = "  foo ";
-      expect(string.trim(), equals("foo"));
+    test('.trim() removes surrounding whitespace', () {
+      var string = '  foo ';
+      expect(string.trim(), equals('foo'));
     });
   });
 
-  group("int", () {
-    test(".remainder() returns the remainder of division", () {
+  group('int', () {
+    test('.remainder() returns the remainder of division', () {
       expect(11.remainder(3), equals(2));
     });
 
-    test(".toRadixString() returns a hex string", () {
-      expect(11.toRadixString(16), equals("b"));
+    test('.toRadixString() returns a hex string', () {
+      expect(11.toRadixString(16), equals('b'));
     });
   });
 }
@@ -87,14 +87,14 @@ complex validations:
 [`matcher`]: https://pub.dev/documentation/matcher/latest/matcher/matcher-library.html
 
 ```dart
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
 void main() {
-  test(".split() splits the string on the delimiter", () {
-    expect("foo,bar,baz", allOf([
-      contains("foo"),
-      isNot(startsWith("bar")),
-      endsWith("baz")
+  test('.split() splits the string on the delimiter', () {
+    expect('foo,bar,baz', allOf([
+      contains('foo'),
+      isNot(startsWith('bar')),
+      endsWith('baz')
     ]));
   });
 }
@@ -106,14 +106,14 @@ suite, and `tearDown()` will run after. `tearDown()` will run even if a test
 fails, to ensure that it has a chance to clean up after itself.
 
 ```dart
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
 void main() {
   HttpServer server;
   Uri url;
   setUp(() async {
     server = await HttpServer.bind('localhost', 0);
-    url = Uri.parse("http://${server.address.host}:${server.port}");
+    url = Uri.parse('http://${server.address.host}:${server.port}');
   });
 
   tearDown(() async {
@@ -195,11 +195,11 @@ file should run on. Just put it at the top of your file, before any `library` or
 `import` declarations:
 
 ```dart
-@TestOn("vm")
+@TestOn('vm')
 
-import "dart:io";
+import 'dart:io';
 
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
 void main() {
   // ...
@@ -274,7 +274,7 @@ only supports boolean operations. The following identifiers are defined:
   equivalent to `!windows`.
 
 For example, if you wanted to run a test on every browser but Chrome, you would
-write `@TestOn("browser && !chrome")`.
+write `@TestOn('browser && !chrome')`.
 
 ### Running Tests on Node.js
 
@@ -290,7 +290,7 @@ meant to be used by JavaScript code.
 The test runner looks for an executable named `node` (on Mac OS or Linux) or
 `node.exe` (on Windows) on your system path. When compiling Node.js tests, it
 passes `-Dnode=true`, so tests can determine whether they're running on Node
-using [`const bool.fromEnvironment("node")`][bool.fromEnvironment]. It also sets
+using [`const bool.fromEnvironment('node')`][bool.fromEnvironment]. It also sets
 `--server-mode`, which will tell the compiler that `dart:html` is not available.
 
 [bool.fromEnvironment]: https://api.dart.dev/stable/dart-core/bool/bool.fromEnvironment.html
@@ -304,13 +304,13 @@ Tests written with `async`/`await` will work automatically. The test runner
 won't consider the test finished until the returned `Future` completes.
 
 ```dart
-import "dart:async";
+import 'dart:async';
 
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
 void main() {
-  test("new Future.value() returns the value", () async {
-    var value = await new Future.value(10);
+  test('Future.value() returns the value', () async {
+    var value = await Future.value(10);
     expect(value, equals(10));
   });
 }
@@ -324,13 +324,13 @@ matcher against that `Future`'s value.
 [`completion()`]: https://pub.dev/documentation/test_api/latest/test_api/completion.html
 
 ```dart
-import "dart:async";
+import 'dart:async';
 
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
 void main() {
-  test("new Future.value() returns the value", () {
-    expect(new Future.value(10), completion(equals(10)));
+  test('Future.value() returns the value', () {
+    expect(Future.value(10), completion(equals(10)));
   });
 }
 ```
@@ -342,14 +342,14 @@ particular type of exception is thrown:
 [`throwsA()`]: https://pub.dev/documentation/test_api/latest/test_api/throwsA.html
 
 ```dart
-import "dart:async";
+import 'dart:async';
 
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
 void main() {
-  test("new Future.error() throws the error", () {
-    expect(new Future.error("oh no"), throwsA(equals("oh no")));
-    expect(new Future.error(new StateError("bad state")), throwsStateError);
+  test('Future.error() throws the error', () {
+    expect(Future.error('oh no'), throwsA(equals('oh no')));
+    expect(Future.error(StateError('bad state')), throwsStateError);
   });
 }
 ```
@@ -360,13 +360,13 @@ will cause the test to fail if it's called too often; second, it keeps the test
 from finishing until the function is called the requisite number of times.
 
 ```dart
-import "dart:async";
+import 'dart:async';
 
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
 void main() {
-  test("Stream.fromIterable() emits the values in the iterable", () {
-    var stream = new Stream.fromIterable([1, 2, 3]);
+  test('Stream.fromIterable() emits the values in the iterable', () {
+    var stream = Stream.fromIterable([1, 2, 3]);
 
     stream.listen(expectAsync1((number) {
       expect(number, inInclusiveRange(1, 3));
@@ -387,29 +387,29 @@ example:
 [Stream]: https://api.dart.dev/stable/dart-async/Stream-class.html
 
 ```dart
-import "dart:async";
+import 'dart:async';
 
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
 void main() {
-  test("process emits status messages", () {
+  test('process emits status messages', () {
     // Dummy data to mimic something that might be emitted by a process.
-    var stdoutLines = new Stream.fromIterable([
-      "Ready.",
-      "Loading took 150ms.",
-      "Succeeded!"
+    var stdoutLines = Stream.fromIterable([
+      'Ready.',
+      'Loading took 150ms.',
+      'Succeeded!'
     ]);
 
     expect(stdoutLines, emitsInOrder([
       // Values match individual events.
-      "Ready.",
+      'Ready.',
 
       // Matchers also run against individual events.
-      startsWith("Loading took"),
+      startsWith('Loading took'),
 
       // Stream matchers can be nested. This asserts that one of two events are
       // emitted after the "Loading took" line.
-      emitsAnyOf(["Succeeded!", "Failed!"]),
+      emitsAnyOf(['Succeeded!', 'Failed!']),
 
       // By default, more events are allowed after the matcher finishes
       // matching. This asserts instead that the stream emits a done event and
@@ -430,29 +430,29 @@ which can only have one subscriber. For example:
 [`StreamQueue`]: https://pub.dev/documentation/async/latest/async/StreamQueue-class.html
 
 ```dart
-import "dart:async";
+import 'dart:async';
 
-import "package:async/async.dart";
-import "package:test/test.dart";
+import 'package:async/async.dart';
+import 'package:test/test.dart';
 
 void main() {
-  test("process emits a WebSocket URL", () async {
+  test('process emits a WebSocket URL', () async {
     // Wrap the Stream in a StreamQueue so that we can request events.
-    var stdout = new StreamQueue(new Stream.fromIterable([
-      "WebSocket URL:",
-      "ws://localhost:1234/",
-      "Waiting for connection..."
+    var stdout = StreamQueue(Stream.fromIterable([
+      'WebSocket URL:',
+      'ws://localhost:1234/',
+      'Waiting for connection...'
     ]));
 
     // Ignore lines from the process until it's about to emit the URL.
-    await expect(stdout, emitsThrough("WebSocket URL:"));
+    await expect(stdout, emitsThrough('WebSocket URL:'));
 
     // Parse the next line as a URL.
     var url = Uri.parse(await stdout.next);
     expect(url.host, equals('localhost'));
 
     // You can match against the same StreamQueue multiple times.
-    await expect(stdout, emits("Waiting for connection..."));
+    await expect(stdout, emits('Waiting for connection...'));
   });
 }
 ```
@@ -474,8 +474,7 @@ The following built-in stream matchers are available:
 * [`neverEmits()`] matches a stream that finishes *without* matching an inner
   matcher.
 
-You can also define your own custom stream matchers by calling
-[`new StreamMatcher()`].
+You can also define your own custom stream matchers with [`StreamMatcher()`].
 
 [`emits()`]: https://pub.dev/documentation/test_api/latest/test_api/emits.html
 [`emitsError()`]: https://pub.dev/documentation/test_api/latest/test_api/emitsError.html
@@ -486,7 +485,7 @@ You can also define your own custom stream matchers by calling
 [`emitsInOrder()`]: https://pub.dev/documentation/test_api/latest/test_api/emitsInOrder.html
 [`emitsInAnyOrder()`]: https://pub.dev/documentation/test_api/latest/test_api/emitsInAnyOrder.html
 [`neverEmits()`]: https://pub.dev/documentation/test_api/latest/test_api/neverEmits.html
-[`new StreamMatcher()`]: https://pub.dev/documentation/test_api/latest/test_api/StreamMatcher-class.html
+[`StreamMatcher()`]: https://pub.dev/documentation/test_api/latest/test_api/StreamMatcher-class.html
 
 ## Running Tests With Custom HTML
 
@@ -571,9 +570,9 @@ should be used instead.
 To skip a test suite, put a `@Skip` annotation at the top of the file:
 
 ```dart
-@Skip("currently failing (see issue 1234)")
+@Skip('currently failing (see issue 1234)')
 
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
 void main() {
   // ...
@@ -587,16 +586,16 @@ Groups and individual tests can be skipped by passing the `skip` parameter. This
 can be either `true` or a String describing why the test is skipped. For example:
 
 ```dart
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
 void main() {
-  group("complicated algorithm tests", () {
+  group('complicated algorithm tests', () {
     // ...
   }, skip: "the algorithm isn't quite right");
 
-  test("error-checking test", () {
+  test('error-checking test', () {
     // ...
-  }, skip: "TODO: add error-checking.");
+  }, skip: 'TODO: add error-checking.');
 }
 ```
 
@@ -609,7 +608,7 @@ for a test suite, put a `@Timeout` annotation at the top of the file:
 ```dart
 @Timeout(const Duration(seconds: 45))
 
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
 void main() {
   // ...
@@ -624,16 +623,16 @@ Timeouts can be set for tests and groups using the `timeout` parameter. This
 parameter takes a `Timeout` object just like the annotation. For example:
 
 ```dart
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
 void main() {
-  group("slow tests", () {
+  group('slow tests', () {
     // ...
 
-    test("even slower test", () {
+    test('even slower test', () {
       // ...
-    }, timeout: new Timeout.factor(2))
-  }, timeout: new Timeout(new Duration(minutes: 1)));
+    }, timeout: Timeout.factor(2))
+  }, timeout: Timeout(Duration(minutes: 1)));
 }
 ```
 
@@ -652,16 +651,16 @@ and `group()`. For example:
 ```dart
 @OnPlatform(const {
   // Give Windows some extra wiggle-room before timing out.
-  "windows": const Timeout.factor(2)
+  'windows': const Timeout.factor(2)
 })
 
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
 void main() {
-  test("do a thing", () {
+  test('do a thing', () {
     // ...
   }, onPlatform: {
-    "safari": new Skip("Safari is currently broken (see #1234)")
+    'safari': Skip('Safari is currently broken (see #1234)')
   });
 }
 ```
@@ -692,18 +691,18 @@ Tags are defined using the `@Tags` annotation for suites and the `tags` named
 parameter to `test()` and `group()`. For example:
 
 ```dart
-@Tags(const ["browser"])
+@Tags(const ['browser'])
 
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
 void main() {
-  test("successfully launches Chrome", () {
+  test('successfully launches Chrome', () {
     // ...
-  }, tags: "chrome");
+  }, tags: 'chrome');
 
-  test("launches two browsers at once", () {
+  test('launches two browsers at once', () {
     // ...
-  }, tags: ["chrome", "firefox"]);
+  }, tags: ['chrome', 'firefox']);
 }
 ```
 
@@ -800,9 +799,9 @@ communicates with the hybrid isolate. For example:
 
 // The library loaded by spawnHybridUri() can import any packages that your
 // package depends on, including those that only work on the VM.
-import "package:shelf/shelf_io.dart" as io;
-import "package:shelf_web_socket/shelf_web_socket.dart";
-import "package:stream_channel/stream_channel.dart";
+import 'package:shelf/shelf_io.dart' as io;
+import 'package:shelf_web_socket/shelf_web_socket.dart';
+import 'package:stream_channel/stream_channel.dart';
 
 // Once the hybrid isolate starts, it will call the special function
 // hybridMain() with a StreamChannel that's connected to the channel
@@ -810,7 +809,7 @@ import "package:stream_channel/stream_channel.dart";
 hybridMain(StreamChannel channel) async {
   // Start a WebSocket server that just sends "hello!" to its clients.
   var server = await io.serve(webSocketHandler((webSocket) {
-    webSocket.sink.add("hello!");
+    webSocket.sink.add('hello!');
   }), 'localhost', 0);
 
   // Send the port number of the WebSocket server to the browser test, so
@@ -821,24 +820,24 @@ hybridMain(StreamChannel channel) async {
 
 // ## test/web_socket_test.dart
 
-@TestOn("browser")
+@TestOn('browser')
 
-import "dart:html";
+import 'dart:html';
 
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
 void main() {
-  test("connects to a server-side WebSocket", () async {
+  test('connects to a server-side WebSocket', () async {
     // Each spawnHybrid function returns a StreamChannel that communicates with
     // the hybrid isolate. You can close this channel to kill the isolate.
-    var channel = spawnHybridUri("web_socket_server.dart");
+    var channel = spawnHybridUri('web_socket_server.dart');
 
     // Get the port for the WebSocket server from the hybrid isolate.
     var port = await channel.stream.first;
 
-    var socket = new WebSocket('ws://localhost:$port');
+    var socket = WebSocket('ws://localhost:$port');
     var message = await socket.onMessage.first;
-    expect(message.data, equals("hello!"));
+    expect(message.data, equals('hello!'));
   });
 }
 ```

--- a/pkgs/test/test/runner/browser/chrome_test.dart
+++ b/pkgs/test/test/runner/browser/chrome_test.dart
@@ -20,7 +20,7 @@ void main() {
     var server = await CodeServer.start();
 
     server.handleJavaScript('''
-var webSocket = WebSocket(window.location.href.replace("http://", "ws://"));
+var webSocket = new WebSocket(window.location.href.replace("http://", "ws://"));
 webSocket.addEventListener("open", function() {
   webSocket.send("loaded!");
 });

--- a/pkgs/test/test/runner/browser/chrome_test.dart
+++ b/pkgs/test/test/runner/browser/chrome_test.dart
@@ -20,7 +20,7 @@ void main() {
     var server = await CodeServer.start();
 
     server.handleJavaScript('''
-var webSocket = new WebSocket(window.location.href.replace("http://", "ws://"));
+var webSocket = WebSocket(window.location.href.replace("http://", "ws://"));
 webSocket.addEventListener("open", function() {
   webSocket.send("loaded!");
 });
@@ -73,7 +73,7 @@ void main() {
 import 'package:test/test.dart';
 
 void main() {
-  test("failure", () => throw new TestFailure("oh no"));
+  test("failure", () => throw TestFailure("oh no"));
 }
 ''').create();
 

--- a/pkgs/test/test/runner/browser/firefox_test.dart
+++ b/pkgs/test/test/runner/browser/firefox_test.dart
@@ -20,7 +20,7 @@ void main() {
     var server = await CodeServer.start();
 
     server.handleJavaScript('''
-var webSocket = WebSocket(window.location.href.replace("http://", "ws://"));
+var webSocket = new WebSocket(window.location.href.replace("http://", "ws://"));
 webSocket.addEventListener("open", function() {
   webSocket.send("loaded!");
 });

--- a/pkgs/test/test/runner/browser/firefox_test.dart
+++ b/pkgs/test/test/runner/browser/firefox_test.dart
@@ -20,7 +20,7 @@ void main() {
     var server = await CodeServer.start();
 
     server.handleJavaScript('''
-var webSocket = new WebSocket(window.location.href.replace("http://", "ws://"));
+var webSocket = WebSocket(window.location.href.replace("http://", "ws://"));
 webSocket.addEventListener("open", function() {
   webSocket.send("loaded!");
 });
@@ -71,7 +71,7 @@ void main() {
 import 'package:test/test.dart';
 
 void main() {
-  test("failure", () => throw new TestFailure("oh no"));
+  test("failure", () => throw TestFailure("oh no"));
 }
 ''').create();
 

--- a/pkgs/test/test/runner/browser/internet_explorer_test.dart
+++ b/pkgs/test/test/runner/browser/internet_explorer_test.dart
@@ -20,7 +20,7 @@ void main() {
     var server = await CodeServer.start();
 
     server.handleJavaScript('''
-var webSocket = WebSocket(window.location.href.replace("http://", "ws://"));
+var webSocket = new WebSocket(window.location.href.replace("http://", "ws://"));
 webSocket.addEventListener("open", function() {
   webSocket.send("loaded!");
 });

--- a/pkgs/test/test/runner/browser/internet_explorer_test.dart
+++ b/pkgs/test/test/runner/browser/internet_explorer_test.dart
@@ -20,7 +20,7 @@ void main() {
     var server = await CodeServer.start();
 
     server.handleJavaScript('''
-var webSocket = new WebSocket(window.location.href.replace("http://", "ws://"));
+var webSocket = WebSocket(window.location.href.replace("http://", "ws://"));
 webSocket.addEventListener("open", function() {
   webSocket.send("loaded!");
 });
@@ -71,7 +71,7 @@ void main() {
 import 'package:test/test.dart';
 
 void main() {
-  test("failure", () => throw new TestFailure("oh no"));
+  test("failure", () => throw TestFailure("oh no"));
 }
 ''').create();
 

--- a/pkgs/test/test/runner/browser/loader_test.dart
+++ b/pkgs/test/test/runner/browser/loader_test.dart
@@ -45,7 +45,7 @@ void main() {
 
       void main() {
         test("success", () {});
-        test("failure", () => throw new TestFailure('oh no'));
+        test("failure", () => throw TestFailure('oh no'));
         test("error", () => throw 'oh no');
       }
     ''').create();
@@ -103,13 +103,13 @@ import 'dart:async';
 import 'package:test/test.dart';
 
 Future main() {
-  return new Future(() {
+  return Future(() {
     test("success", () {});
 
-    return new Future(() {
-      test("failure", () => throw new TestFailure('oh no'));
+    return Future(() {
+      test("failure", () => throw TestFailure('oh no'));
 
-      return new Future(() {
+      return Future(() {
         test("error", () => throw 'oh no');
       });
     });

--- a/pkgs/test/test/runner/browser/phantom_js_test.dart
+++ b/pkgs/test/test/runner/browser/phantom_js_test.dart
@@ -20,7 +20,7 @@ void main() {
     var server = await CodeServer.start();
 
     server.handleJavaScript('''
-var webSocket = WebSocket(window.location.href.replace("http://", "ws://"));
+var webSocket = new WebSocket(window.location.href.replace("http://", "ws://"));
 webSocket.addEventListener("open", function() {
   webSocket.send("loaded!");
 });

--- a/pkgs/test/test/runner/browser/phantom_js_test.dart
+++ b/pkgs/test/test/runner/browser/phantom_js_test.dart
@@ -20,7 +20,7 @@ void main() {
     var server = await CodeServer.start();
 
     server.handleJavaScript('''
-var webSocket = new WebSocket(window.location.href.replace("http://", "ws://"));
+var webSocket = WebSocket(window.location.href.replace("http://", "ws://"));
 webSocket.addEventListener("open", function() {
   webSocket.send("loaded!");
 });
@@ -71,7 +71,7 @@ void main() {
 import 'package:test/test.dart';
 
 void main() {
-  test("failure", () => throw new TestFailure("oh no"));
+  test("failure", () => throw TestFailure("oh no"));
 }
 ''').create();
 

--- a/pkgs/test/test/runner/browser/runner_test.dart
+++ b/pkgs/test/test/runner/browser/runner_test.dart
@@ -23,7 +23,7 @@ final _failure = '''
 import 'package:test/test.dart';
 
 void main() {
-  test("failure", () => throw new TestFailure("oh no"));
+  test("failure", () => throw TestFailure("oh no"));
 }
 ''';
 
@@ -603,7 +603,7 @@ import 'package:test/test.dart';
 
 void main() {
   test("test", () {
-    if (p.style == p.Style.url) throw new TestFailure("oh no");
+    if (p.style == p.Style.url) throw TestFailure("oh no");
   });
 }
 ''').create();
@@ -622,7 +622,7 @@ import 'package:test/test.dart';
 
 void main() {
   test("test", () {
-    if (p.style != p.Style.url) throw new TestFailure("oh no");
+    if (p.style != p.Style.url) throw TestFailure("oh no");
   });
 }
 ''').create();
@@ -684,7 +684,7 @@ import 'package:test/test.dart';
 void main() {
   test("test", () {
     print("Hello,");
-    return new Future(() => print("world!"));
+    return Future(() => print("world!"));
   });
 }
 ''').create();
@@ -727,7 +727,7 @@ import 'dart:async';
 import 'package:test/test.dart';
 
 void main() {
-  test("timeout", () => new Future.delayed(Duration.zero));
+  test("timeout", () => Future.delayed(Duration.zero));
 }
 ''').create();
 
@@ -747,7 +747,7 @@ import 'dart:async';
 import 'package:test/test.dart';
 
 void main() {
-  test("fail", () => throw 'oh no', onPlatform: {"browser": new Skip()});
+  test("fail", () => throw 'oh no', onPlatform: {"browser": Skip()});
 }
 ''').create();
 
@@ -763,7 +763,7 @@ import 'dart:async';
 import 'package:test/test.dart';
 
 void main() {
-  test("success", () {}, onPlatform: {"vm": new Skip()});
+  test("success", () {}, onPlatform: {"vm": Skip()});
 }
 ''').create();
 
@@ -780,10 +780,10 @@ import 'package:test/test.dart';
 
 void main() {
   test("fail", () async {
-    await new Future.delayed(Duration.zero);
+    await Future.delayed(Duration.zero);
     throw 'oh no';
   }, onPlatform: {
-    "browser": new Timeout(Duration.zero)
+    "browser": Timeout(Duration.zero)
   });
 }
 ''').create();
@@ -804,7 +804,7 @@ import 'package:test/test.dart';
 
 void main() {
   test("success", () {}, onPlatform: {
-    "vm": new Timeout(new Duration(seconds: 0))
+    "vm": Timeout(Duration(seconds: 0))
   });
 }
 ''').create();
@@ -822,11 +822,11 @@ import 'package:test/test.dart';
 
 void main() {
   test("success", () {}, onPlatform: {
-    "browser": new Skip("first"),
-    "browser || windows": new Skip("second"),
-    "browser || linux": new Skip("third"),
-    "browser || mac-os": new Skip("fourth"),
-    "browser || android": new Skip("fifth")
+    "browser": Skip("first"),
+    "browser || windows": Skip("second"),
+    "browser || linux": Skip("third"),
+    "browser || mac-os": Skip("fourth"),
+    "browser || android": Skip("fifth")
   });
 }
 ''').create();
@@ -890,7 +890,7 @@ import 'package:test/test.dart';
 
 void main() {
   test("fail", () async {
-    await new Future.delayed(Duration.zero);
+    await Future.delayed(Duration.zero);
     throw 'oh no';
   });
 }

--- a/pkgs/test/test/runner/browser/safari_test.dart
+++ b/pkgs/test/test/runner/browser/safari_test.dart
@@ -20,7 +20,7 @@ void main() {
     var server = await CodeServer.start();
 
     server.handleJavaScript('''
-var webSocket = WebSocket(window.location.href.replace("http://", "ws://"));
+var webSocket = new WebSocket(window.location.href.replace("http://", "ws://"));
 webSocket.addEventListener("open", function() {
   webSocket.send("loaded!");
 });

--- a/pkgs/test/test/runner/browser/safari_test.dart
+++ b/pkgs/test/test/runner/browser/safari_test.dart
@@ -20,7 +20,7 @@ void main() {
     var server = await CodeServer.start();
 
     server.handleJavaScript('''
-var webSocket = new WebSocket(window.location.href.replace("http://", "ws://"));
+var webSocket = WebSocket(window.location.href.replace("http://", "ws://"));
 webSocket.addEventListener("open", function() {
   webSocket.send("loaded!");
 });
@@ -71,7 +71,7 @@ void main() {
 import 'package:test/test.dart';
 
 void main() {
-  test("failure", () => throw new TestFailure("oh no"));
+  test("failure", () => throw TestFailure("oh no"));
 }
 ''').create();
 

--- a/pkgs/test/test/runner/compact_reporter_test.dart
+++ b/pkgs/test/test/runner/compact_reporter_test.dart
@@ -122,22 +122,22 @@ void main() {
         +0: failures
         +0 -1: failures [E]
           first error
-          test.dart 10:38  main.<fn>.<fn>
+          test.dart 10:34  main.<fn>.<fn>
           ===== asynchronous gap ===========================
           dart:async       new Future.microtask
-          test.dart 10:15  main.<fn>
+          test.dart 10:18  main.<fn>
 
           second error
-          test.dart 11:38  main.<fn>.<fn>
+          test.dart 11:34  main.<fn>.<fn>
           ===== asynchronous gap ===========================
           dart:async       new Future.microtask
-          test.dart 11:15  main.<fn>
+          test.dart 11:18  main.<fn>
 
           third error
-          test.dart 12:38  main.<fn>.<fn>
+          test.dart 12:34  main.<fn>.<fn>
           ===== asynchronous gap ===========================
           dart:async       new Future.microtask
-          test.dart 12:15  main.<fn>
+          test.dart 12:18  main.<fn>
 
 
         +0 -1: wait

--- a/pkgs/test/test/runner/compact_reporter_test.dart
+++ b/pkgs/test/test/runner/compact_reporter_test.dart
@@ -38,9 +38,9 @@ void main() {
 
   test('runs several failing tests and reports when each fails', () {
     return _expectReport('''
-        test('failure 1', () => throw new TestFailure('oh no'));
-        test('failure 2', () => throw new TestFailure('oh no'));
-        test('failure 3', () => throw new TestFailure('oh no'));''', '''
+        test('failure 1', () => throw TestFailure('oh no'));
+        test('failure 2', () => throw TestFailure('oh no'));
+        test('failure 3', () => throw TestFailure('oh no'));''', '''
         +0: loading test.dart
         +0: failure 1
         +0 -1: failure 1 [E]
@@ -82,9 +82,9 @@ void main() {
 
   test('runs failing tests along with successful tests', () {
     return _expectReport('''
-        test('failure 1', () => throw new TestFailure('oh no'));
+        test('failure 1', () => throw TestFailure('oh no'));
         test('success 1', () {});
-        test('failure 2', () => throw new TestFailure('oh no'));
+        test('failure 2', () => throw TestFailure('oh no'));
         test('success 2', () {});''', '''
         +0: loading test.dart
         +0: failure 1
@@ -110,12 +110,12 @@ void main() {
     return _expectReport('''
         // This completer ensures that the test isolate isn't killed until all
         // errors have been thrown.
-        var completer = new Completer();
+        var completer = Completer();
         test('failures', () {
-          new Future.microtask(() => throw 'first error');
-          new Future.microtask(() => throw 'second error');
-          new Future.microtask(() => throw 'third error');
-          new Future.microtask(completer.complete);
+          Future.microtask(() => throw 'first error');
+          Future.microtask(() => throw 'second error');
+          Future.microtask(() => throw 'third error');
+          Future.microtask(completer.complete);
         });
         test('wait', () => completer.future);''', '''
         +0: loading test.dart
@@ -152,7 +152,7 @@ void main() {
                'longer. Even more. We have to get to at least 200 characters. '
                'I know that seems like a lot, but I believe in you. A little '
                'more... okay, that should do it.',
-           () => throw new TestFailure('oh no'));''', '''
+           () => throw TestFailure('oh no'));''', '''
         +0: loading test.dart
         +0: really ... than that. No, yet longer. Even more. We have to get to at least 200 characters. I know that seems like a lot, but I believe in you. A little more... okay, that should do it.
         +0 -1: really gosh dang long test name. Even longer than that. No, yet longer. Even more. We have to get to at least 200 characters. I know that seems like a lot, but I believe in you. A little more... okay, that should do it. [E]
@@ -187,15 +187,15 @@ void main() {
       return _expectReport('''
         // This completer ensures that the test isolate isn't killed until all
         // prints have happened.
-        var testDone = new Completer();
-        var waitStarted = new Completer();
+        var testDone = Completer();
+        var waitStarted = Completer();
         test('test', () {
           waitStarted.future.then((_) {
-            new Future(() => print("one"));
-            new Future(() => print("two"));
-            new Future(() => print("three"));
-            new Future(() => print("four"));
-            new Future(testDone.complete);
+            Future(() => print("one"));
+            Future(() => print("two"));
+            Future(() => print("three"));
+            Future(() => print("four"));
+            Future(testDone.complete);
           });
         });
 
@@ -221,7 +221,7 @@ void main() {
       return _expectReport('''
         // This completer ensures that the test isolate isn't killed until all
         // prints have happened.
-        var completer = new Completer();
+        var completer = Completer();
         test('test', () {
           scheduleMicrotask(() {
             print("three");
@@ -287,7 +287,7 @@ void main() {
       return _expectReport('''
           test('slow', () async {
             print('hello');
-            await new Future.delayed(new Duration(seconds: 3));
+            await Future.delayed(Duration(seconds: 3));
             print('goodbye');
           });''', '''
           +0: loading test.dart
@@ -353,10 +353,10 @@ void main() {
 
     test('runs skipped tests along with successful and failing tests', () {
       return _expectReport('''
-          test('failure 1', () => throw new TestFailure('oh no'));
+          test('failure 1', () => throw TestFailure('oh no'));
           test('skip 1', () {}, skip: true);
           test('success 1', () {});
-          test('failure 2', () => throw new TestFailure('oh no'));
+          test('failure 2', () => throw TestFailure('oh no'));
           test('skip 2', () {}, skip: true);
           test('success 2', () {});''', '''
           +0: loading test.dart

--- a/pkgs/test/test/runner/configuration/platform_test.dart
+++ b/pkgs/test/test/runner/configuration/platform_test.dart
@@ -32,7 +32,7 @@ void main() {
         import 'package:test/test.dart';
 
         void main() {
-          test("test", () => new Future.delayed(Duration.zero));
+          test("test", () => Future.delayed(Duration.zero));
         }
       ''').create();
 
@@ -61,7 +61,7 @@ void main() {
         import 'package:test/test.dart';
 
         void main() {
-          test("test", () => new Future.delayed(Duration.zero));
+          test("test", () => Future.delayed(Duration.zero));
         }
       ''').create();
 

--- a/pkgs/test/test/runner/configuration/presets_test.dart
+++ b/pkgs/test/test/runner/configuration/presets_test.dart
@@ -32,7 +32,7 @@ void main() {
         import 'package:test/test.dart';
 
         void main() {
-          test("test", () => new Future.delayed(Duration.zero));
+          test("test", () => Future.delayed(Duration.zero));
         }
       ''').create();
 
@@ -56,7 +56,7 @@ void main() {
         import 'package:test/test.dart';
 
         void main() {
-          test("test", () => new Future.delayed(Duration.zero));
+          test("test", () => Future.delayed(Duration.zero));
         }
       ''').create();
 
@@ -86,7 +86,7 @@ void main() {
         import 'package:test/test.dart';
 
         void main() {
-          test("test", () => new Future.delayed(Duration.zero));
+          test("test", () => Future.delayed(Duration.zero));
         }
       ''').create();
 
@@ -114,7 +114,7 @@ void main() {
         import 'package:test/test.dart';
 
         void main() {
-          test("test", () => new Future.delayed(Duration.zero));
+          test("test", () => Future.delayed(Duration.zero));
         }
       ''').create();
 
@@ -144,7 +144,7 @@ void main() {
         import 'package:test/test.dart';
 
         void main() {
-          test("test", () => new Future.delayed(Duration.zero));
+          test("test", () => Future.delayed(Duration.zero));
         }
       ''').create();
 
@@ -188,8 +188,8 @@ void main() {
         import 'package:test/test.dart';
 
         void main() {
-          test("test 1", () => new Future.delayed(Duration.zero), tags: "foo");
-          test("test 2", () => new Future.delayed(Duration.zero));
+          test("test 1", () => Future.delayed(Duration.zero), tags: "foo");
+          test("test 2", () => Future.delayed(Duration.zero));
         }
       ''').create();
 
@@ -232,7 +232,7 @@ void main() {
         import 'package:test/test.dart';
 
         void main() {
-          test("test", () => new Future.delayed(Duration.zero));
+          test("test", () => Future.delayed(Duration.zero));
         }
       ''').create();
 
@@ -261,7 +261,7 @@ void main() {
         import 'package:test/test.dart';
 
         void main() {
-          test("test", () => new Future.delayed(Duration.zero));
+          test("test", () => Future.delayed(Duration.zero));
         }
       ''').create();
 
@@ -305,7 +305,7 @@ void main() {
         import 'package:test/test.dart';
 
         void main() {
-          test("test", () => new Future.delayed(Duration.zero));
+          test("test", () => Future.delayed(Duration.zero));
         }
       ''').create();
 

--- a/pkgs/test/test/runner/configuration/suite_test.dart
+++ b/pkgs/test/test/runner/configuration/suite_test.dart
@@ -37,7 +37,7 @@ void main() {
         expect(merged.runtimes, equals([Runtime.chrome.identifier]));
       });
 
-      test("if only the new configuration's is defined, uses it", () {
+      test("if only the configuration's is defined, uses it", () {
         var merged = SuiteConfiguration().merge(SuiteConfiguration(
             jsTrace: true,
             runSkipped: true,
@@ -53,7 +53,7 @@ void main() {
       });
 
       test(
-          "if the two configurations conflict, uses the new configuration's "
+          "if the two configurations conflict, uses the configuration's "
           'values', () {
         var older = SuiteConfiguration(
             jsTrace: false,
@@ -92,7 +92,7 @@ void main() {
             merged.excludeTags, equals(BooleanSelector.parse('baz || bang')));
       });
 
-      test("if only the new configuration's is defined, uses it", () {
+      test("if only the configuration's is defined, uses it", () {
         var merged = SuiteConfiguration().merge(SuiteConfiguration(
             includeTags: BooleanSelector.parse('foo || bar'),
             excludeTags: BooleanSelector.parse('baz || bang')));
@@ -131,7 +131,7 @@ void main() {
         expect(merged.patterns, equals(['beep', 'boop']));
       });
 
-      test("if only the new configuration's is defined, uses it", () {
+      test("if only the configuration's is defined, uses it", () {
         var merged = SuiteConfiguration()
             .merge(SuiteConfiguration(patterns: ['beep', 'boop']));
 
@@ -159,7 +159,7 @@ void main() {
         expect(merged.dart2jsArgs, equals(['--foo', '--bar']));
       });
 
-      test("if only the new configuration's is defined, uses it", () {
+      test("if only the configuration's is defined, uses it", () {
         var merged = SuiteConfiguration()
             .merge(SuiteConfiguration(dart2jsArgs: ['--foo', '--bar']));
         expect(merged.dart2jsArgs, equals(['--foo', '--bar']));

--- a/pkgs/test/test/runner/configuration/tags_test.dart
+++ b/pkgs/test/test/runner/configuration/tags_test.dart
@@ -84,8 +84,8 @@ void main() {
         import 'package:test/test.dart';
 
         void main() {
-          test("test 1", () => new Future.delayed(Duration.zero), tags: ['foo']);
-          test("test 2", () => new Future.delayed(Duration.zero));
+          test("test 1", () => Future.delayed(Duration.zero), tags: ['foo']);
+          test("test 2", () => Future.delayed(Duration.zero));
         }
       ''').create();
 
@@ -112,9 +112,9 @@ void main() {
         import 'package:test/test.dart';
 
         void main() {
-          test("test 1", () => new Future.delayed(Duration.zero), tags: ['foo']);
-          test("test 2", () => new Future.delayed(Duration.zero), tags: ['bar']);
-          test("test 3", () => new Future.delayed(Duration.zero),
+          test("test 1", () => Future.delayed(Duration.zero), tags: ['foo']);
+          test("test 2", () => Future.delayed(Duration.zero), tags: ['bar']);
+          test("test 3", () => Future.delayed(Duration.zero),
               tags: ['foo', 'bar']);
         }
       ''').create();

--- a/pkgs/test/test/runner/configuration/top_level_test.dart
+++ b/pkgs/test/test/runner/configuration/top_level_test.dart
@@ -147,8 +147,8 @@ void main() {
 
           void main() {
             test("failure", () async{
-              await new Future((){});
-              await new Future((){});
+              await Future((){});
+              await Future((){});
               throw "oh no";
             });
           }
@@ -390,7 +390,7 @@ transformers:
 
           Future apply(Transform transform) async {
             var contents = await transform.primaryInput.readAsString();
-            transform.addOutput(new Asset.fromString(
+            transform.addOutput(Asset.fromString(
                 transform.primaryInput.id,
                 contents.replaceAll("isFalse", "isTrue")));
           }
@@ -449,7 +449,7 @@ transformers:
       import 'package:test/test.dart';
 
       void main() {
-        test("success", () => new Future.delayed(Duration.zero));
+        test("success", () => Future.delayed(Duration.zero));
       }
     ''').create();
 
@@ -492,7 +492,7 @@ transformers:
       import 'package:test/test.dart';
 
       void main() {
-        test("success", () => new Future.delayed(Duration.zero));
+        test("success", () => Future.delayed(Duration.zero));
       }
     ''').create();
 

--- a/pkgs/test/test/runner/expanded_reporter_test.dart
+++ b/pkgs/test/test/runner/expanded_reporter_test.dart
@@ -34,9 +34,9 @@ void main() {
 
   test('runs several failing tests and reports when each fails', () {
     return _expectReport('''
-        test('failure 1', () => throw new TestFailure('oh no'));
-        test('failure 2', () => throw new TestFailure('oh no'));
-        test('failure 3', () => throw new TestFailure('oh no'));''', '''
+        test('failure 1', () => throw TestFailure('oh no'));
+        test('failure 2', () => throw TestFailure('oh no'));
+        test('failure 3', () => throw TestFailure('oh no'));''', '''
         +0: failure 1
         +0 -1: failure 1 [E]
           oh no
@@ -73,9 +73,9 @@ void main() {
 
   test('runs failing tests along with successful tests', () {
     return _expectReport('''
-        test('failure 1', () => throw new TestFailure('oh no'));
+        test('failure 1', () => throw TestFailure('oh no'));
         test('success 1', () {});
-        test('failure 2', () => throw new TestFailure('oh no'));
+        test('failure 2', () => throw TestFailure('oh no'));
         test('success 2', () {});''', '''
         +0: failure 1
         +0 -1: failure 1 [E]
@@ -106,12 +106,12 @@ void main() {
     return _expectReport('''
         // This completer ensures that the test isolate isn't killed until all
         // errors have been thrown.
-        var completer = new Completer();
+        var completer = Completer();
         test('failures', () {
-          new Future.microtask(() => throw 'first error');
-          new Future.microtask(() => throw 'second error');
-          new Future.microtask(() => throw 'third error');
-          new Future.microtask(completer.complete);
+          Future.microtask(() => throw 'first error');
+          Future.microtask(() => throw 'second error');
+          Future.microtask(() => throw 'third error');
+          Future.microtask(completer.complete);
         });
         test('wait', () => completer.future);''', '''
         +0: failures
@@ -159,15 +159,15 @@ void main() {
       return _expectReport('''
         // This completer ensures that the test isolate isn't killed until all
         // prints have happened.
-        var testDone = new Completer();
-        var waitStarted = new Completer();
+        var testDone = Completer();
+        var waitStarted = Completer();
         test('test', () async {
           waitStarted.future.then((_) {
-            new Future(() => print("one"));
-            new Future(() => print("two"));
-            new Future(() => print("three"));
-            new Future(() => print("four"));
-            new Future(testDone.complete);
+            Future(() => print("one"));
+            Future(() => print("two"));
+            Future(() => print("three"));
+            Future(() => print("four"));
+            Future(testDone.complete);
           });
         });
 
@@ -189,7 +189,7 @@ void main() {
       return _expectReport('''
         // This completer ensures that the test isolate isn't killed until all
         // prints have happened.
-        var completer = new Completer();
+        var completer = Completer();
         test('test', () {
           scheduleMicrotask(() {
             print("three");
@@ -271,10 +271,10 @@ void main() {
 
     test('runs skipped tests along with successful and failing tests', () {
       return _expectReport('''
-          test('failure 1', () => throw new TestFailure('oh no'));
+          test('failure 1', () => throw TestFailure('oh no'));
           test('skip 1', () {}, skip: true);
           test('success 1', () {});
-          test('failure 2', () => throw new TestFailure('oh no'));
+          test('failure 2', () => throw TestFailure('oh no'));
           test('skip 2', () {}, skip: true);
           test('success 2', () {});''', '''
           +0: failure 1

--- a/pkgs/test/test/runner/expanded_reporter_test.dart
+++ b/pkgs/test/test/runner/expanded_reporter_test.dart
@@ -117,22 +117,22 @@ void main() {
         +0: failures
         +0 -1: failures [E]
           first error
-          test.dart 10:38  main.<fn>.<fn>
+          test.dart 10:34  main.<fn>.<fn>
           ===== asynchronous gap ===========================
           dart:async       new Future.microtask
-          test.dart 10:15  main.<fn>
+          test.dart 10:18  main.<fn>
 
           second error
-          test.dart 11:38  main.<fn>.<fn>
+          test.dart 11:34  main.<fn>.<fn>
           ===== asynchronous gap ===========================
           dart:async       new Future.microtask
-          test.dart 11:15  main.<fn>
+          test.dart 11:18  main.<fn>
 
           third error
-          test.dart 12:38  main.<fn>.<fn>
+          test.dart 12:34  main.<fn>.<fn>
           ===== asynchronous gap ===========================
           dart:async       new Future.microtask
-          test.dart 12:15  main.<fn>
+          test.dart 12:18  main.<fn>
 
         +0 -1: wait
         +1 -1: Some tests failed.''');

--- a/pkgs/test/test/runner/hybrid_test.dart
+++ b/pkgs/test/test/runner/hybrid_test.dart
@@ -61,7 +61,7 @@ void main() {
 
               void hybridMain(StreamChannel channel) {
                 channel.sink
-                  ..add(new File("$path").readAsStringSync())
+                  ..add(File("$path").readAsStringSync())
                   ..close();
               }
             """).stream.first, completion(contains("hybrid emits numbers")));
@@ -113,7 +113,7 @@ void main() {
         import "package:stream_channel/stream_channel.dart";
 
         void hybridMain(StreamChannel channel) {
-          channel.sink.addError("oh no!", new Trace.current());
+          channel.sink.addError("oh no!", Trace.current());
         }
       ''');
 
@@ -164,7 +164,7 @@ void main() {
         import "package:test/test.dart";
 
         void hybridMain(StreamChannel channel) {
-          throw new TestFailure("oh no!");
+          throw TestFailure("oh no!");
         }
       ''');
 
@@ -368,7 +368,7 @@ void main() {
                 });
               }
             """, stayAlive: true);
-            queue = new StreamQueue(channel.stream);
+            queue = StreamQueue(channel.stream);
             sink = channel.sink;
           });
 

--- a/pkgs/test/test/runner/json_reporter_test.dart
+++ b/pkgs/test/test/runner/json_reporter_test.dart
@@ -42,9 +42,9 @@ void main() {
 
   test('runs several failing tests and reports when each fails', () {
     return _expectReport('''
-      test('failure 1', () => throw new TestFailure('oh no'));
-      test('failure 2', () => throw new TestFailure('oh no'));
-      test('failure 3', () => throw new TestFailure('oh no'));
+      test('failure 1', () => throw TestFailure('oh no'));
+      test('failure 2', () => throw TestFailure('oh no'));
+      test('failure 3', () => throw TestFailure('oh no'));
     ''', [
       [
         _suite(0),
@@ -85,9 +85,9 @@ void main() {
 
   test('runs failing tests along with successful tests', () {
     return _expectReport('''
-      test('failure 1', () => throw new TestFailure('oh no'));
+      test('failure 1', () => throw TestFailure('oh no'));
       test('success 1', () {});
-      test('failure 2', () => throw new TestFailure('oh no'));
+      test('failure 2', () => throw TestFailure('oh no'));
       test('success 2', () {});
     ''', [
       [
@@ -115,12 +115,12 @@ void main() {
     return _expectReport('''
       // This completer ensures that the test isolate isn't killed until all
       // errors have been thrown.
-      var completer = new Completer();
+      var completer = Completer();
       test('failures', () {
-        new Future.microtask(() => throw 'first error');
-        new Future.microtask(() => throw 'second error');
-        new Future.microtask(() => throw 'third error');
-        new Future.microtask(completer.complete);
+        Future.microtask(() => throw 'first error');
+        Future.microtask(() => throw 'second error');
+        Future.microtask(() => throw 'third error');
+        Future.microtask(completer.complete);
       });
       test('wait', () => completer.future);
     ''', [
@@ -147,11 +147,11 @@ void main() {
       // These completers ensure that the first test won't fail until the second
       // one is running, and that the test isolate isn't killed until all errors
       // have been thrown.
-      var waitStarted = new Completer();
-      var testDone = new Completer();
+      var waitStarted = Completer();
+      var testDone = Completer();
       test('failure', () {
         waitStarted.future.then((_) {
-          new Future.microtask(testDone.complete);
+          Future.microtask(testDone.complete);
           throw 'oh no';
         });
       });
@@ -247,15 +247,15 @@ void main() {
       return _expectReport('''
         // This completer ensures that the test isolate isn't killed until all
         // prints have happened.
-        var testDone = new Completer();
-        var waitStarted = new Completer();
+        var testDone = Completer();
+        var waitStarted = Completer();
         test('test', () async {
           waitStarted.future.then((_) {
-            new Future(() => print("one"));
-            new Future(() => print("two"));
-            new Future(() => print("three"));
-            new Future(() => print("four"));
-            new Future(testDone.complete);
+            Future(() => print("one"));
+            Future(() => print("two"));
+            Future(() => print("three"));
+            Future(() => print("four"));
+            Future(testDone.complete);
           });
         });
 
@@ -287,7 +287,7 @@ void main() {
       return _expectReport('''
         // This completer ensures that the test isolate isn't killed until all
         // prints have happened.
-        var completer = new Completer();
+        var completer = Completer();
         test('test', () {
           scheduleMicrotask(() {
             print("three");

--- a/pkgs/test/test/runner/loader_test.dart
+++ b/pkgs/test/test/runner/loader_test.dart
@@ -27,7 +27,7 @@ import 'package:test/test.dart';
 
 void main() {
   test("success", () {});
-  test("failure", () => throw new TestFailure('oh no'));
+  test("failure", () => throw TestFailure('oh no'));
   test("error", () => throw 'oh no');
 }
 ''';

--- a/pkgs/test/test/runner/name_test.dart
+++ b/pkgs/test/test/runner/name_test.dart
@@ -19,7 +19,7 @@ void main() {
 
         void main() {
           test("selected 1", () {});
-          test("nope", () => throw new TestFailure("oh no"));
+          test("nope", () => throw TestFailure("oh no"));
           test("selected 2", () {});
         }
       ''').create();
@@ -35,7 +35,7 @@ void main() {
 
         void main() {
           test("test 1", () {});
-          test("test 2", () => throw new TestFailure("oh no"));
+          test("test 2", () => throw TestFailure("oh no"));
           test("test 3", () {});
         }
       ''').create();
@@ -51,7 +51,7 @@ void main() {
 
         void main() {
           test("selected 1", () {});
-          test("nope", () => throw new TestFailure("oh no"));
+          test("nope", () => throw TestFailure("oh no"));
           test("selected 2", () {});
         }
       ''').create();
@@ -98,7 +98,7 @@ void main() {
 
         void main() {
           test("selected 1", () {});
-          test("nope", () => throw new TestFailure("oh no"));
+          test("nope", () => throw TestFailure("oh no"));
           test("selected 2", () {});
         }
       ''').create();
@@ -113,8 +113,8 @@ void main() {
         import 'package:test/test.dart';
 
         void main() {
-          test("test 1", () => throw new TestFailure("oh no"));
-          test("test 2", () => throw new TestFailure("oh no"));
+          test("test 1", () => throw TestFailure("oh no"));
+          test("test 2", () => throw TestFailure("oh no"));
           test("test [12]", () {});
         }
       ''').create();
@@ -130,7 +130,7 @@ void main() {
 
         void main() {
           test("selected 1", () {});
-          test("nope", () => throw new TestFailure("oh no"));
+          test("nope", () => throw TestFailure("oh no"));
           test("selected 2", () {});
         }
       ''').create();
@@ -162,7 +162,7 @@ void main() {
 
       void main() {
         test("selected 1", () {});
-        test("nope", () => throw new TestFailure("oh no"));
+        test("nope", () => throw TestFailure("oh no"));
         test("selected 2", () {});
       }
     ''').create();

--- a/pkgs/test/test/runner/node/runner_test.dart
+++ b/pkgs/test/test/runner/node/runner_test.dart
@@ -24,7 +24,7 @@ final _failure = '''
   import 'package:test/test.dart';
 
   void main() {
-    test("failure", () => throw new TestFailure("oh no"));
+    test("failure", () => throw TestFailure("oh no"));
   }
 ''';
 
@@ -140,7 +140,7 @@ void main() {
         void main() {
           test("test", () {
             if (const bool.fromEnvironment("node")) {
-              throw new TestFailure("oh no");
+              throw TestFailure("oh no");
             }
           });
         }
@@ -160,7 +160,7 @@ void main() {
       void main() {
         test("test", () {
           print("Hello,");
-          return new Future(() => print("world!"));
+          return Future(() => print("world!"));
         });
       }
     ''').create();
@@ -183,7 +183,7 @@ void main() {
       void main() {
         test("test", () {
           log("Hello,");
-          return new Future(() => log("world!"));
+          return Future(() => log("world!"));
         });
       }
     ''').create();
@@ -254,7 +254,7 @@ void main() {
         import 'package:test/test.dart';
 
         void main() {
-          test("fail", () => throw 'oh no', onPlatform: {"node": new Skip()});
+          test("fail", () => throw 'oh no', onPlatform: {"node": Skip()});
         }
       ''').create();
 
@@ -270,7 +270,7 @@ void main() {
         import 'package:test/test.dart';
 
         void main() {
-          test("success", () {}, onPlatform: {"browser": new Skip()});
+          test("success", () {}, onPlatform: {"browser": Skip()});
         }
       ''').create();
 
@@ -287,7 +287,7 @@ void main() {
 
         void main() {
           test("fail", () => throw 'oh no',
-              onPlatform: {"${currentOS.identifier}": new Skip()});
+              onPlatform: {"${currentOS.identifier}": Skip()});
         }
       ''').create();
 
@@ -303,7 +303,7 @@ void main() {
         import 'package:test/test.dart';
 
         void main() {
-          test("success", () {}, onPlatform: {"${otherOS}": new Skip()});
+          test("success", () {}, onPlatform: {"${otherOS}": Skip()});
         }
       ''').create();
 

--- a/pkgs/test/test/runner/pause_after_load_test.dart
+++ b/pkgs/test/test/runner/pause_after_load_test.dart
@@ -229,8 +229,8 @@ void main() {
   print('loaded test 1!');
 
   test("success", () async {
-    await new Future.delayed(Duration.zero);
-  }, timeout: new Timeout(Duration.zero));
+    await Future.delayed(Duration.zero);
+  }, timeout: Timeout(Duration.zero));
 }
 ''').create();
 

--- a/pkgs/test/test/runner/pub_serve_test.dart
+++ b/pkgs/test/test/runner/pub_serve_test.dart
@@ -51,7 +51,7 @@ class MyTransformer extends Transformer {
 
   Future apply(Transform transform) async {
     var contents = await transform.primaryInput.readAsString();
-    transform.addOutput(new Asset.fromString(
+    transform.addOutput(Asset.fromString(
         transform.primaryInput.id,
         contents.replaceAll("isFalse", "isTrue")));
   }

--- a/pkgs/test/test/runner/retry_test.dart
+++ b/pkgs/test/test/runner/retry_test.dart
@@ -21,7 +21,7 @@ void main() {
             test("eventually passes", () {
                attempt++;
                if(attempt <= 1 ) {
-                 throw new TestFailure("oh no");
+                 throw TestFailure("oh no");
                }
             }, retry: 1);
           }
@@ -45,7 +45,7 @@ void main() {
             test("eventually passes", () {
                attempt++;
                if(attempt <= 1 ) {
-                 throw new TestFailure("oh no");
+                 throw TestFailure("oh no");
                }
             });
           }
@@ -69,7 +69,7 @@ void main() {
             test("failure", () {
                attempt++;
                if(attempt <= 3) {
-                 throw new TestFailure("oh no");
+                 throw TestFailure("oh no");
                }
             });
           }
@@ -92,7 +92,7 @@ void main() {
               test("failure", () {
                  attempt++;
                  if(attempt <= 3) {
-                   throw new TestFailure("oh no");
+                   throw TestFailure("oh no");
                  }
               });
              }, retry: 3);
@@ -112,8 +112,8 @@ void main() {
               import 'package:test/test.dart';
 
               void main() {
-                var completer1 = new Completer();
-                var completer2 = new Completer();
+                var completer1 = Completer();
+                var completer2 = Completer();
                 test("first", () {
                   completer1.future.then((_) {
                     completer2.complete();
@@ -148,7 +148,7 @@ void main() {
                 test("eventually passes", () {
                  attempt++;
                  if(attempt <= 2) {
-                   throw new TestFailure("oh no");
+                   throw TestFailure("oh no");
                  }
                 }, retry: 2);
               }
@@ -166,16 +166,16 @@ void main() {
               import 'package:test/test.dart';
 
               var attempt = 0;
-              Completer completer = new Completer();
+              Completer completer = Completer();
               void main() {
                 test("failure", () async {
                   attempt++;
                   if (attempt == 1) {
                     completer.future.then((_) => throw 'some error');
-                    throw new TestFailure("oh no");
+                    throw TestFailure("oh no");
                   }
                   completer.complete(null);
-                  await new Future((){});
+                  await Future((){});
                 }, retry: 1);
               }
           ''').create();
@@ -193,7 +193,7 @@ void main() {
 
               void main() {
                 test("failure", () {
-                 throw new TestFailure("oh no");
+                 throw TestFailure("oh no");
                 }, retry: 2);
               }
           ''').create();
@@ -214,7 +214,7 @@ void main() {
                 test("eventually passes", () {
                 attempt++;
                 if (attempt != 2){
-                 throw new TestFailure("oh no");
+                 throw TestFailure("oh no");
                 }
                 }, retry: 5);
           }

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -29,7 +29,7 @@ import 'dart:async';
 import 'package:test/test.dart';
 
 void main() {
-  test("failure", () => throw new TestFailure("oh no"));
+  test("failure", () => throw TestFailure("oh no"));
 }
 ''';
 
@@ -465,7 +465,7 @@ import 'dart:async';
 import 'package:test/test.dart';
 
 void main() {
-  test("fail", () => throw 'oh no', onPlatform: {"vm": new Skip()});
+  test("fail", () => throw 'oh no', onPlatform: {"vm": Skip()});
 }
 ''').create();
 
@@ -481,7 +481,7 @@ import 'dart:async';
 import 'package:test/test.dart';
 
 void main() {
-  test("success", () {}, onPlatform: {"chrome": new Skip()});
+  test("success", () {}, onPlatform: {"chrome": Skip()});
 }
 ''').create();
 
@@ -498,10 +498,10 @@ import 'package:test/test.dart';
 
 void main() {
   test("fail", () async {
-    await new Future.delayed(Duration.zero);
+    await Future.delayed(Duration.zero);
     throw 'oh no';
   }, onPlatform: {
-    "vm": new Timeout(Duration.zero)
+    "vm": Timeout(Duration.zero)
   });
 }
 ''').create();
@@ -522,7 +522,7 @@ import 'package:test/test.dart';
 
 void main() {
   test("success", () {}, onPlatform: {
-    "chrome": new Timeout(new Duration(seconds: 0))
+    "chrome": Timeout(Duration(seconds: 0))
   });
 }
 ''').create();
@@ -540,11 +540,11 @@ import 'package:test/test.dart';
 
 void main() {
   test("success", () {}, onPlatform: {
-    "vm": new Skip("first"),
-    "vm || windows": new Skip("second"),
-    "vm || linux": new Skip("third"),
-    "vm || mac-os": new Skip("fourth"),
-    "vm || android": new Skip("fifth")
+    "vm": Skip("first"),
+    "vm || windows": Skip("second"),
+    "vm || linux": Skip("third"),
+    "vm || mac-os": Skip("fourth"),
+    "vm || android": Skip("fifth")
   });
 }
 ''').create();
@@ -568,7 +568,7 @@ void main() {
   group("group", () {
     test("success", () {});
   }, onPlatform: {
-    "vm": new Skip()
+    "vm": Skip()
   });
 }
 ''').create();
@@ -628,7 +628,7 @@ import 'package:test/test.dart';
 
 void main() {
   test("fail", () async {
-    await new Future.delayed(Duration.zero);
+    await Future.delayed(Duration.zero);
     throw 'oh no';
   });
 }

--- a/pkgs/test/test/runner/signal_test.dart
+++ b/pkgs/test/test/runner/signal_test.dart
@@ -84,14 +84,14 @@ import 'package:test/test.dart';
 
 void main() {
   tearDownAll(() {
-    new File("output_all").writeAsStringSync("ran tearDownAll");
+    File("output_all").writeAsStringSync("ran tearDownAll");
   });
 
-  tearDown(() => new File("output").writeAsStringSync("ran tearDown"));
+  tearDown(() => File("output").writeAsStringSync("ran tearDown"));
 
   test("test", () {
     print("running test");
-    return new Future.delayed(new Duration(seconds: 1));
+    return Future.delayed(Duration(seconds: 1));
   });
 }
 ''').create();
@@ -115,8 +115,8 @@ import 'package:test/test.dart';
 void main() {
   tearDownAll(() async {
     print("running tearDownAll");
-    await new Future.delayed(new Duration(seconds: 1));
-    new File("output").writeAsStringSync("ran tearDownAll");
+    await Future.delayed(Duration(seconds: 1));
+    File("output").writeAsStringSync("ran tearDownAll");
   });
 
   test("test", () {});
@@ -142,7 +142,7 @@ void main() {
     print("running test");
 
     // Allow an event loop to pass so the preceding print can be handled.
-    return new Future(() {
+    return Future(() {
       // Loop forever so that if the test isn't stopped while running, it never
       // stops.
       while (true) {}
@@ -192,13 +192,13 @@ void main() {
   var expectThrewError = false;
 
   tearDown(() {
-    new File("output").writeAsStringSync(expectThrewError.toString());
+    File("output").writeAsStringSync(expectThrewError.toString());
   });
 
   test("test", () async {
     print("running test");
 
-    await new Future.delayed(new Duration(seconds: 1));
+    await Future.delayed(Duration(seconds: 1));
     try {
       expect(true, isTrue);
     } catch (_) {
@@ -227,13 +227,13 @@ void main() {
   var expectAsyncThrewError = false;
 
   tearDown(() {
-    new File("output").writeAsStringSync(expectAsyncThrewError.toString());
+    File("output").writeAsStringSync(expectAsyncThrewError.toString());
   });
 
   test("test", () async {
     print("running test");
 
-    await new Future.delayed(new Duration(seconds: 1));
+    await Future.delayed(Duration(seconds: 1));
     try {
       expectAsync0(() {});
     } catch (_) {

--- a/pkgs/test/test/runner/skip_expect_test.dart
+++ b/pkgs/test/test/runner/skip_expect_test.dart
@@ -123,8 +123,8 @@ void main() {
         import 'package:test/test.dart';
 
         void main() {
-          var skipCompleter = new Completer();
-          var waitCompleter = new Completer();
+          var skipCompleter = Completer();
+          var waitCompleter = Completer();
           test("skip", () {
             skipCompleter.future.then((_) {
               waitCompleter.complete();

--- a/pkgs/test/test/runner/test_chain_test.dart
+++ b/pkgs/test/test/runner/test_chain_test.dart
@@ -20,8 +20,8 @@ void main() {
 
             void main() {
               test("failure", () async{
-                await new Future((){});
-                await new Future((){});
+                await Future((){});
+                await Future((){});
                 throw "oh no";
               });
             }

--- a/pkgs/test/test/runner/timeout_test.dart
+++ b/pkgs/test/test/runner/timeout_test.dart
@@ -21,7 +21,7 @@ import 'package:test/test.dart';
 
 void main() {
   test("timeout", () async {
-    await new Future.delayed(Duration.zero);
+    await Future.delayed(Duration.zero);
   });
 }
 ''').create();
@@ -42,7 +42,7 @@ import 'package:test/test.dart';
 
 void main() {
   test("timeout", () async {
-    await new Future.delayed(Duration.zero);
+    await Future.delayed(Duration.zero);
   });
 }
 ''').create();
@@ -66,7 +66,7 @@ void main() {
   test("timeout", () async {
     runCount++;
     if (runCount <=2) {
-      await new Future.delayed(new Duration(milliseconds: 1000));
+      await Future.delayed(Duration(milliseconds: 1000));
     }
   }, retry: 3);
 }
@@ -92,11 +92,11 @@ import 'package:test/test.dart';
 
 void main() {
   test("no timeout", () async {
-    await new Future.delayed(new Duration(milliseconds: 250));
+    await Future.delayed(Duration(milliseconds: 250));
   });
 
   test("timeout", () async {
-    await new Future.delayed(new Duration(milliseconds: 750));
+    await Future.delayed(Duration(milliseconds: 750));
   });
 }
 ''').create();

--- a/pkgs/test_api/lib/src/backend/invoker.dart
+++ b/pkgs/test_api/lib/src/backend/invoker.dart
@@ -396,8 +396,7 @@ class Invoker {
           // corresponding [onStateChange], which violates the timing
           // guarantees.
           //
-          // Using [new Future] also avoids starving the DOM or other
-          // microtask-level events.
+          // Use the event loop over the microtask queue to avoid starvation.
           unawaited(Future(() async {
             await _test._body();
             await unclosable(_runTearDowns);

--- a/pkgs/test_api/lib/src/backend/metadata.dart
+++ b/pkgs/test_api/lib/src/backend/metadata.dart
@@ -365,7 +365,7 @@ class Metadata {
   }
 
   /// Serializes [this] into a JSON-safe object that can be deserialized using
-  /// [new Metadata.deserialize].
+  /// [Metadata.deserialize].
   Map<String, dynamic> serialize() {
     // Make this a list to guarantee that the order is preserved.
     var serializedOnPlatform = [];

--- a/pkgs/test_api/lib/src/backend/runtime.dart
+++ b/pkgs/test_api/lib/src/backend/runtime.dart
@@ -121,7 +121,7 @@ class Runtime {
   }
 
   /// Converts [this] into a JSON-safe object that can be converted back to a
-  /// [Runtime] using [new Runtime.deserialize].
+  /// [Runtime] using [Runtime.deserialize].
   Object serialize() {
     if (builtIn.contains(this)) return identifier;
 

--- a/pkgs/test_api/lib/src/backend/suite_platform.dart
+++ b/pkgs/test_api/lib/src/backend/suite_platform.dart
@@ -41,7 +41,7 @@ class SuitePlatform {
   }
 
   /// Converts [this] into a JSON-safe object that can be converted back to a
-  /// [SuitePlatform] using [new SuitePlatform.deserialize].
+  /// [SuitePlatform] using [SuitePlatform.deserialize].
   Object serialize() => {
         'runtime': runtime.serialize(),
         'os': os.identifier,

--- a/pkgs/test_api/lib/src/frontend/stream_matcher.dart
+++ b/pkgs/test_api/lib/src/frontend/stream_matcher.dart
@@ -45,7 +45,7 @@ typedef _MatchQueue = Future<String> Function(StreamQueue queue);
 /// at different times:
 ///
 /// ```dart
-/// var stdout = new StreamQueue(stdoutLineStream);
+/// var stdout = StreamQueue(stdoutLineStream);
 ///
 /// // Ignore lines from the process until it's about to emit the URL.
 /// await expect(stdout, emitsThrough("WebSocket URL:"));

--- a/pkgs/test_api/lib/src/frontend/timeout.dart
+++ b/pkgs/test_api/lib/src/frontend/timeout.dart
@@ -20,7 +20,7 @@ final _whitespace = RegExp(r'\s+');
 /// A class representing a modification to the default timeout for a test.
 ///
 /// By default, a test will time out after 30 seconds. With [new Timeout], that
-/// can be overridden entirely; with [new Timeout.factor], it can be scaled
+/// can be overridden entirely; with [Timeout.factor], it can be scaled
 /// relative to the default.
 class Timeout {
   /// A constant indicating that a test should never time out.

--- a/pkgs/test_api/lib/src/frontend/utils.dart
+++ b/pkgs/test_api/lib/src/frontend/utils.dart
@@ -14,9 +14,6 @@ import 'dart:async';
 Future pumpEventQueue({int times}) {
   times ??= 20;
   if (times == 0) return Future.value();
-  // Use [new Future] future to allow microtask events to finish. The [new
-  // Future.value] constructor uses scheduleMicrotask itself and would therefore
-  // not wait for microtask callbacks that are scheduled after invoking this
-  // method.
+  // Use the event loop to allow the microtask queue to finish.
   return Future(() => pumpEventQueue(times: times - 1));
 }

--- a/pkgs/test_api/lib/test_api.dart
+++ b/pkgs/test_api/lib/test_api.dart
@@ -73,15 +73,15 @@ Declarer get _declarer => Zone.current[#test.declarer] as Declarer;
 /// annotation classes: [Timeout], [Skip], or lists of those. These
 /// annotations apply only on the given platforms. For example:
 ///
-///     test("potentially slow test", () {
+///     test('potentially slow test', () {
 ///       // ...
 ///     }, onPlatform: {
 ///       // This test is especially slow on Windows.
-///       "windows": new Timeout.factor(2),
-///       "browser": [
-///         new Skip("TODO: add browser support"),
+///       'windows': Timeout.factor(2),
+///       'browser': [
+///         Skip('TODO: add browser support'),
 ///         // This will be slow on browsers once it works on them.
-///         new Timeout.factor(2)
+///         Timeout.factor(2)
 ///       ]
 ///     });
 ///
@@ -151,15 +151,15 @@ void test(description, dynamic Function() body,
 /// annotation classes: [Timeout], [Skip], or lists of those. These
 /// annotations apply only on the given platforms. For example:
 ///
-///     group("potentially slow tests", () {
+///     group('potentially slow tests', () {
 ///       // ...
 ///     }, onPlatform: {
 ///       // These tests are especially slow on Windows.
-///       "windows": new Timeout.factor(2),
-///       "browser": [
-///         new Skip("TODO: add browser support"),
+///       'windows': Timeout.factor(2),
+///       'browser': [
+///         Skip('TODO: add browser support'),
 ///         // They'll be slow on browsers once it works on them.
-///         new Timeout.factor(2)
+///         Timeout.factor(2)
 ///       ]
 ///     });
 ///

--- a/pkgs/test_api/test/backend/invoker_test.dart
+++ b/pkgs/test_api/test/backend/invoker_test.dart
@@ -46,8 +46,8 @@ void main() {
       Status status;
       var completer = Completer();
       var liveTest = _localTest(() {
-        // Use [new Future] in particular to wait longer than a microtask for
-        // the test to complete.
+        // Use the event loop to wait longer than a microtask for the test to
+        // complete.
         Future(() {
           status = Invoker.current.liveTest.state.status;
           completer.complete(Invoker.current);

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -29,8 +29,8 @@ final ArgParser _parser = (() {
       negatable: false, help: "Shows the package's version.");
 
   // Note that defaultsTo declarations here are only for documentation purposes.
-  // We pass null values rather than defaults to [new Configuration] so that it
-  // merges properly with the config file.
+  // We pass null instead of the default so that it merges properly with the
+  // config file.
 
   parser.addSeparator('======== Selecting Tests');
   parser.addMultiOption('name',

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -48,7 +48,7 @@ final OperatingSystem currentOS = (() {
   throw UnsupportedError('Unsupported operating system "$name".');
 })();
 
-// TODO(nweiz): Make this `new SuitePlatform.current()` once we only support
+// TODO(nweiz): Make this `SuitePlatform.current()` once we only support
 // Dart 2 and we can import `dart:io` from within cross-platform libraries. See
 // commit 4ffda6d2.
 /// Returns a [SuitePlatform] with the given [runtime], and with [os] and

--- a/pkgs/test_core/lib/test_core.dart
+++ b/pkgs/test_core/lib/test_core.dart
@@ -107,15 +107,15 @@ Declarer get _declarer {
 /// annotation classes: [Timeout], [Skip], or lists of those. These
 /// annotations apply only on the given platforms. For example:
 ///
-///     test("potentially slow test", () {
+///     test('potentially slow test', () {
 ///       // ...
 ///     }, onPlatform: {
 ///       // This test is especially slow on Windows.
-///       "windows": new Timeout.factor(2),
-///       "browser": [
-///         new Skip("TODO: add browser support"),
+///       'windows': Timeout.factor(2),
+///       'browser': [
+///         Skip('TODO: add browser support'),
 ///         // This will be slow on browsers once it works on them.
-///         new Timeout.factor(2)
+///         Timeout.factor(2)
 ///       ]
 ///     });
 ///
@@ -185,15 +185,15 @@ void test(description, dynamic Function() body,
 /// annotation classes: [Timeout], [Skip], or lists of those. These
 /// annotations apply only on the given platforms. For example:
 ///
-///     group("potentially slow tests", () {
+///     group('potentially slow tests', () {
 ///       // ...
 ///     }, onPlatform: {
 ///       // These tests are especially slow on Windows.
-///       "windows": new Timeout.factor(2),
-///       "browser": [
-///         new Skip("TODO: add browser support"),
+///       'windows': Timeout.factor(2),
+///       'browser': [
+///         Skip('TODO: add browser support'),
 ///         // They'll be slow on browsers once it works on them.
-///         new Timeout.factor(2)
+///         Timeout.factor(2)
 ///       ]
 ///     });
 ///


### PR DESCRIPTION
Remove the `new` from Dart code in strings, docs, comments, and the
README. Leave the keyword if it's used in a doc comment references to
link specifically to the unnamed constructor instead of a class.

Simplify some implementation comments to avoid repeating information.

In some user facing Dart code, switch to single quotes for consistency.