### PR TITLE
Make the RemoteListener channel non-nullable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v2.5.0
+# Created with package:mono_repo v3.0.0
 language: dart
 
 # Custom configuration
@@ -14,7 +14,7 @@ jobs:
     - stage: mono_repo_self_validate
       name: mono_repo self validate
       os: linux
-      script: tool/mono_repo_self_validate.sh
+      script: "pub global activate mono_repo 3.0.0 && pub global run mono_repo travis --validate"
     - stage: analyze_and_format
       name: "SDK: dev; PKGS: pkgs/test, pkgs/test_api, pkgs/test_core; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .`]"
       dart: dev
@@ -22,31 +22,31 @@ jobs:
       env: PKGS="pkgs/test pkgs/test_api pkgs/test_core"
       script: tool/travis.sh dartfmt dartanalyzer
     - stage: unit_test
-      name: "SDK: dev; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 0`"
+      name: "SDK: dev; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 0`"
       dart: dev
       os: linux
       env: PKGS="pkgs/test"
       script: tool/travis.sh command_0
     - stage: unit_test
-      name: "SDK: dev; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 1`"
+      name: "SDK: dev; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 1`"
       dart: dev
       os: linux
       env: PKGS="pkgs/test"
       script: tool/travis.sh command_1
     - stage: unit_test
-      name: "SDK: dev; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 2`"
+      name: "SDK: dev; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 2`"
       dart: dev
       os: linux
       env: PKGS="pkgs/test"
       script: tool/travis.sh command_2
     - stage: unit_test
-      name: "SDK: dev; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 3`"
+      name: "SDK: dev; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 3`"
       dart: dev
       os: linux
       env: PKGS="pkgs/test"
       script: tool/travis.sh command_3
     - stage: unit_test
-      name: "SDK: dev; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 4`"
+      name: "SDK: dev; PKG: pkgs/test; TASKS: `xvfb-run -s \"-screen 0 1024x768x24\" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 4`"
       dart: dev
       os: linux
       env: PKGS="pkgs/test"

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.16.0-nullsafety.12-dev
+
+* Fix failures trying to run tests on the `node` platform.
+
 ## 1.16.0-nullsafety.11
 
 * Set up a stack trace mapper in precompiled mode if source maps exist. If

