### PR TITLE
Avoid unhandled errors in spawnHybridUri

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -17,6 +17,7 @@
   * Previously the loading pool was 2x larger than the actual concurrency
     setting which could cause flaky tests due to tests being loaded while
     other tests were running, even with `-j1`.
+* Avoid printing uncaught errors within `spawnHybridUri`.
 
 ## 0.2.18
 

--- a/pkgs/test_core/lib/src/runner/hybrid_listener.dart
+++ b/pkgs/test_core/lib/src/runner/hybrid_listener.dart
@@ -74,7 +74,7 @@ void listen(Function Function() getMain, List data) {
   }, onError: (error, stackTrace) async {
     _sendError(channel, error, stackTrace);
     await channel.sink.close();
-    Zone.current.handleUncaughtError(error, stackTrace);
+    Isolate.current.kill();
   });
 }
 


### PR DESCRIPTION
Closes #1007
Closes #1008

We already forward errors across the `StreamChannel` so it isn't
particularly useful to also have them printed to the output on the VM
hosting the runner.

We know that `listen` is only ever called in an Isolate that was spawned
from the runner and the `zone` is the root zone. The uncaught error
handler on the root zone will print the error and then kill the isolate,
we jump straight to killing the isolate instead. This Isolate is only
ever spawned without an `onError` handler that would override the
default.