### PR TITLE
Move `Fake` class from Mockito to the test API.

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 * Support running tests with null safety.
   * Note that the test runner itself is not fully migrated yet.
+* Add the `Fake` class, available through `package:test_api/fake.dart`.  This
+  was previously part of the Mockito package, but with null safety it is useful
+  enough that we decided to make it available through `package:test`.  In a
+  future release it will be made available directly through
+  `package:test_api/test_api.dart` (and hence through
+  `package:test_core/test_core.dart` and `package:test/test.dart`).
 
 ## 1.15.3
 

--- a/pkgs/test/lib/fake.dart
+++ b/pkgs/test/lib/fake.dart
@@ -1,0 +1,10 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Note: eventually we would like to fold this into test.dart, but we can't do
+// so until Mockito stops implementing its own version of `Fake`, because there
+// is code in the wild that imports both test_api.dart and Mockito.
+
+// ignore: deprecated_member_use
+export 'package:test_api/fake.dart';

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.2.20-nullsafety
+
+* Add the `Fake` class, available through `package:test_api/fake.dart`.  This
+  was previously part of the Mockito package, but with null safety it is useful
+  enough that we decided to make it available through `package:test`.  In a
+  future release it will be made available directly through
+  `package:test_api/test_api.dart` (and hence through
+  `package:test_core/test_core.dart` and `package:test/test.dart`).
+
 ## 0.2.19-nullsafety
 
 * Migrate to NNBD.

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,12 +1,3 @@
-## 0.2.20-nullsafety
-
-* Add the `Fake` class, available through `package:test_api/fake.dart`.  This
-  was previously part of the Mockito package, but with null safety it is useful
-  enough that we decided to make it available through `package:test`.  In a
-  future release it will be made available directly through
-  `package:test_api/test_api.dart` (and hence through
-  `package:test_core/test_core.dart` and `package:test/test.dart`).
-
 ## 0.2.19-nullsafety
 
 * Migrate to NNBD.
@@ -14,6 +5,12 @@
     behavior of the code regarding to handling of nulls.
   * **Breaking Change**: `GroupEntry.name` is no longer nullable, the root
     group now has the empty string as its name.
+* Add the `Fake` class, available through `package:test_api/fake.dart`.  This
+  was previously part of the Mockito package, but with null safety it is useful
+  enough that we decided to make it available through `package:test`.  In a
+  future release it will be made available directly through
+  `package:test_api/test_api.dart` (and hence through
+  `package:test_core/test_core.dart` and `package:test/test.dart`).
 
 ## 0.2.18
 

--- a/pkgs/test_api/lib/fake.dart
+++ b/pkgs/test_api/lib/fake.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Note: eventually we would like to fold this into test_api.dart, but we can't
+// do so until Mockito stops implementing its own version of `Fake`, because
+// there is code in the wild that imports both test_api.dart and Mockito.
+
+export 'src/frontend/fake.dart';

--- a/pkgs/test_api/lib/fake.dart
+++ b/pkgs/test_api/lib/fake.dart
@@ -6,4 +6,8 @@
 // do so until Mockito stops implementing its own version of `Fake`, because
 // there is code in the wild that imports both test_api.dart and Mockito.
 
+@Deprecated('package:test_api is not intended for general use. '
+    'Please use package:test.')
+library test_api.fake;
+
 export 'src/frontend/fake.dart';

--- a/pkgs/test_api/lib/src/frontend/fake.dart
+++ b/pkgs/test_api/lib/src/frontend/fake.dart
@@ -2,7 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// Extend or mixin this class to mark the implementation as a [Fake].
+/// A stand-in for another object which cannot be used except for specifically
+/// overridden methods.
 ///
 /// A fake has a default behavior for every field and method of throwing
 /// [UnimplementedError]. Fields and methods that are excersized by the code

--- a/pkgs/test_api/lib/src/frontend/fake.dart
+++ b/pkgs/test_api/lib/src/frontend/fake.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Extend or mixin this class to mark the implementation as a [Fake].
+///
+/// A fake has a default behavior for every field and method of throwing
+/// [UnimplementedError]. Fields and methods that are excersized by the code
+/// under test should be manually overridden in the implementing class.
+///
+/// A fake does not have any support for verification or defining behavior from
+/// the test, it cannot be used as a [Mock].
+///
+/// In most cases a shared full fake implementation without a `noSuchMethod` is
+/// preferable to `extends Fake`, however `extends Fake` is preferred against
+/// `extends Mock` mixed with manual `@override` implementations.
+///
+/// __Example use__:
+///
+///     // Real class.
+///     class Cat {
+///       String meow(String suffix) => 'Meow$suffix';
+///       String hiss(String suffix) => 'Hiss$suffix';
+///     }
+///
+///     // Fake class.
+///     class FakeCat extends Fake implements Cat {
+///       @override
+///       String meow(String suffix) => 'FakeMeow$suffix';
+///     }
+///
+///     void main() {
+///       // Create a new fake Cat at runtime.
+///       var cat = new FakeCat();
+///
+///       // Try making a Cat sound...
+///       print(cat.meow('foo')); // Prints 'FakeMeowfoo'
+///       print(cat.hiss('foo')); // Throws
+///     }
+///
+/// **WARNING**: [Fake] uses [noSuchMethod](goo.gl/r3IQUH), which is a _form_ of
+/// runtime reflection, and causes sub-standard code to be generated. As such,
+/// [Fake] should strictly _not_ be used in any production code, especially if
+/// used within the context of Dart for Web (dart2js, DDC) and Dart for Mobile
+/// (Flutter).
+abstract class Fake {
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnimplementedError(invocation.memberName.toString().split('"')[1]);
+  }
+}

--- a/pkgs/test_api/test/frontend/fake_test.dart
+++ b/pkgs/test_api/test/frontend/fake_test.dart
@@ -6,7 +6,7 @@ import 'package:test/test.dart';
 import 'package:test_api/fake.dart' as test_api;
 
 void main() {
-  _FakeSample fake;
+  late _FakeSample fake;
   setUp(() {
     fake = _FakeSample();
   });
@@ -29,7 +29,7 @@ class _Sample {
 
   int get x => 0;
 
-  void set x(int value) {}
+  set x(int value) {}
 
   int operator +(int other) => 0;
 }

--- a/pkgs/test_api/test/frontend/fake_test.dart
+++ b/pkgs/test_api/test/frontend/fake_test.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+import 'package:test_api/fake.dart' as test_api;
+
+void main() {
+  _FakeSample fake;
+  setUp(() {
+    fake = _FakeSample();
+  });
+  test('method invocation', () {
+    expect(() => fake.f(), throwsA(TypeMatcher<UnimplementedError>()));
+  });
+  test('getter', () {
+    expect(() => fake.x, throwsA(TypeMatcher<UnimplementedError>()));
+  });
+  test('setter', () {
+    expect(() => fake.x = 0, throwsA(TypeMatcher<UnimplementedError>()));
+  });
+  test('operator', () {
+    expect(() => fake + 1, throwsA(TypeMatcher<UnimplementedError>()));
+  });
+}
+
+class _Sample {
+  void f() {}
+
+  int get x => 0;
+
+  void set x(int value) {}
+
+  int operator +(int other) => 0;
+}
+
+class _FakeSample extends test_api.Fake implements _Sample {}


### PR DESCRIPTION
With null safety, making a class derived from Fake will become much
more widely useful, since it will no longer be possible to for a test
method to pass `null` into a non-nullable API.