### PR TITLE
Prep for merge into master

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 1.16.0-dev
+## 1.16.0-nullsafety
 
 * Support running tests with null safety.
+  * Note that the test runner itself is not fully migrated yet.
 
 ## 1.15.3
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,39 +1,39 @@
 name: test
-version: 1.16.0-dev
+version: 1.16.0-nullsafety
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
 environment:
-  sdk: '>=2.9.0-1 <3.0.0'
+  sdk: '>=2.9.0-18.0 <2.9.0'
 
 dependencies:
   analyzer: '>=0.36.0 <0.40.0'
-  async: ^2.0.0
-  boolean_selector: '>=1.0.0 <3.0.0'
+  async: '>=2.5.0-nullsafety <2.5.0'
+  boolean_selector: '>=2.1.0-nullsafety <2.1.0'
   coverage: '>=0.13.4 < 0.15.0'
   http: ^0.12.0
   http_multi_server: ^2.0.0
   io: ^0.3.0
-  js: ^0.6.0
+  js: '>=0.6.3-nullsafety <0.6.3'
   node_preamble: ^1.3.0
   package_config: ^1.9.0
-  path: ^1.2.0
-  pedantic: ^1.1.0
-  pool: ^1.3.0
+  path: '>=1.8.0-nullsafety <1.8.0'
+  pedantic: '>=1.10.0-nullsafety <1.10.0'
+  pool: '>=1.5.0-nullsafety <1.5.0'
   shelf: ^0.7.0
   shelf_packages_handler: ">=1.0.0 <3.0.0"
   shelf_static: ^0.2.6
   shelf_web_socket: ^0.2.0
-  source_span: ^1.4.0
-  stack_trace: ^1.9.0
-  stream_channel: '>=1.7.0 <3.0.0'
-  typed_data: ^1.0.0
+  source_span: '>=1.8.0-nullsafety <1.8.0'
+  stack_trace: '>=1.10.0-nullsafety <1.10.0'
+  stream_channel: '>=2.1.0-nullsafety <2.1.0'
+  typed_data: '>=1.3.0-nullsafety <1.3.0'
   web_socket_channel: ^1.0.0
   webkit_inspection_protocol: ">=0.5.0 <0.8.0"
   yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.2.18
-  test_core: 0.3.11
+  test_api: 0.2.19-nullsafety
+  test_core: 0.3.12-nullsafety
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0-dev
+## 0.2.19-nullsafety
 
 * Migrate to NNBD.
   * The vast majority of changes are intended to express the pre-existing

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,29 +1,29 @@
 name: test_api
-version: 0.3.0-dev
+version: 0.2.19-nullsafety
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 
 environment:
-  sdk: ">=2.9.0-1 <3.0.0"
+  sdk: ">=2.9.0-18.0 <2.9.0"
 
 dependencies:
-  async: ^2.0.0
-  boolean_selector: ">=1.0.0 <3.0.0"
-  collection: ^1.8.0
-  meta: ^1.1.5
-  path: ^1.2.0
-  source_span: ^1.4.0
-  stack_trace: ^1.9.0
-  stream_channel: ">=1.7.0 <3.0.0"
-  string_scanner: ^1.0.0
-  term_glyph: ^1.0.0
+  async: '>=2.5.0-nullsafety <2.5.0'
+  boolean_selector: ">=2.1.0-nullsafety <2.1.0"
+  collection: '>=1.15.0-nullsafety <1.15.0'
+  meta: '>=1.3.0-nullsafety <1.3.0'
+  path: '>=1.8.0-nullsafety <1.8.0'
+  source_span: '>=1.8.0-nullsafety <1.8.0'
+  stack_trace: '>=1.10.0-nullsafety <1.10.0'
+  stream_channel: '>=2.1.0-nullsafety <2.1.0'
+  string_scanner: '>=1.1.0-nullsafety <1.1.0'
+  term_glyph: '>=1.2.0-nullsafety <1.2.0'
 
   # Use a tight version constraint to ensure that a constraint on matcher
   # properly constrains all features it provides.
-  matcher: 0.12.9
+  matcher: '>=0.12.10-nullsafety <0.12.10'
 
 dev_dependencies:
