### PR TITLE
Add a centralized platform import

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.3.12-nullsafety.5-dev
 
+* Add `src/platform.dart` library to consolidate the necessary imports required
+  to write a custom platform.
+
 ## 0.3.12-nullsafety.4
 
 * Support latest `package:vm_service`.

--- a/pkgs/test_core/lib/src/platform.dart
+++ b/pkgs/test_core/lib/src/platform.dart
@@ -1,5 +1,7 @@
 export 'package:test_api/backend.dart' show SuitePlatform, Runtime, runtimes;
-export 'package:test_core/src/runner/environment.dart' show PluginEnvironment;
+export 'package:test_core/src/runner/configuration.dart' show Configuration;
+export 'package:test_core/src/runner/environment.dart'
+    show PluginEnvironment, Environment;
 export 'package:test_core/src/runner/hack_register_platform.dart'
     show registerPlatformPlugin;
 export 'package:test_core/src/runner/platform.dart'

--- a/pkgs/test_core/lib/src/platform.dart
+++ b/pkgs/test_core/lib/src/platform.dart
@@ -1,11 +1,11 @@
-export 'package:test_api/backend.dart' show SuitePlatform, Runtime, runtimes;
+// ignore: deprecated_member_use
+export 'package:test_api/backend.dart' show SuitePlatform, Runtime;
 export 'package:test_core/src/runner/configuration.dart' show Configuration;
 export 'package:test_core/src/runner/environment.dart'
     show PluginEnvironment, Environment;
 export 'package:test_core/src/runner/hack_register_platform.dart'
     show registerPlatformPlugin;
-export 'package:test_core/src/runner/platform.dart'
-    show platforms, PlatformPlugin;
+export 'package:test_core/src/runner/platform.dart' show PlatformPlugin;
 export 'package:test_core/src/runner/plugin/platform_helpers.dart'
     show deserializeSuite;
 export 'package:test_core/src/runner/runner_suite.dart'

--- a/pkgs/test_core/lib/src/platform.dart
+++ b/pkgs/test_core/lib/src/platform.dart
@@ -1,0 +1,11 @@
+export 'package:test_api/backend.dart' show SuitePlatform, Runtime, runtimes;
+export 'package:test_core/src/runner/environment.dart' show PluginEnvironment;
+export 'package:test_core/src/runner/hack_register_platform.dart'
+    show registerPlatformPlugin;
+export 'package:test_core/src/runner/platform.dart'
+    show platforms, PlatformPlugin;
+export 'package:test_core/src/runner/plugin/platform_helpers.dart'
+    show deserializeSuite;
+export 'package:test_core/src/runner/runner_suite.dart'
+    show RunnerSuite, RunnerSuiteController;
+export 'package:test_core/src/runner/suite.dart' show SuiteConfiguration;


### PR DESCRIPTION
Towards #962

Make it easier to import the necessary things for writing a custom
platform. This does not expose `executable` so a custom test runner
would need to import at a minimum this and the executable. The symbols
exported here are the ones used by `flutter_tools` in
`flutter_platform.dart` and `test_wrapper.dart`, if other platforms need
other symbols we may need to expand this some.

The import remains a `src` import since these are not yet stable enough
to be fully public. Centralizing and adding `show` clauses will make it
easier to know what is used and for which intent.