### PR TITLE
Bump SDK constraints for pub

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.16.0-nullsafety.8
+
+* Update SDK constraints to `>=2.12.0-0 <3.0.0` based on beta release
+  guidelines.
+
 ## 1.16.0-nullsafety.7
 
 * Allow prerelease versions of the 2.12 sdk.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,11 +1,10 @@
 name: test
-version: 1.16.0-nullsafety.7
+version: 1.16.0-nullsafety.8
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
 environment:
-  # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.12.0'
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
   analyzer: '>=0.36.0 <0.41.0'
@@ -32,8 +31,8 @@ dependencies:
   webkit_inspection_protocol: ">=0.5.0 <0.8.0"
   yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.2.19-nullsafety.4
-  test_core: 0.3.12-nullsafety.7
+  test_api: 0.2.19-nullsafety.5
+  test_core: 0.3.12-nullsafety.8
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 0.2.19-nullsafety.5-dev
+## 0.2.19-nullsafety.5
+
+* Update SDK constraints to `>=2.12.0-0 <3.0.0` based on beta release
+  guidelines.
 
 ## 0.2.19-nullsafety.4
 

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,11 +1,10 @@
 name: test_api
-version: 0.2.19-nullsafety.5-dev
+version: 0.2.19-nullsafety.5
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 
 environment:
-  # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.12.0'
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
   async: '>=2.5.0-nullsafety <2.5.0'

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,6 +1,9 @@
-## 0.3.12-nullsafety.8-dev
+## 0.3.12-nullsafety.8
 
 * Fix a bug where the test runner could crash when printing the elapsed time.
+* Update SDK constraints to `>=2.12.0-0 <3.0.0` based on beta release
+  guidelines.
+
 
 ## 0.3.12-nullsafety.7
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,11 +1,10 @@
 name: test_core
-version: 0.3.12-nullsafety.8-dev
+version: 0.3.12-nullsafety.8
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
 environment:
-  # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-59.0.dev <2.12.0'
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
   analyzer: ">=0.39.5 <0.41.0"
@@ -31,7 +30,7 @@ dependencies:
   # matcher is tightly constrained by test_api
   matcher: any
   # Use an exact version until the test_api package is stable.
-  test_api: 0.2.19-nullsafety.4
+  test_api: 0.2.19-nullsafety.5
 
 dependency_overrides:
   test_api:


### PR DESCRIPTION
Use a 2.12.0 lower bound since pub does not understand allowed
experiments for earlier versions.

Use a 3.0.0 upper bound to avoid a warning in pub and to give some
flexibility in publishing for stable.