### PR TITLE
Run tests in declaring zone

### DIFF
--- a/pkgs/test_api/lib/src/backend/live_test.dart
+++ b/pkgs/test_api/lib/src/backend/live_test.dart
@@ -125,7 +125,7 @@ abstract class LiveTest {
   ///
   /// This returns the same [Future] as [onComplete]. It may not be called more
   /// than once.
-  Future run();
+  Future run([Map<Object, Object> additionalZoneVariables]);
 
   /// Signals that this test should stop emitting events and release any
   /// resources it may have allocated.

--- a/pkgs/test_api/lib/src/backend/live_test_controller.dart
+++ b/pkgs/test_api/lib/src/backend/live_test_controller.dart
@@ -33,7 +33,7 @@ class LiveTestController extends LiveTest {
   final Test test;
 
   /// The function that will actually start the test running.
-  final void Function() _onRun;
+  final void Function(Map<Object, Object> additionZoneVariables) _onRun;
 
   /// A function to run when the test is closed.
   ///
@@ -140,7 +140,7 @@ class LiveTestController extends LiveTest {
   }
 
   @override
-  Future<void> run() {
+  Future<void> run([Map<Object, Object> additionalZoneVariables]) {
     if (_runCalled) {
       throw StateError('LiveTest.run() may not be called more than once.');
     } else if (_isClosed) {
@@ -149,7 +149,7 @@ class LiveTestController extends LiveTest {
     }
     _runCalled = true;
 
-    _onRun();
+    _onRun(additionalZoneVariables);
     return onComplete;
   }
 

--- a/pkgs/test_api/lib/src/remote_listener.dart
+++ b/pkgs/test_api/lib/src/remote_listener.dart
@@ -255,8 +255,7 @@ class RemoteListener {
       });
     });
 
-    runZoned(() {
-      liveTest.run().then((_) => channel.sink.add({'type': 'complete'}));
-    }, zoneValues: {#test.runner.test_channel: channel});
+    liveTest.run({#test.runner.test_channel: channel}).then(
+        (_) => channel.sink.add({'type': 'complete'}));
   }
 }

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -399,7 +399,7 @@ class Engine {
 
     LiveTestController controller;
     controller =
-        LiveTestController(suiteController.liveSuite.suite, skipped, () {
+        LiveTestController(suiteController.liveSuite.suite, skipped, (_) {
       controller.setState(const State(Status.running, Result.success));
       controller.setState(const State(Status.running, Result.skipped));
 

--- a/pkgs/test_core/lib/src/runner/runner_test.dart
+++ b/pkgs/test_core/lib/src/runner/runner_test.dart
@@ -38,7 +38,7 @@ class RunnerTest extends Test {
   LiveTest load(Suite suite, {Iterable<Group> groups}) {
     LiveTestController controller;
     VirtualChannel testChannel;
-    controller = LiveTestController(suite, this, () {
+    controller = LiveTestController(suite, this, (_) {
       controller.setState(const State(Status.running, Result.success));
 
       testChannel = _channel.virtualChannel();


### PR DESCRIPTION
Three problems (at least) surfaced by using the Zone from when main was
run rather than the zone when the runner is asking the invoker to run:

1 The heartbeat stuff could get stuck by a FakeAsync zone when the users
  calls `test()`. It wouldn't let the timer run.
2 The communication channel for "remote" tests can't find the channel
  for the specific test that it should be speaking over.
3 We expect an Invoker.guard() to funnel the errors to the correct test
  case. If they surface in the same zone as we ran `main()` it looks
  like a test error.

For 1 I _think_ we can run the timer in the root zone since that should
always have sane async behavior. The invoker zone is necessarily a child
of it anyway.

For 2 With some interface changes we can pass the important zone
variable through rather than setting it on a zone in the remote
listener. There might also be a better overall structure that would make
this less awkward.

For 3 it seems sufficient to always "guard" the tests so that uncaught
errors show up for the right invoker, but there is some conversation
about letting errors (probably `Future.error`s...) cross from `setUpAll`
to `tearDownAll` without getting stuck in an error Zone. It _looks_ like
`Invoker.guard` should already handle some of that.