### PR TITLE
Fail with specific error for null runnerSuite

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.14.5
+
+* Add additional information to an exception when we end up with a null
+  `RunnerSuite`.
+
 ## 1.14.4
 
 * Use non-headless Chrome when provided the flag `--pause-after-load`.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.14.4
+version: 1.14.5
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
@@ -34,7 +34,7 @@ dependencies:
   yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.2.15
-  test_core: 0.3.4
+  test_core: 0.3.5
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.16-dev
+## 0.2.16
 
 * Deprecate `LiveTestController.liveTest`, the `LiveTestController` instance now
   implements `LiveTest` and can be used directly.

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.2.16-dev
+version: 0.2.16
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.3.5-dev
 
+* Add additional information to an exception when we end up with a null
+  `RunnerSuite`.
+
 ## 0.3.4
 
 * Fix error messages for incorrect string literals in test annotations.

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.5-dev
+## 0.3.5
 
 * Add additional information to an exception when we end up with a null
   `RunnerSuite`.

--- a/pkgs/test_core/lib/src/runner/reporter/json.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/json.dart
@@ -180,6 +180,12 @@ class JsonReporter implements Reporter {
         _suiteIDs[runnerSuite] = id;
         if (!_config.debug) return;
 
+        if (runnerSuite == null) {
+          throw StateError('Recieved a null runnerSuite from platform '
+              '${suite.platform.runtime.name}. Unable to debug.\n'
+              'Test glob: ${_config.filename}');
+        }
+
         // TODO(nweiz): test this when we have a library for communicating with
         // the Chrome remote debugger, or when we have VM debug support.
         _emit('debug', {

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.5-dev
+version: 0.3.5
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/56457

If we get a null `runnerSuite` the attempt to read the `environment`
file will fail, resulting in a confusing error and stack trace. We can't
reproduce this locally so it isn't clear where the null may be coming
from.

Add additional information to the error thrown to try to narrow down the
places we need to search for a root cause.