### PR TITLE
Replace Stream.fromIterable([]) with Stream.empty()

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.3.12-nullsafety.2-dev
+
 ## 0.3.12-nullsafety.1
 
 * Update source_maps constraint.

--- a/pkgs/test_core/lib/src/runner/loader.dart
+++ b/pkgs/test_core/lib/src/runner/loader.dart
@@ -140,14 +140,10 @@ class Loader {
   Stream<LoadSuite> loadDir(String dir, SuiteConfiguration suiteConfig) {
     return StreamGroup.merge(
         Directory(dir).listSync(recursive: true).map((entry) {
-      if (entry is! File) return Stream.fromIterable([]);
-
-      if (!_config.filename.matches(p.basename(entry.path))) {
-        return Stream.fromIterable([]);
-      }
-
-      if (p.split(entry.path).contains('packages')) {
-        return Stream.fromIterable([]);
+      if (entry is! File ||
+          !_config.filename.matches(p.basename(entry.path)) ||
+          p.split(entry.path).contains('packages')) {
+        return Stream.empty();
       }
 
       return loadFile(entry.path, suiteConfig);

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.12-nullsafety.1
+version: 0.3.12-nullsafety.2-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
Since it's an empty stream it doesn't matter if it is a broadcast or
single-subscription stream. `Stream.empty` is more descriptive than
`Stream.fromIterable` with a hardcoded empty list.

Collapse the short-circuit checks into a single conditional.