### PR TITLE
Fix some static errors after merge from master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,31 +19,31 @@ jobs:
       env: PKGS="pkgs/test pkgs/test_api pkgs/test_core"
       script: ./tool/travis.sh dartfmt dartanalyzer
     - stage: unit_test
-      name: "SDK: be/raw/latest; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 0`"
+      name: "SDK: be/raw/latest; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 0`"
       dart: be/raw/latest
       os: linux
       env: PKGS="pkgs/test"
       script: ./tool/travis.sh command_0
     - stage: unit_test
-      name: "SDK: be/raw/latest; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 1`"
+      name: "SDK: be/raw/latest; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 1`"
       dart: be/raw/latest
       os: linux
       env: PKGS="pkgs/test"
       script: ./tool/travis.sh command_1
     - stage: unit_test
-      name: "SDK: be/raw/latest; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 2`"
+      name: "SDK: be/raw/latest; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 2`"
       dart: be/raw/latest
       os: linux
       env: PKGS="pkgs/test"
       script: ./tool/travis.sh command_2
     - stage: unit_test
-      name: "SDK: be/raw/latest; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 3`"
+      name: "SDK: be/raw/latest; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 3`"
       dart: be/raw/latest
       os: linux
       env: PKGS="pkgs/test"
       script: ./tool/travis.sh command_3
     - stage: unit_test
-      name: "SDK: be/raw/latest; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 4`"
+      name: "SDK: be/raw/latest; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 4`"
       dart: be/raw/latest
       os: linux
       env: PKGS="pkgs/test"

--- a/pkgs/test/mono_pkg.yaml
+++ b/pkgs/test/mono_pkg.yaml
@@ -7,8 +7,8 @@ stages:
         - dartfmt: sdk
         - dartanalyzer: --enable-experiment=non-nullable --fatal-infos --fatal-warnings .
     - unit_test:
-      - command: xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 0
-      - command: xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 1
-      - command: xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 2
-      - command: xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 3
-      - command: xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 4
+      - command: xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 0
+      - command: xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 1
+      - command: xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 2
+      - command: xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 3
+      - command: xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 4

--- a/pkgs/test/test/runner/hybrid_test.dart
+++ b/pkgs/test/test/runner/hybrid_test.dart
@@ -315,6 +315,7 @@ void main() {
 
     test('closes the channel when the test finishes by default', () async {
       await d.file('test.dart', '''
+        // @dart=2.7
         import "package:stream_channel/stream_channel.dart";
         import "package:test/test.dart";
 

--- a/pkgs/test_api/lib/src/backend/invoker.dart
+++ b/pkgs/test_api/lib/src/backend/invoker.dart
@@ -152,7 +152,7 @@ class Invoker {
           // capture [zone] and with it the outstanding callback counter for
           // the zone in which [error] was thrown.
           handleUncaughtError: (self, _, zone, error, stackTrace) {
-        var invoker = zone[#test.invoker] as Invoker;
+        var invoker = zone[#test.invoker] as Invoker?;
         if (invoker != null) {
           self.parent!.run(() => invoker._handleError(zone, error, stackTrace));
         } else {

--- a/pkgs/test_core/lib/src/runner/configuration.dart
+++ b/pkgs/test_core/lib/src/runner/configuration.dart
@@ -229,7 +229,7 @@ class Configuration {
   ///
   /// Throws a [FormatException] if its contents are invalid.
   factory Configuration.loadFromString(String source,
-          {bool global = false, Uri sourceUrl}) =>
+          {bool global = false, Uri? sourceUrl}) =>
       loadFromString(source, global: global, sourceUrl: sourceUrl);
 
   factory Configuration(

--- a/pkgs/test_core/lib/src/runner/configuration/load.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/load.dart
@@ -55,7 +55,7 @@ Configuration load(String path, {bool global = false}) {
 ///
 /// Throws a [FormatException] if the configuration is invalid.
 Configuration loadFromString(String source,
-    {bool global = false, Uri sourceUrl}) {
+    {bool global = false, Uri? sourceUrl}) {
   var document = loadYamlNode(source, sourceUrl: sourceUrl);
 
   if (document.value == null) return Configuration.empty;

--- a/pkgs/test_core/lib/src/runner/parse_metadata.dart
+++ b/pkgs/test_core/lib/src/runner/parse_metadata.dart
@@ -48,7 +48,7 @@ class _Parser {
   final String _contents;
 
   /// The language version override comment if one was present, otherwise null.
-  String? _languageVersionComment;
+  String _languageVersionComment;
 
   _Parser(this._path, this._contents, this._platformVariables) {
     var result =

--- a/pkgs/test_core/lib/src/runner/reporter/json.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/json.dart
@@ -194,7 +194,7 @@ class JsonReporter implements Reporter {
     }
 
     _emit('suite', {
-      'suite': {
+      'suite': <String, Object?>{
         'id': id,
         'platform': suite.platform.runtime.identifier,
         'path': suite.path

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -7,10 +7,8 @@ import 'dart:core' as core;
 import 'dart:core';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:isolate';
 
 import 'package:async/async.dart';
-import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
 
 import 'package:test_api/src/backend/operating_system.dart'; // ignore: implementation_imports
@@ -36,18 +34,6 @@ final int lineLength = () {
   } on StdoutException {
     return _defaultLineLength;
   }
-}();
-
-/// A comment which forces the language version to be that of the current
-/// packages default.
-///
-/// If the cwd is not a package, this returns an empty string which ends up
-/// defaulting to the current sdk version.
-final Future<String> rootPackageLanguageVersionComment = () async {
-  var packageConfig = await loadPackageConfigUri(await Isolate.packageConfig);
-  var rootPackage = packageConfig.packageOf(Uri.file(p.absolute('foo.dart')));
-  if (rootPackage == null) return '';
-  return '// @dart=${rootPackage.languageVersion}';
 }();
 
 /// The root directory of the Dart SDK.

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -55,24 +55,24 @@ for PKG in ${PKGS}; do
     echo -e "\033[1mPKG: ${PKG}; TASK: ${TASK}\033[22m"
     case ${TASK} in
     command_0)
-      echo 'xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 0'
-      xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 0 || EXIT_CODE=$?
+      echo 'xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 0'
+      xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 0 || EXIT_CODE=$?
       ;;
     command_1)
-      echo 'xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 1'
-      xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 1 || EXIT_CODE=$?
+      echo 'xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 1'
+      xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 1 || EXIT_CODE=$?
       ;;
     command_2)
-      echo 'xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 2'
-      xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 2 || EXIT_CODE=$?
+      echo 'xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 2'
+      xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 2 || EXIT_CODE=$?
       ;;
     command_3)
-      echo 'xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 3'
-      xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 3 || EXIT_CODE=$?
+      echo 'xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 3'
+      xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 3 || EXIT_CODE=$?
       ;;
     command_4)
-      echo 'xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 4'
-      xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 4 || EXIT_CODE=$?
+      echo 'xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 4'
+      xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 4 || EXIT_CODE=$?
       ;;
     command_5)
       echo 'pub run --enable-experiment=non-nullable test --preset travis -x browser'


### PR DESCRIPTION
- Add nullable types to the Configuration.loadFromString API which was
  added on the master branch.
- Remove the extra copy of `rootPackageLanguageVersionComment` since
  it was defined in different libraries on the master branch and
  null_safety branch.
- Remove erroneously added `?` on a field in an opt-out library.