### PR TITLE
Backport support for latest package:analyzer

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.15.6 (Backport)
+
+* Support `package:analyzer` version `0.41.x`.
+
 ## 1.15.5 (Backport)
 
 * Fix `spawnHybridUri` to respect language versioning of the spawned uri.

--- a/pkgs/test/lib/src/runner/browser/browser.dart
+++ b/pkgs/test/lib/src/runner/browser/browser.dart
@@ -107,6 +107,7 @@ abstract class Browser {
       }
 
       _onExitCompleter.complete();
+      // ignore: deprecated_member_use
     }, onError: (error, StackTrace stackTrace) {
       // Ignore any errors after the browser has been closed.
       if (_closed) return;

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.15.5
+version: 1.15.6
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.36.0 <0.41.0'
+  analyzer: '>=0.36.0 <0.42.0'
   async: ^2.0.0
   boolean_selector: '>=1.0.0 <3.0.0'
   coverage: '>=0.13.4 < 0.15.0'
@@ -33,7 +33,7 @@ dependencies:
   yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.2.18+1
-  test_core: 0.3.11+2
+  test_core: 0.3.11+3
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test/test/util/string_literal_iterator_test.dart
+++ b/pkgs/test/test/util/string_literal_iterator_test.dart
@@ -2,9 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore: deprecated_member_use
 @TestOn('vm')
-import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:test/test.dart';
 import 'package:test_core/src/util/string_literal_iterator.dart';
 
@@ -239,8 +239,8 @@ Matcher _isRune(String char) {
 /// Parses [dart], which should be a string literal, into a
 /// [StringLiteralIterator].
 StringLiteralIterator _parse(String dart) {
-  // ignore: deprecated_member_use
-  var declaration = parseCompilationUnit('final str = $dart;')
+  var declaration = parseString(content: 'final str = $dart;')
+      .unit
       .declarations
       .single as TopLevelVariableDeclaration;
   var literal = declaration.variables.variables.single.initializer;

--- a/pkgs/test/tool/host.dart
+++ b/pkgs/test/tool/host.dart
@@ -155,6 +155,7 @@ void main() {
     }), restartCurrent: allowInterop(() {
       serverChannel.sink.add({'command': 'restart'});
     }));
+    // ignore: deprecated_member_use
   }, onError: (error, StackTrace stackTrace) {
     print('$error\n${Trace.from(stackTrace).terse}');
   });

--- a/pkgs/test_api/lib/src/remote_listener.dart
+++ b/pkgs/test_api/lib/src/remote_listener.dart
@@ -131,6 +131,7 @@ class RemoteListener {
               // useful errors when calling `test()` and `group()` within a test,
               // and so they can add to the declarer's `tearDownAll()` list.
               zoneValues: {#test.declarer: declarer});
+          // ignore: deprecated_member_use
         }, onError: (error, StackTrace stackTrace) {
           _sendError(channel, error, stackTrace, verboseChain);
         }, zoneSpecification: spec);

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.11+2 (Backport)
+## 0.3.11+3 (Backport)
 
 * Support `package:analyzer` version `0.41.x`.
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.3.11+2 (Backport)
 
+* Support `package:analyzer` version `0.41.x`.
+
+## 0.3.11+2 (Backport)
+
 * Fix `spawnHybridUri` to respect language versioning of the spawned uri.
 
 ## 0.3.11+1

--- a/pkgs/test_core/lib/src/runner/loader.dart
+++ b/pkgs/test_core/lib/src/runner/loader.dart
@@ -5,8 +5,6 @@
 import 'dart:async';
 import 'dart:io';
 
-// ignore: deprecated_member_use
-import 'package:analyzer/analyzer.dart' hide Configuration;
 import 'package:async/async.dart';
 import 'package:path/path.dart' as p;
 import 'package:source_span/source_span.dart';
@@ -170,7 +168,7 @@ class Loader {
       suiteConfig = suiteConfig.merge(SuiteConfiguration.fromMetadata(
           parseMetadata(
               path, File(path).readAsStringSync(), _runtimeVariables.toSet())));
-    } on AnalyzerErrorGroup catch (_) {
+    } on ArgumentError catch (_) {
       // Ignore the analyzer's error, since its formatting is much worse than
       // the VM's or dart2js's.
     } on FormatException catch (error, stackTrace) {

--- a/pkgs/test_core/lib/src/runner/parse_metadata.dart
+++ b/pkgs/test_core/lib/src/runner/parse_metadata.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore: deprecated_member_use
-import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:path/path.dart' as p;

--- a/pkgs/test_core/lib/src/util/dart.dart
+++ b/pkgs/test_core/lib/src/util/dart.dart
@@ -6,8 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:isolate';
 
-// ignore: deprecated_member_use
-import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:source_span/source_span.dart';
 
 import 'string_literal_iterator.dart';

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.11+2
+version: 0.3.11+3
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=0.39.5 <0.41.0"
+  analyzer: ">=0.39.5 <0.42.0"
   async: ^2.0.0
   args: ^1.4.0
   boolean_selector: ">=1.0.0 <3.0.0"


### PR DESCRIPTION
Cherry pick f0bc5c22aa031a6d178b4e46c014ab45e7f25308 to stop using the
removed import.

Bump dependencies to allow the latest analyzer.