### PR TITLE
set up stack trace mappers in precompiled mode if source maps exist

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.16.0-nullsafety.11
+
+* Set up a stack trace mapper in precompiled mode if source maps exist. If
+  the stack traces are already mapped then this has no effect, otherwise it
+  will try to map any JS lines it sees.
+
 ## 1.16.0-nullsafety.10
 
 * Allow injecting a test channel for browser tests.

--- a/pkgs/test/lib/src/runner/browser/platform.dart
+++ b/pkgs/test/lib/src/runner/browser/platform.dart
@@ -421,7 +421,7 @@ class BrowserPlatform extends PlatformPlugin
     if (mapFile.existsSync()) {
       _mappers[dartPath] = JSStackTraceMapper(mapFile.readAsStringSync(),
           mapUrl: p.toUri(mapPath),
-          sdkRoot: Uri.parse(r'packages/$sdk'),
+          sdkRoot: Uri.parse(r'/packages/$sdk'),
           packageMap: (await currentPackageConfig).toPackageMap());
     }
   }

--- a/pkgs/test/lib/src/runner/browser/platform.dart
+++ b/pkgs/test/lib/src/runner/browser/platform.dart
@@ -259,6 +259,8 @@ class BrowserPlatform extends PlatformPlugin
       if (browser.isJS) {
         if (suiteConfig.precompiledPath == null) {
           await _compileSuite(path, suiteConfig);
+        } else {
+          await _addPrecompiledStackTraceMapper(path, suiteConfig);
         }
       }
 
@@ -408,6 +410,20 @@ class BrowserPlatform extends PlatformPlugin
           sdkRoot: Uri.parse('org-dartlang-sdk:///sdk'),
           packageMap: (await currentPackageConfig).toPackageMap());
     });
+  }
+
+  Future<void> _addPrecompiledStackTraceMapper(
+      String dartPath, SuiteConfiguration suiteConfig) async {
+    if (suiteConfig.jsTrace) return;
+    var mapPath = p.join(
+        suiteConfig.precompiledPath, dartPath + '.browser_test.dart.js.map');
+    var mapFile = File(mapPath);
+    if (mapFile.existsSync()) {
+      _mappers[dartPath] = JSStackTraceMapper(mapFile.readAsStringSync(),
+          mapUrl: p.toUri(mapPath),
+          sdkRoot: Uri.parse(r'packages/$sdk'),
+          packageMap: (await currentPackageConfig).toPackageMap());
+    }
   }
 
   /// Returns the [BrowserManager] for [runtime], which should be a browser.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.16.0-nullsafety.10
+version: 1.16.0-nullsafety.11
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/2901

This has no effect for DDC (a source map won't exist in that location), but does provide some mapping for dart2js source maps (although you see more unnecessary lines than you would normally).

Before:

```
  Bad state: Oh no!
  opted_in_test.dart.browser_test.dart.js 975:17    Object.wrapException
  opted_in_test.dart.browser_test.dart.js 26226:15  main_closure0.call$0
  opted_in_test.dart.browser_test.dart.js 23893:53  <fn>
  opted_in_test.dart.browser_test.dart.js 4030:15   _wrapJsFunctionForAsync_closure.$protected
  opted_in_test.dart.browser_test.dart.js 12766:12  _wrapJsFunctionForAsync_closure.call$2
  opted_in_test.dart.browser_test.dart.js 22947:21  StackZoneSpecification__registerBinaryCallback__closure.call$0
  opted_in_test.dart.browser_test.dart.js 22870:16  StackZoneSpecification._stack_zone_specification$_run$1$2
  opted_in_test.dart.browser_test.dart.js 22939:26  StackZoneSpecification__registerBinaryCallback_closure.call$2
  opted_in_test.dart.browser_test.dart.js 12754:32  _awaitOnObject_closure.call$1
  opted_in_test.dart.browser_test.dart.js 4540:18   StaticClosure._rootRunUnary
  ===== asynchronous gap ===========================
  opted_in_test.dart.browser_test.dart.js 14845:39  _CustomZone.registerBinaryCallback$3$1
  opted_in_test.dart.browser_test.dart.js 4038:30   Object._wrapJsFunctionForAsync
  opted_in_test.dart.browser_test.dart.js 24202:29  Invoker_waitForOutstandingCallbacks_closure.call$0
  opted_in_test.dart.browser_test.dart.js 4525:16   StaticClosure._rootRun
  opted_in_test.dart.browser_test.dart.js 14807:39  _CustomZone.run$1$1
  opted_in_test.dart.browser_test.dart.js 4673:89   Object._runZoned
  ===== asynchronous gap ===========================
  opted_in_test.dart.browser_test.dart.js 14845:39  _CustomZone.registerBinaryCallback$3$1
  opted_in_test.dart.browser_test.dart.js 4038:30   Object._wrapJsFunctionForAsync
  opted_in_test.dart.browser_test.dart.js 24311:29  Invoker__onRun___closure.call$0
  opted_in_test.dart.browser_test.dart.js 4525:16   StaticClosure._rootRun
  opted_in_test.dart.browser_test.dart.js 14807:39  _CustomZone.run$1$1
  opted_in_test.dart.browser_test.dart.js 4673:89   Object._runZoned
``` 

After:

```                                                                               
  Bad state: Oh no!
  /_internal/js_runtime/lib/js_helper.dart 1130:37                Object.wrapException
  /opted_in_test.dart 12:5                                        main.<fn>
  /packages/test_api/src/backend/declarer.dart 200:15             <fn>
  /_internal/js_runtime/lib/async_patch.dart 316:19               _wrapJsFunctionForAsync.closure.$protected
  /_internal/js_runtime/lib/async_patch.dart 341:23               _wrapJsFunctionForAsync.<fn>
  /packages/stack_trace/src/stack_zone_specification.dart 138:25  StackZoneSpecification._registerBinaryCallback.<fn>.<fn>
  /packages/stack_trace/src/stack_zone_specification.dart 208:14  StackZoneSpecification._run
  /packages/stack_trace/src/stack_zone_specification.dart 138:14  StackZoneSpecification._registerBinaryCallback.<fn>
  /_internal/js_runtime/lib/async_patch.dart 292:19               _awaitOnObject.<fn>
  /async/zone.dart 1198:46                                        StaticClosure._rootRunUnary
  ===== asynchronous gap ===========================
  /async/zone.dart 1128:34                                        _CustomZone.registerBinaryCallback
  /async/zone.dart 345:30                                         Object._wrapJsFunctionForAsync
  /async/zone.dart 1190:12                                        StaticClosure._rootRun
  /async/zone.dart 1092:34                                        _CustomZone.run
  /async/zone.dart 1630:10                                        Object._runZoned
  ===== asynchronous gap ===========================
  /async/zone.dart 1128:34                                        _CustomZone.registerBinaryCallback
  /async/zone.dart 345:30                                         Object._wrapJsFunctionForAsync
  /async/zone.dart 1190:12                                        StaticClosure._rootRun
  /async/zone.dart 1092:34                                        _CustomZone.run
  /async/zone.dart 1630:10                                        Object._runZoned
```

I did set this up such that if we change the source map to output `packages/$sdk` for sdk paths, it should replace these sdk lines with `dart:` uris (and possibly fold them?)