### PR TITLE
Bump test_api dep from test

### DIFF
--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   webkit_inspection_protocol: ">=0.5.0 <0.8.0"
   yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.2.15
+  test_api: 0.2.16
   test_core: 0.3.5
 
 dev_dependencies:


### PR DESCRIPTION
This was missed when I bumped the dependency on `test_core` which
requires a new `test_api`. Solves an impossible pub get.