### PR TITLE
Drop package resolver from test_core and test, use package_config from test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ after_failure:
 jobs:
   include:
     - stage: analyze_and_format
-      name: "SDK: 2.4.0; PKGS: pkgs/test, pkgs/test_api, pkgs/test_core; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.4.0"
+      name: "SDK: 2.7.0; PKGS: pkgs/test, pkgs/test_api, pkgs/test_core; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: "2.7.0"
       os: linux
       env: PKGS="pkgs/test pkgs/test_api pkgs/test_core"
       script: ./tool/travis.sh dartanalyzer_1

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -23,7 +23,6 @@
   will be removed in version `2.0.0`.
 * Support coverage collection for the Chrome platform. See `README.md` for usage
   details.
-* Drop `package_resolver` dependency for a `package_config` dependency. 
 
 ## 1.11.1
 

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -9,6 +9,7 @@
   will be removed in version `2.0.0`.
 * Support coverage collection for the Chrome platform. See `README.md` for usage
   details.
+* Drop `package_resolver` dependency for a `package_config` dependency. 
 
 ## 1.11.1
 

--- a/pkgs/test/lib/src/runner/browser/platform.dart
+++ b/pkgs/test/lib/src/runner/browser/platform.dart
@@ -9,7 +9,6 @@ import 'dart:isolate';
 
 import 'package:async/async.dart';
 import 'package:http_multi_server/http_multi_server.dart';
-import 'package:package_resolver/package_resolver.dart';
 import 'package:path/path.dart' as p;
 import 'package:pool/pool.dart';
 import 'package:shelf/shelf.dart' as shelf;
@@ -37,6 +36,7 @@ import 'package:test_core/src/runner/load_exception.dart'; // ignore: implementa
 import 'package:test_core/src/runner/plugin/customizable_platform.dart'; // ignore: implementation_imports
 
 import '../executable_settings.dart';
+import '../../util/package_map.dart';
 import '../../util/path_handler.dart';
 import '../../util/one_off_handler.dart';
 import 'browser_manager.dart';
@@ -348,8 +348,9 @@ class BrowserPlatform extends PlatformPlugin
         if (getSourceMap && !suiteConfig.jsTrace) {
           _mappers[path] = JSStackTraceMapper(await utf8.decodeStream(response),
               mapUrl: url,
-              packageResolver: SyncPackageResolver.root('packages'),
-              sdkRoot: p.toUri('packages/\$sdk'));
+              sdkRoot: p.toUri('packages/\$sdk'),
+              packageMap:
+                  (await currentPackageConfig).toPackagesDirPackageMap());
           return;
         }
 
@@ -410,8 +411,8 @@ class BrowserPlatform extends PlatformPlugin
       var mapPath = jsPath + '.map';
       _mappers[dartPath] = JSStackTraceMapper(File(mapPath).readAsStringSync(),
           mapUrl: p.toUri(mapPath),
-          packageResolver: await PackageResolver.current.asSync,
-          sdkRoot: Uri.parse('org-dartlang-sdk:///sdk'));
+          sdkRoot: Uri.parse('org-dartlang-sdk:///sdk'),
+          packageMap: (await currentPackageConfig).toPackageMap());
     });
   }
 

--- a/pkgs/test/lib/src/util/package_map.dart
+++ b/pkgs/test/lib/src/util/package_map.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:isolate';
+
+import 'package:package_config/package_config.dart';
+
+/// The [PackageConfig] parsed from the current isolates package config file.
+final Future<PackageConfig> currentPackageConfig = () async {
+  return loadPackageConfigUri(await Isolate.packageConfig);
+}();
+
+/// Adds methods to convert to a package map on [PackageConfig].
+extension PackageMap on PackageConfig {
+  /// A package map exactly matching the current package config
+  Map<String, Uri> toPackageMap() =>
+      {for (var package in packages) package.name: package.packageUriRoot};
+
+  /// A package map with all the current packages but where the uris are all
+  /// of the form 'packages/${package.name}'.
+  Map<String, Uri> toPackagesDirPackageMap() => {
+        for (var package in packages)
+          package.name: Uri.parse('packages/${package.name}')
+      };
+}

--- a/pkgs/test/mono_pkg.yaml
+++ b/pkgs/test/mono_pkg.yaml
@@ -9,7 +9,7 @@ stages:
         dart: dev
       - group:
         - dartanalyzer: --fatal-warnings .
