### PR TITLE
Allow a timeout following a completed test

### DIFF
--- a/pkgs/test/test/runner/timeout_test.dart
+++ b/pkgs/test/test/runner/timeout_test.dart
@@ -134,7 +134,7 @@ void main() {
         containsInOrder(
             ['Test timed out after 0 seconds.', '-1: Some tests failed.']));
     await test.shouldExit(1);
-  }, solo: true);
+  });
 
   test('times out after failing test', () async {
     await d.file('test.dart', '''
@@ -159,5 +159,5 @@ void main() {
         containsInOrder(
             ['Test timed out after 0 seconds.', '-1: Some tests failed.']));
     await test.shouldExit(1);
-  }, solo: true);
+  });
 }

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -4,6 +4,8 @@
   is done matching.
   * This fixes a bug where using a matcher on a custom stream controller and
     then awaiting the `close()` method on that controller would hang.
+* Avoid causing the test runner to hang if there is a timeout during a
+  `tearDown` callback following a failing test case.
 
 ## 0.2.14
 

--- a/pkgs/test_api/lib/src/backend/invoker.dart
+++ b/pkgs/test_api/lib/src/backend/invoker.dart
@@ -284,7 +284,6 @@ class Invoker {
 
     _timeoutTimer = _invokerZone.createTimer(timeout, () {
       _outstandingCallbackZones.last.run(() {
-        if (liveTest.isComplete) return;
         _handleError(Zone.current, TimeoutException(message(), timeout));
       });
     });


### PR DESCRIPTION
Fixes #1188

A test is marked completed as soon as it fails. If a `tearDown` callback
also take too long, or never completes, we ignore the timeout and never
move on to more tests.