### PR TITLE
Remove a workaround for an old SDK bug

### DIFF
--- a/pkgs/test_api/lib/src/remote_listener.dart
+++ b/pkgs/test_api/lib/src/remote_listener.dart
@@ -61,10 +61,6 @@ class RemoteListener {
       channel.sink.add({'type': 'print', 'line': line});
     });
 
-    // Work-around for https://github.com/dart-lang/sdk/issues/32556. Remove
-    // once fixed.
-    Stream.fromIterable([]).listen((_) {}).cancel();
-
     SuiteChannelManager().asCurrent(() {
       StackTraceFormatter().asCurrent(() {
         runZoned(() async {


### PR DESCRIPTION
The linked issue is closed as fixed.