### PR TITLE
Update dep on matcher and prepare to publish

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.15.3
+
+* Update to `matcher` version `0.12.9` which improves the mismatch description
+  for deep collection equality matchers and TypeMatcher.
+
 ## 1.15.2
 
 * Use the latest `test_core` which resolves an issue with the latest

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.15.2
+version: 1.15.3
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
@@ -32,8 +32,8 @@ dependencies:
   webkit_inspection_protocol: ">=0.5.0 <0.8.0"
   yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.2.17
-  test_core: 0.3.10
+  test_api: 0.2.18
+  test_core: 0.3.11
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 0.2.18-dev
+## 0.2.18
+
+* Update to `matcher` version `0.12.9`.
 
 ## 0.2.17
 

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.2.18-dev
+version: 0.2.18
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 
@@ -20,7 +20,7 @@ dependencies:
 
   # Use a tight version constraint to ensure that a constraint on matcher
   # properly constrains all features it provides.
-  matcher: ">=0.12.6 <0.12.9"
+  matcher: 0.12.9
 
 dev_dependencies:
   pedantic: ^1.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.11
+
+* Update to `matcher` version `0.12.9`.
+
 ## 0.3.10
 
 * Prepare for `unawaited` from `package:meta`.

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.10
+version: 0.3.11
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
@@ -27,11 +27,10 @@ dependencies:
   stream_channel: ">=1.7.0 <3.0.0"
   vm_service: '>=1.0.0 <5.0.0'
   yaml: ^2.0.0
-  # Use a tight version constraint to ensure that a constraint on matcher
-  # properly constrains all features it provides.
-  matcher: ">=0.12.6 <0.12.9"
+  # matcher is tightly constrained by test_api
+  matcher: any
   # Use an exact version until the test_api package is stable.
-  test_api: 0.2.17
+  test_api: 0.2.18
 
 dependency_overrides:
   test_api:


### PR DESCRIPTION
Use an `any` constraint from `test_core` since the constraint from
`test_api` is already narrow.