### PR TITLE
Fix stack trace mapping for SDK locations

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.12.1-dev
+
+* Fix the stack trace labels in SDK code for `dart2js` compiled tests.
+
 ## 1.12.0
 
 * Bump minimum SDK to `2.4.0` for safer usage of for-loop elements.

--- a/pkgs/test/lib/src/runner/browser/platform.dart
+++ b/pkgs/test/lib/src/runner/browser/platform.dart
@@ -411,7 +411,7 @@ class BrowserPlatform extends PlatformPlugin
       _mappers[dartPath] = JSStackTraceMapper(File(mapPath).readAsStringSync(),
           mapUrl: p.toUri(mapPath),
           packageResolver: await PackageResolver.current.asSync,
-          sdkRoot: p.toUri(sdkDir));
+          sdkRoot: Uri.parse('org-dartlang-sdk:///sdk'));
     });
   }
 

--- a/pkgs/test/lib/src/runner/node/platform.dart
+++ b/pkgs/test/lib/src/runner/node/platform.dart
@@ -196,7 +196,7 @@ class NodePlatform extends PlatformPlugin
       mapper = JSStackTraceMapper(await File(mapPath).readAsString(),
           mapUrl: p.toUri(mapPath),
           packageResolver: resolver,
-          sdkRoot: p.toUri(sdkDir));
+          sdkRoot: Uri.parse('org-dartlang-sdk:///sdk'));
     }
 
     return Pair(await _startProcess(runtime, jsPath, socketPort), mapper);

--- a/pkgs/test/lib/src/runner/node/platform.dart
+++ b/pkgs/test/lib/src/runner/node/platform.dart
@@ -173,7 +173,7 @@ class NodePlatform extends PlatformPlugin
       mapper = JSStackTraceMapper(await File(mapPath).readAsString(),
           mapUrl: p.toUri(mapPath),
           packageResolver: await PackageResolver.current.asSync,
-          sdkRoot: p.toUri(sdkDir));
+          sdkRoot: Uri.parse('org-dartlang-sdk:///sdk'));
     }
 
     return Pair(await _startProcess(runtime, jsPath, socketPort), mapper);

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.12.0
+version: 1.12.1-dev
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 

--- a/pkgs/test/test/runner/browser/runner_test.dart
+++ b/pkgs/test/test/runner/browser/runner_test.dart
@@ -700,10 +700,13 @@ void main() {
     var test = await runTest(['-p', 'chrome', '--verbose-trace', 'test.dart']);
     expect(
         test.stdout,
-        containsInOrder(
-            [' main.<fn>', 'package:test', 'dart:async/zone.dart']));
+        containsInOrder([
+          ' main.<fn>',
+          'package:test',
+          'org-dartlang-sdk:///sdk/lib/async/zone.dart'
+        ]));
     await test.shouldExit(1);
-  }, tags: 'chrome', skip: 'Broken by sdk#32633');
+  }, tags: 'chrome');
 
   test("doesn't dartify stack traces for JS-compiled tests with --js-trace",
       () async {
@@ -713,7 +716,8 @@ void main() {
         ['-p', 'chrome', '--verbose-trace', '--js-trace', 'test.dart']);
     expect(test.stdoutStream(), neverEmits(endsWith(' main.<fn>')));
     expect(test.stdoutStream(), neverEmits(contains('package:test')));
-    expect(test.stdoutStream(), neverEmits(contains('dart:async/zone.dart')));
+    expect(test.stdoutStream(),
+        neverEmits(contains('org-dartlang-sdk:///sdk/lib/async/zone.dart')));
     expect(test.stdout, emitsThrough(contains('-1: Some tests failed.')));
     await test.shouldExit(1);
   }, tags: 'chrome');

--- a/pkgs/test/test/runner/browser/runner_test.dart
+++ b/pkgs/test/test/runner/browser/runner_test.dart
@@ -700,11 +700,8 @@ void main() {
     var test = await runTest(['-p', 'chrome', '--verbose-trace', 'test.dart']);
     expect(
         test.stdout,
-        containsInOrder([
-          ' main.<fn>',
-          'package:test',
-          'org-dartlang-sdk:///sdk/lib/async/zone.dart'
-        ]));
+        containsInOrder(
+            [' main.<fn>', 'package:test', 'dart:async/zone.dart']));
     await test.shouldExit(1);
   }, tags: 'chrome');
 
@@ -716,8 +713,7 @@ void main() {
         ['-p', 'chrome', '--verbose-trace', '--js-trace', 'test.dart']);
     expect(test.stdoutStream(), neverEmits(endsWith(' main.<fn>')));
     expect(test.stdoutStream(), neverEmits(contains('package:test')));
-    expect(test.stdoutStream(),
-        neverEmits(contains('org-dartlang-sdk:///sdk/lib/async/zone.dart')));
+    expect(test.stdoutStream(), neverEmits(contains('dart:async/zone.dart')));
     expect(test.stdout, emitsThrough(contains('-1: Some tests failed.')));
     await test.shouldExit(1);
   }, tags: 'chrome');

--- a/pkgs/test/test/runner/node/runner_test.dart
+++ b/pkgs/test/test/runner/node/runner_test.dart
@@ -199,11 +199,8 @@ void main() {
     var test = await runTest(['-p', 'node', '--verbose-trace', 'test.dart']);
     expect(
         test.stdout,
-        containsInOrder([
-          ' main.<fn>',
-          'package:test',
-          'org-dartlang-sdk:///sdk/lib/async/zone.dart'
-        ]));
+        containsInOrder(
+            [' main.<fn>', 'package:test', 'dart:async/zone.dart']));
     await test.shouldExit(1);
   });
 
