### PR TITLE
Use a more consistent wait-for-callbacks pattern

### DIFF
--- a/pkgs/test_api/lib/src/backend/declarer.dart
+++ b/pkgs/test_api/lib/src/backend/declarer.dart
@@ -166,11 +166,10 @@ class Declarer {
         }
       }
 
-      await runZoned(
-          () => Invoker.current.waitForOutstandingCallbacks(() async {
-                await _runSetUps();
-                await body();
-              }),
+      await runZoned(() async {
+        await _runSetUps();
+        await body();
+      },
           // Make the declarer visible to running tests so that they'll throw
           // useful errors when calling `test()` and `group()` within a test.
           zoneValues: {#test.declarer: this});


### PR DESCRIPTION
There are two guarantees in play around outstanding callbacks:
-  `tearDown` callbacks are not called until after outstanding callbacks
   from the test body are complete.
-  The overall test is not considered complete until after outstanding
   callbacks from `tearDown` callbacks are also complete.

Previously these two guarantees were split in two locations. In
`Declarer` the setups and test body are wrapped with
`Invoker.waitForOutstandingCallbacks` to handle the first guarantee. In
`Invoker` a _separate_ outstanding callbacks counter wraps the zone
where the setups and test body are run, and it only counts the
callbacks from the teardown callbacks. It is immediately awaited after
spawning the future that runs the entire case - setups, test body, and
teardowns.

Now the two guarantees are handled together in sequence with a pattern
that matches the intent - there are two calls to
`waitForOutstandingCallbacks` so that both guarantees are clear.

- Remove the call to `waitForOutstandingCallbacks` in `Declarer`.
- Remove the wrapping in `Future` in `Invoker`. Since we immediately
  awaited the async counter the only thing that the Future wrapping was
  accomplishing was to delay the start of the test body - this is now
  accomplished with `await Future(() {});`.
- Use two calls to `waitForOutstandingCallbacks` instead of wrapping a
  different levels - remove the counter zone key from the surrounding
  zone.