### PR TITLE
test_core: Remove unused dart:async imports.

### DIFF
--- a/pkgs/test_core/lib/src/runner/compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/compiler_pool.dart
@@ -4,7 +4,6 @@
 //
 // @dart=2.9
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:isolate';

--- a/pkgs/test_core/lib/src/runner/spawn_hybrid.dart
+++ b/pkgs/test_core/lib/src/runner/spawn_hybrid.dart
@@ -4,7 +4,6 @@
 //
 // @dart=2.9
 
-import 'dart:async';
 import 'dart:io';
 import 'dart:isolate';
 


### PR DESCRIPTION
As of Dart 2.1, Future/Stream have been exported from dart:core.