@@ -215,8 +212,7 @@ void main() {
         ['-p', 'node', '--verbose-trace', '--js-trace', 'test.dart']);
     expect(test.stdoutStream(), neverEmits(endsWith(' main.<fn>')));
     expect(test.stdoutStream(), neverEmits(contains('package:test')));
-    expect(test.stdoutStream(),
-        neverEmits(contains('org-dartlang-sdk:///sdk/lib/async/zone.dart')));
+    expect(test.stdoutStream(), neverEmits(contains('dart:async/zone.dart')));
     expect(test.stdout, emitsThrough(contains('-1: Some tests failed.')));
     await test.shouldExit(1);
   });

--- a/pkgs/test/test/runner/node/runner_test.dart
+++ b/pkgs/test/test/runner/node/runner_test.dart
@@ -199,10 +199,13 @@ void main() {
     var test = await runTest(['-p', 'node', '--verbose-trace', 'test.dart']);
     expect(
         test.stdout,
-        containsInOrder(
-            [' main.<fn>', 'package:test', 'dart:async/zone.dart']));
+        containsInOrder([
+          ' main.<fn>',
+          'package:test',
+          'org-dartlang-sdk:///sdk/lib/async/zone.dart'
+        ]));
     await test.shouldExit(1);
-  }, skip: 'Broken by sdk#32633');
+  });
 
   test("doesn't dartify stack traces for JS-compiled tests with --js-trace",
       () async {
@@ -212,7 +215,8 @@ void main() {
         ['-p', 'node', '--verbose-trace', '--js-trace', 'test.dart']);
     expect(test.stdoutStream(), neverEmits(endsWith(' main.<fn>')));
     expect(test.stdoutStream(), neverEmits(contains('package:test')));
-    expect(test.stdoutStream(), neverEmits(contains('dart:async/zone.dart')));
+    expect(test.stdoutStream(),
+        neverEmits(contains('org-dartlang-sdk:///sdk/lib/async/zone.dart')));
     expect(test.stdout, emitsThrough(contains('-1: Some tests failed.')));
     await test.shouldExit(1);
   });

--- a/pkgs/test/test/runner/pub_serve_test.dart
+++ b/pkgs/test/test/runner/pub_serve_test.dart
@@ -218,11 +218,8 @@ void main() {
             await runTest([_pubServeArg, '-p', 'chrome', '--verbose-trace']);
         expect(
             test.stdout,
-            containsInOrder([
-              ' main.<fn>',
-              'package:test',
-              'org-dartlang-sdk:///sdk/lib/async/zone.dart'
-            ]));
+            containsInOrder(
+                [' main.<fn>', 'package:test', 'dart:async/zone.dart']));
         await test.shouldExit(1);
         await pub.kill();
       }, tags: 'chrome');
@@ -233,11 +230,8 @@ void main() {
             await runTest([_pubServeArg, '-p', 'node', '--verbose-trace']);
         expect(
             test.stdout,
-            containsInOrder([
-              ' main.<fn>',
-              'package:test',
-              'org-dartlang-sdk:///sdk/lib/async/zone.dart'
-            ]));
+            containsInOrder(
+                [' main.<fn>', 'package:test', 'dart:async/zone.dart']));
         await test.shouldExit(1);
         await pub.kill();
       }, tags: 'node');

--- a/pkgs/test/test/runner/pub_serve_test.dart
+++ b/pkgs/test/test/runner/pub_serve_test.dart
@@ -218,8 +218,11 @@ void main() {
             await runTest([_pubServeArg, '-p', 'chrome', '--verbose-trace']);
         expect(
             test.stdout,
-            containsInOrder(
-                [' main.<fn>', 'package:test', 'dart:async/zone.dart']));
+            containsInOrder([
+              ' main.<fn>',
+              'package:test',
+              'org-dartlang-sdk:///sdk/lib/async/zone.dart'
+            ]));
         await test.shouldExit(1);
         await pub.kill();
       }, tags: 'chrome');
@@ -230,12 +233,15 @@ void main() {
             await runTest([_pubServeArg, '-p', 'node', '--verbose-trace']);
         expect(
             test.stdout,
-            containsInOrder(
-                [' main.<fn>', 'package:test', 'dart:async/zone.dart']));
+            containsInOrder([
+              ' main.<fn>',
+              'package:test',
+              'org-dartlang-sdk:///sdk/lib/async/zone.dart'
+            ]));
         await test.shouldExit(1);
         await pub.kill();
       }, tags: 'node');
-    }, skip: 'Broken by sdk#32633');
+    });
 
     group("doesn't dartify stack traces for JS-compiled tests with --js-trace",
         () {


### PR DESCRIPTION
These were disabled because non-hermetic URIs were present. They have
been replaced with `org-dartlang-sdk` URIs. Update the SDK URI base so
that the replacement works for these URIs.

The tests in `pub_serve_test.dart` are still skipped for other reasons
so we can't guarantee they are fixed correctly here. Once we unskip
those tests we wouldn't want to hide issues with the stack trace
mapping, so we'll remove that reason for the skip.