-        dart: 2.4.0
+        dart: 2.7.0
     - unit_test:
       - command: xvfb-run -s "-screen 0 1024x768x24" pub run test --preset travis -x phantomjs --total-shards 5 --shard-index 0
       - command: xvfb-run -s "-screen 0 1024x768x24" pub run test --preset travis -x phantomjs --total-shards 5 --shard-index 1

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -4,12 +4,12 @@ description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
 environment:
-  sdk: '>=2.4.0 <3.0.0'
+  sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
-  analyzer: ">=0.36.0 <0.40.0"
+  analyzer: '>=0.36.0 <0.40.0'
   async: ^2.0.0
-  boolean_selector: ">=1.0.0 <3.0.0"
+  boolean_selector: '>=1.0.0 <3.0.0'
   coverage: ^0.13.4
   http: ^0.12.0
   http_multi_server: ^2.0.0
@@ -17,7 +17,7 @@ dependencies:
   js: ^0.6.0
   multi_server_socket: ^1.0.0
   node_preamble: ^1.3.0
-  package_resolver: ^1.0.0
+  package_config: ^1.9.0
   path: ^1.2.0
   pedantic: ^1.1.0
   pool: ^1.3.0
@@ -27,7 +27,7 @@ dependencies:
   shelf_web_socket: ^0.2.0
   source_span: ^1.4.0
   stack_trace: ^1.9.0
-  stream_channel: ">=1.7.0 <3.0.0"
+  stream_channel: '>=1.7.0 <3.0.0'
   typed_data: ^1.0.0
   web_socket_channel: ^1.0.0
   webkit_inspection_protocol: ^0.5.0
@@ -47,3 +47,11 @@ dependency_overrides:
     path: ../test_api
   test_core:
     path: ../test_core
+  package_config:
+    git:
+      url: https://github.com/dart-lang/package_config.git
+      ref: '1.9'
+  source_map_stack_trace:
+    git:
+      url: https://github.com/dart-lang/source_map_stack_trace.git
+      ref: drop-package-resolver

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.2.15
-  test_core: 0.3.1
+  test_core: 0.3.2
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -47,10 +47,6 @@ dependency_overrides:
     path: ../test_api
   test_core:
     path: ../test_core
-  package_config:
-    git:
-      url: https://github.com/dart-lang/package_config.git
-      ref: '1.9'
   source_map_stack_trace:
     git:
       url: https://github.com/dart-lang/source_map_stack_trace.git

--- a/pkgs/test/test/io.dart
+++ b/pkgs/test/test/io.dart
@@ -4,8 +4,8 @@
 
 import 'dart:async';
 import 'dart:io';
+import 'dart:isolate';
 
-import 'package:package_resolver/package_resolver.dart';
 import 'package:path/path.dart' as p;
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
@@ -13,7 +13,9 @@ import 'package:test_process/test_process.dart';
 import 'package:test/test.dart';
 
 /// The path to the root directory of the `test` package.
