### PR TITLE
Prepare to publish test_core and test

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,8 +1,7 @@
-## 1.10.1-dev
+## 1.11.0
 
 * Add `file_reporters` configuration option and `--file-reporter` CLI option to
   allow specifying a separate reporter that writes to a file instead of stdout.
-* Internal cleanup.
 
 ## 1.10.0
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.10.1-dev
+version: 1.11.0
 author: Dart Team <misc@dartlang.org>
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -32,7 +32,7 @@ dependencies:
   yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.2.12
-  test_core: 0.2.16
+  test_core: 0.2.17
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,8 +1,7 @@
-## 0.2.17-dev
+## 0.2.17
 
 * Add `file_reporters` configuration option and `--file-reporter` CLI option to
   allow specifying a separate reporter that writes to a file instead of stdout.
-* Internal cleanup.
 
 ## 0.2.16
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.2.17-dev
+version: 0.2.17
 author: Dart Team <misc@dartlang.org>
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core


### PR DESCRIPTION
- Bump to feature version change in `test`.
- Drop `-dev` from pubspecs.
- Pin to latest `test_core` from `test`.