### PR TITLE
Remove dependency on `http_multi_socket`.

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.14.8-dev
+
+* The Node platform will now communicate over only IPv6 if it is available.
+
 ## 1.14.7
 
 * Support the latest `package:coverage`.

--- a/pkgs/test/lib/src/runner/node/platform.dart
+++ b/pkgs/test/lib/src/runner/node/platform.dart
@@ -8,7 +8,6 @@ import 'dart:convert';
 
 import 'package:async/async.dart';
 import 'package:package_config/package_config.dart';
-import 'package:multi_server_socket/multi_server_socket.dart';
 import 'package:node_preamble/preamble.dart' as preamble;
 import 'package:path/path.dart' as p;
 import 'package:stream_channel/stream_channel.dart';
@@ -100,7 +99,12 @@ class NodePlatform extends PlatformPlugin
   /// source map for the compiled suite.
   Future<Pair<StreamChannel, StackTraceMapper>> _loadChannel(
       String path, Runtime runtime, SuiteConfiguration suiteConfig) async {
-    var server = await MultiServerSocket.loopback(0);
+    ServerSocket server;
+    try {
+      server = await ServerSocket.bind(InternetAddress.loopbackIPv6, 0);
+    } on SocketException {
+      server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    }
 
     try {
       var pair = await _spawnProcess(path, runtime, suiteConfig, server.port);

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.14.7
+version: 1.14.8-dev
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
@@ -15,7 +15,6 @@ dependencies:
   http_multi_server: ^2.0.0
   io: ^0.3.0
   js: ^0.6.0
-  multi_server_socket: ^1.0.0
   node_preamble: ^1.3.0
   package_config: ^1.9.0
   path: ^1.2.0


### PR DESCRIPTION
Closes #1264

Listening on both IPv6 and IPv4 allows for the case where `node` only
supports IPv4 but the OS supports IPv6, however this is not a situation
that should come up in the real world.

Bind to IPv6 and fall back to IPv4 if it doesn't work. The node side
calls `net.connect(port)` which should support either assuming OS
support.