### PR TITLE
Fix spawnHybridUri on windows

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.16.0-nullsafety.12
 
-* Update to the latest `test_core`.
+* Fix `spawnHybridUri` on windows.
 
 ## 1.16.0-nullsafety.11
 

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.16.0-nullsafety.12
+
+* Update to the latest `test_core`.
+
 ## 1.16.0-nullsafety.11
 
 * Set up a stack trace mapper in precompiled mode if source maps exist. If

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.16.0-nullsafety.11
+version: 1.16.0-nullsafety.12
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
@@ -32,7 +32,7 @@ dependencies:
   yaml: ^2.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.2.19-nullsafety.6
-  test_core: 0.3.12-nullsafety.10
+  test_core: 0.3.12-nullsafety.11
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test/test/io.dart
+++ b/pkgs/test/test/io.dart
@@ -17,7 +17,11 @@ import 'package:test/test.dart';
 /// The path to the root directory of the `test` package.
 final Future<String> packageDir =
     Isolate.resolvePackageUri(Uri(scheme: 'package', path: 'test/'))
-        .then((uri) => p.dirname(uri.path));
+        .then((uri) {
+  var dir = p.dirname(uri.path);
+  if (dir.startsWith('/C:')) dir = dir.substring(1);
+  return dir;
+});
 
 /// The path to the `pub` executable in the current Dart SDK.
 final _pubPath = p.absolute(p.join(p.dirname(Platform.resolvedExecutable),
@@ -78,7 +82,7 @@ Future<TestProcess> runTest(Iterable<String> args,
 
   var allArgs = [
     ...?vmArgs,
-    p.absolute(p.join(await packageDir, 'bin/test.dart')),
+    Uri.file(p.url.join(await packageDir, 'bin', 'test.dart')).toString(),
     '--concurrency=$concurrency',
     if (reporter != null) '--reporter=$reporter',
     if (fileReporter != null) '--file-reporter=$fileReporter',

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.12-nullsafety.11
+
+* Fix `spawnHybridUri` on windows.
+
 ## 0.3.12-nullsafety.10
 
 * Allow `package:analyzer` version `0.41.x`.

--- a/pkgs/test_core/lib/src/runner/spawn_hybrid.dart
+++ b/pkgs/test_core/lib/src/runner/spawn_hybrid.dart
@@ -125,7 +125,7 @@ Future<String> _languageVersionCommentFor(String url) async {
   // Returns the explicit language version comment if one exists.
   var result = parseString(
       content: await _readUri(parsedUri),
-      path: p.fromUri(parsedUri),
+      path: parsedUri.scheme == 'data' ? null : p.fromUri(parsedUri),
       throwIfDiagnostics: false);
   var languageVersionComment = result.unit.languageVersionToken?.value();
   if (languageVersionComment != null) return languageVersionComment.toString();

--- a/pkgs/test_core/lib/src/runner/spawn_hybrid.dart
+++ b/pkgs/test_core/lib/src/runner/spawn_hybrid.dart
@@ -86,7 +86,7 @@ StreamChannel /*!*/ spawnHybridUri(
 /// Normalizes [url] to an absolute url, or returns it as is if it has a
 /// scheme.
 ///
-/// Follows the rules for relatives/absolute paths outlit
+/// Follows the rules for relative/absolute paths outlined in [spawnHybridUri].
 String _normalizeUrl(String url, Suite suite) {
   final parsedUri = Uri.parse(url);
 
@@ -125,7 +125,7 @@ Future<String> _languageVersionCommentFor(String url) async {
   // Returns the explicit language version comment if one exists.
   var result = parseString(
       content: await _readUri(parsedUri),
-      path: parsedUri.path,
+      path: p.fromUri(parsedUri),
       throwIfDiagnostics: false);
   var languageVersionComment = result.unit.languageVersionToken?.value();
   if (languageVersionComment != null) return languageVersionComment.toString();

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.12-nullsafety.10
+version: 0.3.12-nullsafety.11
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
Previously we were getting uris like `file:///C:/C:/<stuff>`. I had to do some funky things to get rid of the leading `/` from the `C:` style uris as well.

I also noticed that the uris I get back from `Isolate.resolvePackageUri` are always posix style and not windows style paths, so this keeps the consistency with that where previously we ended up with mixes of `\` and `/` in some places.

This will also probably have to be backported.

Fixes https://github.com/dart-lang/test/issues/1382