### PR TITLE
Allow to inject a test channel for browser tests

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.16.0-nullsafety.10
+
+* Allow to inject a test channel for browser tests.
+
 ## 1.16.0-nullsafety.9
 
 * Fix `spawnHybridUri` to respect language versioning of the spawned uri.

--- a/pkgs/test/lib/src/bootstrap/browser.dart
+++ b/pkgs/test/lib/src/bootstrap/browser.dart
@@ -2,13 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:stream_channel/stream_channel.dart';
 import 'package:test_core/src/util/stack_trace_mapper.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/plugin/remote_platform_helpers.dart'; // ignore: implementation_imports
 
 import '../runner/browser/post_message_channel.dart';
 
 /// Bootstraps a browser test to communicate with the test runner.
-void internalBootstrapBrowserTest(Function Function() getMain) {
+void internalBootstrapBrowserTest(Function Function() getMain,
+    {StreamChannel<Object?>? testChannel}) {
   var channel =
       serializeSuite(getMain, hidePrints: false, beforeLoad: () async {
     var serialized =
@@ -16,5 +18,5 @@ void internalBootstrapBrowserTest(Function Function() getMain) {
     if (serialized == null) return;
     setStackTraceMapper(JSStackTraceMapper.deserialize(serialized)!);
   });
-  postMessageChannel().pipe(channel);
+  (testChannel ?? postMessageChannel()).pipe(channel);
 }

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.16.0-nullsafety.9
+version: 1.16.0-nullsafety.10
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 


### PR DESCRIPTION
This lifts a requirement that browser tests must be executed
inside an <iframe>.