### PR TITLE
Use await for setUp callbacks

### DIFF
--- a/pkgs/test_api/lib/src/backend/declarer.dart
+++ b/pkgs/test_api/lib/src/backend/declarer.dart
@@ -293,7 +293,9 @@ class Declarer {
   /// completes immediately.
   Future _runSetUps() async {
     if (_parent != null) await _parent._runSetUps();
-    await Future.forEach(_setUps, (setUp) => setUp());
+    for (final setup in _setUps) {
+      await setup();
+    }
   }
 
   /// Returns a [Test] that runs the callbacks in [_setUpAll].


### PR DESCRIPTION
This improves the stacktraces for exceptions thrown in a setUp() callback.