--- a/pkgs/test/lib/src/bootstrap/browser.dart
+++ b/pkgs/test/lib/src/bootstrap/browser.dart
@@ -10,7 +10,7 @@ import '../runner/browser/post_message_channel.dart';
 
 /// Bootstraps a browser test to communicate with the test runner.
 void internalBootstrapBrowserTest(Function Function() getMain,
-    {StreamChannel<Object?>? testChannel}) {
+    {StreamChannel<Object>? testChannel}) {
   var channel =
       serializeSuite(getMain, hidePrints: false, beforeLoad: () async {
     var serialized =

--- a/pkgs/test/lib/src/runner/browser/post_message_channel.dart
+++ b/pkgs/test/lib/src/runner/browser/post_message_channel.dart
@@ -17,8 +17,8 @@ external void _postParentMessage(Object message, String targetOrigin);
 
 /// Constructs a [StreamChannel] wrapping [MessageChannel] communication with
 /// the host page.
-StreamChannel<Object?> postMessageChannel() {
-  var controller = StreamChannelController<Object?>(sync: true);
+StreamChannel<Object> postMessageChannel() {
+  var controller = StreamChannelController<Object>(sync: true);
 
   // Listen for a message from the host that transfers a message port. Using
   // `firstWhere` automatically unsubscribes from further messages. This is
@@ -33,7 +33,10 @@ StreamChannel<Object?> postMessageChannel() {
   }).then((message) {
     var port = message.ports.first;
     var portSubscription = port.onMessage.listen((message) {
-      controller.local.sink.add(message.data);
+      var data = message.data;
+      if (data is Object) {
+        controller.local.sink.add(data);
+      }
     });
 
     controller.local.stream.listen((data) {

--- a/pkgs/test/lib/src/runner/node/socket_channel.dart
+++ b/pkgs/test/lib/src/runner/node/socket_channel.dart
@@ -5,9 +5,11 @@
 @JS()
 library node;
 
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:js/js.dart';
 import 'package:stream_channel/stream_channel.dart';
-import 'package:test_api/src/utils.dart'; // ignore: implementation_imports
 
 @JS('require')
 external _Net _require(String module);
@@ -29,15 +31,22 @@ class _Socket {
 
 /// Returns a [StreamChannel] of JSON-encodable objects that communicates over a
 /// socket whose port is given by `process.argv[2]`.
-StreamChannel<Object?> socketChannel() {
-  var controller =
-      StreamChannelController<String?>(allowForeignErrors: false, sync: true);
+StreamChannel<Object> socketChannel() {
   var net = _require('net');
   var socket = net.connect(int.parse(_args[2]));
   socket.setEncoding('utf8');
 
-  controller.local.stream.listen((chunk) => socket.write(chunk!));
-  socket.on('data', allowInterop(controller.local.sink.add));
+  var socketSink = StreamController<Object>(sync: true)
+    ..stream.listen((event) => socket.write('${jsonEncode(event)}\n'));
 
-  return controller.foreign.transform(chunksToLines).transform(jsonDocument);
+  var socketStream = StreamController<String>(sync: true);
+  socket.on('data', allowInterop(socketStream.add));
+
+  return StreamChannel.withCloseGuarantee(
+      socketStream.stream
+          .transform(const LineSplitter())
+          .map(jsonDecode)
+          .where((e) => e != null)
+          .cast<Object>(),
+      socketSink);
 }

--- a/pkgs/test/mono_pkg.yaml
+++ b/pkgs/test/mono_pkg.yaml
@@ -7,8 +7,8 @@ stages:
         - dartfmt: sdk
         - dartanalyzer: --enable-experiment=non-nullable --fatal-infos --fatal-warnings .
     - unit_test:
-      - command: xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 0
-      - command: xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 1
-      - command: xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 2
-      - command: xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 3
-      - command: xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 4
+      - command: xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 0
+      - command: xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 1
+      - command: xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 2
+      - command: xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 3
+      - command: xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 4

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.16.0-nullsafety.11
+version: 1.16.0-nullsafety.12-dev
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
@@ -31,8 +31,8 @@ dependencies:
   webkit_inspection_protocol: ">=0.5.0 <0.8.0"
   yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.2.19-nullsafety.6
-  test_core: 0.3.12-nullsafety.10
+  test_api: 0.2.19-nullsafety.7
+  test_core: 0.3.12-nullsafety.11
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.19-nullsafety.7-dev
+
+* Make the `StreamChannel` returned by `RemoteListener.start` use non-nullable
+  events.
+
 ## 0.2.19-nullsafety.6
 
 * Fix `spawnHybridUri` to respect language versioning of the spawned uri.

--- a/pkgs/test_api/lib/src/remote_listener.dart
+++ b/pkgs/test_api/lib/src/remote_listener.dart
@@ -44,13 +44,13 @@ class RemoteListener {
   ///
   /// If [beforeLoad] is passed, it's called before the tests have been declared
   /// for this worker.
-  static StreamChannel<Object?> start(Function Function() getMain,
+  static StreamChannel<Object> start(Function Function() getMain,
       {bool hidePrints = true, Future Function()? beforeLoad}) {
     // Synchronous in order to allow `print` output to show up immediately, even
     // if they are followed by long running synchronous work.
     var controller =
-        StreamChannelController<Object?>(allowForeignErrors: false, sync: true);
-    var channel = MultiChannel<Object?>(controller.local);
+        StreamChannelController<Object>(allowForeignErrors: false, sync: true);
+    var channel = MultiChannel<Object>(controller.local);
 
     var verboseChain = true;
 

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.2.19-nullsafety.6
+version: 0.2.19-nullsafety.7-dev
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.12-nullsafety.11
+
+* Make the `StreamChannel` returned by `serializeSuite` use non-nullable events.
+
 ## 0.3.12-nullsafety.10
 
 * Allow `package:analyzer` version `0.41.x`.

--- a/pkgs/test_core/lib/src/bootstrap/vm.dart
+++ b/pkgs/test_core/lib/src/bootstrap/vm.dart
@@ -11,5 +11,5 @@ import 'package:test_core/src/runner/plugin/remote_platform_helpers.dart';
 /// Bootstraps a vm test to communicate with the test runner.
 void internalBootstrapVmTest(Function Function() getMain, SendPort sendPort) {
   var channel = serializeSuite(getMain);
-  IsolateChannel<Object?>.connectSend(sendPort).pipe(channel);
+  IsolateChannel<Object>.connectSend(sendPort).pipe(channel);
 }

--- a/pkgs/test_core/lib/src/runner/plugin/remote_platform_helpers.dart
+++ b/pkgs/test_core/lib/src/runner/plugin/remote_platform_helpers.dart
@@ -28,7 +28,7 @@ import 'package:test_api/src/suite_channel_manager.dart'; // ignore: implementat
 ///
 /// If [beforeLoad] is passed, it's called before the tests have been declared
 /// for this worker.
-StreamChannel<Object?> serializeSuite(Function Function() getMain,
+StreamChannel<Object> serializeSuite(Function Function() getMain,
         {bool hidePrints = true, Future Function()? beforeLoad}) =>
     RemoteListener.start(
       getMain,

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.12-nullsafety.10
+version: 0.3.12-nullsafety.11-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
@@ -30,7 +30,7 @@ dependencies:
   # matcher is tightly constrained by test_api
   matcher: any
   # Use an exact version until the test_api package is stable.
-  test_api: 0.2.19-nullsafety.6
+  test_api: 0.2.19-nullsafety.7
 
 dependency_overrides:
   test_api:

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
-# Created with package:mono_repo v2.5.0
+# Created with package:mono_repo v3.0.0
 
 # Support built in commands on windows out of the box.
-function pub {
+function pub() {
   if [[ $TRAVIS_OS_NAME == "windows" ]]; then
     command pub.bat "$@"
   else
     command pub "$@"
   fi
 }
-function dartfmt {
+function dartfmt() {
   if [[ $TRAVIS_OS_NAME == "windows" ]]; then
     command dartfmt.bat "$@"
   else
     command dartfmt "$@"
   fi
 }
-function dartanalyzer {
+function dartanalyzer() {
   if [[ $TRAVIS_OS_NAME == "windows" ]]; then
     command dartanalyzer.bat "$@"
   else
@@ -25,75 +25,102 @@ function dartanalyzer {
 }
 
 if [[ -z ${PKGS} ]]; then
-  echo -e '\033[31mPKGS environment variable must be set!\033[0m'
-  exit 1
+  echo -e '\033[31mPKGS environment variable must be set! - TERMINATING JOB\033[0m'
+  exit 64
 fi
 
 if [[ "$#" == "0" ]]; then
-  echo -e '\033[31mAt least one task argument must be provided!\033[0m'
-  exit 1
+  echo -e '\033[31mAt least one task argument must be provided! - TERMINATING JOB\033[0m'
+  exit 64
 fi
 
-EXIT_CODE=0
+SUCCESS_COUNT=0
+declare -a FAILURES
 
 for PKG in ${PKGS}; do
   echo -e "\033[1mPKG: ${PKG}\033[22m"
-  pushd "${PKG}" || exit $?
+  EXIT_CODE=0
+  pushd "${PKG}" >/dev/null || EXIT_CODE=$?
 
-  PUB_EXIT_CODE=0
-  pub upgrade --no-precompile || PUB_EXIT_CODE=$?
-
-  if [[ ${PUB_EXIT_CODE} -ne 0 ]]; then
-    EXIT_CODE=1
-    echo -e '\033[31mpub upgrade failed\033[0m'
-    popd
-    continue
+  if [[ ${EXIT_CODE} -ne 0 ]]; then
+    echo -e "\033[31mPKG: '${PKG}' does not exist - TERMINATING JOB\033[0m"
+    exit 64
   fi
 
-  for TASK in "$@"; do
-    echo
-    echo -e "\033[1mPKG: ${PKG}; TASK: ${TASK}\033[22m"
-    case ${TASK} in
-    command_0)
-      echo 'xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 0'
-      xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 0 || EXIT_CODE=$?
-      ;;
-    command_1)
-      echo 'xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 1'
-      xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 1 || EXIT_CODE=$?
-      ;;
-    command_2)
-      echo 'xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 2'
-      xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 2 || EXIT_CODE=$?
-      ;;
-    command_3)
-      echo 'xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 3'
-      xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 3 || EXIT_CODE=$?
-      ;;
-    command_4)
-      echo 'xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 4'
-      xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs -x node --total-shards 5 --shard-index 4 || EXIT_CODE=$?
-      ;;
-    command_5)
-      echo 'pub run --enable-experiment=non-nullable test --preset travis -x browser'
-      pub run --enable-experiment=non-nullable test --preset travis -x browser || EXIT_CODE=$?
-      ;;
-    dartanalyzer)
-      echo 'dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .'
-      dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings . || EXIT_CODE=$?
-      ;;
-    dartfmt)
-      echo 'dartfmt -n --set-exit-if-changed .'
-      dartfmt -n --set-exit-if-changed . || EXIT_CODE=$?
-      ;;
-    *)
-      echo -e "\033[31mNot expecting TASK '${TASK}'. Error!\033[0m"
-      EXIT_CODE=1
-      ;;
-    esac
-  done
+  pub upgrade --no-precompile || EXIT_CODE=$?
 
-  popd
+  if [[ ${EXIT_CODE} -ne 0 ]]; then
+    echo -e "\033[31mPKG: ${PKG}; 'pub upgrade' - FAILED  (${EXIT_CODE})\033[0m"
+    FAILURES+=("${PKG}; 'pub upgrade'")
+  else
+    for TASK in "$@"; do
+      EXIT_CODE=0
+      echo
+      echo -e "\033[1mPKG: ${PKG}; TASK: ${TASK}\033[22m"
+      case ${TASK} in
+      command_0)
+        echo 'xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 0'
+        xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 0 || EXIT_CODE=$?
+        ;;
+      command_1)
+        echo 'xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 1'
+        xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 1 || EXIT_CODE=$?
+        ;;
+      command_2)
+        echo 'xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 2'
+        xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 2 || EXIT_CODE=$?
+        ;;
+      command_3)
+        echo 'xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 3'
+        xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 3 || EXIT_CODE=$?
+        ;;
+      command_4)
+        echo 'xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 4'
+        xvfb-run -s "-screen 0 1024x768x24" pub run --enable-experiment=non-nullable test --preset travis -x phantomjs --total-shards 5 --shard-index 4 || EXIT_CODE=$?
+        ;;
+      command_5)
+        echo 'pub run --enable-experiment=non-nullable test --preset travis -x browser'
+        pub run --enable-experiment=non-nullable test --preset travis -x browser || EXIT_CODE=$?
+        ;;
+      dartanalyzer)
+        echo 'dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .'
+        dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings . || EXIT_CODE=$?
+        ;;
+      dartfmt)
+        echo 'dartfmt -n --set-exit-if-changed .'
+        dartfmt -n --set-exit-if-changed . || EXIT_CODE=$?
+        ;;
+      *)
+        echo -e "\033[31mUnknown TASK '${TASK}' - TERMINATING JOB\033[0m"
+        exit 64
+        ;;
+      esac
+
+      if [[ ${EXIT_CODE} -ne 0 ]]; then
+        echo -e "\033[31mPKG: ${PKG}; TASK: ${TASK} - FAILED (${EXIT_CODE})\033[0m"
+        FAILURES+=("${PKG}; TASK: ${TASK}")
+      else
+        echo -e "\033[32mPKG: ${PKG}; TASK: ${TASK} - SUCCEEDED\033[0m"
+        SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+      fi
+
+    done
+  fi
+
+  echo
+  echo -e "\033[32mSUCCESS COUNT: ${SUCCESS_COUNT}\033[0m"
+
+  if [ ${#FAILURES[@]} -ne 0 ]; then
+    echo -e "\033[31mFAILURES: ${#FAILURES[@]}\033[0m"
+    for i in "${FAILURES[@]}"; do
+      echo -e "\033[31m  $i\033[0m"
+    done
+  fi
+
+  popd >/dev/null || exit 70
+  echo
 done
 
-exit ${EXIT_CODE}
+if [ ${#FAILURES[@]} -ne 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
This channel had been `StremChannel<Object?>` primarily because the
`jsonDocument` transformer could emit `null`. Filter out nulls where
they are decoded to keep the rest of the channel non-nullable.

Refactor the `socketChannel` utility method to resolve casting
difficulties with `StreamChannelTransfomer` APIs. It is easier to
separately deal with the `Stream` and `Sink` portions of the channel
because they have separate needs around casting.

Make `RemoteChannel.start` and `serializeSuite` non-nullable channels.