### PR TITLE
Fix some hybrid_tests.dart

### DIFF
--- a/pkgs/test/test/runner/hybrid_test.dart
+++ b/pkgs/test/test/runner/hybrid_test.dart
@@ -10,9 +10,8 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:path/path.dart' as p;
-import 'package:test_descriptor/test_descriptor.dart' as d;
-
 import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
 
 import '../io.dart';
 

--- a/pkgs/test_core/lib/src/runner/hybrid_listener.dart
+++ b/pkgs/test_core/lib/src/runner/hybrid_listener.dart
@@ -53,7 +53,7 @@ void listen(Function Function() getMain, List data) {
         _sendError(channel, 'Top-level hybridMain is not a function.');
         return;
       } else if (main is! Function(StreamChannel) &&
-          main is! Function(StreamChannel, Null)) {
+          main is! Function(StreamChannel, Never)) {
         _sendError(channel,
             'Top-level hybridMain() function must take one or two arguments.');
         return;


### PR DESCRIPTION
`Null` is no longer the base type so this type check was no longer valid.