### PR TITLE
Remove an unnecessary await on event loop

### DIFF
--- a/pkgs/test/test/runner/engine_test.dart
+++ b/pkgs/test/test/runner/engine_test.dart
@@ -69,8 +69,8 @@ void main() {
       });
     });
     expect(engine.run(), completion(isFalse));
-    unawaited(engine.close());
     await pumpEventQueue();
+    unawaited(engine.close());
     // We need to complete this so the outer test finishes.
     completer.complete();
   });

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -536,8 +536,8 @@ class Engine {
   Future close() async {
     _closed = true;
     if (_closedBeforeDone != null) _closedBeforeDone = true;
-    await _onSuiteAddedController.close();
     await _suiteController.close();
+    await _onSuiteAddedController.close();
 
     // Close the running tests first so that we're sure to wait for them to
     // finish before we close their suites and cause them to become unloaded.

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -534,8 +534,6 @@ class Engine {
   /// Closing [suiteSink] indicates that no more input will be provided, closing
   /// the engine indicates that no more output should be emitted.
   Future close() async {
-    // TODO(grouma) - Remove this unecessary await.
-    await Future(() {});
     _closed = true;
     if (_closedBeforeDone != null) _closedBeforeDone = true;
     await _onSuiteAddedController.close();


### PR DESCRIPTION
Closes #865

The tests no longer fail without this.