### PR TITLE
Prepare for the 2.10 SDK

### DIFF
--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -4,7 +4,7 @@ description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
 environment:
-  sdk: '>=2.9.0-18.0 <2.9.0'
+  sdk: '>=2.10.0-0 <2.10.0'
 
 dependencies:
   analyzer: '>=0.36.0 <0.40.0'

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -4,7 +4,7 @@ description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 
 environment:
-  sdk: ">=2.9.0-18.0 <2.9.0"
+  sdk: '>=2.10.0-0 <2.10.0'
 
 dependencies:
   async: '>=2.5.0-nullsafety <2.5.0'

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -4,7 +4,7 @@ description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
 environment:
-  sdk: ">=2.9.0-18.0 <2.9.0"
+  sdk: '>=2.10.0-0 <2.10.0'
 
 dependencies:
   analyzer: ">=0.39.5 <0.40.0"


### PR DESCRIPTION
Bump the min SDK constraint to `2.10.0-0` so that they pick up the
`2.10` language version which is required to opt in to null safety with
the `2.10` SDKs.