### PR TITLE
Update package_config dependencies to allow versions >2.0.0.

### DIFF
--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.16.0-nullsafety.10
+version: 1.16.0-nullsafety.11
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
@@ -15,7 +15,7 @@ dependencies:
   io: ^0.3.0
   js: '>=0.6.3-nullsafety <0.6.3'
   node_preamble: ^1.3.0
-  package_config: ^1.9.0
+  package_config: ">=1.9.2 <3.0.0"
   path: '>=1.8.0-nullsafety <1.8.0'
   pedantic: '>=1.10.0-nullsafety <1.10.0'
   pool: '>=1.5.0-nullsafety <1.5.0'

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.12-nullsafety.9
+version: 0.3.12-nullsafety.10
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
@@ -16,7 +16,7 @@ dependencies:
   glob: ^1.0.0
   io: ^0.3.0
   meta: '>=1.3.0-nullsafety <1.3.0'
-  package_config: ^1.9.2
+  package_config: ">=1.9.2 <3.0.0"
   path: '>=1.8.0-nullsafety <1.8.0'
   pedantic: '>=1.10.0-nullsafety <1.10.0'
   pool: '>=1.5.0-nullsafety <1.5.0'


### PR DESCRIPTION
The 2.0.0 versions will remove deprecated backwards compatibility functionality.
The test package no longer needs this functionality, and since the test package
depends on pkg:package_config, it's impossible to build a 2.0.0 version before test
accepts it.