### PR TITLE
Remove arguments to runInIsolate utility

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1-dev
+
+* Enable asserts in code running through `spawnHybrid` APIs.
+
 ## 0.3.0
 
 * Bump minimum SDK to `2.4.0` for safer usage of for-loop elements.

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -139,7 +139,7 @@ Future<Isolate> _spawnDataIsolate(String path, SendPort message) async {
       var channel = serializeSuite(() => test.main);
       IsolateChannel.connectSend(message).pipe(channel);
     }
-  ''', message, checked: true);
+  ''', message);
 }
 
 Future<Isolate> _spawnPrecompiledIsolate(

--- a/pkgs/test_core/lib/src/util/dart.dart
+++ b/pkgs/test_core/lib/src/util/dart.dart
@@ -8,7 +8,6 @@ import 'dart:isolate';
 
 // ignore: deprecated_member_use
 import 'package:analyzer/analyzer.dart';
-import 'package:package_resolver/package_resolver.dart';
 import 'package:source_span/source_span.dart';
 
 import 'string_literal_iterator.dart';
@@ -19,20 +18,13 @@ import 'string_literal_iterator.dart';
 /// they will be resolved in the same context as the host isolate. [message] is
 /// passed to the [main] method of the code being run; the caller is responsible
 /// for using this to establish communication with the isolate.
-///
-/// If [resolver] is passed, its package resolution strategy is used to resolve
-/// code in the spawned isolate. It defaults to [PackageResolver.current].
-Future<Isolate> runInIsolate(String code, message,
-    {PackageResolver resolver, bool checked, SendPort onExit}) async {
-  resolver ??= PackageResolver.current;
-  return await Isolate.spawnUri(
-      Uri.dataFromString(code, mimeType: 'application/dart', encoding: utf8),
-      [],
-      message,
-      packageConfig: await resolver.packageConfigUri,
-      checked: checked,
-      onExit: onExit);
-}
+Future<Isolate> runInIsolate(String code, Object message, {SendPort onExit}) =>
+    Isolate.spawnUri(
+        Uri.dataFromString(code, mimeType: 'application/dart', encoding: utf8),
+        [],
+        message,
+        checked: true,
+        onExit: onExit);
 
 /// Takes a span whose source is the value of a string that has been parsed from
 /// a Dart file and returns the corresponding span from within that Dart file.

--- a/pkgs/test_core/lib/src/util/dart.dart
+++ b/pkgs/test_core/lib/src/util/dart.dart
@@ -18,11 +18,13 @@ import 'string_literal_iterator.dart';
 /// they will be resolved in the same context as the host isolate. [message] is
 /// passed to the [main] method of the code being run; the caller is responsible
 /// for using this to establish communication with the isolate.
-Future<Isolate> runInIsolate(String code, Object message, {SendPort onExit}) =>
+Future<Isolate> runInIsolate(String code, Object message,
+        {SendPort onExit}) async =>
     Isolate.spawnUri(
         Uri.dataFromString(code, mimeType: 'application/dart', encoding: utf8),
         [],
         message,
+        packageConfig: await Isolate.packageConfig,
         checked: true,
         onExit: onExit);
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.0
+version: 0.3.1-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
The `resolver` argument was only used from external packages which can
be migrated off this utility.

The `checked` argument was only used to allow `spawnHybrid` APIs to run
code without asserts, but we want all test code to run with asserts,
including server side utilities.