### PR TITLE
Allow the latest package:args

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.16.0-nullsafety.14
+
+* Allow the latest args release (`2.x`).
+
 ## 1.16.0-nullsafety.13
 
 * Allow the latest glob release (`2.x`).

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.16.0-nullsafety.13
+version: 1.16.0-nullsafety.14
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
@@ -32,7 +32,7 @@ dependencies:
   yaml: ">=2.0.0 <4.0.0"
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.2.19-nullsafety.6
-  test_core: 0.3.12-nullsafety.12
+  test_core: 0.3.12-nullsafety.13
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.12-nullsafety.13
+
+* Allow the latest args release (`2.x`).
+
 ## 0.3.12-nullsafety.12
 
 * Allow the latest glob release (`2.x`).

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.12-nullsafety.12
+version: 0.3.12-nullsafety.13
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
@@ -9,7 +9,7 @@ environment:
 dependencies:
   analyzer: ">=0.39.5 <0.42.0"
   async: '>=2.5.0-nullsafety <2.5.0'
-  args: ^1.4.0
+  args: ">=1.4.0 <3.0.0"
   boolean_selector: ">=2.1.0-nullsafety <2.1.0"
   collection: '>=1.15.0-nullsafety <1.15.0'
   coverage: ">=0.13.3 <0.15.0"


### PR DESCRIPTION
The pub solve still won't pick these up due to constraints from
`analyzer` and `coverage`.