### PR TITLE
Add capabilities for building direct test runners

### DIFF
--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.19-nullsafety.3
+
+* Add capability for ensuring unique test names and collecting all test names to
+  `Declarer.`
+* Add capability to filter to a single unique test name in `Declarer`.
+
 ## 0.2.19-nullsafety.2
 
 * Allow `2.10` stable and `2.11.0-dev` SDKs.

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## 0.2.19-nullsafety.3
 
-* Add capability for ensuring unique test names and collecting all test names to
-  `Declarer.`
 * Add capability to filter to a single unique test name in `Declarer`.
 
 ## 0.2.19-nullsafety.2

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.19-nullsafety.3
+## 0.2.19-nullsafety.3-dev
 
 * Add capability to filter to a single unique test name in `Declarer`.
 

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.2.19-nullsafety.3-dev
 
-* Add capability to filter to a single unique test name in `Declarer`.
+* Add capability to filter to a single exact test name in `Declarer`.
 
 ## 0.2.19-nullsafety.2
 

--- a/pkgs/test_api/lib/src/backend/declarer.dart
+++ b/pkgs/test_api/lib/src/backend/declarer.dart
@@ -93,8 +93,7 @@ class Declarer {
 
   /// A full test name to match when running in single test mode.
   ///
-  /// Groups which are not a strict prefix of `filterToSingleTestName` will be
-  /// skipped.
+  /// Groups which are not a strict prefix of this name will be ignored.
   final String? _filterToSingleTestName;
 
   /// The current zone-scoped declarer.

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.2.19-nullsafety.2
+version: 0.2.19-nullsafety.3-dev
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.12-nullsafety.6-dev
+
+* Add experimental `directRunTests`, `directRunSingle`, and `enumerateTestCases`
+  APIs to enable test runners written around a single executable that can report
+  and run any single test case.
+
 ## 0.3.12-nullsafety.5
 
 * Allow `2.10` stable and `2.11.0-dev` SDKs.

--- a/pkgs/test_core/lib/direct_run.dart
+++ b/pkgs/test_core/lib/direct_run.dart
@@ -19,7 +19,7 @@ import 'src/util/print_sink.dart';
 Future<bool> directRunTests(FutureOr<void> Function() testMain,
     {Reporter Function(Engine)? reporter}) async {
   reporter ??= (engine) => ExpandedReporter.watch(engine, PrintSink(),
-      color: Configuration.empty.color);
+      color: Configuration.empty.color, printPath: false, printPlatform: false);
   final declarer = Declarer();
   await declarer.declare(testMain);
 

--- a/pkgs/test_core/lib/direct_run.dart
+++ b/pkgs/test_core/lib/direct_run.dart
@@ -1,9 +1,17 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
+import 'dart:collection';
 
 import 'package:path/path.dart' as p;
 import 'package:test_api/backend.dart'; //ignore: deprecated_member_use
 import 'package:test_api/src/backend/declarer.dart'; //ignore: implementation_imports
+import 'package:test_api/src/backend/group.dart'; //ignore: implementation_imports
+import 'package:test_api/src/backend/group_entry.dart'; //ignore: implementation_imports
 import 'package:test_api/src/backend/invoker.dart'; // ignore: implementation_imports
+import 'package:test_api/src/backend/test.dart'; //ignore: implementation_imports
 import 'package:test_api/src/frontend/utils.dart'; // ignore: implementation_imports
 import 'package:test_api/src/utils.dart'; // ignore: implementation_imports
 
@@ -16,11 +24,34 @@ import 'src/runner/runner_suite.dart';
 import 'src/runner/suite.dart';
 import 'src/util/print_sink.dart';
 
+/// Run all test cases declared in [testMain].
+///
+/// Test suite level metadata defined in annotations is not read. No filtering
+/// is applied except for the filtering defined by `solo` or `skip` arguments to
+/// `group` and `test`.
 Future<bool> directRunTests(FutureOr<void> Function() testMain,
-    {Reporter Function(Engine)? reporter}) async {
-  reporter ??= (engine) => ExpandedReporter.watch(engine, PrintSink(),
+        {Reporter Function(Engine)? reporterFactory}) =>
+    _directRunTests(testMain, reporterFactory: reporterFactory);
+
+/// Run a single test declared in [testMain].
+///
+/// There must be exactly one test defined with the name [testName]. Note that
+/// not all tests and groups are checked, so a test case that may not be
+/// intended to be run (due to a `solo` on a different test) may still be run
+/// with this API. Only the test names returned by [enumerateTestCases] should
+/// be used.
+Future<bool> directRunSingleTest(
+        FutureOr<void> Function() testMain, String testName,
+        {Reporter Function(Engine)? reporterFactory}) =>
+    _directRunTests(testMain,
+        reporterFactory: reporterFactory, runSingleTestByName: testName);
+
+Future<bool> _directRunTests(FutureOr<void> Function() testMain,
+    {Reporter Function(Engine)? reporterFactory,
+    String? runSingleTestByName}) async {
+  reporterFactory ??= (engine) => ExpandedReporter.watch(engine, PrintSink(),
       color: Configuration.empty.color, printPath: false, printPlatform: false);
-  final declarer = Declarer();
+  final declarer = Declarer(filterToSingleTestName: runSingleTestByName);
   await declarer.declare(testMain);
 
   await pumpEventQueue();
@@ -33,9 +64,72 @@ Future<bool> directRunTests(FutureOr<void> Function() testMain,
     ..suiteSink.add(suite)
     ..suiteSink.close();
 
-  reporter(engine);
+  reporterFactory(engine);
 
   final success = await runZoned(() => Invoker.guard(engine.run),
       zoneValues: {#test.declarer: declarer});
+
+  if (runSingleTestByName != null) {
+    final testCount = engine.liveTests.length;
+    if (testCount > 1) {
+      throw DuplicateTestNameException(runSingleTestByName);
+    }
+    if (testCount == 0) {
+      throw MissingTestException(runSingleTestByName);
+    }
+  }
   return success!;
+}
+
+/// Return the names of all tests declared by [testMain].
+///
+/// Test names declared must be unique. If any test repeats the name of a prior
+/// test a [DuplicateTestNameException] will be thrown.
+///
+/// Skipped tests are ignored.
+Future<Iterable<String>> enumerateTestCases(
+    FutureOr<void> Function() testMain) async {
+  final declarer = Declarer();
+  await declarer.declare(testMain);
+
+  await pumpEventQueue();
+
+  final toVisit = Queue<GroupEntry>.of([declarer.build()]);
+  final allTestNames = <String>{};
+  while (toVisit.isNotEmpty) {
+    final current = toVisit.removeLast();
+    if (current is Group) {
+      toVisit.addAll(current.entries.reversed);
+    } else if (current is Test) {
+      if (current.metadata.skip) continue;
+      if (!allTestNames.add(current.name)) {
+        throw DuplicateTestNameException(current.name);
+      }
+    } else {
+      throw StateError('Unandled Group Entry: ${current.runtimeType}');
+    }
+  }
+  return allTestNames;
+}
+
+/// An exception thrown when two test cases in the same test suite (same `main`)
+/// have an identical name.
+class DuplicateTestNameException implements Exception {
+  final String name;
+  DuplicateTestNameException(this.name);
+
+  @override
+  String toString() => 'A test with the name "$name" was already declared. '
+      'Test cases much have unique names.';
+}
+
+/// An exception thrown when a specific test was requested by name that does not
+/// exist.
+class MissingTestException implements Exception {
+  final String name;
+  MissingTestException(this.name);
+
+  @override
+  String toString() =>
+      'A test with the name "$name" was not declared in the test suite.';
 }

--- a/pkgs/test_core/lib/direct_run.dart
+++ b/pkgs/test_core/lib/direct_run.dart
@@ -1,0 +1,41 @@
+import 'dart:async';
+
+import 'package:path/path.dart' as p;
+import 'package:test_api/backend.dart'; //ignore: deprecated_member_use
+import 'package:test_api/src/backend/declarer.dart'; //ignore: implementation_imports
+import 'package:test_api/src/backend/invoker.dart'; // ignore: implementation_imports
+import 'package:test_api/src/frontend/utils.dart'; // ignore: implementation_imports
+import 'package:test_api/src/utils.dart'; // ignore: implementation_imports
+
+import 'src/runner/configuration.dart';
+import 'src/runner/engine.dart';
+import 'src/runner/plugin/environment.dart';
+import 'src/runner/reporter.dart';
+import 'src/runner/reporter/expanded.dart';
+import 'src/runner/runner_suite.dart';
+import 'src/runner/suite.dart';
+import 'src/util/print_sink.dart';
+
+Future<bool> directRunTests(FutureOr<void> Function() testMain,
+    {Reporter Function(Engine)? reporter}) async {
+  reporter ??= (engine) => ExpandedReporter.watch(engine, PrintSink(),
+      color: Configuration.empty.color);
+  final declarer = Declarer();
+  await declarer.declare(testMain);
+
+  await pumpEventQueue();
+
+  final suite = RunnerSuite(const PluginEnvironment(), SuiteConfiguration.empty,
+      declarer.build(), SuitePlatform(Runtime.vm, os: currentOSGuess),
+      path: p.prettyUri(Uri.base));
+
+  final engine = Engine()
+    ..suiteSink.add(suite)
+    ..suiteSink.close();
+
+  reporter(engine);
+
+  final success = await runZoned(() => Invoker.guard(engine.run),
+      zoneValues: {#test.declarer: declarer});
+  return success!;
+}

--- a/pkgs/test_core/lib/src/direct_run.dart
+++ b/pkgs/test_core/lib/src/direct_run.dart
@@ -120,7 +120,7 @@ class DuplicateTestNameException implements Exception {
 
   @override
   String toString() => 'A test with the name "$name" was already declared. '
-      'Test cases much have unique names.';
+      'Test cases must have unique names.';
 }
 
 /// An exception thrown when a specific test was requested by name that does not

--- a/pkgs/test_core/lib/src/direct_run.dart
+++ b/pkgs/test_core/lib/src/direct_run.dart
@@ -15,14 +15,14 @@ import 'package:test_api/src/backend/test.dart'; //ignore: implementation_import
 import 'package:test_api/src/frontend/utils.dart'; // ignore: implementation_imports
 import 'package:test_api/src/utils.dart'; // ignore: implementation_imports
 
-import 'src/runner/configuration.dart';
-import 'src/runner/engine.dart';
-import 'src/runner/plugin/environment.dart';
-import 'src/runner/reporter.dart';
-import 'src/runner/reporter/expanded.dart';
-import 'src/runner/runner_suite.dart';
-import 'src/runner/suite.dart';
-import 'src/util/print_sink.dart';
+import 'runner/configuration.dart';
+import 'runner/engine.dart';
+import 'runner/plugin/environment.dart';
+import 'runner/reporter.dart';
+import 'runner/reporter/expanded.dart';
+import 'runner/runner_suite.dart';
+import 'runner/suite.dart';
+import 'util/print_sink.dart';
 
 /// Run all test cases declared in [testMain].
 ///

--- a/pkgs/test_core/lib/src/direct_run.dart
+++ b/pkgs/test_core/lib/src/direct_run.dart
@@ -12,7 +12,6 @@ import 'package:test_api/src/backend/group.dart'; //ignore: implementation_impor
 import 'package:test_api/src/backend/group_entry.dart'; //ignore: implementation_imports
 import 'package:test_api/src/backend/invoker.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/test.dart'; //ignore: implementation_imports
-import 'package:test_api/src/frontend/utils.dart'; // ignore: implementation_imports
 import 'package:test_api/src/utils.dart'; // ignore: implementation_imports
 
 import 'runner/configuration.dart';
@@ -54,8 +53,6 @@ Future<bool> _directRunTests(FutureOr<void> Function() testMain,
   final declarer = Declarer(filterToSingleTestName: runSingleTestByName);
   await declarer.declare(testMain);
 
-  await pumpEventQueue();
-
   final suite = RunnerSuite(const PluginEnvironment(), SuiteConfiguration.empty,
       declarer.build(), SuitePlatform(Runtime.vm, os: currentOSGuess),
       path: p.prettyUri(Uri.base));
@@ -91,8 +88,6 @@ Future<Iterable<String>> enumerateTestCases(
     FutureOr<void> Function() testMain) async {
   final declarer = Declarer();
   await declarer.declare(testMain);
-
-  await pumpEventQueue();
 
   final toVisit = Queue<GroupEntry>.of([declarer.build()]);
   final allTestNames = <String>{};

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.12-nullsafety.5
+version: 0.3.12-nullsafety.6-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
@@ -31,7 +31,7 @@ dependencies:
   # matcher is tightly constrained by test_api
   matcher: any
   # Use an exact version until the test_api package is stable.
-  test_api: 0.2.19-nullsafety.2
+  test_api: 0.2.19-nullsafety.3
 
 dependency_overrides:
   test_api:


### PR DESCRIPTION
Towards #1310, #1328

Add `directRunTest` to configure a reporter and run tests directly in
the same isolate.

Add `enumerateTestCases` to collect test names without running them, and
`directRunSingleTest` to run a specific test by its full name. These
APIs ensure the uniqueness of test names to avoid ambiguity. This
restriction may be spread to tests run through the normal test runner as
well.

- Add `fullTestName` option on `Declarer`. When used, only the test (or
  tests if uniqueness is not checked separately) will be considered as a
  test case.
- Add `directRunTest`, `enumerateTestCases`, and `directRunSingleTest`
  APIs. These are kept under a `lib/src/` import for now, and any other
  package that uses these APIs should pin to a specific version of
  `package:test_core`. The details of these APIs might change without a
  major version bump.