### PR TITLE
Fix declarer inconsistencies with async test setup

### DIFF
--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -30,22 +30,6 @@ void main() {
 }
 ''';
 
-final _successWithAsync = '''
-import 'dart:async';
-
-import 'package:test/test.dart';
-
-void main() async {
-  test("success 1", () {});
-
-  await otherSetUp();
-
-  test("success 2", () {});
-}
-
-Future<void> otherSetUp() {}
-''';
-
 final _failure = '''
 import 'dart:async';
 
@@ -379,17 +363,28 @@ $_usage''');
   });
 
   group('runs successful tests with async setup', () {
+    setUp(() async {
+      await d.file('test.dart', '''
+        import 'package:test/test.dart';
+
+        void main() async {
+          test("success 1", () {});
+
+          await () async {};
+
+          test("success 2", () {});
+        }
+      ''').create();
+    });
+
     test('defined in a single file', () async {
-      await d.file('test.dart', _successWithAsync).create();
       var test = await runTest(['test.dart']);
       expect(test.stdout, emitsThrough(contains('+2: All tests passed!')));
       await test.shouldExit(0);
     });
 
     test('directly', () async {
-      await d.file('test.dart', _successWithAsync).create();
       var test = await runDart(['test.dart']);
-
       expect(test.stdout, emitsThrough(contains('All tests passed!')));
       await test.shouldExit(0);
     });

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -30,6 +30,22 @@ void main() {
 }
 ''';
 
+final _successWithAsync = '''
+import 'dart:async';
+
+import 'package:test/test.dart';
+
+void main() async {
+  test("success 1", () {});
+
+  await otherSetUp();
+
+  test("success 2", () {});
+}
+
+Future<void> otherSetUp() {}
+''';
+
 final _failure = '''
 import 'dart:async';
 
@@ -358,6 +374,23 @@ $_usage''');
 
       var test = await runTest(['dir/test.dart']);
       expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
+      await test.shouldExit(0);
+    });
+  });
+
+  group('runs successful tests with async setup', () {
+    test('defined in a single file', () async {
+      await d.file('test.dart', _successWithAsync).create();
+      var test = await runTest(['test.dart']);
+      expect(test.stdout, emitsThrough(contains('+2: All tests passed!')));
+      await test.shouldExit(0);
+    });
+
+    test('directly', () async {
+      await d.file('test.dart', _successWithAsync).create();
+      var test = await runDart(['test.dart']);
+
+      expect(test.stdout, emitsThrough(contains('All tests passed!')));
       await test.shouldExit(0);
     });
   });

--- a/pkgs/test_core/lib/test_core.dart
+++ b/pkgs/test_core/lib/test_core.dart
@@ -51,7 +51,7 @@ Declarer get _declarer {
   // [_globalDeclarer], and schedule a microtask to run the tests once they're
   // finished being defined.
   _globalDeclarer = Declarer();
-  scheduleMicrotask(() async {
+  Future(() async {
     var suite = RunnerSuite(const PluginEnvironment(), SuiteConfiguration.empty,
         _globalDeclarer!.build(), SuitePlatform(Runtime.vm, os: currentOSGuess),
         path: p.prettyUri(Uri.base));


### PR DESCRIPTION
When I have a test like this:

```dart
import 'package:test/test.dart';

void main() async {
  setUp(() {});

  await otherSetUp();

  test('a test', () {});
}

Future<void> otherSetUp() {}
```

Running it with `pub test $this_file` works, but running it with `pub run $this_file` throws the following error:

```
Unhandled exception:
Bad state: Can't call test() once tests have begun running.
#0      Declarer._checkNotBuilt (package:test_api/src/backend/declarer.dart:286:5)
#1      Declarer.test (package:test_api/src/backend/declarer.dart:142:5)
#2      test (package:test_core/test_core.dart:138:13)
#3      main (file:///Users/jiahaog/dev/hello_dart/test/hello_dart_test.dart:8:3)
<asynchronous suspension>
#4      _startIsolate.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:301:19)
#5      _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:168:12)
```

This is because there is no declarer when running the tests directly, and the test execution is scheduled for the next microtask before the next test can be declared. When running with the test runner, the declarer is set [explicitly](https://github.com/dart-lang/test/blob/3b8d3b90efd24f55f7316cd414716d1cb031761c/pkgs/test_api/lib/src/remote_listener.dart#L128) and microtasks are not involved, so this issue does not occur.

This might just be working as intended, and I'm not sure of the exact semantics of using `scheduleMicrotask` here, but this error was rather unexpected.