### PR TITLE
Add Target annotations to annotation classes

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.16.0-nullsafety.5-dev
+
+* Annotate the classes used as annotations to restrict their usage to library
+  level.
+
 ## 1.16.0-nullsafety.4
 
 * Depend on the latest test_core.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.16.0-nullsafety.4
+version: 1.16.0-nullsafety.5-dev
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
@@ -33,8 +33,8 @@ dependencies:
   webkit_inspection_protocol: ">=0.5.0 <0.8.0"
   yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.2.19-nullsafety
-  test_core: 0.3.12-nullsafety.4
+  test_api: 0.2.19-nullsafety.2
+  test_core: 0.3.12-nullsafety.5
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.19-nullsafety.2-dev
+
+* Annotate the classes used as annotations to restrict their usage to library
+  level.
+
 ## 0.2.19-nullsafety
 
 * Migrate to NNBD.

--- a/pkgs/test_api/lib/src/frontend/on_platform.dart
+++ b/pkgs/test_api/lib/src/frontend/on_platform.dart
@@ -2,11 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:meta/meta_meta.dart';
+
 /// An annotation for platform-specific customizations for a test suite.
 ///
 /// See [the README][onPlatform].
 ///
 /// [onPlatform]: https://github.com/dart-lang/test/tree/master/pkgs/test#platform-specific-configuration
+@Target({TargetKind.library})
 class OnPlatform {
   final Map<String, dynamic> annotationsByPlatform;
 

--- a/pkgs/test_api/lib/src/frontend/retry.dart
+++ b/pkgs/test_api/lib/src/frontend/retry.dart
@@ -2,10 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// An annotation for marking a test to be retried.
+import 'package:meta/meta_meta.dart';
+
+/// An annotation for marking a test suite to be retried.
 ///
 /// A test with retries enabled will be re-run if it fails for a reason
 /// other than [TestFailure].
+@Target({TargetKind.library})
 class Retry {
   /// The number of times the test will be retried.
   final int count;

--- a/pkgs/test_api/lib/src/frontend/skip.dart
+++ b/pkgs/test_api/lib/src/frontend/skip.dart
@@ -2,7 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:meta/meta_meta.dart';
+
 /// An annotation for marking a test suite as skipped.
+@Target({TargetKind.library})
 class Skip {
   /// The reason the test suite is skipped, or `null` if no reason is given.
   final String? reason;

--- a/pkgs/test_api/lib/src/frontend/tags.dart
+++ b/pkgs/test_api/lib/src/frontend/tags.dart
@@ -2,11 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:meta/meta_meta.dart';
+
 /// An annotation for applying a set of user-defined tags to a test suite.
 ///
 /// See [the documentation on tagging tests][tagging tests].
 ///
 /// [tagging tests]: https://github.com/dart-lang/test/blob/master/README.md#tagging-tests
+@Target({TargetKind.library})
 class Tags {
   /// The tags for the test suite.
   Set<String> get tags => _tags.toSet();

--- a/pkgs/test_api/lib/src/frontend/timeout.dart
+++ b/pkgs/test_api/lib/src/frontend/timeout.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:string_scanner/string_scanner.dart';
+import 'package:meta/meta_meta.dart';
 
 /// A regular expression that matches text until a letter or whitespace.
 ///
@@ -22,6 +23,7 @@ final _whitespace = RegExp(r'\s+');
 /// By default, a test will time out after 30 seconds. With [new Timeout], that
 /// can be overridden entirely; with [Timeout.factor], it can be scaled
 /// relative to the default.
+@Target({TargetKind.library})
 class Timeout {
   /// A constant indicating that a test should never time out.
   static const none = Timeout._none();

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.2.19-nullsafety
+version: 0.2.19-nullsafety.2-dev
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.10.0'
+  sdk: '>=2.10.0-59.0.dev <2.10.0'
 
 dependencies:
   analyzer: ">=0.39.5 <0.41.0"
@@ -31,7 +31,7 @@ dependencies:
   # matcher is tightly constrained by test_api
   matcher: any
   # Use an exact version until the test_api package is stable.
-  test_api: 0.2.19-nullsafety
+  test_api: 0.2.19-nullsafety.2
 
 dependency_overrides:
   test_api:


### PR DESCRIPTION
This will allow the analyzer to emit diagnostics when the annotations
are used in places where they will not be honored by the test runner.
When used as annotations (as opposed to arguments to `test` or `group`)
the test runner only looks at the library level and all annotations
apply to an entire test suite.