### PR TITLE
Ignore a null runner suite in json reporter

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.15.1-dev
+
+* Avoid a confusing stack trace when there is a problem loading a platform when
+  using the JSON reporter and enabling debugging.
+
 ## 1.15.0
 
 * Update bootstrapping logic to ensure the bootstrap library has

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.15.0
+version: 1.15.1-dev
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.9-dev
+
+* Ignore a null `RunnerSuite` rather than throw an error.
+
 ## 0.3.8
 
 * Update vm bootstrapping logic to ensure the bootstrap library has the same

--- a/pkgs/test_core/lib/src/runner/reporter/json.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/json.dart
@@ -177,14 +177,9 @@ class JsonReporter implements Reporter {
     // different metadata.
     if (suite is LoadSuite) {
       suite.suite.then((runnerSuite) {
+        if (runnerSuite == null) return;
         _suiteIDs[runnerSuite] = id;
         if (!_config.debug) return;
-
-        if (runnerSuite == null) {
-          throw StateError('Recieved a null runnerSuite from platform '
-              '${suite.platform.runtime.name}. Unable to debug.\n'
-              'Test glob: ${_config.filename}');
-        }
 
         // TODO(nweiz): test this when we have a library for communicating with
         // the Chrome remote debugger, or when we have VM debug support.

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.8
+version: 0.3.9-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
The `StateError` had been put in with #1245 in order to facilitate
debugging this problem when it surfaces sometimes for flutter.

In #1258 Jake pointed out that there is a comment which mentions that
the `runnerSuite` may be null if it is unavailable due to a load error.

I'm still not sure exactly the conditions that lead to this behavior,
but it should ideally come with some other more clear error, so ignoring
it here should hopefully make things less confusing.