### PR TITLE
Support Fuchsia in test_core executable.

### DIFF
--- a/pkgs/test_core/lib/src/executable.dart
+++ b/pkgs/test_core/lib/src/executable.dart
@@ -48,11 +48,7 @@ void completeShutdown() {
     signalSubscription = null;
   }
   isShutdown = true;
-
-  // Applications can't access stdin on Fuchsia.
-  if (!Platform.isFuchsia) {
-    stdinLines.cancel(immediate: true);
-  }
+  stdinLines.cancel(immediate: true);
 }
 
 Future<void> _execute(List<String> args) async {

--- a/pkgs/test_core/lib/src/executable.dart
+++ b/pkgs/test_core/lib/src/executable.dart
@@ -48,7 +48,11 @@ void completeShutdown() {
     signalSubscription = null;
   }
   isShutdown = true;
-  stdinLines.cancel(immediate: true);
+
+  // Applications can't access stdin on Fuchsia.
+  if (!Platform.isFuchsia) {
+    stdinLines.cancel(immediate: true);
+  }
 }
 
 Future<void> _execute(List<String> args) async {
@@ -60,6 +64,8 @@ Future<void> _execute(List<String> args) async {
   /// terminates the program immediately.
   final _signals = Platform.isWindows
       ? ProcessSignal.sigint.watch()
+      : Platform.isFuchsia // Signals don't exist on Fuchsia.
+      ? Stream.empty()
       : StreamGroup.merge(
           [ProcessSignal.sigterm.watch(), ProcessSignal.sigint.watch()]);
 

--- a/pkgs/test_core/lib/src/executable.dart
+++ b/pkgs/test_core/lib/src/executable.dart
@@ -61,9 +61,9 @@ Future<void> _execute(List<String> args) async {
   final _signals = Platform.isWindows
       ? ProcessSignal.sigint.watch()
       : Platform.isFuchsia // Signals don't exist on Fuchsia.
-      ? Stream.empty()
-      : StreamGroup.merge(
-          [ProcessSignal.sigterm.watch(), ProcessSignal.sigint.watch()]);
+          ? Stream.empty()
+          : StreamGroup.merge(
+              [ProcessSignal.sigterm.watch(), ProcessSignal.sigint.watch()]);
 
   Configuration configuration;
   try {

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -65,7 +65,11 @@ SuitePlatform currentPlatform(Runtime runtime) => SuitePlatform(runtime,
     inGoogle: inGoogle);
 
 /// A queue of lines of standard input.
-final stdinLines = StreamQueue(lineSplitter.bind(stdin));
+///
+/// Also returns an empty stream for Fuchsia since Fuchsia components can't
+/// access stdin.
+final stdinLines = StreamQueue(
+    Platform.isFuchsia ? Stream<String>.empty() : lineSplitter.bind(stdin));
 
 /// Whether this is being run as a subprocess in the test package's own tests.
 bool inTestTests = Platform.environment['_DART_TEST_TESTING'] == 'true';


### PR DESCRIPTION
Fuchsia doesn't have POSIX signals, and compons can't access stdin on
Fuchsia. Avoid accessing anything related to prevent test runner from
crashing for Fuchsia on-device tests.