### PR TITLE
Add a `Fake` base class to the test API.

### DIFF
--- a/pkgs/test/test/util/fake_test.dart
+++ b/pkgs/test/test/util/fake_test.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// ignore: deprecated_member_use
+@TestOn('vm')
+import 'package:test/test.dart';
+
+import '../utils.dart';
+
+void main() {
+  _FakeSample fake;
+  setUp(() {
+    fake = _FakeSample();
+  });
+  test('method invocation', () {
+    expect(
+        () => fake.f(),
+        throwsA(isTestFailure(
+            'Symbol("f") invoked on fake object of type _FakeSample')));
+  });
+  test('getter', () {
+    expect(
+        () => fake.x,
+        throwsA(isTestFailure(
+            'Symbol("x") invoked on fake object of type _FakeSample')));
+  });
+  test('setter', () {
+    expect(
+        () => fake.x = 0,
+        throwsA(isTestFailure(
+            'Symbol("x=") invoked on fake object of type _FakeSample')));
+  });
+  test('operator', () {
+    expect(
+        () => fake + 1,
+        throwsA(isTestFailure(
+            'Symbol("+") invoked on fake object of type _FakeSample')));
+  });
+  test('==', () {
+    expect(
+        () => fake == Object(),
+        throwsA(isTestFailure(
+            'Symbol("==") invoked on fake object of type _FakeSample')));
+  });
+  test('hashCode', () {
+    expect(
+        () => fake.hashCode,
+        throwsA(isTestFailure(
+            'Symbol("hashCode") invoked on fake object of type _FakeSample')));
+  });
+  test('runtimeType', () {
+    expect(
+        () => fake.runtimeType,
+        throwsA(isTestFailure(
+            'Symbol("runtimeType") invoked on fake object of type _FakeSample')));
+  });
+}
+
+class _Sample {
+  void f() {}
+
+  int get x => 0;
+
+  void set x(int value) {}
+
+  int operator +(int other) => 0;
+}
+
+class _FakeSample extends Fake implements _Sample {}

--- a/pkgs/test/test/util/fake_test.dart
+++ b/pkgs/test/test/util/fake_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/pkgs/test/test/util/fake_test.dart
+++ b/pkgs/test/test/util/fake_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore: deprecated_member_use
 @TestOn('vm')
 import 'package:test/test.dart';
 

--- a/pkgs/test_core/lib/test_core.dart
+++ b/pkgs/test_core/lib/test_core.dart
@@ -287,7 +287,7 @@ void setUpAll(dynamic Function() callback) => _declarer.setUpAll(callback);
 void tearDownAll(dynamic Function() callback) =>
     _declarer.tearDownAll(callback);
 
-/// Base class that may be used by a test to create a mock object that should
+/// Base class that may be used by a test to create a fake object that should
 /// never be used.  For example:
 ///
 ///     class FakeFoo extends Fake implements Foo {}

--- a/pkgs/test_core/lib/test_core.dart
+++ b/pkgs/test_core/lib/test_core.dart
@@ -13,6 +13,7 @@ import 'package:path/path.dart' as p;
 import 'package:test_api/backend.dart'; //ignore: deprecated_member_use
 import 'package:test_api/src/backend/declarer.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/invoker.dart'; // ignore: implementation_imports
+import 'package:test_api/src/frontend/expect.dart'; // ignore: implementation_imports
 import 'package:test_api/src/frontend/timeout.dart'; // ignore: implementation_imports
 import 'package:test_api/src/utils.dart'; // ignore: implementation_imports
 
@@ -285,3 +286,33 @@ void setUpAll(dynamic Function() callback) => _declarer.setUpAll(callback);
 /// prohibitively slow.
 void tearDownAll(dynamic Function() callback) =>
     _declarer.tearDownAll(callback);
+
+/// Base class that may be used by a test to create a mock object that should
+/// never be used.  For example:
+///
+///     class FakeFoo extends Fake implements Foo {}
+///
+/// The behavior of a fake object is similar to `null`, except that:
+/// - It may be passed into a non-nullable API.
+/// - It satisfies `is` checks for the type it is mocking.
+/// - It throws an exception for any method invocation, whereas `null` supports
+///   toString(), hashCode, etc.
+class Fake {
+  const Fake();
+
+  @override
+  bool operator ==(Object other) =>
+      noSuchMethod(Invocation.method(#==, [other]));
+
+  @override
+  int get hashCode => noSuchMethod(Invocation.getter(#hashCode));
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    fail('${invocation.memberName} invoked on fake object of type '
+        '${super.runtimeType}');
+  }
+
+  @override
+  Type get runtimeType => noSuchMethod(Invocation.getter(#runtimeType));
+}


### PR DESCRIPTION
This can be used by tests to create mock objects that are not expected
to be used; these can be useful when testing non-nullable APIs.