### PR TITLE
Merge _LiveTest into LiveTestController

### DIFF
--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.2.16-dev
 
+* Deprecate `LiveTestController.liveTest`, the `LiveTestController` instance now
+  implements `LiveTest` and can be used directly.
+
 ## 0.2.15
 
 * Cancel any StreamQueue that is created as a part of a stream matcher once it

--- a/pkgs/test_api/lib/src/backend/invoker.dart
+++ b/pkgs/test_api/lib/src/backend/invoker.dart
@@ -76,7 +76,7 @@ class Invoker {
   /// The live test being driven by the invoker.
   ///
   /// This provides a view into the state of the test being executed.
-  LiveTest get liveTest => _controller.liveTest;
+  LiveTest get liveTest => _controller;
   LiveTestController _controller;
 
   /// Whether to run this test in its own error zone.

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -412,7 +412,7 @@ class Engine {
       controller.completer.complete();
     }, () {}, groups: parents);
 
-    return await _runLiveTest(suiteController, controller.liveTest);
+    return await _runLiveTest(suiteController, controller);
   }
 
   /// Closes [liveTest] and tells the engine to re-run it once it's done

--- a/pkgs/test_core/lib/src/runner/runner_test.dart
+++ b/pkgs/test_core/lib/src/runner/runner_test.dart
@@ -97,7 +97,7 @@ class RunnerTest extends Test {
         await testChannel.sink.close();
       }());
     }, groups: groups);
-    return controller.liveTest;
+    return controller;
   }
 
   @override

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   # properly constrains all features it provides.
   matcher: ">=0.12.6 <0.12.7"
   # Use an exact version until the test_api package is stable.
-  test_api: 0.2.15
+  test_api: 0.2.16
 
 dependency_overrides:
   test_api:


### PR DESCRIPTION
The `_LiveTest` was already a very thin wrapper around
`LiveTestController` which exposed some of it's private members.
Instead, make `LiveTestController` implement `LiveTest` directly and
skip the extra level of classes that have cyclical references.

This is a small refactoring to make it easier to understand structure
and dependencies for future changes.