### PR TITLE
Simplify currentOS initialization

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.3.5-dev
+
 ## 0.3.4
 
 * Fix error messages for incorrect string literals in test annotations.

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -39,14 +39,8 @@ final int lineLength = () {
 /// The root directory of the Dart SDK.
 final String sdkDir = p.dirname(p.dirname(Platform.resolvedExecutable));
 
-/// Returns the current operating system.
-final OperatingSystem currentOS = (() {
-  var name = Platform.operatingSystem;
-  var os = OperatingSystem.findByIoName(name);
-  if (os != null) return os;
-
-  throw UnsupportedError('Unsupported operating system "$name".');
-})();
+/// The current operating system.
+final currentOS = OperatingSystem.findByIoName(Platform.operatingSystem);
 
 /// Returns a [SuitePlatform] with the given [runtime], and with [os] and
 /// [inGoogle] determined automatically.

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.4
+version: 0.3.5-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
The previous code was working around the possibility of getting a `null`
OS, that that is never returned. Instead `OperatingSystem.none` is used.
Since we can't hit the null branch and exception, the entire initializer
can simplify to the static method call. This will be more clearly
correct after the null safety migration.