### PR TITLE
Fix rune iteration

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.4-dev
+
+* Fix error messages for incorrect string literals in test annotations.
+
 ## 0.3.3
 
 * Support latest `package:vm_service`.

--- a/pkgs/test_core/lib/src/util/string_literal_iterator.dart
+++ b/pkgs/test_core/lib/src/util/string_literal_iterator.dart
@@ -101,7 +101,7 @@ class StringLiteralIterator extends Iterator<int> {
   bool moveNext() {
     // If we're at beginning of a [SimpleStringLiteral], move forward until
     // there's actually text to consume.
-    while (_runes == null || _runes.current == null) {
+    while (_runes == null || _runes.current == null || _runes.current < 0) {
       if (_strings.isEmpty) {
         // Move the offset past the end of the text.
         _offset = _nextOffset;
@@ -139,7 +139,7 @@ class StringLiteralIterator extends Iterator<int> {
     if (_isRaw || _runes.current != _backslash) {
       var rune = _runes.current;
       _moveRunesNext();
-      return rune;
+      return (rune < 0) ? null : rune;
     }
 
     if (!_moveRunesNext()) return null;

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.3
+version: 0.3.4-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
In `2.8.0-dev.15.0` the `Iterator.current` returns `-1` instead of
`null` when there is no value. A better fix would be to avoid reading
`_runes.current` if the last `moveNext` returned `false`, but this would
be a larger refactoring.