### PR TITLE
Remove unused dart:async imports

### DIFF
--- a/pkgs/test_api/lib/src/frontend/throws_matcher.dart
+++ b/pkgs/test_api/lib/src/frontend/throws_matcher.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:matcher/matcher.dart';
 
 import '../utils.dart';

--- a/pkgs/test_api/test/frontend/expect_async_test.dart
+++ b/pkgs/test_api/test/frontend/expect_async_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:test_api/src/backend/live_test.dart';
 import 'package:test_api/src/backend/state.dart';
 import 'package:test/test.dart';

--- a/pkgs/test_core/lib/src/runner/live_suite.dart
+++ b/pkgs/test_core/lib/src/runner/live_suite.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:collection/collection.dart';
 
 import 'package:test_api/src/backend/live_test.dart'; // ignore: implementation_imports

--- a/pkgs/test_core/lib/src/runner/platform.dart
+++ b/pkgs/test_core/lib/src/runner/platform.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:stream_channel/stream_channel.dart';
 
 import 'package:test_api/src/backend/suite_platform.dart'; // ignore: implementation_imports

--- a/pkgs/test_core/lib/src/runner/plugin/remote_platform_helpers.dart
+++ b/pkgs/test_core/lib/src/runner/plugin/remote_platform_helpers.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:stream_channel/stream_channel.dart';
 
 import 'package:test_api/src/backend/stack_trace_formatter.dart'; // ignore: implementation_imports

--- a/pkgs/test_core/lib/src/util/dart.dart
+++ b/pkgs/test_core/lib/src/util/dart.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:isolate';
 


### PR DESCRIPTION
Since Dart 2.1, Future and Stream have been exported from dart:core