### PR TITLE
Rely on non-null stack trace from AsyncError

### DIFF
--- a/pkgs/test_core/lib/src/runner/reporter/compact.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/compact.dart
@@ -229,9 +229,7 @@ class CompactReporter implements Reporter {
   }
 
   /// A callback called when [liveTest] throws [error].
-  //
-  // TODO: make `stackTrace` non-nullable once they are non-nullable in the sdk
-  void _onError(LiveTest liveTest, error, StackTrace? stackTrace) {
+  void _onError(LiveTest liveTest, error, StackTrace stackTrace) {
     if (liveTest.state.status != Status.complete) return;
 
     _progressLine(_description(liveTest),

--- a/pkgs/test_core/lib/src/runner/reporter/expanded.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/expanded.dart
@@ -195,9 +195,7 @@ class ExpandedReporter implements Reporter {
   }
 
   /// A callback called when [liveTest] throws [error].
-  //
-  // TODO: Make `stackTrace` non-nullable once it's non-nullable in the sdk.
-  void _onError(LiveTest liveTest, error, StackTrace? stackTrace) {
+  void _onError(LiveTest liveTest, error, StackTrace stackTrace) {
     if (liveTest.state.status != Status.complete) return;
 
     _progressLine(_description(liveTest), suffix: ' $_bold$_red[E]$_noColor');

--- a/pkgs/test_core/lib/src/runner/reporter/json.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/json.dart
@@ -259,9 +259,7 @@ class JsonReporter implements Reporter {
   }
 
   /// A callback called when [liveTest] throws [error].
-  //
-  // TODO: make `stackTrace` non-nullable once it's non-nullable in the sdk.
-  void _onError(LiveTest liveTest, error, StackTrace? stackTrace) {
+  void _onError(LiveTest liveTest, error, StackTrace stackTrace) {
     _emit('error', {
       'testID': _liveTestIDs[liveTest],
       'error': error.toString(),


### PR DESCRIPTION
Resolves some TODOs from the migration, the `AsyncError` type in the SDK
now has non-nullable `stackTrace` field.