### PR TITLE
Drop need for SILENT_OBSERVATORY environment

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Annotate the classes used as annotations to restrict their usage to library
   level.
+* Stop required a `SILENT_OBSERVATORY` environment variable to run with
+  debugging and the JSON reporter.
 
 ## 1.16.0-nullsafety.4
 

--- a/pkgs/test/test/runner/pause_after_load_test.dart
+++ b/pkgs/test/test/runner/pause_after_load_test.dart
@@ -174,28 +174,6 @@ void main() {
     await test.shouldExit(0);
   }, tags: ['firefox', 'chrome', 'vm']);
 
-  test("warns if SILENT_OBSERVATORY isn't set when trying to debug the vm",
-      () async {
-    await d.file('test.dart', '''
-import 'package:test/test.dart';
-
-void main() {
-  test("success", () {});
-}
-''').create();
-
-    var test = await runTest(['--pause-after-load', '-p', 'vm', 'test.dart']);
-    await expectLater(
-        test.stderr,
-        emits('Warning: You should set `SILENT_OBSERVATORY` to true when '
-            'debugging the VM as it will output the observatory URL by '
-            'default.'));
-    test.stdin.writeln();
-    await expectLater(
-        test.stdout, emitsThrough(contains('+1: All tests passed!')));
-    await test.shouldExit(0);
-  });
-
   test('stops immediately if killed while paused', () async {
     await d.file('test.dart', '''
 import 'package:test/test.dart';

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Add `src/platform.dart` library to consolidate the necessary imports required
   to write a custom platform.
+* Stop required a `SILENT_OBSERVATORY` environment variable to run with
+  debugging and the JSON reporter.
 
 ## 0.3.12-nullsafety.4
 

--- a/pkgs/test_core/lib/src/runner.dart
+++ b/pkgs/test_core/lib/src/runner.dart
@@ -31,8 +31,6 @@ import 'runner/reporter.dart';
 import 'runner/reporter/compact.dart';
 import 'runner/reporter/expanded.dart';
 
-final _silentObservatory = const bool.fromEnvironment('SILENT_OBSERVATORY');
-
 /// A class that loads and runs tests based on a [Configuration].
 ///
 /// This maintains a [Loader] and an [Engine] and passes test suites from one to
@@ -113,20 +111,6 @@ class Runner {
         _warnForUnsupportedPlatforms();
 
         var suites = _loadSuites();
-
-        var runTimes = _config.suiteDefaults.runtimes.map(_loader.findRuntime);
-
-        // TODO(grouma) - Remove this check when
-        // https://github.com/dart-lang/sdk/issues/31308 is resolved.
-        if (!_silentObservatory &&
-            runTimes.contains(Runtime.vm) &&
-            _config.debug) {
-          warn('You should set `SILENT_OBSERVATORY` to true when debugging the '
-              'VM as it will output the observatory URL by '
-              'default.\nThis breaks the various reporter contracts.'
-              '\nTo set the value define '
-              '`DART_VM_OPTIONS=-DSILENT_OBSERVATORY=true`.');
-        }
 
         if (_config.coverage != null) {
           await Directory(_config.coverage!).create(recursive: true);

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -67,12 +67,8 @@ class VMPlatform extends PlatformPlugin {
     Environment? environment;
     IsolateRef? isolateRef;
     if (_config.debug) {
-      // Print an empty line because the VM prints an "Observatory listening on"
-      // line and we don't want that to end up on the same line as the reporter
-      // info.
-      if (_config.reporter == 'compact') stdout.writeln();
-
-      var info = await Service.controlWebServer(enable: true);
+      var info =
+          await Service.controlWebServer(enable: true, silenceOutput: true);
       var isolateID = Service.getIsolateID(isolate)!;
 
       var libraryPath = p.toUri(p.absolute(path)).toString();


### PR DESCRIPTION
Closes #1206

- Pass `silenceOutput` when calling `controlWebServer`.
- Drop the check and warning for missing `SILENT_OBSERVATORY`.
- Drop the test for the warning.