### PR TITLE
Pass experiment flags to dart2js

### DIFF
--- a/pkgs/test_core/lib/src/runner/compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/compiler_pool.dart
@@ -152,7 +152,7 @@ final List<String> _enabledExperiments = () {
     if (arg == '--enable-experiment') {
       if (!itr.moveNext()) break;
       experiments.add(itr.current);
-    } else if (arg.startsWith('--enable-experiment')) {
+    } else if (arg.startsWith('--enable-experiment=')) {
       var parts = arg.split('=');
       if (parts.length == 2) {
         experiments.addAll(parts[1].split(','));

--- a/pkgs/test_core/lib/src/runner/compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/compiler_pool.dart
@@ -64,6 +64,8 @@ class CompilerPool {
         if (Platform.isWindows) dart2jsPath += '.bat';
 
         var args = [
+          for (var experiment in _enabledExperiments)
+            '--enable-experiment=$experiment',
           '--enable-asserts',
           wrapperPath,
           '--out=$jsPath',
@@ -139,3 +141,23 @@ class CompilerPool {
     });
   }
 }
+
+/// Parses and returns the currently enabled experiments from
+/// [Platform.executableArguments].
+final List<String> _enabledExperiments = () {
+  var experiments = <String>[];
+  var itr = Platform.executableArguments.iterator;
+  while (itr.moveNext()) {
+    var arg = itr.current;
+    if (arg == '--enable-experiment') {
+      if (!itr.moveNext()) break;
+      experiments.add(itr.current);
+    } else if (arg.startsWith('--enable-experiment')) {
+      var parts = arg.split('=');
+      if (parts.length == 2) {
+        experiments.addAll(parts[1].split(','));
+      }
+    }
+  }
+  return experiments;
+}();


### PR DESCRIPTION
This starts getting web tests compiling through the test runner, if used in combination with https://github.com/dart-lang/test/pull/1240.

However I see some late initialization errors that need to be tracked down still, can follow up with that later.