### PR TITLE
rev the dep on package: webkit_inspection_protocol

### DIFF
--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   stream_channel: '>=1.7.0 <3.0.0'
   typed_data: ^1.0.0
   web_socket_channel: ^1.0.0
-  webkit_inspection_protocol: ^0.5.0
+  webkit_inspection_protocol: ">=0.5.0 <0.8.0"
   yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.2.15


### PR DESCRIPTION
- rev the dep on package: webkit_inspection_protocol (widen the supported range to `0.7.0`)
- fix https://github.com/dart-lang/test/issues/1235

Test pass locally and the project analyzes cleanly (w/ 0.5.0, 0.6.0, and 0.7.0).
