### PR TITLE
Add a cast on the Invoker pulled from the zone

### DIFF
--- a/pkgs/test_api/lib/src/backend/invoker.dart
+++ b/pkgs/test_api/lib/src/backend/invoker.dart
@@ -150,7 +150,7 @@ class Invoker {
           // capture [zone] and with it the outstanding callback counter for
           // the zone in which [error] was thrown.
           handleUncaughtError: (self, _, zone, error, stackTrace) {
-        var invoker = zone[#test.invoker];
+        var invoker = zone[#test.invoker] as Invoker;
         if (invoker != null) {
           self.parent.run(() => invoker._handleError(zone, error, stackTrace));
         } else {


### PR DESCRIPTION
Very minor - allows jumping to definition on `_handleError` which makes
things slightly easier to navigate around.