### PR TITLE
expose the ability to load test configuration files from the test_core package

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.14.6
+
+* Update `test_core` to `0.3.6`.
+
 ## 1.14.5
 
 * Add additional information to an exception when we end up with a null

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.14.5
+version: 1.14.6
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
@@ -34,7 +34,7 @@ dependencies:
   yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.2.16
-  test_core: 0.3.5
+  test_core: 0.3.6
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.6
+
+* Expose the `Configuration` class and related classes.
+* Expose the `load` and `loadFromString` methods for loading a `Configuration`
+  from yaml.
+
 ## 0.3.5
 
 * Add additional information to an exception when we end up with a null

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,8 +1,6 @@
 ## 0.3.6
 
-* Expose the `Configuration` class and related classes.
-* Expose the `load` and `loadFromString` methods for loading a `Configuration`
-  from yaml.
+* Expose the `Configuration` class and related classes through `backend.dart`.
 
 ## 0.3.5
 

--- a/pkgs/test_core/lib/backend.dart
+++ b/pkgs/test_core/lib/backend.dart
@@ -11,3 +11,10 @@ export 'package:test_api/backend.dart'
     show Metadata, PlatformSelector, Runtime, SuitePlatform;
 
 export 'src/runner/parse_metadata.dart' show parseMetadata;
+
+export 'src/runner/configuration/load.dart' show load, loadFromString;
+export 'src/runner/suite.dart' show SuiteConfiguration;
+
+export 'src/runner/configuration.dart' show Configuration;
+export 'src/runner/configuration/custom_runtime.dart' show CustomRuntime;
+export 'src/runner/configuration/runtime_settings.dart' show RuntimeSettings;

--- a/pkgs/test_core/lib/backend.dart
+++ b/pkgs/test_core/lib/backend.dart
@@ -10,11 +10,8 @@ library test_core.backend;
 export 'package:test_api/backend.dart'
     show Metadata, PlatformSelector, Runtime, SuitePlatform;
 
-export 'src/runner/parse_metadata.dart' show parseMetadata;
-
-export 'src/runner/configuration/load.dart' show load, loadFromString;
-export 'src/runner/suite.dart' show SuiteConfiguration;
-
 export 'src/runner/configuration.dart' show Configuration;
 export 'src/runner/configuration/custom_runtime.dart' show CustomRuntime;
 export 'src/runner/configuration/runtime_settings.dart' show RuntimeSettings;
+export 'src/runner/parse_metadata.dart' show parseMetadata;
+export 'src/runner/suite.dart' show SuiteConfiguration;

--- a/pkgs/test_core/lib/src/runner/configuration.dart
+++ b/pkgs/test_core/lib/src/runner/configuration.dart
@@ -221,6 +221,19 @@ class Configuration {
   factory Configuration.load(String path, {bool global = false}) =>
       load(path, global: global);
 
+  /// Loads the configuration from YAML formatted [source].
+  ///
+  /// If [global] is `true`, this restricts the configuration file to only rules
+  /// that are supported globally.
+  ///
+  /// If [sourceUrl] is provided then that will be set as the source url for
+  /// the yaml document.
+  ///
+  /// Throws a [FormatException] if its contents are invalid.
+  factory Configuration.loadFromString(String source,
+          {bool global = false, Uri sourceUrl}) =>
+      loadFromString(source, global: global, sourceUrl: sourceUrl);
+
   factory Configuration(
       {bool help,
       String customHtmlTemplatePath,

--- a/pkgs/test_core/lib/src/runner/configuration/load.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/load.dart
@@ -39,14 +39,25 @@ final _packageName =
 
 /// Loads configuration information from a YAML file at [path].
 ///
+/// See [loadFromString] for further documentation.
+Configuration load(String path, {bool global = false}) {
+  var source = File(path).readAsStringSync();
+  return loadFromString(source, global: global, sourceUrl: p.toUri(path));
+}
+
+/// Loads configuration information from YAML formatted [source].
+///
 /// If [global] is `true`, this restricts the configuration file to only rules
 /// that are supported globally.
 ///
+/// If [sourceUrl] is provided then that will be set as the source url for
+/// the yaml document.
+///
 /// Throws a [FormatException] if the configuration is invalid, and a
 /// [FileSystemException] if it can't be read.
-Configuration load(String path, {bool global = false}) {
-  var source = File(path).readAsStringSync();
-  var document = loadYamlNode(source, sourceUrl: p.toUri(path));
+Configuration loadFromString(String source,
+    {bool global = false, Uri sourceUrl}) {
+  var document = loadYamlNode(source, sourceUrl: sourceUrl);
 
   if (document.value == null) return Configuration.empty;
 

--- a/pkgs/test_core/lib/src/runner/configuration/load.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/load.dart
@@ -53,8 +53,7 @@ Configuration load(String path, {bool global = false}) {
 /// If [sourceUrl] is provided then that will be set as the source url for
 /// the yaml document.
 ///
-/// Throws a [FormatException] if the configuration is invalid, and a
-/// [FileSystemException] if it can't be read.
+/// Throws a [FormatException] if the configuration is invalid.
 Configuration loadFromString(String source,
     {bool global = false, Uri sourceUrl}) {
   var document = loadYamlNode(source, sourceUrl: sourceUrl);

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.5
+version: 0.3.6
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
* Expose the `Configuration` class and related classes.
* Expose the `load` and `loadFromString` methods for loading a `Configuration`
  from yaml.

Towards https://github.com/dart-lang/build/issues/2684