### PR TITLE
Remove dependency on package:http

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.16.0-nullsafety.6-dev
+
 ## 1.16.0-nullsafety.5
 
 * Allow `2.10` stable and `2.11.0-dev` SDKs.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.16.0-nullsafety.5
+version: 1.16.0-nullsafety.6-dev
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
@@ -12,7 +12,6 @@ dependencies:
   async: '>=2.5.0-nullsafety <2.5.0'
   boolean_selector: '>=2.1.0-nullsafety <2.1.0'
   coverage: '>=0.13.4 < 0.15.0'
-  http: ^0.12.0
   http_multi_server: ^2.0.0
   io: ^0.3.0
   js: '>=0.6.3-nullsafety <0.6.3'


### PR DESCRIPTION
The usage was unnecessary since the library it is used in is not cross
platform. The `package:http` is a little nicer, add a small extension to
give a similar API here.

Also reuse the HttpClient across both requests rather than create a
separate client for each one which is what the `package:http` top-level
APIs would do.