### PR TITLE
Fix usage string for test-randomize-ordering-seed

### DIFF
--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -100,10 +100,10 @@ Usage: pub run test [files or directories...]
                                       (defaults to on)
 
     --no-retry                        Don't re-run tests that have retry set.
-    --test-randomize-ordering-seed    If positive, use this as a seed to randomize the execution
-                                      of test cases (must be a 32bit unsigned integer).
+    --test-randomize-ordering-seed    The seed to randomize the execution order of test cases.
+                                      Must be a 32bit unsigned integer or "random".
                                       If "random", pick a random seed to use.
-                                      If 0 or not set, do not randomize test case execution order.
+                                      If not passed, do not randomize test case execution order.
 
 ======== Output
 -r, --reporter                        The runner used to print test results.

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -108,10 +108,10 @@ final ArgParser _parser = (() {
       defaultsTo: false,
       negatable: false);
   parser.addOption('test-randomize-ordering-seed',
-      help: 'If positive, use this as a seed to randomize the execution\n'
-          'of test cases (must be a 32bit unsigned integer).\n'
+      help: 'The seed to randomize the execution order of test cases.\n'
+          'Must be a 32bit unsigned integer or "random".\n'
           'If "random", pick a random seed to use.\n'
-          'If 0 or not set, do not randomize test case execution order.\n');
+          'If not passed, do not randomize test case execution order.');
 
   var reporterDescriptions = <String, String>{};
   for (var reporter in allReporters.keys) {


### PR DESCRIPTION
We changed the behavior to allow passing an explicit `0` and treating
that differently from omitting the argument in #1150