### PR TITLE
Add DetachingFuture utility

### DIFF
--- a/pkgs/test_core/lib/src/runner/package_version.dart
+++ b/pkgs/test_core/lib/src/runner/package_version.dart
@@ -9,14 +9,18 @@ import 'dart:isolate';
 import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
 
+import '../util/detaching_future.dart';
+
 /// A comment which forces the language version to be that of the current
 /// packages default.
 ///
 /// If the cwd is not a package, this returns an empty string which ends up
 /// defaulting to the current sdk version.
-final Future<String> rootPackageLanguageVersionComment = () async {
+Future<String> get rootPackageLanguageVersionComment =>
+    _rootPackageLanguageVersionComment.asFuture;
+final _rootPackageLanguageVersionComment = DetachingFuture(() async {
   var packageConfig = await loadPackageConfigUri(await Isolate.packageConfig);
   var rootPackage = packageConfig.packageOf(Uri.file(p.absolute('foo.dart')));
   if (rootPackage == null) return '';
   return '// @dart=${rootPackage.languageVersion}';
-}();
+}());

--- a/pkgs/test_core/lib/src/util/detaching_future.dart
+++ b/pkgs/test_core/lib/src/util/detaching_future.dart
@@ -14,11 +14,11 @@
 /// In the case of a future that resolves to an error the original future is
 /// retained.
 class DetachingFuture<T> {
-  T _value;
-  Future<T> _inProgress;
+  late T _value;
+  Future<T>? _inProgress;
 
-  DetachingFuture(this._inProgress) {
-    _inProgress.then((result) {
+  DetachingFuture(Future<T> inProgress) : _inProgress = inProgress {
+    inProgress.then((result) {
       _value = result;
       _inProgress = null;
     });

--- a/pkgs/test_core/lib/src/util/detaching_future.dart
+++ b/pkgs/test_core/lib/src/util/detaching_future.dart
@@ -1,0 +1,28 @@
+/// A handle on a [Future] that detaches from the original evaluation context
+/// after it has resolved.
+///
+/// A [Future] holds the Zone it was created in and may hold references to
+/// `async` functions that `await` it. When a future is stored in a static
+/// variable it won't be garbage collected which means all zone variables and
+/// variables in async functions get leaked. [DetachingFuture] works around this
+/// by forgetting the original [Future] after it has resolved, and wrapping the
+/// resolved value with `Future.value` for later calls.
+///
+/// https://github.com/dart-lang/sdk/issues/42457
+/// https://github.com/dart-lang/sdk/issues/42458
+///
+/// In the case of a future that resolves to an error the original future is
+/// retained.
+class DetachingFuture<T> {
+  T _value;
+  Future<T> _inProgress;
+
+  DetachingFuture(this._inProgress) {
+    _inProgress.then((result) {
+      _value = result;
+      _inProgress = null;
+    });
+  }
+
+  Future<T> get asFuture => _inProgress ?? Future.value(_value);
+}

--- a/pkgs/test_core/lib/src/util/detaching_future.dart
+++ b/pkgs/test_core/lib/src/util/detaching_future.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 /// A handle on a [Future] that detaches from the original evaluation context
 /// after it has resolved.
 ///


### PR DESCRIPTION
Fixes one reason that an instance of `Invoker` is always retained        
through the end of the test. Working towards making it easier to         
diagnose why the test runner sometimes fails to exit on travis for #599.