### PR TITLE
Prepare to publish test_core and test

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.16.0-nullsafety.2-dev
+## 1.16.0-nullsafety.2
 
 * Allow version `0.40.x` of `analyzer`.
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.16.0-nullsafety.2-dev
+version: 1.16.0-nullsafety.2
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.12-nullsafety.2-dev
+## 0.3.12-nullsafety.2
 
 * Allow version `0.40.x` of `analyzer`.
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.12-nullsafety.2-dev
+version: 0.3.12-nullsafety.2
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
Expands the pub constraint in both packages to allow the latest
`analyzer`.