### PR TITLE
Stop holding the InvokerZone on the Invoker

### DIFF
--- a/pkgs/test_api/lib/src/backend/invoker.dart
+++ b/pkgs/test_api/lib/src/backend/invoker.dart
@@ -158,12 +158,6 @@ class Invoker {
         }
       }));
 
-  /// The zone that the top level of [_test.body] is running in.
-  ///
-  /// Tracking this ensures that [_timeoutTimer] isn't created in a
-  /// timer-mocking zone created by the test.
-  Zone _invokerZone;
-
   /// The timer for tracking timeouts.
   ///
   /// This will be `null` until the test starts running.
@@ -271,7 +265,7 @@ class Invoker {
       return message;
     }
 
-    _timeoutTimer = _invokerZone.createTimer(timeout, () {
+    _timeoutTimer = Zone.root.createTimer(timeout, () {
       _outstandingCallbackZones.last.run(() {
         _handleError(Zone.current, TimeoutException(message(), timeout));
       });
@@ -372,7 +366,6 @@ class Invoker {
     Chain.capture(() {
       _guardIfGuarded(() {
         runZoned(() async {
-          _invokerZone = Zone.current;
           _outstandingCallbackZones.add(Zone.current);
 
           // Run the test asynchronously so that the "running" state change

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   matcher: ">=0.12.6 <0.12.9"
 
 dev_dependencies:
-  fake_async: ^1.0.0
   pedantic: ^1.0.0
   test_descriptor: ^1.0.0
   test_process: ^1.0.0

--- a/pkgs/test_api/test/backend/invoker_test.dart
+++ b/pkgs/test_api/test/backend/invoker_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:fake_async/fake_async.dart';
 import 'package:test/test.dart';
 import 'package:test_api/src/backend/group.dart';
 import 'package:test_api/src/backend/invoker.dart';
@@ -425,90 +424,25 @@ void main() {
   });
 
   group('timeout:', () {
-    test('a test times out after 30 seconds by default', () {
-      FakeAsync().run((async) {
-        var liveTest = _localTest(() {
-          Invoker.current.addOutstandingCallback();
-        }).load(suite);
+    test('A test can be timed out', () {
+      var liveTest = _localTest(() {
+        Invoker.current.addOutstandingCallback();
+      }, metadata: Metadata(timeout: Timeout(Duration(milliseconds: 100))))
+          .load(suite);
 
-        expectStates(liveTest, [
-          const State(Status.running, Result.success),
-          const State(Status.complete, Result.error)
-        ]);
+      expectStates(liveTest, [
+        const State(Status.running, Result.success),
+        const State(Status.complete, Result.error)
+      ]);
 
-        expectErrors(liveTest, [
-          (error) {
-            expect(lastState.status, equals(Status.complete));
-            expect(error, TypeMatcher<TimeoutException>());
-          }
-        ]);
+      expectErrors(liveTest, [
+        (error) {
+          expect(lastState.status, equals(Status.complete));
+          expect(error, TypeMatcher<TimeoutException>());
+        }
+      ]);
 
-        liveTest.run();
-        async.elapse(Duration(seconds: 30));
-      });
-    });
-
-    test("a test's custom timeout takes precedence", () {
-      FakeAsync().run((async) {
-        var liveTest = _localTest(() {
-          Invoker.current.addOutstandingCallback();
-        }, metadata: Metadata(timeout: Timeout(Duration(seconds: 15))))
-            .load(suite);
-
-        expectStates(liveTest, [
-          const State(Status.running, Result.success),
-          const State(Status.complete, Result.error)
-        ]);
-
-        expectErrors(liveTest, [
-          (error) {
-            expect(lastState.status, equals(Status.complete));
-            expect(error, TypeMatcher<TimeoutException>());
-          }
-        ]);
-
-        liveTest.run();
-        async.elapse(Duration(seconds: 15));
-      });
-    });
-
-    test('a timeout factor is applied on top of the 30s default', () {
-      FakeAsync().run((async) {
-        var liveTest = _localTest(() {
-          Invoker.current.addOutstandingCallback();
-        }, metadata: Metadata(timeout: Timeout.factor(0.5)))
-            .load(suite);
-
-        expectStates(liveTest, [
-          const State(Status.running, Result.success),
-          const State(Status.complete, Result.error)
-        ]);
-
-        expectErrors(liveTest, [
-          (error) {
-            expect(lastState.status, equals(Status.complete));
-            expect(error, TypeMatcher<TimeoutException>());
-          }
-        ]);
-
-        liveTest.run();
-        async.elapse(Duration(seconds: 15));
-      });
-    });
-
-    test('a test with Timeout.none never times out', () {
-      FakeAsync().run((async) {
-        var liveTest = _localTest(() {
-          Invoker.current.addOutstandingCallback();
-        }, metadata: Metadata(timeout: Timeout.none))
-            .load(suite);
-
-        expectStates(liveTest, [const State(Status.running, Result.success)]);
-
-        liveTest.run();
-        async.elapse(Duration(hours: 10));
-        expect(liveTest.state.status, equals(Status.running));
-      });
+      liveTest.run();
     });
   });
 


### PR DESCRIPTION
The commented purpose and usage of this field are to avoid problems
where a `heartbeat` call is in a `Zone` which interferes with `Timer`
behavior. `Zone.root` should always have known behavior, or at the least
the `_invokerZone` would have always been a descendent of this root zone
anyway, so it shouldn't introduce any problems that weren't present
before.