### PR TITLE
Remove cancel from Reporter interface

### DIFF
--- a/pkgs/test_core/lib/src/runner/reporter.dart
+++ b/pkgs/test_core/lib/src/runner/reporter.dart
@@ -19,7 +19,4 @@ abstract class Reporter {
   /// Subclasses should ensure that this does nothing if the reporter isn't
   /// paused.
   void resume();
-
-  /// Cancels the reporter's output.
-  void cancel();
 }

--- a/pkgs/test_core/lib/src/runner/reporter/compact.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/compact.dart
@@ -145,8 +145,7 @@ class CompactReporter implements Reporter {
     }
   }
 
-  @override
-  void cancel() {
+  void _cancel() {
     for (var subscription in _subscriptions) {
       subscription.cancel();
     }
@@ -239,7 +238,7 @@ class CompactReporter implements Reporter {
   /// [success] will be `true` if all tests passed, `false` if some tests
   /// failed, and `null` if the engine was closed prematurely.
   void _onDone(bool? success) {
-    cancel();
+    _cancel();
     _stopwatch.stop();
 
     // A null success value indicates that the engine was closed before the

--- a/pkgs/test_core/lib/src/runner/reporter/expanded.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/expanded.dart
@@ -141,8 +141,7 @@ class ExpandedReporter implements Reporter {
     }
   }
 
-  @override
-  void cancel() {
+  void _cancel() {
     for (var subscription in _subscriptions) {
       subscription.cancel();
     }
@@ -220,6 +219,7 @@ class ExpandedReporter implements Reporter {
   /// [success] will be `true` if all tests passed, `false` if some tests
   /// failed, and `null` if the engine was closed prematurely.
   void _onDone(bool? success) {
+    _cancel();
     // A null success value indicates that the engine was closed before the
     // tests finished running, probably because of a signal from the user, in
     // which case we shouldn't print summary information.

--- a/pkgs/test_core/lib/src/runner/reporter/json.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/json.dart
@@ -106,8 +106,7 @@ class JsonReporter implements Reporter {
     }
   }
 
-  @override
-  void cancel() {
+  void _cancel() {
     for (var subscription in _subscriptions) {
       subscription.cancel();
     }
@@ -276,7 +275,7 @@ class JsonReporter implements Reporter {
   /// [success] will be `true` if all tests passed, `false` if some tests
   /// failed, and `null` if the engine was closed prematurely.
   void _onDone(bool? success) {
-    cancel();
+    _cancel();
     _stopwatch.stop();
 
     _emit('done', {'success': success});

--- a/pkgs/test_core/lib/src/runner/reporter/multiplex.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/multiplex.dart
@@ -10,13 +10,6 @@ class MultiplexReporter implements Reporter {
   MultiplexReporter(this.delegates);
 
   @override
-  void cancel() {
-    for (var d in delegates) {
-      d.cancel();
-    }
-  }
-
-  @override
   void pause() {
     for (var d in delegates) {
       d.pause();


### PR DESCRIPTION
This method is never called from outside any reporter so it is
unnecessary to require it. The cancel method on `ExpandedReporter` was
never called before, add a call in `_onDone` to match the other
reporters.