### PR TITLE
Fix some documentation to use expectLater

### DIFF
--- a/pkgs/test/README.md
+++ b/pkgs/test/README.md
@@ -459,14 +459,14 @@ void main() {
     ]));
 
     // Ignore lines from the process until it's about to emit the URL.
-    await expect(stdout, emitsThrough('WebSocket URL:'));
+    await expectLater(stdout, emitsThrough('WebSocket URL:'));
 
     // Parse the next line as a URL.
     var url = Uri.parse(await stdout.next);
     expect(url.host, equals('localhost'));
 
     // You can match against the same StreamQueue multiple times.
-    await expect(stdout, emits('Waiting for connection...'));
+    await expectLater(stdout, emits('Waiting for connection...'));
   });
 }
 ```

--- a/pkgs/test_api/lib/src/frontend/stream_matcher.dart
+++ b/pkgs/test_api/lib/src/frontend/stream_matcher.dart
@@ -48,14 +48,14 @@ typedef _MatchQueue = Future<String> Function(StreamQueue queue);
 /// var stdout = StreamQueue(stdoutLineStream);
 ///
 /// // Ignore lines from the process until it's about to emit the URL.
-/// await expect(stdout, emitsThrough("WebSocket URL:"));
+/// await expectLater(stdout, emitsThrough('WebSocket URL:'));
 ///
 /// // Parse the next line as a URL.
 /// var url = Uri.parse(await stdout.next);
 /// expect(url.host, equals('localhost'));
 ///
 /// // You can match against the same StreamQueue multiple times.
-/// await expect(stdout, emits("Waiting for connection..."));
+/// await expectLater(stdout, emits('Waiting for connection...'));
 /// ```
 ///
 /// Users can call [new StreamMatcher] to create custom matchers.


### PR DESCRIPTION
Closes #1015

Our recommendation is that code which wants to `await` the result of an
expectation should use `expectLater`. Update the docs and README to
reflect this.