### PR TITLE
Avoid importing all of test_core from load_suite

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.3.12-nullsafety.5-dev
+
 ## 0.3.12-nullsafety.4
 
 * Support latest `package:vm_service`.

--- a/pkgs/test_core/lib/src/runner/load_suite.dart
+++ b/pkgs/test_core/lib/src/runner/load_suite.dart
@@ -14,11 +14,10 @@ import 'package:test_api/src/backend/suite.dart'; // ignore: implementation_impo
 import 'package:test_api/src/backend/suite_platform.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/test.dart'; // ignore: implementation_imports
 import 'package:test_api/src/utils.dart'; // ignore: implementation_imports
+// ignore: deprecated_member_use
+import 'package:test_api/test_api.dart' show Timeout;
 
-import '../../test_core.dart';
-import '../util/io_stub.dart'
-    // ignore: uri_does_not_exist
-    if (dart.library.io) '../util/io.dart';
+import '../util/io_stub.dart' if (dart.library.io) '../util/io.dart';
 import 'load_exception.dart';
 import 'plugin/environment.dart';
 import 'runner_suite.dart';
@@ -76,7 +75,7 @@ class LoadSuite extends Suite implements RunnerSuite {
   ///
   /// Load suites are guaranteed to only contain one test. This is a utility
   /// method for accessing it directly.
-  Test get test => this.group.entries.single as Test;
+  Test get test => group.entries.single as Test;
 
   /// Creates a load suite named [name] on [platform].
   ///
@@ -199,7 +198,7 @@ class LoadSuite extends Suite implements RunnerSuite {
 
   @override
   LoadSuite filter(bool Function(Test) callback) {
-    var filtered = this.group.filter(callback);
+    var filtered = group.filter(callback);
     filtered ??= Group.root([], metadata: metadata);
     return LoadSuite._filtered(this, filtered);
   }

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.12-nullsafety.4
+version: 0.3.12-nullsafety.5-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
Change an import of `test_core.dart` to an import of `package:test_api`. 
Add an explicit show to make it more clear that only Timeout is used.

Other minor cleanup:
- Remove a stale ignore from when DDC struggled with conditional
  imports.
- Fix some lints about unnecessary `this`.