### PR TITLE
Add language version comments to bootstrap files

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.14.4-dev
+
+* Update browser/node bootstrapping logic to ensure the bootstrap library has
+  the same language version as the test.
+
 ## 1.14.3
 
 * Fix an issue where coverage tests could not run in Chrome headless. 

--- a/pkgs/test/lib/src/runner/node/platform.dart
+++ b/pkgs/test/lib/src/runner/node/platform.dart
@@ -155,6 +155,7 @@ class NodePlatform extends PlatformPlugin
     var dir = Directory(_compiledDir).createTempSync('test_').path;
     var jsPath = p.join(dir, p.basename(testPath) + '.node_test.dart.js');
     await _compilers.compile('''
+        ${suiteConfig.metadata.languageVersionComment ?? await rootPackageLanguageVersionComment}
         import "package:test/src/bootstrap/node.dart";
 
         import "${p.toUri(p.absolute(testPath))}" as test;

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.14.3
+version: 1.14.4-dev
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 

--- a/pkgs/test/test/io.dart
+++ b/pkgs/test/test/io.dart
@@ -71,7 +71,8 @@ Future<TestProcess> runTest(Iterable<String> args,
     String fileReporter,
     int concurrency,
     Map<String, String> environment,
-    bool forwardStdio = false}) async {
+    bool forwardStdio = false,
+    String packageConfig}) async {
   concurrency ??= 1;
 
   var allArgs = [
@@ -88,18 +89,23 @@ Future<TestProcess> runTest(Iterable<String> args,
   return await runDart(allArgs,
       environment: environment,
       description: 'dart bin/test.dart',
-      forwardStdio: forwardStdio);
+      forwardStdio: forwardStdio,
+      packageConfig: packageConfig);
 }
 
 /// Runs Dart.
+///
+/// If [packageConfig] is provided then that is passed for the `--packages`
+/// arg, otherwise the current isolate config is passed.
 Future<TestProcess> runDart(Iterable<String> args,
     {Map<String, String> environment,
     String description,
-    bool forwardStdio = false}) async {
+    bool forwardStdio = false,
+    String packageConfig}) async {
   var allArgs = <String>[
     ...Platform.executableArguments.where((arg) =>
         !arg.startsWith('--package-root=') && !arg.startsWith('--packages=')),
-    '--packages=${await Isolate.packageConfig}',
+    '--packages=${packageConfig ?? await Isolate.packageConfig}',
     ...args
   ];
 

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -707,7 +707,7 @@ void main(List<String> args) async {
   group('nnbd', () {
     final _testContents = '''
 import 'package:test/test.dart';
-import 'weak.dart';
+import 'opted_out.dart';
 
 void main() {
   test("success", () {
@@ -716,12 +716,13 @@ void main() {
 }''';
 
     setUp(() async {
-      await d.file('weak.dart', '''
+      await d.file('opted_out.dart', '''
 // @dart=2.8
 final foo = true;''').create();
     });
 
-    test('strong mode is used if the entrypoint opts in explicitly', () async {
+    test('sound null safety is enabled if the entrypoint opts in explicitly',
+        () async {
       await d.file('test.dart', '''
 // @dart=2.9
 $_testContents
@@ -732,12 +733,14 @@ $_testContents
           test.stdout,
           containsInOrder([
             'Unable to spawn isolate:',
-            'Error: A library can\'t opt out of non-nullable by default, when in nnbd-strong mode.'
+            'Error: A library can\'t opt out of non-nullable by default, when '
+                'in nnbd-strong mode.'
           ]));
       await test.shouldExit(1);
     });
 
-    test('weak mode is used if the entrypoint opts out explicitly', () async {
+    test('sound null safety is disabled if the entrypoint opts out explicitly',
+        () async {
       await d.file('test.dart', '''
 // @dart=2.8
 $_testContents''').create();
@@ -759,7 +762,7 @@ $_testContents''').create();
         await d.file('test.dart', _testContents).create();
       });
 
-      test('to strong if the package is opted in', () async {
+      test('sound null safety is enabled if the package is opted in', () async {
         var newPackageConfig = PackageConfig([
           ...currentPackageConfig.packages,
           Package('example', Uri.file('${d.sandbox}/'),
@@ -785,7 +788,8 @@ $_testContents''').create();
         await test.shouldExit(1);
       });
 
-      test('to weak if the package is opted out', () async {
+      test('sound null safety is disabled if the package is opted out',
+          () async {
         var newPackageConfig = PackageConfig([
           ...currentPackageConfig.packages,
           Package('example', Uri.file('${d.sandbox}/'),

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -6,8 +6,13 @@
 
 @TestOn('vm')
 
+import 'dart:convert';
 import 'dart:io';
+import 'dart:isolate';
 import 'dart:math' as math;
+
+import 'package:package_config/package_config.dart';
+import 'package:path/path.dart' as p;
 
 import 'package:test/test.dart';
 import 'package:test_core/src/util/exit_codes.dart' as exit_codes;
@@ -696,6 +701,110 @@ void main(List<String> args) async {
             '+1: All tests passed!',
           ])));
       await test.shouldExit(0);
+    });
+  });
+
+  group('nnbd', () {
+    final _testContents = '''
+import 'package:test/test.dart';
+import 'weak.dart';
+
+void main() {
+  test("success", () {
+    expect(foo, true);
+  });
+}''';
+
+    setUp(() async {
+      await d.file('weak.dart', '''
+// @dart=2.8
+final foo = true;''').create();
+    });
+
+    test('strong mode is used if the entrypoint opts in explicitly', () async {
+      await d.file('test.dart', '''
+// @dart=2.9
+$_testContents
+''').create();
+      var test = await runTest(['test.dart']);
+
+      expect(
+          test.stdout,
+          containsInOrder([
+            'Unable to spawn isolate:',
+            'Error: A library can\'t opt out of non-nullable by default, when in nnbd-strong mode.'
+          ]));
+      await test.shouldExit(1);
+    });
+
+    test('weak mode is used if the entrypoint opts out explicitly', () async {
+      await d.file('test.dart', '''
+// @dart=2.8
+$_testContents''').create();
+      var test = await runTest(['test.dart']);
+
+      expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
+      await test.shouldExit(0);
+    });
+
+    group('defaults', () {
+      PackageConfig currentPackageConfig;
+
+      setUpAll(() async {
+        currentPackageConfig =
+            await loadPackageConfigUri(await Isolate.packageConfig);
+      });
+
+      setUp(() async {
+        await d.file('test.dart', _testContents).create();
+      });
+
+      test('to strong if the package is opted in', () async {
+        var newPackageConfig = PackageConfig([
+          ...currentPackageConfig.packages,
+          Package('example', Uri.file('${d.sandbox}/'),
+              languageVersion: LanguageVersion(2, 9),
+              // TODO: https://github.com/dart-lang/package_config/issues/81
+              packageUriRoot: Uri.file('${d.sandbox}/')),
+        ]);
+
+        await d
+            .file('package_config.json',
+                jsonEncode(PackageConfig.toJson(newPackageConfig)))
+            .create();
+
+        var test = await runTest(['test.dart'],
+            packageConfig: p.join(d.sandbox, 'package_config.json'));
+
+        expect(
+            test.stdout,
+            containsInOrder([
+              'Unable to spawn isolate:',
+              'Error: A library can\'t opt out of non-nullable by default, when in nnbd-strong mode.'
+            ]));
+        await test.shouldExit(1);
+      });
+
+      test('to weak if the package is opted out', () async {
+        var newPackageConfig = PackageConfig([
+          ...currentPackageConfig.packages,
+          Package('example', Uri.file('${d.sandbox}/'),
+              languageVersion: LanguageVersion(2, 8),
+              // TODO: https://github.com/dart-lang/package_config/issues/81
+              packageUriRoot: Uri.file('${d.sandbox}/')),
+        ]);
+
+        await d
+            .file('package_config.json',
+                jsonEncode(PackageConfig.toJson(newPackageConfig)))
+            .create();
+
+        var test = await runTest(['test.dart'],
+            packageConfig: p.join(d.sandbox, 'package_config.json'));
+
+        expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
+        await test.shouldExit(0);
+      });
     });
   });
 }

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -5,8 +5,8 @@
     behavior of the code regarding to handling of nulls.
   * **Breaking Change**: `GroupEntry.name` is no longer nullable, the root
     group now has the empty string as its name.
-  
-## 0.2.16-dev
+* Add `languageVersionComment` on the `MetaData` class. This should only be
+  presen for test suites.
 
 ## 0.2.15
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.3.5-dev
 
+* Update vm bootstrapping logic to ensure the bootstrap library has the same
+  language version as the test.
+* Populate `languageVersionComment` in the `Metadata` returned from
+  `parseMetadata`.
+
 ## 0.3.4
 
 * Fix error messages for incorrect string literals in test annotations.

--- a/pkgs/test_core/lib/src/runner/parse_metadata.dart
+++ b/pkgs/test_core/lib/src/runner/parse_metadata.dart
@@ -49,7 +49,8 @@ class _Parser {
   late final String? _languageVersionComment;
 
   _Parser(this._path, this._contents, this._platformVariables) {
-    var result = parseString(content: _contents, path: _path);
+    var result =
+        parseString(content: _contents, path: _path, throwIfDiagnostics: false);
     var directives = result.unit.directives;
     _annotations = directives.isEmpty ? [] : directives.first.metadata;
     _languageVersionComment = result.unit.languageVersionToken?.value();

--- a/pkgs/test_core/lib/src/runner/parse_metadata.dart
+++ b/pkgs/test_core/lib/src/runner/parse_metadata.dart
@@ -4,6 +4,7 @@
 
 // ignore: deprecated_member_use
 import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:path/path.dart' as p;
 import 'package:source_span/source_span.dart';
@@ -44,10 +45,16 @@ class _Parser {
   /// The actual contents of the file.
   final String _contents;
 
+  /// The language version override comment if one was present
+  late final String? _languageVersionComment;
+
   _Parser(this._path, this._contents, this._platformVariables) {
-    // ignore: deprecated_member_use
-    var directives = parseDirectives(_contents, name: _path).directives;
+    var result = parseString(content: _contents, path: _path);
+    var directives = result.unit.directives;
     _annotations = directives.isEmpty ? [] : directives.first.metadata;
+    _languageVersionComment = result.unit.languageVersionToken?.value();
+
+    // var comments = result.unit./
 
     // We explicitly *don't* just look for "package:test" imports here,
     // because it could be re-exported from another library.
@@ -105,7 +112,8 @@ class _Parser {
         skipReason: skip is String ? skip : null,
         onPlatform: onPlatform,
         tags: tags,
-        retry: retry);
+        retry: retry,
+        languageVersionComment: _languageVersionComment);
   }
 
   /// Parses a `@TestOn` annotation.

--- a/pkgs/test_core/lib/src/runner/parse_metadata.dart
+++ b/pkgs/test_core/lib/src/runner/parse_metadata.dart
@@ -54,8 +54,6 @@ class _Parser {
     _annotations = directives.isEmpty ? [] : directives.first.metadata;
     _languageVersionComment = result.unit.languageVersionToken?.value();
 
-    // var comments = result.unit./
-
     // We explicitly *don't* just look for "package:test" imports here,
     // because it could be re-exported from another library.
     _prefixes = directives

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -38,9 +38,15 @@ final int lineLength = () {
   }
 }();
 
+/// A comment which forces the language version to be that of the current
+/// packages default.
+///
+/// If the cwd is not a package, this returns an empty string which ends up
+/// defaulting to the current sdk version.
 final Future<String> rootPackageLanguageVersionComment = () async {
   var packageConfig = await loadPackageConfigUri(await Isolate.packageConfig);
   var rootPackage = packageConfig.packageOf(Uri.file(p.absolute('foo.dart')));
+  if (rootPackage == null) return '';
   return '// @dart=${rootPackage.languageVersion}';
 }();
 

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -7,8 +7,10 @@ import 'dart:core' as core;
 import 'dart:core';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:async/async.dart';
+import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
 
 import 'package:test_api/src/backend/operating_system.dart'; // ignore: implementation_imports
@@ -34,6 +36,12 @@ final int lineLength = () {
   } on StdoutException {
     return _defaultLineLength;
   }
+}();
+
+final Future<String> rootPackageLanguageVersionComment = () async {
+  var packageConfig = await loadPackageConfigUri(await Isolate.packageConfig);
+  var rootPackage = packageConfig.packageOf(Uri.file(p.absolute('foo.dart')));
+  return '// @dart=${rootPackage.languageVersion}';
 }();
 
 /// The root directory of the Dart SDK.

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.9.0-1 <3.0.0"
 
 dependencies:
-  analyzer: ">=0.36.0 <0.40.0"
+  analyzer: ">=0.39.5 <0.40.0"
   async: ^2.0.0
   args: ^1.4.0
   boolean_selector: ">=1.0.0 <3.0.0"
@@ -16,6 +16,7 @@ dependencies:
   glob: ^1.0.0
   io: ^0.3.0
   meta: ^1.1.5
+  package_config: ^1.9.2
   path: ^1.2.0
   pedantic: ^1.0.0
   pool: ^1.3.0


### PR DESCRIPTION
- Adds a nullable `languageVersionComment` field to `Metadata`
- Adds a utility to get a language comment that matches the root packages version
- Adds explicit language version comments to all bootstrap files ensuring the versions matches that of the test (note this assumes tests live in the root package)
- Clean up the handling of serving bootstrap dart files in the browser platform which had diverged and was serving the wrong content.

Closes https://github.com/dart-lang/test/issues/1236

I am not sure of the proper way to test this exactly, suggestions welcome. I manually tested the vm stuff and it seems to work correctly in terms of opting in/out of strong mode.