### PR TITLE
Bump min SDK to 2.4.0 for bug in for-loop elements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ after_failure:
 jobs:
   include:
     - stage: analyze_and_format
-      name: "SDK: 2.3.0; PKGS: pkgs/test, pkgs/test_api, pkgs/test_core; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.3.0"
+      name: "SDK: 2.4.0; PKGS: pkgs/test, pkgs/test_api, pkgs/test_core; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: "2.4.0"
       os: linux
       env: PKGS="pkgs/test pkgs/test_api pkgs/test_core"
       script: ./tool/travis.sh dartanalyzer_1

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.2-dev
+
+* Bump minimum SDK to `2.4.0` for safer usage of for-loop elements.
+
 ## 1.11.1
 
 * Allow `test_api` `0.2.13` to work around a bug in the SDK version `2.3.0`.

--- a/pkgs/test/mono_pkg.yaml
+++ b/pkgs/test/mono_pkg.yaml
@@ -9,7 +9,7 @@ stages:
         dart: dev
       - group:
         - dartanalyzer: --fatal-warnings .
-        dart: 2.3.0
+        dart: 2.4.0
     - unit_test:
       - command: xvfb-run -s "-screen 0 1024x768x24" pub run test --preset travis --total-shards 5 --shard-index 0
       - command: xvfb-run -s "-screen 0 1024x768x24" pub run test --preset travis --total-shards 5 --shard-index 1

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,10 +1,10 @@
 name: test
-version: 1.11.1
+version: 1.11.2-dev
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: '>=2.4.0 <3.0.0'
 
 dependencies:
   analyzer: ">=0.36.0 <0.40.0"
@@ -30,8 +30,8 @@ dependencies:
   web_socket_channel: ^1.0.0
   yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.2.13
-  test_core: 0.2.18
+  test_api: 0.2.14
+  test_core: 0.2.19
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 * Bump minimum SDK to `2.4.0` for safer usage of for-loop elements.
 
-
 ## 0.2.13
 
 * Work around a bug in the `2.3.0` SDK by avoiding for-loop elements at the top

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.14
+
+* Bump minimum SDK to `2.4.0` for safer usage of for-loop elements.
+
+
 ## 0.2.13
 
 * Work around a bug in the `2.3.0` SDK by avoiding for-loop elements at the top

--- a/pkgs/test_api/lib/src/backend/platform_selector.dart
+++ b/pkgs/test_api/lib/src/backend/platform_selector.dart
@@ -16,10 +16,10 @@ final _universalValidVariables = {
   'browser',
   'js',
   'blink',
-  'google'
-}
-  ..addAll(Runtime.builtIn.map((r) => r.identifier))
-  ..addAll(OperatingSystem.all.map((os) => os.identifier));
+  'google',
+  for (var runtime in Runtime.builtIn) runtime.identifier,
+  for (var os in OperatingSystem.all) os.identifier,
+};
 
 /// An expression for selecting certain platforms, including operating systems
 /// and browsers.

--- a/pkgs/test_api/mono_pkg.yaml
+++ b/pkgs/test_api/mono_pkg.yaml
@@ -6,7 +6,7 @@ stages:
         dart: dev
       - group:
         - dartanalyzer: --fatal-warnings .
-        dart: 2.3.0
+        dart: 2.4.0
     - unit_test:
       - group:
         - test: --preset travis

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,10 +1,10 @@
 name: test_api
-version: 0.2.13
+version: 0.2.14-dev
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.4.0 <3.0.0"
 
 dependencies:
   async: ^2.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.19-dev
+
+* Bump minimum SDK to `2.4.0` for safer usage of for-loop elements.
+
 ## 0.2.18
 
 * Allow `test_api` `0.2.13` to work around a bug in the SDK version `2.3.0`.

--- a/pkgs/test_core/mono_pkg.yaml
+++ b/pkgs/test_core/mono_pkg.yaml
@@ -6,4 +6,4 @@ stages:
       dart: dev
     - group:
       - dartanalyzer: --fatal-warnings .
-      dart: 2.3.0
+      dart: 2.4.0

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,10 +1,10 @@
 name: test_core
-version: 0.2.18
+version: 0.2.19-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.4.0 <3.0.0"
 
 dependencies:
   analyzer: ">=0.36.0 <0.40.0"
@@ -31,7 +31,7 @@ dependencies:
   # properly constrains all features it provides.
   matcher: ">=0.12.6 <0.12.7"
   # Use an exact version until the test_api package is stable.
-  test_api: 0.2.13
+  test_api: 0.2.14
 
 dependency_overrides:
   test_api:


### PR DESCRIPTION
Close #1141

Bump min SDK in all packages for safety. Restore use of for-loop
elements in a top level variable since they work in this SDK.