### PR TITLE
fix crash if _lastProgressMessage is null when logging progress

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.12-nullsafety.8-dev
+
+* Fix a bug where the test runner could crash when printing the elapsed time.
+
 ## 0.3.12-nullsafety.7
 
 * Allow prerelease versions of the 2.12 sdk.

--- a/pkgs/test_core/lib/src/runner/reporter/compact.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/compact.dart
@@ -184,7 +184,7 @@ class CompactReporter implements Reporter {
 
       // Keep updating the time even when nothing else is happening.
       _subscriptions.add(Stream.periodic(Duration(seconds: 1))
-          .listen((_) => _progressLine(_lastProgressMessage!)));
+          .listen((_) => _progressLine(_lastProgressMessage ?? '')));
     }
 
     // If this is the first test to start, print a progress line so the user

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.12-nullsafety.7
+version: 0.3.12-nullsafety.8-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/test/issues/1362