### PR TITLE
Make Declarer.declare generic

### DIFF
--- a/pkgs/test_api/lib/src/backend/declarer.dart
+++ b/pkgs/test_api/lib/src/backend/declarer.dart
@@ -127,7 +127,7 @@ class Declarer {
   /// Runs [body] with this declarer as [Declarer.current].
   ///
   /// Returns the return value of [body].
-  void declare(void Function() body) =>
+  T declare<T>(T Function() body) =>
       runZoned(body, zoneValues: {#test.declarer: this});
 
   /// Defines a test case with the given name and body.

--- a/pkgs/test_api/lib/src/remote_listener.dart
+++ b/pkgs/test_api/lib/src/remote_listener.dart
@@ -121,8 +121,7 @@ class RemoteListener {
 
           if (beforeLoad != null) await beforeLoad();
 
-          // TODO - is this await necessary?
-          await (declarer.declare(main as Function()) as dynamic);
+          await declarer.declare(main as Function());
 
           var suite = Suite(
               declarer.build(), SuitePlatform.deserialize(message['platform']),


### PR DESCRIPTION
The doc comment explicitly mentions returning a value so the `void`
return is not sensible. Avoids strangeness of needing to add an extra
`as dynamic` to allow an `await`.

Remove a TODO - the `await` is important since the `main` could be
async.