-  pedantic: ^1.0.0
+  pedantic: '>=1.10.0-nullsafety <1.10.0'
   test_descriptor: ^1.0.0
   test_process: ^1.0.0
   test: any
@@ -50,10 +50,7 @@ dependency_overrides:
     git:
       url: git://github.com/dart-lang/clock.git
       ref: null_safety
-  collection:
-    git:
-      url: git://github.com/dart-lang/collection.git
-      ref: null_safety
+  collection: 1.15.0-nullsafety
   fake_async:
     git:
       url: git://github.com/dart-lang/fake_async.git
@@ -61,17 +58,12 @@ dependency_overrides:
   js:
     git:
       url: git://github.com/dart-lang/sdk.git
-      ref: null_safety-pkgs
       path: pkg/js
   matcher:
     git:
       url: git://github.com/dart-lang/matcher.git
       ref: null_safety
-  meta:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      ref: null_safety-pkgs
-      path: pkg/meta
+  meta: 1.3.0-nullsafety
   path:
     git:
       url: git://github.com/dart-lang/path.git

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.12-nullsafety
+
+* Migrate to null safety.
+
 ## 0.3.11
 
 * Update to `matcher` version `0.12.9`.

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,36 +1,36 @@
 name: test_core
-version: 0.3.11
+version: 0.3.12-nullsafety
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
 environment:
-  sdk: ">=2.9.0-1 <3.0.0"
+  sdk: ">=2.9.0-18.0 <2.9.0"
 
 dependencies:
   analyzer: ">=0.39.5 <0.40.0"
-  async: ^2.0.0
+  async: '>=2.5.0-nullsafety <2.5.0'
   args: ^1.4.0
-  boolean_selector: ">=1.0.0 <3.0.0"
-  collection: ^1.8.0
+  boolean_selector: ">=2.1.0-nullsafety <2.1.0"
+  collection: '>=1.15.0-nullsafety <1.15.0'
   coverage: ">=0.13.3 < 0.15.0"
   glob: ^1.0.0
   io: ^0.3.0
-  meta: ^1.1.5
+  meta: '>=1.3.0-nullsafety <1.3.0'
   package_config: ^1.9.2
-  path: ^1.2.0
-  pedantic: ^1.0.0
-  pool: ^1.3.0
-  source_map_stack_trace: ^2.0.0
-  source_maps: ^0.10.2
-  source_span: ^1.4.0
-  stack_trace: ^1.9.0
-  stream_channel: ">=1.7.0 <3.0.0"
+  path: '>=1.8.0-nullsafety <1.8.0'
+  pedantic: '>=1.10.0-nullsafety <1.10.0'
+  pool: '>=1.5.0-nullsafety <1.5.0'
+  source_map_stack_trace: '>=2.1.0-nullsafety <2.1.0'
+  source_maps: '>=0.11.0-nullsafety <0.11.0'
+  source_span: '>=1.8.0-nullsafety <1.8.0'
+  stack_trace: '>=1.10.0-nullsafety <1.10.0'
+  stream_channel: ">=2.1.0-nullsafety <2.1.0"
   vm_service: '>=1.0.0 <5.0.0'
   yaml: ^2.0.0
   # matcher is tightly constrained by test_api
   matcher: any
   # Use an exact version until the test_api package is stable.
-  test_api: 0.3.0
+  test_api: 0.2.19-nullsafety
 
 dependency_overrides:
   test_api:
@@ -47,24 +47,16 @@ dependency_overrides:
     git:
       url: git://github.com/dart-lang/charcode.git
       ref: null_safety
-  collection:
-    git:
-      url: git://github.com/dart-lang/collection.git
-      ref: null_safety
+  collection: 1.15.0-nullsafety
   js:
     git:
       url: git://github.com/dart-lang/sdk.git
-      ref: null_safety-pkgs
       path: pkg/js
   matcher:
     git:
       url: git://github.com/dart-lang/matcher.git
       ref: null_safety
-  meta:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      ref: null_safety-pkgs
-      path: pkg/meta
+  meta: 1.3.0-nullsafety
   path:
     git:
       url: git://github.com/dart-lang/path.git


### PR DESCRIPTION
I kept these as all non-breaking for now.

The main reason is that test_api and test_core do have some dependencies that are not migrated (mockito, build_test), and I don't want to have issues landing in flutter.