### PR TITLE
Refactor tests for consistent error zones

### DIFF
--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.2.18-dev
+
 ## 0.2.17
 
 * Add `languageVersionComment` on the `MetaData` class. This should only be

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.2.17
+version: 0.2.18-dev
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 

--- a/pkgs/test_api/test/backend/declarer_test.dart
+++ b/pkgs/test_api/test/backend/declarer_test.dart
@@ -286,16 +286,17 @@ void main() {
 
     test('runs in the same error zone as the test', () {
       return expectTestsPass(() {
-        Future future;
+        Zone testBodyZone;
+
         tearDown(() {
-          // If the tear-down is in a different error zone than the test, the
-          // error will try to cross the zone boundary and get top-leveled.
-          expect(future, throwsA('oh no'));
+          final tearDownZone = Zone.current;
+          expect(tearDownZone.inSameErrorZone(testBodyZone), isTrue,
+              reason: 'The tear down callback is in a different error zone '
+                  'than the test body.');
         });
 
         test('test', () {
-          future = Future.error('oh no');
-          expect(future, throwsA('oh no'));
+          testBodyZone = Zone.current;
         });
       });
     });

--- a/pkgs/test_api/test/frontend/add_tear_down_test.dart
+++ b/pkgs/test_api/test/frontend/add_tear_down_test.dart
@@ -166,13 +166,13 @@ void main() {
     test('runs in the same error zone as the test', () {
       return expectTestsPass(() {
         test('test', () {
-          var future = Future.error('oh no');
-          expect(future, throwsA('oh no'));
+          final testBodyZone = Zone.current;
 
           addTearDown(() {
-            // If the tear-down is in a different error zone than the test, the
-            // error will try to cross the zone boundary and get top-leveled.
-            expect(future, throwsA('oh no'));
+            final tearDownZone = Zone.current;
+            expect(tearDownZone.inSameErrorZone(testBodyZone), isTrue,
+                reason: 'The tear down callback is in a different error zone '
+                    'than the test body.');
           });
         });
       });
@@ -566,14 +566,13 @@ void main() {
     test('runs in the same error zone as the setUpAll', () async {
       return expectTestsPass(() {
         setUpAll(() {
-          var future = Future.error('oh no');
-          expect(future, throwsA('oh no'));
+          final setUpAllZone = Zone.current;
 
           addTearDown(() {
-            // If the tear-down is in a different error zone than the setUpAll,
-            // the error will try to cross the zone boundary and get
-            // top-leveled.
-            expect(future, throwsA('oh no'));
+            final tearDownZone = Zone.current;
+            expect(tearDownZone.inSameErrorZone(setUpAllZone), isTrue,
+                reason: 'The tear down callback is in a different error zone '
+                    'than the set up all callback.');
           });
         });
 


### PR DESCRIPTION
Previously the tests validated that an error Future which originates in
one zone is able to complete as an error in the other zone. Since errors
are not allowed to cross zone boundaries the future would never complete
and result in a test timeout.

Zones can indicate directly when they are in the same error zone. Using
this API means the test can fail fast instead of a waiting for a
timeout, and the API more directly expresses the intent of the test.