### PR TITLE
Fix documentation over custom HTML templates

### DIFF
--- a/pkgs/test/README.md
+++ b/pkgs/test/README.md
@@ -550,7 +550,7 @@ the following HTML file:
 ### Providing a custom HTML template
 
 If you want to share the same HTML file across all tests, you can provide a
-`custom-html-template-path` configuration option to your configuration file.
+`custom_html_template_path` configuration option to your configuration file.
 This file should follow the rules above, except that instead of the link tag
 add exactly one `{{testScript}}` in the place where you want the template processor to insert it.
 
@@ -562,7 +562,7 @@ custom HTML mechanics. In such a case, an error will be thrown.
 For example:
 
 ```yaml
-custom-html-template-path: html_template.html.tpl
+custom_html_template_path: html_template.html.tpl
 ```
 
 ```html


### PR DESCRIPTION
The documentation recommends adding `custom-html-template-path` to a configuration file to use custom HTML templates. However, this will not work - you actually have to add `custom_html_template_path` (See https://github.com/dart-lang/test/pull/1127/files#diff-b9a58c9d38842cb742b063d60ff6fb18R254)