### PR TITLE
Expand constraints on package:yaml

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix `spawnHybridUri` on windows.
 * Fix failures running tests on the `node` platform.
+* Allow `package:yaml` version `3.x.x`.
 
 ## 1.16.0-nullsafety.11
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   typed_data: '>=1.3.0-nullsafety <1.3.0'
   web_socket_channel: ^1.0.0
   webkit_inspection_protocol: ">=0.5.0 <0.8.0"
-  yaml: ^2.0.0
+  yaml: ">=2.0.0 <4.0.0"
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.2.19-nullsafety.6
   test_core: 0.3.12-nullsafety.11

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.3.12-nullsafety.11
 
 * Fix `spawnHybridUri` on windows.
+* Allow `package:yaml` version `3.x.x`.
 
 ## 0.3.12-nullsafety.10
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   stack_trace: '>=1.10.0-nullsafety <1.10.0'
   stream_channel: ">=2.1.0-nullsafety <2.1.0"
   vm_service: '>=1.0.0 <6.0.0'
-  yaml: ^2.0.0
+  yaml: ">=2.0.0 <4.0.0"
   # matcher is tightly constrained by test_api
   matcher: any
   # Use an exact version until the test_api package is stable.


### PR DESCRIPTION
The breaking changes do not impact the usage from the package.