### PR TITLE
Fix legacy import violations in opted in libraries

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.3.12-nullsafety.9
 
 * Fix `spawnHybridUri` to respect language versioning of the spawned uri.
+* Pre-emptively fix legacy library import lint violations, and unmigrate some
+  libraries as necessary.
 
 ## 0.3.12-nullsafety.8
 

--- a/pkgs/test_core/lib/src/direct_run.dart
+++ b/pkgs/test_core/lib/src/direct_run.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'dart:async';
 import 'dart:collection';
@@ -29,7 +31,7 @@ import 'util/print_sink.dart';
 /// is applied except for the filtering defined by `solo` or `skip` arguments to
 /// `group` and `test`. Returns [true] if all tests passed.
 Future<bool> directRunTests(FutureOr<void> Function() testMain,
-        {Reporter Function(Engine)? reporterFactory}) =>
+        {Reporter Function(Engine) /*?*/ reporterFactory}) =>
     _directRunTests(testMain, reporterFactory: reporterFactory);
 
 /// Runs a single test declared in [testMain] matched by it's full test name.
@@ -47,12 +49,13 @@ Future<bool> directRunTests(FutureOr<void> Function() testMain,
 /// will both be run, then a [DuplicateTestnameException] will be thrown.
 Future<bool> directRunSingleTest(
         FutureOr<void> Function() testMain, String fullTestName,
-        {Reporter Function(Engine)? reporterFactory}) =>
+        {Reporter Function(Engine) /*?*/ reporterFactory}) =>
     _directRunTests(testMain,
         reporterFactory: reporterFactory, fullTestName: fullTestName);
 
 Future<bool> _directRunTests(FutureOr<void> Function() testMain,
-    {Reporter Function(Engine)? reporterFactory, String? fullTestName}) async {
+    {Reporter Function(Engine) /*?*/ reporterFactory,
+    String /*?*/ fullTestName}) async {
   reporterFactory ??= (engine) => ExpandedReporter.watch(engine, PrintSink(),
       color: Configuration.empty.color, printPath: false, printPlatform: false);
   final declarer = Declarer(fullTestName: fullTestName);
@@ -80,7 +83,7 @@ Future<bool> _directRunTests(FutureOr<void> Function() testMain,
       throw MissingTestException(fullTestName);
     }
   }
-  return success!;
+  return success;
 }
 
 /// Runs [testMain] and returns the names of all declared tests.

--- a/pkgs/test_core/lib/src/executable.dart
+++ b/pkgs/test_core/lib/src/executable.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'dart:async';
 import 'dart:io';
@@ -18,16 +20,15 @@ import 'runner.dart';
 import 'util/exit_codes.dart' as exit_codes;
 import 'util/io.dart';
 
