### PR TITLE
Update comment referring to closed issue

### DIFF
--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.2.19-nullsafety.5-dev
+
 ## 0.2.19-nullsafety.4
 
 * Allow prerelease versions of the 2.12 sdk.

--- a/pkgs/test_api/lib/src/remote_listener.dart
+++ b/pkgs/test_api/lib/src/remote_listener.dart
@@ -46,8 +46,10 @@ class RemoteListener {
   /// for this worker.
   static StreamChannel<Object?> start(Function Function() getMain,
       {bool hidePrints = true, Future Function()? beforeLoad}) {
+    // Synchronous in order to allow `print` output to show up immediately, even
+    // if they are followed by long running synchronous work.
     var controller =
-        StreamChannelController<Object?>(allowForeignErrors: false);
+        StreamChannelController<Object?>(allowForeignErrors: false, sync: true);
     var channel = MultiChannel<Object?>(controller.local);
 
     var verboseChain = true;

--- a/pkgs/test_api/lib/src/remote_listener.dart
+++ b/pkgs/test_api/lib/src/remote_listener.dart
@@ -46,11 +46,8 @@ class RemoteListener {
   /// for this worker.
   static StreamChannel<Object?> start(Function Function() getMain,
       {bool hidePrints = true, Future Function()? beforeLoad}) {
-    // This has to be synchronous to work around sdk#25745. Otherwise, there'll
-    // be an asynchronous pause before a syntax error notification is sent,
-    // which will cause the send to fail entirely.
     var controller =
-        StreamChannelController<Object?>(allowForeignErrors: false, sync: true);
+        StreamChannelController<Object?>(allowForeignErrors: false);
     var channel = MultiChannel<Object?>(controller.local);
 
     var verboseChain = true;

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.2.19-nullsafety.4
+version: 0.2.19-nullsafety.5-dev
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 


### PR DESCRIPTION
This had been synchronous in order to respond to syntax errors when the
isolate tried to start running. In dart 2 the isolate will fail to start
entirely and no code will run.