### PR TITLE
Allow 2.10 stable and 2.11.0-dev SDKs

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 1.16.0-nullsafety.5-dev
+## 1.16.0-nullsafety.5
 
+* Allow `2.10` stable and `2.11.0-dev` SDKs.
 * Annotate the classes used as annotations to restrict their usage to library
   level.
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,11 +1,11 @@
 name: test
-version: 1.16.0-nullsafety.5-dev
+version: 1.16.0-nullsafety.5
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.10.0'
+  sdk: '>=2.10.0-0 <2.11.0'
 
 dependencies:
   analyzer: '>=0.36.0 <0.41.0'

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.2.19-nullsafety.2-dev
+## 0.2.19-nullsafety.2
 
+* Allow `2.10` stable and `2.11.0-dev` SDKs.
 * Annotate the classes used as annotations to restrict their usage to library
   level.
 

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,11 +1,11 @@
 name: test_api
-version: 0.2.19-nullsafety.2-dev
+version: 0.2.19-nullsafety.2
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.10.0'
+  sdk: '>=2.10.0-0 <2.11.0'
 
 dependencies:
   async: '>=2.5.0-nullsafety <2.5.0'

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.3.12-nullsafety.5-dev
+## 0.3.12-nullsafety.5
 
+* Allow `2.10` stable and `2.11.0-dev` SDKs.
 * Add `src/platform.dart` library to consolidate the necessary imports required
   to write a custom platform.
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,11 +1,11 @@
 name: test_core
-version: 0.3.12-nullsafety.5-dev
+version: 0.3.12-nullsafety.5
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-59.0.dev <2.10.0'
+  sdk: '>=2.10.0-59.0.dev <2.11.0'
 
 dependencies:
   analyzer: ">=0.39.5 <0.41.0"


### PR DESCRIPTION
Now that we are rolling 2.11-dev SDKs to flutter, we need published
versions that allow the `2.11.0-dev` SDK.