### PR TITLE
Allow retry load suites

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -5,9 +5,6 @@
   will be removed in version `2.0.0`.
 * Support coverage collection for the Chrome platform. See `README.md` for usage
   details.
-* Support retrying of entire test suites when they fail to load.
-* Fix the `compiling` message in precompiled mode so it says `loading` instead,
-  which is more accurate.
 
 ## 1.11.1
 

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -5,6 +5,9 @@
   will be removed in version `2.0.0`.
 * Support coverage collection for the Chrome platform. See `README.md` for usage
   details.
+* Support retrying of entire test suites when they fail to load.
+* Fix the `compiling` message in precompiled mode so it says `loading` instead,
+  which is more accurate.
 
 ## 1.11.1
 

--- a/pkgs/test/test/runner/loader_test.dart
+++ b/pkgs/test/test/runner/loader_test.dart
@@ -3,7 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+import 'dart:async';
 
+import 'package:pedantic/pedantic.dart';
 import 'package:path/path.dart' as p;
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
@@ -150,6 +152,46 @@ void main() {
         completion(equals('print within test')));
     await liveTest.run();
     expectTestPassed(liveTest);
+  });
+
+  group('LoadException', () {
+    test('suites can be retried', () async {
+      var numRetries = 5;
+
+      await d.file('a_test.dart', '''
+      import 'hello.dart';
+
+      void main() {}
+    ''').create();
+
+      var firstFailureCompleter = Completer<void>();
+
+      // After the first load failure we create the missing dependency.
+      unawaited(firstFailureCompleter.future.then((_) async {
+        await d.file('hello.dart', '''
+      String get message => 'hello';
+    ''').create();
+      }));
+
+      await runZoned(() async {
+        var suites = await _loader
+            .loadFile(p.join(d.sandbox, 'a_test.dart'),
+                SuiteConfiguration(retry: numRetries))
+            .toList();
+        expect(suites, hasLength(1));
+        var loadSuite = suites.first;
+        var suite = await loadSuite.getSuite();
+        expect(suite.path, equals(p.join(d.sandbox, 'a_test.dart')));
+        expect(suite.platform.runtime, equals(Runtime.vm));
+      }, zoneSpecification:
+          ZoneSpecification(print: (_, parent, zone, message) {
+        if (message.contains('Retrying load of') &&
+            !firstFailureCompleter.isCompleted) {
+          firstFailureCompleter.complete(null);
+        }
+        parent.print(zone, message);
+      }));
+    });
   });
 
   // TODO: Test load suites. Don't forget to test that prints in loaded files

--- a/pkgs/test/test/runner/loader_test.dart
+++ b/pkgs/test/test/runner/loader_test.dart
@@ -191,6 +191,8 @@ void main() {
         }
         parent.print(zone, message);
       }));
+
+      expect(firstFailureCompleter.isCompleted, true);
     });
   });
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Differentiate between test-randomize-ordering-seed not set and 0 being chosen
   as the random seed.
 * `deserializeSuite` now takes an optional `gatherCoverage` callback.
+* Support retrying of entire test suites when they fail to load.
+* Fix the `compiling` message in precompiled mode so it says `loading` instead,
+  which is more accurate.
 
 ## 0.2.18
 

--- a/pkgs/test_core/lib/src/runner/loader.dart
+++ b/pkgs/test_core/lib/src/runner/loader.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'package:analyzer/analyzer.dart' hide Configuration;
 import 'package:async/async.dart';
 import 'package:path/path.dart' as p;
+import 'package:pool/pool.dart';
 import 'package:source_span/source_span.dart';
 import 'package:yaml/yaml.dart';
 
@@ -55,6 +56,10 @@ class Loader {
 
   /// The user-provided settings for runtimes.
   final _parsedRuntimeSettings = <Runtime, Object>{};
+
+  /// Pool that limits the number of suites loaded at once to the current
+  /// configurations concurrency limit.
+  final _loadingPool = Pool(Configuration.current.concurrency);
 
   /// All plaforms supported by this [Loader].
   List<Runtime> get allRuntimes => List.unmodifiable(_platformCallbacks.keys);
@@ -220,34 +225,43 @@ class Loader {
                   ? 'compiling '
                   : 'loading ') +
               path;
-      yield LoadSuite(name, platformConfig, platform, () async {
-        var memo = _platformPlugins[platform.runtime];
+      yield LoadSuite(
+          name,
+          platformConfig,
+          platform,
+          () => _loadingPool.withResource<RunnerSuite>(() async {
+                var memo = _platformPlugins[platform.runtime];
 
-        var retriesLeft = suiteConfig.metadata.retry;
-        while (true) {
-          try {
-            var plugin =
-                await memo.runOnce(_platformCallbacks[platform.runtime]);
-            _customizePlatform(plugin, platform.runtime);
-            var suite = await plugin.load(path, platform, platformConfig,
-                {'platformVariables': _runtimeVariables.toList()});
-            if (suite != null) _suites.add(suite);
-            return suite;
-          } catch (error, stackTrace) {
-            if (retriesLeft > 0) {
-              retriesLeft--;
-              print('Retrying load of $path in 1s ($retriesLeft remaining)');
-              await Future.delayed(Duration(seconds: 1));
-              continue;
-            }
-            if (error is LoadException) {
-              rethrow;
-            }
-            await Future.error(LoadException(path, error), stackTrace);
-            return null;
-          }
-        }
-      }, path: path);
+                var retriesLeft = suiteConfig.metadata.retry;
+                while (true) {
+                  try {
+                    var plugin = await memo
+                        .runOnce(_platformCallbacks[platform.runtime]);
+                    _customizePlatform(plugin, platform.runtime);
+                    var suite = await plugin.load(
+                        path,
+                        platform,
+                        platformConfig,
+                        {'platformVariables': _runtimeVariables.toList()});
+                    if (suite != null) _suites.add(suite);
+                    return suite;
+                  } catch (error, stackTrace) {
+                    if (retriesLeft > 0) {
+                      retriesLeft--;
+                      print(
+                          'Retrying load of $path in 1s ($retriesLeft remaining)');
+                      await Future.delayed(Duration(seconds: 1));
+                      continue;
+                    }
+                    if (error is LoadException) {
+                      rethrow;
+                    }
+                    await Future.error(LoadException(path, error), stackTrace);
+                    return null;
+                  }
+                }
+              }),
+          path: path);
     }
   }
 

--- a/pkgs/test_core/lib/src/runner/loader.dart
+++ b/pkgs/test_core/lib/src/runner/loader.dart
@@ -215,7 +215,11 @@ class Loader {
         continue;
       }
 
-      var name = (platform.runtime.isJS ? 'compiling ' : 'loading ') + path;
+      var name =
+          (platform.runtime.isJS && platformConfig.precompiledPath == null
+                  ? 'compiling '
+                  : 'loading ') +
+              path;
       yield LoadSuite(name, platformConfig, platform, () async {
         var memo = _platformPlugins[platform.runtime];
 


### PR DESCRIPTION
Partial resolution for https://github.com/dart-lang/test/issues/1159.

Retries loading test suites (in loader.dart). Retry configuration is currently based on the suite metadata - and is counted separately from the test retries (does not count as a retry for tests).

Should we configure this separately from normal test retries? It might be reasonable to do retries for loading errors by default for instance (as they are likely transient and caused by test infrastructure). Also you might want to be able to opt into retrying load errors but not test failures.

Note that I also added an artificial delay of 1 second between retries. This seems reasonable to allow for any external factors that might be causing the load error to work themselves out. We might want to also make that configurable or have it do an exponential backoff.

Any other general comments?

cc @jonahwilliams