### PR TITLE
Avoid for-loop elements at the top level

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.1
+
+* Allow `test_api` `0.2.13` to work around a bug in the SDK version `2.3.0`.
+
 ## 1.11.0
 
 * Add `file_reporters` configuration option and `--file-reporter` CLI option to

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.11.1-dev
+version: 1.11.1
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
@@ -30,8 +30,8 @@ dependencies:
   web_socket_channel: ^1.0.0
   yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.2.12
-  test_core: 0.2.17
+  test_api: 0.2.13
+  test_core: 0.2.18
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.2.13-dev
+## 0.2.13
 
-* Internal cleanup.
+* Work around a bug in the `2.3.0` SDK by avoiding for-loop elements at the top
+  level.
 
 ## 0.2.12
 

--- a/pkgs/test_api/lib/src/backend/platform_selector.dart
+++ b/pkgs/test_api/lib/src/backend/platform_selector.dart
@@ -16,10 +16,10 @@ final _universalValidVariables = {
   'browser',
   'js',
   'blink',
-  'google',
-  for (var runtime in Runtime.builtIn) runtime.identifier,
-  for (var os in OperatingSystem.all) os.identifier,
-};
+  'google'
+}
+  ..addAll(Runtime.builtIn.map((r) => r.identifier))
+  ..addAll(OperatingSystem.all.map((os) => os.identifier));
 
 /// An expression for selecting certain platforms, including operating systems
 /// and browsers.

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.2.13-dev
+version: 0.2.13
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.18
+
+* Allow `test_api` `0.2.13` to work around a bug in the SDK version `2.3.0`.
+
 ## 0.2.17
 
 * Add `file_reporters` configuration option and `--file-reporter` CLI option to

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: test_core
-version: 0.2.18-dev
-description: A basic library for writing tests and running them on the VM.
+version: 0.2.18
+description: A basicanlibrary for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
 environment:
@@ -31,7 +31,7 @@ dependencies:
   # properly constrains all features it provides.
   matcher: ">=0.12.6 <0.12.7"
   # Use an exact version until the test_api package is stable.
-  test_api: 0.2.12
+  test_api: 0.2.13
 
 dependency_overrides:
   test_api:

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: test_core
 version: 0.2.18
-description: A basicanlibrary for writing tests and running them on the VM.
+description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
 environment:


### PR DESCRIPTION
Towards #1141

Work around the bug in the SDK by switching back to `..addAll`. After we
publish this version that works we can bump the min SDK.

Prepare to publish.