### PR TITLE
Cancel any StreamQueue that is created as a part of a stream matcher

### DIFF
--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.15-dev
+
+* Cancel any StreamQueue that is created as a part of a stream matcher once it
+  is done matching.
+  * This fixes a bug where using a matcher on a custom stream controller and
+    then awaiting the `close()` method on that controller would hang.
+
 ## 0.2.14
 
 * Bump minimum SDK to `2.4.0` for safer usage of for-loop elements.

--- a/pkgs/test_api/lib/src/frontend/stream_matcher.dart
+++ b/pkgs/test_api/lib/src/frontend/stream_matcher.dart
@@ -129,10 +129,12 @@ class _StreamMatcher extends AsyncMatcher implements StreamMatcher {
   @override
   dynamic /*FutureOr<String>*/ matchAsync(item) {
     StreamQueue queue;
+    var shouldCancelQueue = false;
     if (item is StreamQueue) {
       queue = item;
     } else if (item is Stream) {
       queue = StreamQueue(item);
+      shouldCancelQueue = true;
     } else {
       return 'was not a Stream or a StreamQueue';
     }
@@ -184,6 +186,9 @@ class _StreamMatcher extends AsyncMatcher implements StreamMatcher {
     }, onError: (error) {
       transaction.reject();
       throw error;
+    }).then((result) {
+      if (shouldCancelQueue) queue.cancel();
+      return result;
     });
   }
 

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.2.14
+version: 0.2.15-dev
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 

--- a/pkgs/test_api/test/frontend/stream_matcher_test.dart
+++ b/pkgs/test_api/test/frontend/stream_matcher_test.dart
@@ -347,4 +347,12 @@ void main() {
           throwsA('oh no!'));
     });
   });
+
+  test('A custom StreamController doesn\'t hang on close', () async {
+    var controller = StreamController<void>();
+    var done = expectLater(controller.stream, emits(null));
+    controller.add(null);
+    await done;
+    await controller.close();
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/dart-lang/test/issues/1183

Ran through an internal presubmit and everything came back green so this should be safe.