-StreamSubscription? signalSubscription;
+StreamSubscription /*?*/ signalSubscription;
 bool isShutdown = false;
 
 /// Returns the path to the global test configuration file.
 final String _globalConfigPath = () {
   if (Platform.environment.containsKey('DART_TEST_CONFIG')) {
-    return Platform.environment['DART_TEST_CONFIG'] as String;
+    return Platform.environment['DART_TEST_CONFIG'];
   } else if (Platform.operatingSystem == 'windows') {
-    return p.join(
-        Platform.environment['LOCALAPPDATA'] as String, 'DartTest.yaml');
+    return p.join(Platform.environment['LOCALAPPDATA'], 'DartTest.yaml');
   } else {
     return '${Platform.environment['HOME']}/.dart_test.yaml';
   }
@@ -45,7 +46,7 @@ Future<void> runTests(List<String> args) async {
 void completeShutdown() {
   if (isShutdown) return;
   if (signalSubscription != null) {
-    signalSubscription!.cancel();
+    signalSubscription.cancel();
     signalSubscription = null;
   }
   isShutdown = true;
@@ -136,7 +137,7 @@ Future<void> _execute(List<String> args) async {
     return;
   }
 
-  Runner? runner;
+  Runner /*?*/ runner;
 
   signalSubscription ??= _signals.listen((signal) async {
     completeShutdown();
@@ -179,7 +180,7 @@ Future<void> _execute(List<String> args) async {
 ///
 /// If [error] is passed, it's used in place of the usage message and the whole
 /// thing is printed to stderr instead of stdout.
-void _printUsage([String? error]) {
+void _printUsage([String /*?*/ error]) {
   var output = stdout;
 
   var message = 'Runs tests in this package.';

--- a/pkgs/test_core/lib/src/platform.dart
+++ b/pkgs/test_core/lib/src/platform.dart
@@ -1,3 +1,9 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
+
 // ignore: deprecated_member_use
 export 'package:test_api/backend.dart' show SuitePlatform, Runtime;
 export 'package:test_core/src/runner/configuration.dart' show Configuration;

--- a/pkgs/test_core/lib/src/runner.dart
+++ b/pkgs/test_core/lib/src/runner.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'dart:async';
 import 'dart:io';
@@ -50,7 +52,7 @@ class Runner {
   final Reporter _reporter;
 
   /// The subscription to the stream returned by [_loadSuites].
-  StreamSubscription? _suiteSubscription;
+  StreamSubscription /*?*/ _suiteSubscription;
 
   /// The set of suite paths for which [_warnForUnknownTags] has already been
   /// called.
@@ -62,7 +64,7 @@ class Runner {
   /// The current debug operation, if any.
   ///
   /// This is stored so that we can cancel it when the runner is closed.
-  CancelableOperation? _debugOperation;
+  CancelableOperation /*?*/ _debugOperation;
 
   /// The memoizer for ensuring [close] only runs once.
   final _closeMemo = AsyncMemoizer();
@@ -81,17 +83,17 @@ class Runner {
           final sink =
               (File(filepath)..createSync(recursive: true)).openWrite();
           sinks.add(sink);
-          return allReporters[reporterName]!.factory(config, engine, sink);
+          return allReporters[reporterName].factory(config, engine, sink);
         }
 
         return Runner._(
           engine,
           MultiplexReporter([
             // Standard reporter.
-            allReporters[config.reporter]!.factory(config, engine, stdout),
+            allReporters[config.reporter].factory(config, engine, stdout),
             // File reporters.
             for (var reporter in config.fileReporters.keys)
-              createFileReporter(reporter, config.fileReporters[reporter]!),
+              createFileReporter(reporter, config.fileReporters[reporter]),
           ]),
           sinks,
         );
@@ -113,21 +115,21 @@ class Runner {
         var suites = _loadSuites();
 
         if (_config.coverage != null) {
-          await Directory(_config.coverage!).create(recursive: true);
+          await Directory(_config.coverage).create(recursive: true);
         }
 
-        bool? success;
+        bool /*?*/ success;
         if (_config.pauseAfterLoad) {
           success = await _loadThenPause(suites);
         } else {
           _suiteSubscription = suites.listen(_engine.suiteSink.add);
           var results = await Future.wait(<Future>[
-            _suiteSubscription!
+            _suiteSubscription
                 .asFuture()
                 .then((_) => _engine.suiteSink.close()),
             _engine.run()
           ], eagerError: true);
-          success = results.last as bool?;
+          success = results.last as bool /*?*/;
         }
 
         if (_closed) return false;
@@ -206,7 +208,7 @@ class Runner {
   /// currently-running VM tests, in case they have stuff to clean up on the
   /// filesystem.
   Future close() => _closeMemo.runOnce(() async {
-        Timer? timer;
+        Timer /*?*/ timer;
         if (!_engine.isIdle) {
           // Wait a bit to print this message, since printing it eagerly looks weird
           // if the tests then finish immediately.
@@ -287,7 +289,7 @@ class Runner {
   /// children.
   void _warnForUnknownTags(Suite suite) {
     if (_tagWarningSuites.contains(suite.path)) return;
-    _tagWarningSuites.add(suite.path!);
+    _tagWarningSuites.add(suite.path);
 
     var unknownTags = _collectUnknownTags(suite);
     if (unknownTags.isEmpty) return;
@@ -339,7 +341,7 @@ class Runner {
       }
 
       if (entry is! Group) return;
-      var group = entry;
+      var group = entry as Group;
 
       currentTags.addAll(newTags);
       for (var child in group.entries) {
@@ -369,8 +371,8 @@ class Runner {
   T _shardSuite<T extends Suite>(T suite) {
     if (_config.totalShards == null) return suite;
 
-    var shardSize = suite.group.testCount / _config.totalShards!;
-    var shardIndex = _config.shardIndex!;
+    var shardSize = suite.group.testCount / _config.totalShards;
+    var shardIndex = _config.shardIndex;
     var shardStart = (shardSize * shardIndex).round();
     var shardEnd = (shardSize * (shardIndex + 1)).round();
 
@@ -388,11 +390,11 @@ class Runner {
   Future<bool> _loadThenPause(Stream<LoadSuite> suites) async {
     _suiteSubscription = suites.asyncMap((loadSuite) async {
       _debugOperation = debug(_engine, _reporter, loadSuite);
-      await _debugOperation!.valueOrCancellation();
+      await _debugOperation.valueOrCancellation();
     }).listen(null);
 
     var results = await Future.wait(<Future>[
-      _suiteSubscription!.asFuture().then((_) => _engine.suiteSink.close()),
+      _suiteSubscription.asFuture().then((_) => _engine.suiteSink.close()),
       _engine.run()
     ], eagerError: true);
     return results.last as bool;

--- a/pkgs/test_core/lib/src/runner/compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/compiler_pool.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'dart:async';
 import 'dart:convert';
@@ -42,7 +44,7 @@ class CompilerPool {
   final List<String> _extraArgs;
 
   /// Creates a compiler pool that multiple instances of `dart2js` at once.
-  CompilerPool([Iterable<String>? extraArgs])
+  CompilerPool([Iterable<String> /*?*/ extraArgs])
       : _pool = Pool(Configuration.current.concurrency),
         _extraArgs = extraArgs?.toList() ?? const [];
 

--- a/pkgs/test_core/lib/src/runner/configuration.dart
+++ b/pkgs/test_core/lib/src/runner/configuration.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'dart:async';
 
@@ -41,40 +43,40 @@ class Configuration {
 
   /// Whether `--help` was passed.
   bool get help => _help ?? false;
-  final bool? _help;
+  final bool /*?*/ _help;
 
   /// Custom HTML template file.
-  final String? customHtmlTemplatePath;
+  final String /*?*/ customHtmlTemplatePath;
 
   /// Whether `--version` was passed.
   bool get version => _version ?? false;
-  final bool? _version;
+  final bool /*?*/ _version;
 
   /// Whether to pause for debugging after loading each test suite.
   bool get pauseAfterLoad => _pauseAfterLoad ?? false;
-  final bool? _pauseAfterLoad;
+  final bool /*?*/ _pauseAfterLoad;
 
   /// Whether to run browsers in their respective debug modes
   bool get debug => pauseAfterLoad || (_debug ?? false) || _coverage != null;
-  final bool? _debug;
+  final bool /*?*/ _debug;
 
   /// The output folder for coverage gathering
-  String? get coverage => _coverage;
-  final String? _coverage;
+  String /*?*/ get coverage => _coverage;
+  final String /*?*/ _coverage;
 
   /// The path to the file from which to load more configuration information.
   ///
   /// This is *not* resolved automatically.
   String get configurationPath => _configurationPath ?? 'dart_test.yaml';
-  final String? _configurationPath;
+  final String /*?*/ _configurationPath;
 
   /// The path to dart2js.
   String get dart2jsPath => _dart2jsPath ?? p.join(sdkDir, 'bin', 'dart2js');
-  final String? _dart2jsPath;
+  final String /*?*/ _dart2jsPath;
 
   /// The name of the reporter to use to display results.
   String get reporter => _reporter ?? defaultReporter;
-  final String? _reporter;
+  final String /*?*/ _reporter;
 
   /// The map of file reporters where the key is the name of the reporter and
   /// the value is the filepath to which its output should be written.
@@ -82,20 +84,20 @@ class Configuration {
 
   /// Whether to disable retries of tests.
   bool get noRetry => _noRetry ?? false;
-  final bool? _noRetry;
+  final bool /*?*/ _noRetry;
 
   /// The URL for the `pub serve` instance from which to load tests, or `null`
   /// if tests should be loaded from the filesystem.
-  final Uri? pubServeUrl;
+  final Uri /*?*/ pubServeUrl;
 
   /// Whether to use command-line color escapes.
   bool get color => _color ?? canUseSpecialChars;
-  final bool? _color;
+  final bool /*?*/ _color;
 
   /// How many tests to run concurrently.
   int get concurrency =>
       pauseAfterLoad ? 1 : (_concurrency ?? defaultConcurrency);
-  final int? _concurrency;
+  final int /*?*/ _concurrency;
 
   /// The index of the current shard, if sharding is in use, or `null` if it's
   /// not.
@@ -111,25 +113,25 @@ class Configuration {
   /// * Across all shards, each test must be run exactly once.
   ///
   /// In addition, tests should be balanced across shards as much as possible.
-  final int? shardIndex;
+  final int /*?*/ shardIndex;
 
   /// The total number of shards, if sharding is in use, or `null` if it's not.
   ///
   /// See [shardIndex] for details.
-  final int? totalShards;
+  final int /*?*/ totalShards;
 
   /// The list of packages to fold when producing [StackTrace]s.
   Set<String> get foldTraceExcept => _foldTraceExcept ?? {};
-  final Set<String>? _foldTraceExcept;
+  final Set<String> /*?*/ _foldTraceExcept;
 
   /// If non-empty, all packages not in this list will be folded when producing
   /// [StackTrace]s.
   Set<String> get foldTraceOnly => _foldTraceOnly ?? {};
-  final Set<String>? _foldTraceOnly;
+  final Set<String> /*?*/ _foldTraceOnly;
 
   /// The paths from which to load tests.
   List<String> get paths => _paths ?? ['test'];
-  final List<String>? _paths;
+  final List<String> /*?*/ _paths;
 
   /// Whether the load paths were passed explicitly or the default was used.
   bool get explicitPaths => _paths != null;
@@ -138,7 +140,7 @@ class Configuration {
   ///
   /// This is used to find tests within a directory.
   Glob get filename => _filename ?? defaultFilename;
-  final Glob? _filename;
+  final Glob /*?*/ _filename;
 
   /// The set of presets to use.
   ///
@@ -153,7 +155,7 @@ class Configuration {
         ...suiteDefaults.knownTags,
         for (var configuration in presets.values) ...configuration.knownTags
       });
-  Set<String>? _knownTags;
+  Set<String> /*?*/ _knownTags;
 
   /// Configuration presets.
   ///
@@ -172,7 +174,7 @@ class Configuration {
         ...presets.keys,
         for (var configuration in presets.values) ...configuration.knownPresets
       });
-  Set<String>? _knownPresets;
+  Set<String> /*?*/ _knownPresets;
 
   /// Built-in runtimes whose settings are overridden by the user.
   final Map<String, RuntimeSettings> overrideRuntimes;
@@ -188,7 +190,7 @@ class Configuration {
   ///
   /// The current configuration is set using [asCurrent].
   static Configuration get current =>
-      Zone.current[_currentKey] as Configuration? ?? Configuration();
+      Zone.current[_currentKey] as Configuration /*?*/ ?? Configuration();
 
   /// Parses the configuration from [args].
   ///
@@ -215,57 +217,57 @@ class Configuration {
   ///
   /// Throws a [FormatException] if its contents are invalid.
   factory Configuration.loadFromString(String source,
-          {bool global = false, Uri? sourceUrl}) =>
+          {bool global = false, Uri /*?*/ sourceUrl}) =>
       loadFromString(source, global: global, sourceUrl: sourceUrl);
 
   factory Configuration(
-      {bool? help,
-      String? customHtmlTemplatePath,
-      bool? version,
-      bool? pauseAfterLoad,
-      bool? debug,
-      bool? color,
-      String? configurationPath,
-      String? dart2jsPath,
-      String? reporter,
-      Map<String, String>? fileReporters,
-      String? coverage,
-      int? pubServePort,
-      int? concurrency,
-      int? shardIndex,
-      int? totalShards,
-      Iterable<String>? paths,
-      Iterable<String>? foldTraceExcept,
-      Iterable<String>? foldTraceOnly,
-      Glob? filename,
-      Iterable<String>? chosenPresets,
-      Map<String, Configuration>? presets,
-      Map<String, RuntimeSettings>? overrideRuntimes,
-      Map<String, CustomRuntime>? defineRuntimes,
-      bool? noRetry,
+      {bool /*?*/ help,
+      String /*?*/ customHtmlTemplatePath,
+      bool /*?*/ version,
+      bool /*?*/ pauseAfterLoad,
+      bool /*?*/ debug,
+      bool /*?*/ color,
+      String /*?*/ configurationPath,
+      String /*?*/ dart2jsPath,
+      String /*?*/ reporter,
+      Map<String, String> /*?*/ fileReporters,
+      String /*?*/ coverage,
+      int /*?*/ pubServePort,
+      int /*?*/ concurrency,
+      int /*?*/ shardIndex,
+      int /*?*/ totalShards,
+      Iterable<String> /*?*/ paths,
+      Iterable<String> /*?*/ foldTraceExcept,
+      Iterable<String> /*?*/ foldTraceOnly,
+      Glob /*?*/ filename,
+      Iterable<String> /*?*/ chosenPresets,
+      Map<String, Configuration> /*?*/ presets,
+      Map<String, RuntimeSettings> /*?*/ overrideRuntimes,
+      Map<String, CustomRuntime> /*?*/ defineRuntimes,
+      bool /*?*/ noRetry,
 
       // Suite-level configuration
-      bool? jsTrace,
-      bool? runSkipped,
-      Iterable<String>? dart2jsArgs,
-      String? precompiledPath,
-      Iterable<Pattern>? patterns,
-      Iterable<RuntimeSelection>? runtimes,
-      BooleanSelector? includeTags,
-      BooleanSelector? excludeTags,
-      Map<BooleanSelector, SuiteConfiguration>? tags,
-      Map<PlatformSelector, SuiteConfiguration>? onPlatform,
-      int? testRandomizeOrderingSeed,
+      bool /*?*/ jsTrace,
+      bool /*?*/ runSkipped,
+      Iterable<String> /*?*/ dart2jsArgs,
+      String /*?*/ precompiledPath,
+      Iterable<Pattern> /*?*/ patterns,
+      Iterable<RuntimeSelection> /*?*/ runtimes,
+      BooleanSelector /*?*/ includeTags,
+      BooleanSelector /*?*/ excludeTags,
+      Map<BooleanSelector, SuiteConfiguration> /*?*/ tags,
+      Map<PlatformSelector, SuiteConfiguration> /*?*/ onPlatform,
+      int /*?*/ testRandomizeOrderingSeed,
 
       // Test-level configuration
-      Timeout? timeout,
-      bool? verboseTrace,
-      bool? chainStackTraces,
-      bool? skip,
-      int? retry,
-      String? skipReason,
-      PlatformSelector? testOn,
-      Iterable<String>? addTags}) {
+      Timeout /*?*/ timeout,
+      bool /*?*/ verboseTrace,
+      bool /*?*/ chainStackTraces,
+      bool /*?*/ skip,
+      int /*?*/ retry,
+      String /*?*/ skipReason,
+      PlatformSelector /*?*/ testOn,
+      Iterable<String> /*?*/ addTags}) {
     var chosenPresetSet = chosenPresets?.toSet();
     var configuration = Configuration._(
         help: help,
@@ -317,8 +319,8 @@ class Configuration {
     return configuration._resolvePresets();
   }
 
-  static Map<String, Configuration>? _withChosenPresets(
-      Map<String, Configuration>? map, Set<String>? chosenPresets) {
+  static Map<String, Configuration> /*?*/ _withChosenPresets(
+      Map<String, Configuration> /*?*/ map, Set<String> /*?*/ chosenPresets) {
     if (map == null || chosenPresets == null) return map;
     return map.map((key, config) => MapEntry(
         key,
@@ -330,31 +332,31 @@ class Configuration {
   ///
   /// Unlike [new Configuration], this assumes [presets] is already resolved.
   Configuration._(
-      {bool? help,
-      String? customHtmlTemplatePath,
-      bool? version,
-      bool? pauseAfterLoad,
-      bool? debug,
-      bool? color,
-      String? configurationPath,
-      String? dart2jsPath,
-      String? reporter,
-      Map<String, String>? fileReporters,
-      String? coverage,
-      int? pubServePort,
-      int? concurrency,
+      {bool /*?*/ help,
+      String /*?*/ customHtmlTemplatePath,
+      bool /*?*/ version,
+      bool /*?*/ pauseAfterLoad,
+      bool /*?*/ debug,
+      bool /*?*/ color,
+      String /*?*/ configurationPath,
+      String /*?*/ dart2jsPath,
+      String /*?*/ reporter,
+      Map<String, String> /*?*/ fileReporters,
+      String /*?*/ coverage,
+      int /*?*/ pubServePort,
+      int /*?*/ concurrency,
       this.shardIndex,
       this.totalShards,
-      Iterable<String>? paths,
-      Iterable<String>? foldTraceExcept,
-      Iterable<String>? foldTraceOnly,
-      Glob? filename,
-      Iterable<String>? chosenPresets,
-      Map<String, Configuration>? presets,
-      Map<String, RuntimeSettings>? overrideRuntimes,
-      Map<String, CustomRuntime>? defineRuntimes,
-      bool? noRetry,
-      SuiteConfiguration? suiteDefaults})
+      Iterable<String> /*?*/ paths,
+      Iterable<String> /*?*/ foldTraceExcept,
+      Iterable<String> /*?*/ foldTraceOnly,
+      Glob /*?*/ filename,
+      Iterable<String> /*?*/ chosenPresets,
+      Map<String, Configuration> /*?*/ presets,
+      Map<String, RuntimeSettings> /*?*/ overrideRuntimes,
+      Map<String, CustomRuntime> /*?*/ defineRuntimes,
+      bool /*?*/ noRetry,
+      SuiteConfiguration /*?*/ suiteDefaults})
       : _help = help,
         customHtmlTemplatePath = customHtmlTemplatePath,
         _version = version,
@@ -383,10 +385,10 @@ class Configuration {
             ? suiteDefaults?.change(timeout: Timeout.none) ??
                 SuiteConfiguration(timeout: Timeout.none)
             : suiteDefaults ?? SuiteConfiguration.empty {
-    if (_filename != null && _filename!.context.style != p.style) {
+    if (_filename != null && _filename.context.style != p.style) {
       throw ArgumentError(
           "filename's context must match the current operating system, was "
-          '${_filename!.context.style}.');
+          '${_filename.context.style}.');
     }
 
     if ((shardIndex == null) != (totalShards == null)) {
@@ -394,7 +396,7 @@ class Configuration {
           'shardIndex and totalShards may only be passed together.');
     } else if (shardIndex != null) {
       RangeError.checkValueInInterval(
-          shardIndex!, 0, totalShards! - 1, 'shardIndex');
+          shardIndex, 0, totalShards - 1, 'shardIndex');
     }
   }
 
@@ -407,7 +409,7 @@ class Configuration {
   /// Returns an unmodifiable copy of [input].
   ///
   /// If [input] is `null` or empty, this returns `null`.
-  static List<T>? _list<T>(Iterable<T>? input) {
+  static List<T> /*?*/ _list<T>(Iterable<T> /*?*/ input) {
     if (input == null) return null;
     var list = List<T>.unmodifiable(input);
     if (list.isEmpty) return null;
@@ -417,7 +419,7 @@ class Configuration {
   /// Returns a set from [input].
   ///
   /// If [input] is `null` or empty, this returns `null`.
-  static Set<T>? _set<T>(Iterable<T>? input) {
+  static Set<T> /*?*/ _set<T>(Iterable<T> /*?*/ input) {
     if (input == null) return null;
     var set = Set<T>.from(input);
     if (set.isEmpty) return null;
@@ -425,7 +427,7 @@ class Configuration {
   }
 
   /// Returns an unmodifiable copy of [input] or an empty unmodifiable map.
-  static Map<K, V> _map<K, V>(Map<K, V>? input) {
+  static Map<K, V> _map<K, V>(Map<K, V> /*?*/ input) {
     input ??= {};
     return Map.unmodifiable(input);
   }
@@ -470,15 +472,15 @@ class Configuration {
     var foldTraceExcept = other._foldTraceExcept ?? _foldTraceExcept;
     if (_foldTraceOnly != null) {
       if (other._foldTraceExcept != null) {
-        foldTraceOnly = _foldTraceOnly!.difference(other._foldTraceExcept!);
+        foldTraceOnly = _foldTraceOnly.difference(other._foldTraceExcept);
       } else if (other._foldTraceOnly != null) {
-        foldTraceOnly = other._foldTraceOnly!.intersection(_foldTraceOnly!);
+        foldTraceOnly = other._foldTraceOnly.intersection(_foldTraceOnly);
       }
     } else if (_foldTraceExcept != null) {
       if (other._foldTraceOnly != null) {
-        foldTraceOnly = other._foldTraceOnly!.difference(_foldTraceExcept!);
+        foldTraceOnly = other._foldTraceOnly.difference(_foldTraceExcept);
       } else if (other._foldTraceExcept != null) {
-        foldTraceExcept = other._foldTraceExcept!.union(_foldTraceExcept!);
+        foldTraceExcept = other._foldTraceExcept.union(_foldTraceExcept);
       }
     }
 
@@ -527,50 +529,50 @@ class Configuration {
   /// Note that unlike [merge], this has no merging behavior—the old value is
   /// always replaced by the new one.
   Configuration change(
-      {bool? help,
-      String? customHtmlTemplatePath,
-      bool? version,
-      bool? pauseAfterLoad,
-      bool? color,
-      String? configurationPath,
-      String? dart2jsPath,
-      String? reporter,
-      Map<String, String>? fileReporters,
-      int? pubServePort,
-      int? concurrency,
-      int? shardIndex,
-      int? totalShards,
-      Iterable<String>? paths,
-      Iterable<String>? exceptPackages,
-      Iterable<String>? onlyPackages,
-      Glob? filename,
-      Iterable<String>? chosenPresets,
-      Map<String, Configuration>? presets,
-      Map<String, RuntimeSettings>? overrideRuntimes,
-      Map<String, CustomRuntime>? defineRuntimes,
-      bool? noRetry,
+      {bool /*?*/ help,
+      String /*?*/ customHtmlTemplatePath,
+      bool /*?*/ version,
+      bool /*?*/ pauseAfterLoad,
+      bool /*?*/ color,
+      String /*?*/ configurationPath,
+      String /*?*/ dart2jsPath,
+      String /*?*/ reporter,
+      Map<String, String> /*?*/ fileReporters,
+      int /*?*/ pubServePort,
+      int /*?*/ concurrency,
+      int /*?*/ shardIndex,
+      int /*?*/ totalShards,
+      Iterable<String> /*?*/ paths,
+      Iterable<String> /*?*/ exceptPackages,
+      Iterable<String> /*?*/ onlyPackages,
+      Glob /*?*/ filename,
+      Iterable<String> /*?*/ chosenPresets,
+      Map<String, Configuration> /*?*/ presets,
+      Map<String, RuntimeSettings> /*?*/ overrideRuntimes,
+      Map<String, CustomRuntime> /*?*/ defineRuntimes,
+      bool /*?*/ noRetry,
 
       // Suite-level configuration
-      bool? jsTrace,
-      bool? runSkipped,
-      Iterable<String>? dart2jsArgs,
-      String? precompiledPath,
-      Iterable<Pattern>? patterns,
-      Iterable<RuntimeSelection>? runtimes,
-      BooleanSelector? includeTags,
-      BooleanSelector? excludeTags,
-      Map<BooleanSelector, SuiteConfiguration>? tags,
-      Map<PlatformSelector, SuiteConfiguration>? onPlatform,
-      int? testRandomizeOrderingSeed,
+      bool /*?*/ jsTrace,
+      bool /*?*/ runSkipped,
+      Iterable<String> /*?*/ dart2jsArgs,
+      String /*?*/ precompiledPath,
+      Iterable<Pattern> /*?*/ patterns,
+      Iterable<RuntimeSelection> /*?*/ runtimes,
+      BooleanSelector /*?*/ includeTags,
+      BooleanSelector /*?*/ excludeTags,
+      Map<BooleanSelector, SuiteConfiguration> /*?*/ tags,
+      Map<PlatformSelector, SuiteConfiguration> /*?*/ onPlatform,
+      int /*?*/ testRandomizeOrderingSeed,
 
       // Test-level configuration
-      Timeout? timeout,
-      bool? verboseTrace,
-      bool? chainStackTraces,
-      bool? skip,
-      String? skipReason,
-      PlatformSelector? testOn,
-      Iterable<String>? addTags}) {
+      Timeout /*?*/ timeout,
+      bool /*?*/ verboseTrace,
+      bool /*?*/ chainStackTraces,
+      bool /*?*/ skip,
+      String /*?*/ skipReason,
+      PlatformSelector /*?*/ testOn,
+      Iterable<String> /*?*/ addTags}) {
     var config = Configuration._(
         help: help ?? _help,
         customHtmlTemplatePath:

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'dart:io';
 import 'dart:math';
@@ -116,7 +118,7 @@ final ArgParser _parser = (() {
 
   var reporterDescriptions = <String, String>{};
   for (var reporter in allReporters.keys) {
-    reporterDescriptions[reporter] = allReporters[reporter]!.description;
+    reporterDescriptions[reporter] = allReporters[reporter].description;
   }
 
   parser.addSeparator('Output:');
@@ -183,8 +185,8 @@ class _Parser {
         .toList()
           ..addAll(_options['plain-name'] as List<String>);
 
-    var includeTagSet = Set.from(_options['tags'] as Iterable? ?? [])
-      ..addAll(_options['tag'] as Iterable? ?? []);
+    var includeTagSet = Set.from(_options['tags'] as Iterable /*?*/ ?? [])
+      ..addAll(_options['tag'] as Iterable /*?*/ ?? []);
 
     var includeTags = includeTagSet.fold(BooleanSelector.all,
         (BooleanSelector selector, tag) {
@@ -192,8 +194,9 @@ class _Parser {
       return selector.intersection(tagSelector);
     });
 
-    var excludeTagSet = Set.from(_options['exclude-tags'] as Iterable? ?? [])
-      ..addAll(_options['exclude-tag'] as Iterable? ?? []);
+    var excludeTagSet =
+        Set.from(_options['exclude-tags'] as Iterable /*?*/ ?? [])
+          ..addAll(_options['exclude-tag'] as Iterable /*?*/ ?? []);
 
     var excludeTags = excludeTagSet.fold(BooleanSelector.none,
         (BooleanSelector selector, tag) {
@@ -209,7 +212,7 @@ class _Parser {
     } else if (shardIndex != null) {
       if (shardIndex < 0) {
         throw FormatException('--shard-index may not be negative.');
-      } else if (shardIndex >= totalShards!) {
+      } else if (shardIndex >= totalShards) {
         throw FormatException(
             '--shard-index must be less than --total-shards.');
       }
@@ -229,7 +232,7 @@ class _Parser {
 
     var platform = _ifParsed<List<String>>('platform')
         ?.map((runtime) => RuntimeSelection(runtime))
-        .toList();
+        ?.toList();
     if (platform
             ?.any((runtime) => runtime.name == Runtime.phantomJS.identifier) ??
         false) {
@@ -276,12 +279,12 @@ class _Parser {
   /// If the user hasn't explicitly chosen a value, we want to pass null values
   /// to [new Configuration] so that it considers those fields unset when
   /// merging with configuration from the config file.
-  T? _ifParsed<T>(String name) =>
+  T /*?*/ _ifParsed<T>(String name) =>
       _options.wasParsed(name) ? _options[name] as T : null;
 
   /// Runs [parse] on the value of the option [name], and wraps any
   /// [FormatException] it throws with additional information.
-  T? _parseOption<T>(String name, T Function(String) parse) {
+  T /*?*/ _parseOption<T>(String name, T Function(String) parse) {
     if (!_options.wasParsed(name)) return null;
 
     var value = _options[name];
@@ -290,7 +293,7 @@ class _Parser {
     return _wrapFormatException(name, () => parse(value as String));
   }
 
-  Map<String, String>? _parseFileReporterOption() =>
+  Map<String, String> /*?*/ _parseFileReporterOption() =>
       _parseOption('file-reporter', (value) {
         if (!value.contains(':')) {
           throw FormatException(

--- a/pkgs/test_core/lib/src/runner/configuration/custom_runtime.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/custom_runtime.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'package:source_span/source_span.dart';
 import 'package:yaml/yaml.dart';

--- a/pkgs/test_core/lib/src/runner/configuration/load.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/load.dart
@@ -1,11 +1,14 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'dart:io';
 
 import 'package:boolean_selector/boolean_selector.dart';
 import 'package:glob/glob.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:source_span/source_span.dart';
 import 'package:yaml/yaml.dart';
@@ -55,7 +58,7 @@ Configuration load(String path, {bool global = false}) {
 ///
 /// Throws a [FormatException] if the configuration is invalid.
 Configuration loadFromString(String source,
-    {bool global = false, Uri? sourceUrl}) {
+    {bool global = false, Uri /*?*/ sourceUrl}) {
   var document = loadYamlNode(source, sourceUrl: sourceUrl);
 
   if (document.value == null) return Configuration.empty;
@@ -184,8 +187,8 @@ class _ConfigurationLoader {
     }
 
     var skipRaw = _getValue('skip', 'boolean or string',
-        (value) => (value is bool?) || value is String?);
-    String? skipReason;
+        (value) => (value is bool /*?*/) || value is String /*?*/);
+    String /*?*/ skipReason;
     bool skip;
     if (skipRaw is String) {
       skipReason = skipRaw;
@@ -294,13 +297,13 @@ class _ConfigurationLoader {
   Map<String, RuntimeSettings> _loadOverrideRuntimes() {
     var runtimesNode =
         _getNode('override_platforms', 'map', (value) => value is Map)
-            as YamlMap?;
+            as YamlMap /*?*/;
     if (runtimesNode == null) return const {};
 
     var runtimes = <String, RuntimeSettings>{};
     runtimesNode.nodes.forEach((identifierNode, valueNode) {
-      var identifier = _parseIdentifierLike(
-          identifierNode as YamlNode, 'Platform identifier');
+      var yamlNode = identifierNode as YamlNode;
+      var identifier = _parseIdentifierLike(yamlNode, 'Platform identifier');
 
       _validate(valueNode, 'Platform definition must be a map.',
           (value) => value is Map);
@@ -309,8 +312,8 @@ class _ConfigurationLoader {
       var settings = _expect(map, 'settings');
       _validate(settings, 'Must be a map.', (value) => value is Map);
 
-      runtimes[identifier] = RuntimeSettings(
-          identifier, identifierNode.span, [settings as YamlMap]);
+      runtimes[identifier] =
+          RuntimeSettings(identifier, yamlNode.span, [settings as YamlMap]);
     });
     return runtimes;
   }
@@ -412,13 +415,13 @@ class _ConfigurationLoader {
   Map<String, CustomRuntime> _loadDefineRuntimes() {
     var runtimesNode =
         _getNode('define_platforms', 'map', (value) => value is Map)
-            as YamlMap?;
+            as YamlMap /*?*/;
     if (runtimesNode == null) return const {};
 
     var runtimes = <String, CustomRuntime>{};
     runtimesNode.nodes.forEach((identifierNode, valueNode) {
-      var identifier = _parseIdentifierLike(
-          identifierNode as YamlNode, 'Platform identifier');
+      var yamlNode = identifierNode as YamlNode;
+      var identifier = _parseIdentifierLike(yamlNode, 'Platform identifier');
 
       _validate(valueNode, 'Platform definition must be a map.',
           (value) => value is Map);
@@ -435,7 +438,7 @@ class _ConfigurationLoader {
       _validate(settings, 'Must be a map.', (value) => value is Map);
 
       runtimes[identifier] = CustomRuntime(name, nameNode.span, identifier,
-          identifierNode.span, parent, parentNode.span, settings as YamlMap);
+          yamlNode.span, parent, parentNode.span, settings as YamlMap);
     });
     return runtimes;
   }
@@ -451,7 +454,7 @@ class _ConfigurationLoader {
   ///
   /// If [typeTest] returns `false` for that value, instead throws an error
   /// complaining that the field is not a [typeName].
-  Object? _getValue(
+  Object /*?*/ _getValue(
       String field, String typeName, bool Function(dynamic) typeTest) {
     var value = _document[field];
     if (typeTest(value)) return value;
@@ -464,7 +467,7 @@ class _ConfigurationLoader {
   /// error complaining that the field is not a [typeName].
   ///
   /// Returns `null` if [field] does not have a node in [_document].
-  YamlNode? _getNode(
+  YamlNode /*?*/ _getNode(
       String field, String typeName, bool Function(dynamic) typeTest) {
     var node = _document.nodes[field];
     if (node == null) return null;
@@ -473,30 +476,32 @@ class _ConfigurationLoader {
   }
 
   /// Asserts that [field] is an int and returns its value.
-  int? _getInt(String field) =>
-      _getValue(field, 'int', (value) => value is int?) as int?;
+  int /*?*/ _getInt(String field) =>
+      _getValue(field, 'int', (value) => value is int /*?*/) as int /*?*/;
 
   /// Asserts that [field] is a non-negative int and returns its value.
-  int? _getNonNegativeInt(String field) =>
+  int /*?*/ _getNonNegativeInt(String field) =>
       _getValue(field, 'non-negative int', (value) {
         if (value == null) return true;
         return value is int && value >= 0;
-      }) as int?;
+      }) as int /*?*/;
 
   /// Asserts that [field] is a boolean and returns its value.
-  bool? _getBool(String field) =>
-      _getValue(field, 'boolean', (value) => value is bool?) as bool?;
+  bool /*?*/ _getBool(String field) =>
+      _getValue(field, 'boolean', (value) => value is bool /*?*/) as bool /*?*/;
 
   /// Asserts that [field] is a string and returns its value.
-  String? _getString(String field) =>
-      _getValue(field, 'string', (value) => value is String?) as String?;
+  String /*?*/ _getString(String field) =>
+      _getValue(field, 'string', (value) => value is String /*?*/)
+          as String /*?*/;
 
   /// Asserts that [field] is a list and runs [forElement] for each element it
   /// contains.
   ///
   /// Returns a list of values returned by [forElement].
   List<T> _getList<T>(String field, T Function(YamlNode) forElement) {
-    var node = _getNode(field, 'list', (value) => value is List) as YamlList?;
+    var node =
+        _getNode(field, 'list', (value) => value is List) as YamlList /*?*/;
     if (node == null) return [];
     return node.nodes.map(forElement).toList();
   }
@@ -506,8 +511,8 @@ class _ConfigurationLoader {
   /// Returns a map with the keys and values returned by [key] and [value]. Each
   /// of these defaults to asserting that the value is a string.
   Map<K, V> _getMap<K, V>(String field,
-      {K Function(YamlNode)? key, V Function(YamlNode)? value}) {
-    var node = _getNode(field, 'map', (value) => value is Map) as YamlMap?;
+      {K Function(YamlNode) /*?*/ key, V Function(YamlNode) /*?*/ value}) {
+    var node = _getNode(field, 'map', (value) => value is Map) as YamlMap /*?*/;
     if (node == null) return {};
 
     key ??= (keyNode) {
@@ -525,7 +530,7 @@ class _ConfigurationLoader {
     };
 
     return node.nodes.map((keyNode, valueNode) =>
-        MapEntry(key!(keyNode as YamlNode), value!(valueNode)));
+        MapEntry(key(keyNode as YamlNode), value(valueNode)));
   }
 
   /// Verifies that [node]'s value is an optionally hyphenated Dart identifier,
@@ -538,11 +543,11 @@ class _ConfigurationLoader {
   }
 
   /// Parses [node]'s value as a boolean selector.
-  BooleanSelector? _parseBooleanSelector(String name) =>
+  BooleanSelector /*?*/ _parseBooleanSelector(String name) =>
       _parseValue(name, (value) => BooleanSelector.parse(value));
 
   /// Parses [node]'s value as a platform selector.
-  PlatformSelector? _parsePlatformSelector(String field) {
+  PlatformSelector /*?*/ _parsePlatformSelector(String field) {
     var node = _document.nodes[field];
     if (node == null) return null;
     return _parseNode(
@@ -570,7 +575,7 @@ class _ConfigurationLoader {
   ///
   /// If [parse] throws a [FormatException], it's wrapped to include [field]'s
   /// span.
-  T? _parseValue<T>(String field, T Function(String) parse) {
+  T /*?*/ _parseValue<T>(String field, T Function(String) parse) {
     var node = _document.nodes[field];
     if (node == null) return null;
     return _parseNode(node, field, parse);
@@ -581,8 +586,8 @@ class _ConfigurationLoader {
   /// [name] is the name of the field, which is used for error-handling.
   /// [runnerConfig] controls whether runner configuration is allowed in the
   /// nested configuration. It defaults to [_runnerConfig].
-  Configuration _nestedConfig(YamlNode? node, String name,
-      {bool? runnerConfig}) {
+  Configuration _nestedConfig(YamlNode /*?*/ node, String name,
+      {bool /*?*/ runnerConfig}) {
     if (node == null || node.value == null) return Configuration.empty;
 
     _validate(node, '$name must be a map.', (value) => value is Map);
@@ -644,8 +649,9 @@ class _ConfigurationLoader {
   }
 
   /// Throws a [SourceSpanFormatException] with [message] about [field].
+  @alwaysThrows
   void _error(String message, String field) {
     throw SourceSpanFormatException(
-        message, _document.nodes[field]!.span, _source);
+        message, _document.nodes[field].span, _source);
   }
 }

--- a/pkgs/test_core/lib/src/runner/configuration/reporters.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/reporters.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'dart:collection';
 import 'dart:io';

--- a/pkgs/test_core/lib/src/runner/configuration/runtime_settings.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/runtime_settings.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'package:source_span/source_span.dart';
 import 'package:yaml/yaml.dart';

--- a/pkgs/test_core/lib/src/runner/configuration/values.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/values.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'dart:io';
 import 'dart:math' as math;

--- a/pkgs/test_core/lib/src/runner/debugger.dart
+++ b/pkgs/test_core/lib/src/runner/debugger.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'dart:async';
 
@@ -27,7 +29,7 @@ import 'reporter.dart';
 /// any resources it allocated.
 CancelableOperation debug(
     Engine engine, Reporter reporter, LoadSuite loadSuite) {
-  _Debugger? debugger;
+  _Debugger /*?*/ debugger;
   var canceled = false;
   return CancelableOperation.fromFuture(() async {
     // Make the underlying suite null so that the engine doesn't start running
@@ -45,7 +47,7 @@ CancelableOperation debug(
     canceled = true;
     // Make sure the load test finishes so the engine can close.
     engine.resume();
-    if (debugger != null) debugger!.close();
+    if (debugger != null) debugger.close();
   });
 }
 
@@ -76,10 +78,10 @@ class _Debugger {
   final _pauseCompleter = CancelableCompleter();
 
   /// The subscription to [_suite.onDebugging].
-  StreamSubscription<bool>? _onDebuggingSubscription;
+  StreamSubscription<bool> /*?*/ _onDebuggingSubscription;
 
   /// The subscription to [_suite.environment.onRestart].
-  late final StreamSubscription _onRestartSubscription;
+  /*late final*/ StreamSubscription _onRestartSubscription;
 
   /// Whether [close] has been called.
   bool _closed = false;

--- a/pkgs/test_core/lib/src/runner/loader.dart
+++ b/pkgs/test_core/lib/src/runner/loader.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'dart:async';
 import 'dart:io';
@@ -107,8 +109,8 @@ class Loader {
       }
 
       var runtime = parent.extend(customRuntime.name, customRuntime.identifier);
-      _platformPlugins[runtime] = _platformPlugins[parent]!;
-      _platformCallbacks[runtime] = _platformCallbacks[parent]!;
+      _platformPlugins[runtime] = _platformPlugins[parent];
+      _platformCallbacks[runtime] = _platformCallbacks[parent];
       _runtimesByIdentifier[runtime.identifier] = runtime;
 
       _runtimeSettings[runtime] = [customRuntime.settings];
@@ -119,15 +121,14 @@ class Loader {
   void _registerRuntimeOverrides() {
     for (var settings in _config.overrideRuntimes.values) {
       var runtime = _runtimesByIdentifier[settings.identifier];
-      _runtimeSettings
-          .putIfAbsent(runtime!, () => [])
-          .addAll(settings.settings);
+      _runtimeSettings.putIfAbsent(runtime, () => []).addAll(settings.settings);
     }
   }
 
   /// Returns the [Runtime] registered with this loader that's identified
   /// by [identifier], or `null` if none can be found.
-  Runtime? findRuntime(String identifier) => _runtimesByIdentifier[identifier];
+  Runtime /*?*/ findRuntime(String identifier) =>
+      _runtimesByIdentifier[identifier];
 
   /// Loads all test suites in [dir] according to [suiteConfig].
   ///
@@ -188,7 +189,7 @@ class Loader {
       var runtime = findRuntime(runtimeName);
       assert(runtime != null, 'Unknown platform "$runtimeName".');
 
-      var platform = currentPlatform(runtime!);
+      var platform = currentPlatform(runtime);
       if (!suiteConfig.metadata.testOn.evaluate(platform)) {
         continue;
       }
@@ -213,13 +214,13 @@ class Loader {
                   : 'loading ') +
               path;
       yield LoadSuite(name, platformConfig, platform, () async {
-        var memo = _platformPlugins[platform.runtime]!;
+        var memo = _platformPlugins[platform.runtime];
 
         var retriesLeft = suiteConfig.metadata.retry;
         while (true) {
           try {
             var plugin =
-                await memo.runOnce(_platformCallbacks[platform.runtime]!);
+                await memo.runOnce(_platformCallbacks[platform.runtime]);
             _customizePlatform(plugin, platform.runtime);
             var suite = await plugin.load(path, platform, platformConfig,
                 {'platformVariables': _runtimeVariables.toList()});
@@ -259,16 +260,16 @@ class Loader {
           .map(plugin.parsePlatformSettings)
           .reduce(plugin.mergePlatformSettings);
       plugin.customizePlatform(runtime, parsed);
-      _parsedRuntimeSettings[runtime] = parsed!;
+      _parsedRuntimeSettings[runtime] = parsed;
     } else {
       String identifier;
       SourceSpan span;
       if (runtime.isChild) {
-        identifier = runtime.parent!.identifier;
-        span = _config.defineRuntimes[runtime.identifier]!.parentSpan;
+        identifier = runtime.parent.identifier;
+        span = _config.defineRuntimes[runtime.identifier].parentSpan;
       } else {
         identifier = runtime.identifier;
-        span = _config.overrideRuntimes[runtime.identifier]!.identifierSpan;
+        span = _config.overrideRuntimes[runtime.identifier].identifierSpan;
       }
 
       throw SourceSpanFormatException(

--- a/pkgs/test_core/lib/src/runner/plugin/customizable_platform.dart
+++ b/pkgs/test_core/lib/src/runner/plugin/customizable_platform.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'package:yaml/yaml.dart';
 

--- a/pkgs/test_core/lib/src/runner/plugin/platform_helpers.dart
+++ b/pkgs/test_core/lib/src/runner/plugin/platform_helpers.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'dart:async';
 import 'dart:io';
@@ -44,7 +46,7 @@ RunnerSuiteController deserializeSuite(
     Environment environment,
     StreamChannel channel,
     Object message,
-    {Future<Map<String, dynamic>> Function()? gatherCoverage}) {
+    {Future<Map<String, dynamic>> Function() /*?*/ gatherCoverage}) {
   var disconnector = Disconnector();
   var suiteChannel = MultiChannel(channel.transform(disconnector));
 
@@ -132,7 +134,7 @@ class _Deserializer {
         (group['entries'] as List).map((entry) {
           var map = entry as Map;
           if (map['type'] == 'group') return deserializeGroup(map);
-          return _deserializeTest(map)!;
+          return _deserializeTest(map);
         }),
         metadata: metadata,
         trace: group['trace'] == null
@@ -145,7 +147,7 @@ class _Deserializer {
   /// Deserializes [test] into a concrete [Test] class.
   ///
   /// Returns `null` if [test] is `null`.
-  Test? _deserializeTest(Map? test) {
+  Test /*?*/ _deserializeTest(Map /*?*/ test) {
     if (test == null) return null;
 
     var metadata = Metadata.deserialize(test['metadata']);

--- a/pkgs/test_core/lib/src/runner/reporter/json.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/json.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'dart:async';
 import 'dart:convert';
@@ -143,7 +145,7 @@ class JsonReporter implements Reporter {
           },
           liveTest.test,
           liveTest.suite.platform.runtime,
-          liveTest.suite.path!)
+          liveTest.suite.path)
     });
 
     // Convert the future to a stream so that the subscription can be paused or
@@ -168,7 +170,7 @@ class JsonReporter implements Reporter {
   /// If [suite] doesn't have an ID yet, this assigns one and emits a new event
   /// for that suite.
   int _idForSuite(Suite suite) {
-    if (_suiteIDs.containsKey(suite)) return _suiteIDs[suite]!;
+    if (_suiteIDs.containsKey(suite)) return _suiteIDs[suite];
 
     var id = _nextID++;
     _suiteIDs[suite] = id;
@@ -193,7 +195,7 @@ class JsonReporter implements Reporter {
     }
 
     _emit('suite', {
-      'suite': <String, Object?>{
+      'suite': <String, Object /*?*/ >{
         'id': id,
         'platform': suite.platform.runtime.identifier,
         'path': suite.path
@@ -208,11 +210,11 @@ class JsonReporter implements Reporter {
   /// If a group doesn't have an ID yet, this assigns one and emits a new event
   /// for that group.
   List<int> _idsForGroups(Iterable<Group> groups, Suite suite) {
-    int? parentID;
+    int /*?*/ parentID;
     return groups.map((group) {
       if (_groupIDs.containsKey(group)) {
-        parentID = _groupIDs[group]!;
-        return parentID!;
+        parentID = _groupIDs[group];
+        return parentID;
       }
 
       var id = _nextID++;
@@ -232,7 +234,7 @@ class JsonReporter implements Reporter {
             },
             group,
             suite.platform.runtime,
-            suite.path!)
+            suite.path)
       });
       parentID = id;
       return id;
@@ -272,7 +274,7 @@ class JsonReporter implements Reporter {
   ///
   /// [success] will be `true` if all tests passed, `false` if some tests
   /// failed, and `null` if the engine was closed prematurely.
-  void _onDone(bool? success) {
+  void _onDone(bool /*?*/ success) {
     _cancel();
     _stopwatch.stop();
 
@@ -303,8 +305,8 @@ class JsonReporter implements Reporter {
       GroupEntry entry,
       Runtime runtime,
       String suitePath) {
-    var frame = entry.trace?.frames.first;
-    Frame? rootFrame;
+    var frame = entry.trace?.frames?.first;
+    Frame /*?*/ rootFrame;
     for (var frame in entry.trace?.frames ?? <Frame>[]) {
       if (frame.uri.scheme == 'file' &&
           frame.uri.toFilePath() == p.absolute(suitePath)) {

--- a/pkgs/test_core/lib/src/runner/runner_test.dart
+++ b/pkgs/test_core/lib/src/runner/runner_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'package:pedantic/pedantic.dart';
 import 'package:stack_trace/stack_trace.dart';
@@ -25,7 +27,7 @@ class RunnerTest extends Test {
   @override
   final Metadata metadata;
   @override
-  final Trace? trace;
+  final Trace /*?*/ trace;
 
   /// The channel used to communicate with the test's [IframeListener].
   final MultiChannel _channel;
@@ -35,9 +37,9 @@ class RunnerTest extends Test {
   RunnerTest._(this.name, this.metadata, this.trace, this._channel);
 
   @override
-  LiveTest load(Suite suite, {Iterable<Group>? groups}) {
-    late final LiveTestController controller;
-    late final VirtualChannel testChannel;
+  LiveTest load(Suite suite, {Iterable<Group> /*?*/ groups}) {
+    /*late final*/ LiveTestController controller;
+    /*late final*/ VirtualChannel testChannel;
     controller = LiveTestController(suite, this, () {
       controller.setState(const State(Status.running, Result.success));
 
@@ -101,7 +103,7 @@ class RunnerTest extends Test {
   }
 
   @override
-  Test? forPlatform(SuitePlatform platform) {
+  Test /*?*/ forPlatform(SuitePlatform platform) {
     if (!metadata.testOn.evaluate(platform)) return null;
     return RunnerTest._(name, metadata.forPlatform(platform), trace, _channel);
   }

--- a/pkgs/test_core/lib/src/runner/spawn_hybrid.dart
+++ b/pkgs/test_core/lib/src/runner/spawn_hybrid.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'dart:async';
 import 'dart:isolate';
@@ -19,7 +21,7 @@ import 'package:test_api/src/util/remote_exception.dart'; // ignore: implementat
 /// This connects the main isolate to the hybrid isolate, whereas
 /// `lib/src/frontend/spawn_hybrid.dart` connects the test isolate to the main
 /// isolate.
-StreamChannel spawnHybridUri(String url, Object? message) {
+StreamChannel spawnHybridUri(String url, Object /*?*/ message) {
   return StreamChannelCompleter.fromFuture(() async {
     var port = ReceivePort();
     var onExitPort = ReceivePort();

--- a/pkgs/test_core/lib/src/runner/version.dart
+++ b/pkgs/test_core/lib/src/runner/version.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'dart:io';
 
@@ -10,7 +12,7 @@ import 'package:yaml/yaml.dart';
 ///
 /// This is a semantic version, optionally followed by a space and additional
 /// data about its source.
-final String? testVersion = (() {
+final String /*?*/ testVersion = (() {
   dynamic lockfile;
   try {
     lockfile = loadYaml(File('pubspec.lock').readAsStringSync());
@@ -29,7 +31,7 @@ final String? testVersion = (() {
   var source = package['source'];
   if (source is! String) return null;
 
-  switch (source) {
+  switch (source as String) {
     case 'hosted':
       var version = package['version'];
       return (version is String) ? version : null;

--- a/pkgs/test_core/lib/src/runner/vm/environment.dart
+++ b/pkgs/test_core/lib/src/runner/vm/environment.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'dart:async';
 
@@ -22,7 +24,7 @@ class VMEnvironment implements Environment {
   VMEnvironment(this.observatoryUrl, this._isolate, this._client);
 
   @override
-  Uri? get remoteDebuggerUrl => null;
+  Uri /*?*/ get remoteDebuggerUrl => null;
 
   @override
   Stream get onRestart => StreamController.broadcast().stream;

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'dart:async';
 import 'dart:developer';
@@ -54,8 +56,8 @@ class VMPlatform extends PlatformPlugin {
       rethrow;
     }
 
-    VmService? client;
-    StreamSubscription<Event>? eventSub;
+    VmService /*?*/ client;
+    StreamSubscription<Event> /*?*/ eventSub;
     var channel = IsolateChannel.connectReceive(receivePort)
         .transformStream(StreamTransformer.fromHandlers(handleDone: (sink) {
       isolate.kill();
@@ -64,12 +66,12 @@ class VMPlatform extends PlatformPlugin {
       sink.close();
     }));
 
-    Environment? environment;
-    IsolateRef? isolateRef;
+    Environment /*?*/ environment;
+    IsolateRef /*?*/ isolateRef;
     if (_config.debug) {
       var info =
           await Service.controlWebServer(enable: true, silenceOutput: true);
-      var isolateID = Service.getIsolateID(isolate)!;
+      var isolateID = Service.getIsolateID(isolate);
 
       var libraryPath = p.toUri(p.absolute(path)).toString();
       client = await vmServiceConnectUri(_wsUriFor(info.serverUri.toString()));
@@ -90,10 +92,10 @@ class VMPlatform extends PlatformPlugin {
 
     var controller = deserializeSuite(
         path, platform, suiteConfig, environment, channel, message,
-        gatherCoverage: () => _gatherCoverage(environment!));
+        gatherCoverage: () => _gatherCoverage(environment));
 
     if (isolateRef != null) {
-      await client!.streamListen('Debug');
+      await client.streamListen('Debug');
       eventSub = client.onDebugEvent.listen((event) {
         if (event.kind == EventKind.kResume) {
           controller.setDebugging(false);
@@ -118,7 +120,7 @@ class VMPlatform extends PlatformPlugin {
     if (precompiledPath != null) {
       return _spawnPrecompiledIsolate(path, message, precompiledPath);
     } else if (_config.pubServeUrl != null) {
-      return _spawnPubServeIsolate(path, message, _config.pubServeUrl!);
+      return _spawnPubServeIsolate(path, message, _config.pubServeUrl);
     } else {
       return _spawnDataIsolate(path, message, suiteMetadata);
     }
@@ -155,8 +157,8 @@ Future<Isolate> _spawnPrecompiledIsolate(
 }
 
 Future<Map<String, dynamic>> _gatherCoverage(Environment environment) async {
-  final isolateId = Uri.parse(environment.observatoryUrl!.fragment)
-      .queryParameters['isolateId']!;
+  final isolateId = Uri.parse(environment.observatoryUrl.fragment)
+      .queryParameters['isolateId'];
   return await collect(environment.observatoryUrl, false, false, false, {},
       isolateIds: {isolateId});
 }

--- a/pkgs/test_core/lib/src/util/dart.dart
+++ b/pkgs/test_core/lib/src/util/dart.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'dart:convert';
 import 'dart:isolate';
@@ -17,7 +19,7 @@ import 'string_literal_iterator.dart';
 /// passed to the [main] method of the code being run; the caller is responsible
 /// for using this to establish communication with the isolate.
 Future<Isolate> runInIsolate(String code, Object message,
-        {SendPort? onExit}) async =>
+        {SendPort /*?*/ onExit}) async =>
     Isolate.spawnUri(
         Uri.dataFromString(code, mimeType: 'application/dart', encoding: utf8),
         [],
@@ -51,7 +53,7 @@ Future<Isolate> runInIsolate(String code, Object message,
 ///
 /// This will return `null` if [context] contains an invalid string or does not
 /// contain [span].
-SourceSpan? contextualizeSpan(
+SourceSpan /*?*/ contextualizeSpan(
     SourceSpan span, StringLiteral context, SourceFile file) {
   var contextRunes = StringLiteralIterator(context)..moveNext();
 

--- a/pkgs/test_core/lib/src/util/string_literal_iterator.dart
+++ b/pkgs/test_core/lib/src/util/string_literal_iterator.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+//
+// @dart=2.9
 
 import 'dart:collection';
 
@@ -38,23 +40,23 @@ const _verticalTab = 0xB;
 /// exposes the offset of the current rune in the Dart source file.
 class StringLiteralIterator extends Iterator<int> {
   @override
-  int get current => _current!;
-  int? _current;
+  int get current => _current;
+  int /*?*/ _current;
 
   /// The offset of the beginning of [current] in the Dart source file that
   /// contains the string literal.
   ///
   /// Before iteration begins, this points to the character before the first
   /// rune.
-  int get offset => _offset!;
-  int? _offset;
+  int get offset => _offset;
+  int /*?*/ _offset;
 
   /// The offset of the next rune.
   ///
   /// This isn't necessarily just `offset + 1`, since a single rune may be
   /// represented by multiple characters in the source file, or a string literal
   /// may be composed of several adjacent string literals.
-  int? _nextOffset;
+  int /*?*/ _nextOffset;
 
   /// All [SimpleStringLiteral]s that compose the input literal.
   ///
@@ -66,13 +68,13 @@ class StringLiteralIterator extends Iterator<int> {
   /// Whether this is a raw string that begins with `r`.
   ///
   /// This is necessary for knowing how to parse escape sequences.
-  bool? _isRaw;
+  bool /*?*/ _isRaw;
 
   /// The iterator over the runes in the Dart source file.
   ///
   /// When switching to a new string in [_strings], this is updated to point to
   /// that string's component runes.
-  Iterator<int>? _runes;
+  Iterator<int> /*?*/ _runes;
 
   /// Creates a new [StringLiteralIterator] iterating over the contents of
   /// [literal].
@@ -101,7 +103,7 @@ class StringLiteralIterator extends Iterator<int> {
   bool moveNext() {
     // If we're at beginning of a [SimpleStringLiteral], move forward until
     // there's actually text to consume.
-    while (_runes == null || _runes!.current == -1) {
+    while (_runes == null || _runes.current == -1) {
       if (_strings.isEmpty) {
         // Move the offset past the end of the text.
         _offset = _nextOffset;
@@ -122,7 +124,7 @@ class StringLiteralIterator extends Iterator<int> {
       _nextOffset = string.contentsOffset;
       _isRaw = string.isRaw;
       _runes = text.runes.iterator;
-      _runes!.moveNext();
+      _runes.moveNext();
     }
 
     _offset = _nextOffset;
@@ -135,9 +137,9 @@ class StringLiteralIterator extends Iterator<int> {
   }
 
   /// Consume and return the next rune.
-  int? _nextRune() {
-    if (_isRaw! || _runes!.current != _backslash) {
-      var rune = _runes!.current;
+  int /*?*/ _nextRune() {
+    if (_isRaw || _runes.current != _backslash) {
+      var rune = _runes.current;
       _moveRunesNext();
       return (rune < 0) ? null : rune;
     }
@@ -150,8 +152,8 @@ class StringLiteralIterator extends Iterator<int> {
   ///
   /// This assumes that a backslash has already been consumed. It leaves the
   /// [_runes] cursor on the first character after the escape sequence.
-  int? _parseEscapeSequence() {
-    switch (_runes!.current) {
+  int /*?*/ _parseEscapeSequence() {
+    switch (_runes.current) {
       case _n:
         _moveRunesNext();
         return _newline;
@@ -175,15 +177,15 @@ class StringLiteralIterator extends Iterator<int> {
         return _parseHex(2);
       case _u:
         if (!_moveRunesNext()) return null;
-        if (_runes!.current != _openCurly) return _parseHex(4);
+        if (_runes.current != _openCurly) return _parseHex(4);
         if (!_moveRunesNext()) return null;
 
         var number = _parseHexSequence();
-        if (_runes!.current != _closeCurly) return null;
+        if (_runes.current != _closeCurly) return null;
         if (!_moveRunesNext()) return null;
         return number;
       default:
-        var rune = _runes!.current;
+        var rune = _runes.current;
         _moveRunesNext();
         return rune;
     }
@@ -194,15 +196,15 @@ class StringLiteralIterator extends Iterator<int> {
   ///
   /// This parses digits as they appear in a unicode escape sequence: one to six
   /// hex digits.
-  int? _parseHexSequence() {
-    var number = _parseHexDigit(_runes!.current);
+  int /*?*/ _parseHexSequence() {
+    var number = _parseHexDigit(_runes.current);
     if (number == null) return null;
     if (!_moveRunesNext()) return null;
 
     for (var i = 0; i < 5; i++) {
-      var digit = _parseHexDigit(_runes!.current);
+      var digit = _parseHexDigit(_runes.current);
       if (digit == null) break;
-      number = number! * 16 + digit;
+      number = number * 16 + digit;
       if (!_moveRunesNext()) return null;
     }
 
@@ -210,11 +212,11 @@ class StringLiteralIterator extends Iterator<int> {
   }
 
   /// Parses [digits] hexadecimal digits and returns their value as an [int].
-  int? _parseHex(int digits) {
+  int /*?*/ _parseHex(int digits) {
     var number = 0;
     for (var i = 0; i < digits; i++) {
-      if (_runes!.current == -1) return null;
-      var digit = _parseHexDigit(_runes!.current);
+      if (_runes.current == -1) return null;
+      var digit = _parseHexDigit(_runes.current);
       if (digit == null) return null;
       number = number * 16 + digit;
       _moveRunesNext();
@@ -223,7 +225,7 @@ class StringLiteralIterator extends Iterator<int> {
   }
 
   /// Parses a single hexadecimal digit.
-  int? _parseHexDigit(int rune) {
+  int /*?*/ _parseHexDigit(int rune) {
     if (rune < _zero) return null;
     if (rune <= _nine) return rune - _zero;
     if (rune < _capitalA) return null;
@@ -235,8 +237,8 @@ class StringLiteralIterator extends Iterator<int> {
 
   /// Move [_runes] to the next rune and update [_nextOffset].
   bool _moveRunesNext() {
-    var result = _runes!.moveNext();
-    _nextOffset = _nextOffset! + 1;
+    var result = _runes.moveNext();
+    _nextOffset = _nextOffset + 1;
     return result;
   }
 }


### PR DESCRIPTION
Part of https://github.com/dart-lang/sdk/issues/44063

Had to opt out several libraries and undo their migrations, but we were in a bad state previously where we could have been broken by migrations of several packages. 