### PR TITLE
Fix error when meta add unawaited

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 0.3.10-dev
+## 0.3.10
+
+* Prepare for `unawaited` from `package:meta`.
 
 ## 0.3.9
 

--- a/pkgs/test_core/lib/test_core.dart
+++ b/pkgs/test_core/lib/test_core.dart
@@ -8,7 +8,7 @@ library test_core;
 
 import 'dart:async';
 
-import 'package:meta/meta.dart';
+import 'package:meta/meta.dart' show isTest, isTestGroup;
 import 'package:path/path.dart' as p;
 import 'package:test_api/backend.dart'; //ignore: deprecated_member_use
 import 'package:test_api/src/backend/declarer.dart'; // ignore: implementation_imports

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.10-dev
+version: 0.3.10
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
We have a definition of `unawaited` which is visible from of of the
`test_api/src/` imports to avoid a transitive dep on `pedeantic`. This
causes a static error onces `meta` has a method with the same name.
`pedantic` will be updated to export this method and `test_api` should
do the same until we migrate all usages to the definition from `meta`.
We can't migrate directly to the definition from `meta` since the
version which adds this has a lower SDK bound of `2.9.0` and we aren't
prepared to set our lower bound that high, especially since that SDK is
not yet published. An explicit show on the import of `meta` is backwards
and forward compatible.