-final Future<String> packageDir = PackageResolver.current.packagePath('test');
+final Future<String> packageDir =
+    Isolate.resolvePackageUri(Uri(scheme: 'package', path: 'test/'))
+        .then((uri) => uri.path);
 
 /// The path to the `pub` executable in the current Dart SDK.
 final _pubPath = p.absolute(p.join(p.dirname(Platform.resolvedExecutable),
@@ -95,7 +97,7 @@ Future<TestProcess> runDart(Iterable<String> args,
   var allArgs = <String>[
     ...Platform.executableArguments.where((arg) =>
         !arg.startsWith('--package-root=') && !arg.startsWith('--packages=')),
-    await PackageResolver.current.processArgument,
+    '--packages=${await Isolate.packageConfig}',
     ...args
   ];
 

--- a/pkgs/test/test/io.dart
+++ b/pkgs/test/test/io.dart
@@ -15,7 +15,7 @@ import 'package:test/test.dart';
 /// The path to the root directory of the `test` package.
 final Future<String> packageDir =
     Isolate.resolvePackageUri(Uri(scheme: 'package', path: 'test/'))
-        .then((uri) => uri.path);
+        .then((uri) => p.dirname(uri.path));
 
 /// The path to the `pub` executable in the current Dart SDK.
 final _pubPath = p.absolute(p.join(p.dirname(Platform.resolvedExecutable),

--- a/pkgs/test_api/mono_pkg.yaml
+++ b/pkgs/test_api/mono_pkg.yaml
@@ -1,13 +1,13 @@
 stages:
-    - analyze_and_format:
-      - group:
-        - dartfmt: sdk
-        - dartanalyzer: --fatal-infos --fatal-warnings .
-        dart: dev
-      - group:
-        - dartanalyzer: --fatal-warnings .
-        dart: 2.4.0
-    - unit_test:
-      - group:
-        - test: --preset travis
-        dart: dev
+  - analyze_and_format:
+    - group:
+      - dartfmt: sdk
+      - dartanalyzer: --fatal-infos --fatal-warnings .
+      dart: dev
+    - group:
+      - dartanalyzer: --fatal-warnings .
+      dart: 2.7.0
+  - unit_test:
+    - group:
+      - test: --preset travis
+      dart: dev

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -35,10 +35,6 @@ dependency_overrides:
     path: ./../test
   test_core:
     path: ./../test_core
-  package_config:
-    git:
-      url: https://github.com/dart-lang/package_config.git
-      ref: '1.9'
   source_map_stack_trace:
     git:
       url: https://github.com/dart-lang/source_map_stack_trace.git

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -35,3 +35,11 @@ dependency_overrides:
     path: ./../test
   test_core:
     path: ./../test_core
+  package_config:
+    git:
+      url: https://github.com/dart-lang/package_config.git
+      ref: '1.9'
+  source_map_stack_trace:
+    git:
+      url: https://github.com/dart-lang/source_map_stack_trace.git
+      ref: drop-package-resolver

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -35,7 +35,3 @@ dependency_overrides:
     path: ./../test
   test_core:
     path: ./../test_core
-  source_map_stack_trace:
-    git:
-      url: https://github.com/dart-lang/source_map_stack_trace.git
-      ref: drop-package-resolver

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -4,7 +4,7 @@ description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 
 environment:
-  sdk: ">=2.4.0 <3.0.0"
+  sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
   async: ^2.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.3.1-dev
 
 * Enable asserts in code running through `spawnHybrid` APIs.
+* Drop the `package_resolver` dependency.
 
 ## 0.3.0
 

--- a/pkgs/test_core/lib/src/runner/compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/compiler_pool.dart
@@ -5,9 +5,9 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:async/async.dart';
-import 'package:package_resolver/package_resolver.dart';
 import 'package:path/path.dart' as p;
 import 'package:pool/pool.dart';
 
@@ -67,7 +67,7 @@ class CompilerPool {
           '--enable-asserts',
           wrapperPath,
           '--out=$jsPath',
-          await PackageResolver.current.processArgument,
+          '--packages=${await Isolate.packageConfig}',
           ..._extraArgs,
           ...suiteConfig.dart2jsArgs
         ];

--- a/pkgs/test_core/mono_pkg.yaml
+++ b/pkgs/test_core/mono_pkg.yaml
@@ -6,4 +6,4 @@ stages:
       dart: dev
     - group:
       - dartanalyzer: --fatal-warnings .
-      dart: 2.4.0
+      dart: 2.7.0

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -4,7 +4,7 @@ description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
 environment:
-  sdk: ">=2.4.0 <3.0.0"
+  sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
   analyzer: ">=0.36.0 <0.40.0"

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -16,11 +16,10 @@ dependencies:
   glob: ^1.0.0
   io: ^0.3.0
   meta: ^1.1.5
-  package_resolver: ^1.0.0
   path: ^1.2.0
   pedantic: ^1.0.0
   pool: ^1.3.0
-  source_map_stack_trace: ^1.1.4
+  source_map_stack_trace: ^2.0.0
   source_maps: ^0.10.2
   source_span: ^1.4.0
   stack_trace: ^1.9.0
@@ -36,3 +35,7 @@ dependencies:
 dependency_overrides:
   test_api:
     path: ../test_api
+  source_map_stack_trace:
+    git:
+      url: https://github.com/dart-lang/source_map_stack_trace.git
+      ref: drop-package-resolver


### PR DESCRIPTION
Towards https://github.com/dart-lang/test/issues/1177.

This relies on the new source_map_stack_trace here https://github.com/dart-lang/source_map_stack_trace/pull/11 which no longer requires you to pass a `PackageResolver`.

It also relies on the upcoming package_config 1.9.0.

Once package_config is published and this goes green I will merge and publish source_map_stack_trace, and then we can remove the git override here.