### PR TITLE
start working on browser test bootstrap fixes

### DIFF
--- a/pkgs/test/lib/src/runner/browser/post_message_channel.dart
+++ b/pkgs/test/lib/src/runner/browser/post_message_channel.dart
@@ -17,8 +17,8 @@ external void _postParentMessage(Object message, String targetOrigin);
 
 /// Constructs a [StreamChannel] wrapping [MessageChannel] communication with
 /// the host page.
-StreamChannel postMessageChannel() {
-  var controller = StreamChannelController(sync: true);
+StreamChannel<Object?> postMessageChannel() {
+  var controller = StreamChannelController<Object?>(sync: true);
 
   // Listen for a message from the host that transfers a message port. Using
   // `firstWhere` automatically unsubscribes from further messages. This is

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -63,6 +63,11 @@ dependency_overrides:
     git:
       url: git://github.com/dart-lang/collection.git
       ref: null_safety
+  js:
+    git:
+      url: git://github.com/dart-lang/sdk.git
+      ref: null_safety-pkgs
+      path: pkg/js
   matcher:
     git:
       url: git://github.com/dart-lang/matcher.git
@@ -83,6 +88,14 @@ dependency_overrides:
   pool:
     git:
       url: git://github.com/dart-lang/pool.git
+      ref: null_safety
+  source_maps:
+    git:
+      url: git://github.com/dart-lang/source_maps.git
+      ref: null_safety
+  source_map_stack_trace:
+    git:
+      url: git://github.com/dart-lang/source_map_stack_trace.git
       ref: null_safety
   source_span:
     git:

--- a/pkgs/test_api/lib/src/remote_listener.dart
+++ b/pkgs/test_api/lib/src/remote_listener.dart
@@ -44,14 +44,14 @@ class RemoteListener {
   ///
   /// If [beforeLoad] is passed, it's called before the tests have been declared
   /// for this worker.
-  static StreamChannel<Object> start(Function Function() getMain,
+  static StreamChannel<Object?> start(Function Function() getMain,
       {bool hidePrints = true, Future Function()? beforeLoad}) {
     // This has to be synchronous to work around sdk#25745. Otherwise, there'll
     // be an asynchronous pause before a syntax error notification is sent,
     // which will cause the send to fail entirely.
     var controller =
-        StreamChannelController<Object>(allowForeignErrors: false, sync: true);
-    var channel = MultiChannel(controller.local);
+        StreamChannelController<Object?>(allowForeignErrors: false, sync: true);
+    var channel = MultiChannel<Object?>(controller.local);
 
     var verboseChain = true;
 
@@ -91,10 +91,10 @@ class RemoteListener {
           }
 
           var queue = StreamQueue(channel.stream);
-          var message = await queue.next;
+          var message = await queue.next as Map;
           assert(message['type'] == 'initial');
 
-          queue.rest.listen((message) {
+          queue.rest.cast<Map>().listen((message) {
             if (message['type'] == 'close') {
               controller.local.sink.close();
               return;

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -51,6 +51,11 @@ dependency_overrides:
     git:
       url: git://github.com/dart-lang/collection.git
       ref: null_safety
+  js:
+    git:
+      url: git://github.com/dart-lang/sdk.git
+      ref: null_safety-pkgs
+      path: pkg/js
   matcher:
     git:
       url: git://github.com/dart-lang/matcher.git
@@ -71,6 +76,14 @@ dependency_overrides:
   pool:
     git:
       url: git://github.com/dart-lang/pool.git
+      ref: null_safety
+  source_maps:
+    git:
+      url: git://github.com/dart-lang/source_maps.git
+      ref: null_safety
+  source_map_stack_trace:
+    git:
+      url: git://github.com/dart-lang/source_map_stack_trace.git
       ref: null_safety
   source_span:
     git:

--- a/pkgs/test_core/lib/src/bootstrap/vm.dart
+++ b/pkgs/test_core/lib/src/bootstrap/vm.dart
@@ -11,5 +11,5 @@ import 'package:test_core/src/runner/plugin/remote_platform_helpers.dart';
 /// Bootstraps a vm test to communicate with the test runner.
 void internalBootstrapVmTest(Function Function() getMain, SendPort sendPort) {
   var channel = serializeSuite(getMain);
-  IsolateChannel.connectSend(sendPort).pipe(channel);
+  IsolateChannel<Object?>.connectSend(sendPort).pipe(channel);
 }

--- a/pkgs/test_core/lib/src/runner/plugin/remote_platform_helpers.dart
+++ b/pkgs/test_core/lib/src/runner/plugin/remote_platform_helpers.dart
@@ -30,7 +30,7 @@ import 'package:test_api/src/suite_channel_manager.dart'; // ignore: implementat
 ///
 /// If [beforeLoad] is passed, it's called before the tests have been declared
 /// for this worker.
-StreamChannel<Object> serializeSuite(Function Function() getMain,
+StreamChannel<Object?> serializeSuite(Function Function() getMain,
         {bool hidePrints = true, Future Function()? beforeLoad}) =>
     RemoteListener.start(
       getMain,

--- a/pkgs/test_core/lib/src/runner/runner_suite.dart
+++ b/pkgs/test_core/lib/src/runner/runner_suite.dart
@@ -84,7 +84,8 @@ class RunnerSuite extends Suite {
   Future<Map<String, dynamic>> gatherCoverage() async {
     // TODO(https://github.com/dart-lang/sdk/issues/41108): Remove cast
     var coverage =
-        (await _controller._gatherCoverage?.call()) as Map<String, dynamic>?;
+        // ignore: unnecessary_cast
+        await _controller._gatherCoverage?.call() as Map<String, dynamic>?;
     return coverage ?? {};
   }
 }

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -135,15 +135,12 @@ Future<Isolate> _spawnDataIsolate(
     ${suiteMetadata.languageVersionComment ?? await rootPackageLanguageVersionComment}
     import "dart:isolate";
 
-    import "package:stream_channel/isolate_channel.dart";
-
-    import "package:test_core/src/runner/plugin/remote_platform_helpers.dart";
+    import "package:test_core/src/bootstrap/vm.dart";
 
     import "${p.toUri(p.absolute(path))}" as test;
 
-    void main(_, SendPort message) {
-      var channel = serializeSuite(() => test.main);
-      IsolateChannel<Object>.connectSend(message).pipe(channel);
+    void main(_, SendPort sendPort) {
+      internalBootstrapVmTest(() => test.main, sendPort);
     }
   ''', message);
 }

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -52,6 +52,11 @@ dependency_overrides:
     git:
       url: git://github.com/dart-lang/collection.git
       ref: null_safety
+  js:
+    git:
+      url: git://github.com/dart-lang/sdk.git
+      ref: null_safety-pkgs
+      path: pkg/js
   matcher:
     git:
       url: git://github.com/dart-lang/matcher.git
@@ -72,6 +77,14 @@ dependency_overrides:
   pool:
     git:
       url: git://github.com/dart-lang/pool.git
+      ref: null_safety
+  source_maps:
+    git:
+      url: git://github.com/dart-lang/source_maps.git
+      ref: null_safety
+  source_map_stack_trace:
+    git:
+      url: git://github.com/dart-lang/source_map_stack_trace.git
       ref: null_safety
   source_span:
     git:


### PR DESCRIPTION
- update pinned package deps for browser tests
- change serializeSuite return type to `StreamChannel<Object?>` since browser tests seem to send nulls here.
- migrate some `dynamic` things to `Object?`