### PR TITLE
Use Never return type for function which throws

### DIFF
--- a/pkgs/test_api/lib/src/frontend/expect.dart
+++ b/pkgs/test_api/lib/src/frontend/expect.dart
@@ -154,7 +154,7 @@ Future _expect(actual, matcher,
 /// Convenience method for throwing a new [TestFailure] with the provided
 /// [message].
 @alwaysThrows
-Null fail(String message) => throw TestFailure(message);
+Never fail(String message) => throw TestFailure(message);
 
 // The default error formatter.
 @Deprecated('Will be removed in 0.13.0.')

--- a/pkgs/test_api/lib/src/frontend/expect.dart
+++ b/pkgs/test_api/lib/src/frontend/expect.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:matcher/matcher.dart';
-import 'package:meta/meta.dart';
 
 import '../backend/closed_exception.dart';
 import '../backend/invoker.dart';
@@ -153,7 +152,6 @@ Future _expect(actual, matcher,
 
 /// Convenience method for throwing a new [TestFailure] with the provided
 /// [message].
-@alwaysThrows
 Never fail(String message) => throw TestFailure(message);
 
 // The default error formatter.


### PR DESCRIPTION
Fixes a static error:

```
pkgs/test_api/lib/src/frontend/expect.dart:82:8: Error: A non-null value must be returned since the return type 'Future<dynamic>' doesn't allow null.
 - 'Future' is from 'dart:async'.
Future _expect(actual, matcher,
```

The CFE does not appear to support `@alwaysThrows`, but a return type of
`Never` is the correct way to express this with null safety.