### PR TITLE
Remove stale or inactionable TODO comments

### DIFF
--- a/pkgs/test/lib/src/executable.dart
+++ b/pkgs/test/lib/src/executable.dart
@@ -19,6 +19,5 @@ void main(List<String> args) async {
     Runtime.internetExplorer
   ], () => BrowserPlatform.start());
 
-  // TODO figure out if this await is necessary
-  await (executable.main(args) as dynamic);
+  await executable.main(args);
 }

--- a/pkgs/test/test/runner/json_reporter_test.dart
+++ b/pkgs/test/test/runner/json_reporter_test.dart
@@ -603,8 +603,6 @@ import 'package:test/test.dart';
   expect(stdoutLines.length, equals(expected.fold(3, (a, m) => a + m.length)),
       reason: 'Expected $stdoutLines to match $expected.');
 
-  // TODO(nweiz): validate each event against the JSON schema when
-  // patefacio/json_schema#4 is merged.
   dynamic decodeLine(String l) =>
       jsonDecode(l)..remove('time')..remove('stackTrace');
 

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.13-dev
+
+* Internal cleanup.
+
 ## 0.2.12
 
 * Link to docs on setting timeout when a test times out with the default

--- a/pkgs/test_api/lib/src/frontend/spawn_hybrid.dart
+++ b/pkgs/test_api/lib/src/frontend/spawn_hybrid.dart
@@ -192,8 +192,6 @@ StreamChannel spawnHybridCode(String dartCode,
 StreamChannel _spawn(String uri, Object message, {bool stayAlive = false}) {
   var channel = Zone.current[#test.runner.test_channel] as MultiChannel;
   if (channel == null) {
-    // TODO(nweiz): Link to an issue tracking support when running the test file
-    // directly.
     throw UnsupportedError("Can't connect to the test runner.\n"
         'spawnHybridUri() is currently only supported within "pub run test".');
   }

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.2.12
+version: 0.2.13-dev
 author: Dart Team <misc@dartlang.org>
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.17-dev
+
+* Internal cleanup.
+
 ## 0.2.16
 
 * Internal cleanup.

--- a/pkgs/test_core/lib/src/executable.dart
+++ b/pkgs/test_core/lib/src/executable.dart
@@ -2,9 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// TODO(nweiz): This is under lib so that it can be used by the unittest dummy
-// package. Once that package is no longer being updated, move this back into
-// bin.
 import 'dart:async';
 import 'dart:io';
 

--- a/pkgs/test_core/lib/src/util/dart.dart
+++ b/pkgs/test_core/lib/src/util/dart.dart
@@ -34,8 +34,6 @@ Future<Isolate> runInIsolate(String code, message,
       onExit: onExit);
 }
 
-// TODO(nweiz): Move this into the analyzer once it starts using SourceSpan
-// (issue 22977).
 /// Takes a span whose source is the value of a string that has been parsed from
 /// a Dart file and returns the corresponding span from within that Dart file.
 ///

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -48,9 +48,6 @@ final OperatingSystem currentOS = (() {
   throw UnsupportedError('Unsupported operating system "$name".');
 })();
 
-// TODO(nweiz): Make this `new SuitePlatform.current()` once we only support
-// Dart 2 and we can import `dart:io` from within cross-platform libraries. See
-// commit 4ffda6d2.
 /// Returns a [SuitePlatform] with the given [runtime], and with [os] and
 /// [inGoogle] determined automatically.
 ///

--- a/pkgs/test_core/lib/test_core.dart
+++ b/pkgs/test_core/lib/test_core.dart
@@ -64,7 +64,6 @@ Declarer get _declarer {
 
     var success = await runZoned(() => Invoker.guard(engine.run),
         zoneValues: {#test.declarer: _globalDeclarer});
-    // TODO(nweiz): Set the exit code on the VM when issue 6943 is fixed.
     if (success) return null;
     print('');
     unawaited(Future.error('Dummy exception to set exit code.'));

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.2.16
+version: 0.2.17-dev
 author: Dart Team <misc@dartlang.org>
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core


### PR DESCRIPTION
Remove TODO comments waiting for things that will never change or that
we don't intend to take action on.

- https://github.com/dart-lang/sdk/issues/22977 is closed as not
  planned.
- Dart 2 does not support importing `dart:io` in cross platform code.
- Setting the exit code is not supported on web.
- We plan on keeping `executable.dart` under lib to allow reuse from
  other packages internally.
- We don't plan on trying to support `spawnHybridUri` outside of the
  test runner.
- `executable.main` is now declared to return a `Future`.
- We don't intend to take a dependency on `json_schema`.