### PR TITLE
Move package config dep to its own library

### DIFF
--- a/pkgs/test/lib/src/runner/browser/platform.dart
+++ b/pkgs/test/lib/src/runner/browser/platform.dart
@@ -26,6 +26,7 @@ import 'package:test_api/src/utils.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/compiler_pool.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/configuration.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/load_exception.dart'; // ignore: implementation_imports
+import 'package:test_core/src/runner/package_version.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/platform.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/plugin/customizable_platform.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/runner_suite.dart'; // ignore: implementation_imports

--- a/pkgs/test/lib/src/runner/node/platform.dart
+++ b/pkgs/test/lib/src/runner/node/platform.dart
@@ -20,6 +20,7 @@ import 'package:test_api/src/backend/runtime.dart'; // ignore: implementation_im
 import 'package:test_api/src/backend/suite_platform.dart'; // ignore: implementation_imports
 import 'package:test_api/src/util/stack_trace_mapper.dart'; // ignore: implementation_imports
 import 'package:test_api/src/utils.dart'; // ignore: implementation_imports
+import 'package:test_core/src/runner/package_version.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/platform.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/runner_suite.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/suite.dart'; // ignore: implementation_imports

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -76,6 +76,14 @@ dependency_overrides:
     git:
       url: git://github.com/dart-lang/path.git
       ref: null_safety
+  pedantic:
+    git:
+      url: git://github.com/dart-lang/pedantic.git
+      ref: null_safety
+  pool:
+    git:
+      url: git://github.com/dart-lang/pool.git
+      ref: null_safety
   source_span:
     git:
       url: git://github.com/dart-lang/source_span.git
@@ -83,6 +91,10 @@ dependency_overrides:
   stack_trace:
     git:
       url: git://github.com/dart-lang/stack_trace.git
+      ref: null_safety
+  stream_channel:
+    git:
+      url: git://github.com/dart-lang/stream_channel.git
       ref: null_safety
   string_scanner:
     git:

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -64,6 +64,14 @@ dependency_overrides:
     git:
       url: git://github.com/dart-lang/path.git
       ref: null_safety
+  pedantic:
+    git:
+      url: git://github.com/dart-lang/pedantic.git
+      ref: null_safety
+  pool:
+    git:
+      url: git://github.com/dart-lang/pool.git
+      ref: null_safety
   source_span:
     git:
       url: git://github.com/dart-lang/source_span.git

--- a/pkgs/test_core/lib/src/runner/package_version.dart
+++ b/pkgs/test_core/lib/src/runner/package_version.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:isolate';
+
+import 'package:package_config/package_config.dart';
+import 'package:path/path.dart' as p;
+
+/// A comment which forces the language version to be that of the current
+/// packages default.
+///
+/// If the cwd is not a package, this returns an empty string which ends up
+/// defaulting to the current sdk version.
+final Future<String> rootPackageLanguageVersionComment = () async {
+  var packageConfig = await loadPackageConfigUri(await Isolate.packageConfig);
+  var rootPackage = packageConfig.packageOf(Uri.file(p.absolute('foo.dart')));
+  if (rootPackage == null) return '';
+  return '// @dart=${rootPackage.languageVersion}';
+}();

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -25,7 +25,7 @@ import '../../runner/plugin/platform_helpers.dart';
 import '../../runner/runner_suite.dart';
 import '../../runner/suite.dart';
 import '../../util/dart.dart' as dart;
-import '../../util/io.dart';
+import '../package_version.dart';
 import 'environment.dart';
 
 /// A platform that loads tests in isolates spawned within this Dart process.

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -7,10 +7,8 @@ import 'dart:core' as core;
 import 'dart:core';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:isolate';
 
 import 'package:async/async.dart';
-import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
 
 import 'package:test_api/src/backend/operating_system.dart'; // ignore: implementation_imports
@@ -36,18 +34,6 @@ final int lineLength = () {
   } on StdoutException {
     return _defaultLineLength;
   }
-}();
-
-/// A comment which forces the language version to be that of the current
-/// packages default.
-///
-/// If the cwd is not a package, this returns an empty string which ends up
-/// defaulting to the current sdk version.
-final Future<String> rootPackageLanguageVersionComment = () async {
-  var packageConfig = await loadPackageConfigUri(await Isolate.packageConfig);
-  var rootPackage = packageConfig.packageOf(Uri.file(p.absolute('foo.dart')));
-  if (rootPackage == null) return '';
-  return '// @dart=${rootPackage.languageVersion}';
 }();
 
 /// The root directory of the Dart SDK.

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -65,6 +65,14 @@ dependency_overrides:
     git:
       url: git://github.com/dart-lang/path.git
       ref: null_safety
+  pedantic:
+    git:
+      url: git://github.com/dart-lang/pedantic.git
+      ref: null_safety
+  pool:
+    git:
+      url: git://github.com/dart-lang/pool.git
+      ref: null_safety
   source_span:
     git:
       url: git://github.com/dart-lang/source_span.git


### PR DESCRIPTION
This also adds more dependency overrides so the entire test isolate is migrated.

After this change, `DART_VM_OPTIONS="--enable-experiment=non-nullable" pub run test <some-test>` can pass even with null safety enabled 🎉 .

cc @kevmoo 

We do get these two warnings which I don't understand:

```
../test_core/lib/src/runner/parse_metadata.dart:56:43: Warning: Operand of null-aware operation '?.' has type 'LanguageVersionToken' which excludes null.
 - 'LanguageVersionToken' is from 'package:_fe_analyzer_shared/src/scanner/token.dart' ('../../../.pub-cache/hosted/pub.dartlang.org/_fe_analyzer_shared-3.0.0/lib/src/scanner/token.dart').
    _languageVersionComment = result.unit.languageVersionToken?.value();
                                          ^
../test_core/lib/src/runner/parse_metadata.dart:63:30: Warning: Operand of null-aware operation '?.' has type 'SimpleIdentifier' which excludes null.
 - 'SimpleIdentifier' is from 'package:analyzer/dart/ast/ast.dart' ('../../../.pub-cache/hosted/pub.dartlang.org/analyzer-0.39.8/lib/dart/ast/ast.dart').
            return directive.prefix?.name;
```

These are analyzer apis, and analyzer _is not_ opted in.