### PR TITLE
Flexible Coverage API

### DIFF
--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.2.14
-  test_core: 0.2.19
+  test_core: 0.3.0
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,10 +1,11 @@
-## 0.2.19-dev
+## 0.3.0-dev
 
 * Bump minimum SDK to `2.4.0` for safer usage of for-loop elements.
 * Deprecate `PhantomJS` and provide warning when used. Support for `PhantomJS`
   will be removed in version `2.0.0`.
 * Differentiate between test-randomize-ordering-seed not set and 0 being chosen
   as the random seed.
+* `deserializeSuite` now takes an optional `gatherCoverage` callback.
 
 ## 0.2.18
 

--- a/pkgs/test_core/lib/src/runner/coverage.dart
+++ b/pkgs/test_core/lib/src/runner/coverage.dart
@@ -14,7 +14,7 @@ Future<void> writeCoverage(
     String coveragePath, LiveSuiteController controller) async {
   var suite = controller.liveSuite.suite;
   var coverage = await controller.liveSuite.suite.gatherCoverage();
-  final outfile = File(p.join('$coveragePath',
+  final outfile = File(p.join(coveragePath,
       '${suite.path}.${suite.platform.runtime.name.toLowerCase()}.json'))
     ..createSync(recursive: true);
   final out = outfile.openWrite();

--- a/pkgs/test_core/lib/src/runner/coverage.dart
+++ b/pkgs/test_core/lib/src/runner/coverage.dart
@@ -5,29 +5,20 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:coverage/coverage.dart';
 import 'package:path/path.dart' as p;
 
 import 'live_suite_controller.dart';
 
-/// Collects coverage and outputs to the [coverage] path.
-Future<void> gatherCoverage(
-    String coverage, LiveSuiteController controller) async {
-  final suite = controller.liveSuite.suite;
-
-  if (!suite.platform.runtime.isDartVM) return;
-
-  final isolateId = Uri.parse(suite.environment.observatoryUrl.fragment)
-      .queryParameters['isolateId'];
-
-  final cov = await collect(
-      suite.environment.observatoryUrl, false, false, false, {},
-      isolateIds: {isolateId});
-
-  final outfile = File(p.join('$coverage', '${suite.path}.vm.json'))
+/// Collects coverage and outputs to the [coveragePath] path.
+Future<void> writeCoverage(
+    String coveragePath, LiveSuiteController controller) async {
+  var suite = controller.liveSuite.suite;
+  var coverage = await controller.liveSuite.suite.gatherCoverage();
+  final outfile = File(p.join('$coveragePath',
+      '${suite.path}.${suite.platform.runtime.name.toLowerCase()}.json'))
     ..createSync(recursive: true);
   final out = outfile.openWrite();
-  out.write(json.encode(cov));
+  out.write(json.encode(coverage));
   await out.flush();
   await out.close();
 }

--- a/pkgs/test_core/lib/src/runner/coverage_stub.dart
+++ b/pkgs/test_core/lib/src/runner/coverage_stub.dart
@@ -4,6 +4,7 @@
 
 import 'live_suite_controller.dart';
 
-Future<void> gatherCoverage(String coverage, LiveSuiteController controller) =>
+Future<void> writeCoverage(
+        String coveragePath, LiveSuiteController controller) =>
     throw UnsupportedError(
         'Coverage is only supported through the test runner.');

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -285,7 +285,7 @@ class Engine {
           if (_closed) return;
           await _runGroup(controller, controller.liveSuite.suite.group, []);
           controller.noMoreLiveTests();
-          if (_coverage != null) await gatherCoverage(_coverage, controller);
+          if (_coverage != null) await writeCoverage(_coverage, controller);
           loadResource.allowRelease(() => controller.close());
         });
       }());

--- a/pkgs/test_core/lib/src/runner/load_suite.dart
+++ b/pkgs/test_core/lib/src/runner/load_suite.dart
@@ -6,27 +6,23 @@ import 'dart:async';
 
 import 'package:stack_trace/stack_trace.dart';
 import 'package:stream_channel/stream_channel.dart';
-
 import 'package:test_api/src/backend/group.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/invoker.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/metadata.dart'; // ignore: implementation_imports
+import 'package:test_api/src/backend/runtime.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/suite.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/suite_platform.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/test.dart'; // ignore: implementation_imports
-import 'package:test_api/src/backend/runtime.dart'; // ignore: implementation_imports
 import 'package:test_api/src/utils.dart'; // ignore: implementation_imports
 
-import 'runner_suite.dart';
-import 'suite.dart';
-
 import '../../test_core.dart';
-
-// ignore: uri_does_not_exist
 import '../util/io_stub.dart'
     // ignore: uri_does_not_exist
     if (dart.library.io) '../util/io.dart';
 import 'load_exception.dart';
 import 'plugin/environment.dart';
+import 'runner_suite.dart';
+import 'suite.dart';
 
 /// The timeout for loading a test suite.
 ///
@@ -214,4 +210,8 @@ class LoadSuite extends Suite implements RunnerSuite {
 
   @override
   Future close() async {}
+
+  @override
+  Future<Map<String, dynamic>> gatherCoverage() =>
+      throw UnsupportedError('Coverage is not supported for LoadSuite tests.');
 }

--- a/pkgs/test_core/lib/src/runner/plugin/platform_helpers.dart
+++ b/pkgs/test_core/lib/src/runner/plugin/platform_helpers.dart
@@ -7,19 +7,18 @@ import 'dart:io';
 
 import 'package:stack_trace/stack_trace.dart';
 import 'package:stream_channel/stream_channel.dart';
-
 import 'package:test_api/src/backend/group.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/metadata.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/suite_platform.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/test.dart'; // ignore: implementation_imports
 import 'package:test_api/src/util/remote_exception.dart'; // ignore: implementation_imports
 
-import '../runner_suite.dart';
-import '../environment.dart';
-import '../suite.dart';
 import '../configuration.dart';
+import '../environment.dart';
 import '../load_exception.dart';
+import '../runner_suite.dart';
 import '../runner_test.dart';
+import '../suite.dart';
 
 /// A helper method for creating a [RunnerSuiteController] containing tests
 /// that communicate over [channel].
@@ -35,13 +34,17 @@ import '../runner_test.dart';
 ///
 /// If [mapper] is passed, it will be used to adjust stack traces for any errors
 /// emitted by tests.
+///
+/// [gatherCoverage] is a callback which returns a hit-map containing merged
+/// coverage report suitable for use with `package:coverage`.
 RunnerSuiteController deserializeSuite(
     String path,
     SuitePlatform platform,
     SuiteConfiguration suiteConfig,
     Environment environment,
     StreamChannel channel,
-    Object message) {
+    Object message,
+    {Future<Map<String, dynamic>> Function() gatherCoverage}) {
   var disconnector = Disconnector();
   var suiteChannel = MultiChannel(channel.transform(disconnector));
 
@@ -110,7 +113,8 @@ RunnerSuiteController deserializeSuite(
   return RunnerSuiteController(
       environment, suiteConfig, suiteChannel, completer.future, platform,
       path: path,
-      onClose: () => disconnector.disconnect().catchError(handleError));
+      onClose: () => disconnector.disconnect().catchError(handleError),
+      gatherCoverage: gatherCoverage);
 }
 
 /// A utility class for storing state while deserializing tests.

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.2.19-dev
+version: 0.3.0-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
Towards https://github.com/dart-lang/test/issues/36

Update `deserializeSuite` to take an optional callback for coverage collection. Note that each platform e.g. VM, Browser etc. makes use of this helper. This sets the foundation for per platform custom coverage collection logic. 