### PR TITLE
Remove some comment references to "[this]"

### DIFF
--- a/pkgs/test_api/lib/src/backend/stack_trace_formatter.dart
+++ b/pkgs/test_api/lib/src/backend/stack_trace_formatter.dart
@@ -34,9 +34,9 @@ class StackTraceFormatter {
   static StackTraceFormatter get current =>
       Zone.current[_currentKey] as StackTraceFormatter;
 
-  /// Runs [body] with [this] as [StackTraceFormatter.current].
+  /// Runs [body] with this as [StackTraceFormatter.current].
   ///
-  /// This is zone-scoped, so [this] will be the current configuration in any
+  /// This is zone-scoped, so this will be the current configuration in any
   /// asynchronous callbacks transitively created by [body].
   T asCurrent<T>(T Function() body) =>
       runZoned(body, zoneValues: {_currentKey: this});

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.3.10-dev
+
 ## 0.3.9
 
 * Ignore a null `RunnerSuite` rather than throw an error.

--- a/pkgs/test_core/lib/src/runner/configuration.dart
+++ b/pkgs/test_core/lib/src/runner/configuration.dart
@@ -444,14 +444,14 @@ class Configuration {
     return Map.unmodifiable(input);
   }
 
-  /// Runs [body] with [this] as [Configuration.current].
+  /// Runs [body] with this as [Configuration.current].
   ///
-  /// This is zone-scoped, so [this] will be the current configuration in any
+  /// This is zone-scoped, so this will be the current configuration in any
   /// asynchronous callbacks transitively created by [body].
   T asCurrent<T>(T Function() body) =>
       runZoned(body, zoneValues: {_currentKey: this});
 
-  /// Throws a [FormatException] if [this] refers to any undefined runtimes.
+  /// Throws a [FormatException] if this refers to any undefined runtimes.
   void validateRuntimes(List<Runtime> allRuntimes) {
     // We don't need to verify [customRuntimes] here because those runtimes
     // already need to be verified and resolved to create [allRuntimes].

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -73,14 +73,14 @@ class Engine {
   /// A pool that limits the number of test suites running concurrently.
   final Pool _runPool;
 
-  /// A completer that will complete when [this] is unpaused.
+  /// A completer that will complete when this engine is unpaused.
   ///
-  /// If [this] isn't paused, [_pauseCompleter] is `null`.
+  /// `null` if this engine is not paused.
   Completer _pauseCompleter;
 
-  /// A future that completes once [this] is unpaused.
+  /// A future that completes once this is unpaused.
   ///
-  /// If [this] isn't paused, this completes immediately.
+  /// If this engine isn't paused, this future completes immediately.
   Future get _onUnpaused =>
       _pauseCompleter == null ? Future.value() : _pauseCompleter.future;
 

--- a/pkgs/test_core/lib/src/runner/live_suite_controller.dart
+++ b/pkgs/test_core/lib/src/runner/live_suite_controller.dart
@@ -61,7 +61,7 @@ class _LiveSuite extends LiveSuite {
 /// suite, [noMoreLiveTests] should be called. Once the suite should be torn
 /// down, [close] should be called.
 class LiveSuiteController {
-  /// The [LiveSuite] controlled by [this].
+  /// The [LiveSuite] being controlled.
   LiveSuite get liveSuite => _liveSuite;
   LiveSuite _liveSuite;
 

--- a/pkgs/test_core/lib/src/runner/suite.dart
+++ b/pkgs/test_core/lib/src/runner/suite.dart
@@ -122,8 +122,7 @@ class SuiteConfiguration {
 
   Set<String> _knownTags;
 
-  /// All child configurations of [this] that may be selected under various
-  /// circumstances.
+  /// All child configurations that may be selected under various circumstances.
   Iterable<SuiteConfiguration> get _children sync* {
     yield* tags.values;
     yield* onPlatform.values;
@@ -307,7 +306,7 @@ class SuiteConfiguration {
     return config._resolveTags();
   }
 
-  /// Throws a [FormatException] if [this] refers to any undefined runtimes.
+  /// Throws a [FormatException] if this refers to any undefined runtimes.
   void validateRuntimes(List<Runtime> allRuntimes) {
     var validVariables =
         allRuntimes.map((runtime) => runtime.identifier).toSet();
@@ -333,7 +332,7 @@ class SuiteConfiguration {
     });
   }
 
-  /// Returns a copy of [this] with all platform-specific configuration from
+  /// Returns a copy of this with all platform-specific configuration from
   /// [onPlatform] resolved.
   SuiteConfiguration forPlatform(SuitePlatform platform) {
     if (onPlatform.isEmpty) return this;

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.9
+version: 0.3.10-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
These references don't work in the analysis server and would report an
error if we turn on the `comment_references` lint.