### PR TITLE
Drop author from pubspecs

### DIFF
--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,6 +1,5 @@
 name: test
-version: 1.11.0
-author: Dart Team <misc@dartlang.org>
+version: 1.11.1-dev
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,6 +1,5 @@
 name: test_api
 version: 0.2.13-dev
-author: Dart Team <misc@dartlang.org>
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,6 +1,5 @@
 name: test_core
-version: 0.2.17
-author: Dart Team <misc@dartlang.org>
+version: 0.2.18-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
The field is no longer used by pub and triggers a warning on publish.