### PR TITLE
Comply with strict-raw-types in test package.

### DIFF
--- a/pkgs/test/lib/src/runner/browser/browser.dart
+++ b/pkgs/test/lib/src/runner/browser/browser.dart
@@ -49,11 +49,11 @@ abstract class Browser {
   ///
   /// If there's a problem starting or running the browser, this will complete
   /// with an error.
-  Future get onExit => _onExitCompleter.future;
-  final _onExitCompleter = Completer();
+  Future<void> get onExit => _onExitCompleter.future;
+  final _onExitCompleter = Completer<void>();
 
   /// Standard IO streams for the underlying browser process.
-  final _ioSubscriptions = <StreamSubscription>[];
+  final _ioSubscriptions = <StreamSubscription<List<int>>>[];
 
   /// Creates a new browser.
   ///
@@ -127,7 +127,7 @@ abstract class Browser {
   ///
   /// Returns the same [Future] as [onExit], except that it won't emit
   /// exceptions.
-  Future close() async {
+  Future<void> close() async {
     _closed = true;
 
     // If we don't manually close the stream the test runner can hang.

--- a/pkgs/test/lib/src/runner/browser/browser_manager.dart
+++ b/pkgs/test/lib/src/runner/browser/browser_manager.dart
@@ -45,7 +45,7 @@ class BrowserManager {
   /// The channel used to communicate with the browser.
   ///
   /// This is connected to a page running `static/host.dart`.
-  MultiChannel _channel;
+  MultiChannel<Object> _channel;
 
   /// A pool that ensures that limits the number of initial connections the
   /// manager will wait for at once.
@@ -69,10 +69,10 @@ class BrowserManager {
   ///
   /// This will be `null` as long as the browser isn't displaying a pause
   /// screen.
-  CancelableCompleter _pauseCompleter;
+  CancelableCompleter<void> _pauseCompleter;
 
   /// The controller for [_BrowserEnvironment.onRestart].
-  final _onRestartController = StreamController.broadcast();
+  final _onRestartController = StreamController<Null>.broadcast();
 
   /// The environment to attach to each suite.
   Future<_BrowserEnvironment> _environment;
@@ -265,7 +265,7 @@ class BrowserManager {
   }
 
   /// An implementation of [Environment.displayPause].
-  CancelableOperation _displayPause() {
+  CancelableOperation<void> _displayPause() {
     if (_pauseCompleter != null) return _pauseCompleter.operation;
 
     _pauseCompleter = CancelableCompleter(onCancel: () {
@@ -283,7 +283,7 @@ class BrowserManager {
   }
 
   /// The callback for handling messages received from the host page.
-  void _onMessage(Map message) {
+  void _onMessage(Map<Object, Object> message) {
     switch (message['command'] as String) {
       case 'ping':
         break;
@@ -305,7 +305,7 @@ class BrowserManager {
 
   /// Closes the manager and releases any resources it owns, including closing
   /// the browser.
-  Future close() => _closeMemoizer.runOnce(() {
+  Future<void> close() => _closeMemoizer.runOnce(() {
         _closed = true;
         _timer.cancel();
         if (_pauseCompleter != null) _pauseCompleter.complete();
@@ -332,11 +332,11 @@ class _BrowserEnvironment implements Environment {
   final Uri remoteDebuggerUrl;
 
   @override
-  final Stream onRestart;
+  final Stream<Null> onRestart;
 
   _BrowserEnvironment(this._manager, this.observatoryUrl,
       this.remoteDebuggerUrl, this.onRestart);
 
   @override
-  CancelableOperation displayPause() => _manager._displayPause();
+  CancelableOperation<void> displayPause() => _manager._displayPause();
 }

--- a/pkgs/test/lib/src/runner/node/platform.dart
+++ b/pkgs/test/lib/src/runner/node/platform.dart
@@ -82,7 +82,7 @@ class NodePlatform extends PlatformPlugin
   }
 
   @override
-  StreamChannel loadChannel(String path, SuitePlatform platform) =>
+  StreamChannel<dynamic> loadChannel(String path, SuitePlatform platform) =>
       throw UnimplementedError();
 
   @override
@@ -101,7 +101,7 @@ class NodePlatform extends PlatformPlugin
   ///
   /// Returns that channel along with a [StackTraceMapper] representing the
   /// source map for the compiled suite.
-  Future<Pair<StreamChannel, StackTraceMapper>> _loadChannel(
+  Future<Pair<StreamChannel<Object>, StackTraceMapper>> _loadChannel(
       String path, Runtime runtime, SuiteConfiguration suiteConfig) async {
     final servers = await _loopback();
 
@@ -288,7 +288,7 @@ class NodePlatform extends PlatformPlugin
   }
 
   @override
-  Future close() => _closeMemo.runOnce(() async {
+  Future<void> close() => _closeMemo.runOnce(() async {
         await _compilers.close();
 
         if (_config.pubServeUrl == null) {
@@ -297,7 +297,7 @@ class NodePlatform extends PlatformPlugin
           _http.close();
         }
       });
-  final _closeMemo = AsyncMemoizer();
+  final _closeMemo = AsyncMemoizer<void>();
 }
 
 Future<List<ServerSocket>> _loopback({int remainingRetries = 5}) async {

--- a/pkgs/test/test/runner/compact_reporter_test.dart
+++ b/pkgs/test/test/runner/compact_reporter_test.dart
@@ -415,7 +415,8 @@ void main() {
   });
 }
 
-Future _expectReport(String tests, String expected, {List<String> args}) async {
+Future<void> _expectReport(String tests, String expected,
+    {List<String> args}) async {
   await d.file('test.dart', '''
     import 'dart:async';
 

--- a/pkgs/test/test/runner/expanded_reporter_test.dart
+++ b/pkgs/test/test/runner/expanded_reporter_test.dart
@@ -318,7 +318,8 @@ void main() {
   });
 }
 
-Future _expectReport(String tests, String expected, {List<String> args}) async {
+Future<void> _expectReport(String tests, String expected,
+    {List<String> args}) async {
   await d.file('test.dart', '''
     import 'dart:async';
 

--- a/pkgs/test/test/runner/json_file_reporter_test.dart
+++ b/pkgs/test/test/runner/json_file_reporter_test.dart
@@ -106,8 +106,11 @@ void main() {
   });
 }
 
-Future _expectReports(String tests, String stdoutExpected,
-    List<List<dynamic /*Map|Matcher*/ >> jsonFileExpected, Map jsonFileDone,
+Future<void> _expectReports(
+    String tests,
+    String stdoutExpected,
+    List<List<dynamic /*Map|Matcher*/ >> jsonFileExpected,
+    Map<Object, Object> jsonFileDone,
     {List<String> args}) async {
   await d.file('test.dart', '''
     import 'dart:async';

--- a/pkgs/test/test/runner/json_reporter_test.dart
+++ b/pkgs/test/test/runner/json_reporter_test.dart
@@ -577,8 +577,8 @@ void customTest(String name, dynamic Function() testFn) => test(name, testFn);
 /// If [externalLibraries] are provided it should be a map of relative file
 /// paths to contents. All libraries will be added as imports to the test, and
 /// files will be created for them.
-Future _expectReport(
-    String tests, List<List<dynamic /*Map|Matcher*/ >> expected, Map done,
+Future<void> _expectReport(String tests,
+    List<List<dynamic /*Map|Matcher*/ >> expected, Map<Object, Object> done,
     {List<String> args, Map<String, String> externalLibraries}) async {
   args ??= [];
   externalLibraries ??= {};

--- a/pkgs/test/test/runner/json_reporter_utils.dart
+++ b/pkgs/test/test/runner/json_reporter_utils.dart
@@ -17,8 +17,11 @@ import 'package:test_core/src/runner/version.dart';
 ///
 /// Verifies that [outputLines] matches each set of matchers in [expected],
 /// includes the [testPid] from the test process, and ends with [done].
-Future expectJsonReport(List<String> outputLines, int testPid,
-    List<List<dynamic /*Map|Matcher*/ >> expected, Map done) async {
+Future<void> expectJsonReport(
+    List<String> outputLines,
+    int testPid,
+    List<List<dynamic /*Map|Matcher*/ >> expected,
+    Map<Object, Object> done) async {
   // Ensure the output is of the same length, including start, done and all
   // suites messages.
   expect(outputLines.length, equals(expected.fold(3, (a, m) => a + m.length)),
@@ -51,7 +54,7 @@ Future expectJsonReport(List<String> outputLines, int testPid,
 /// all suites.
 ///
 /// The [count] defaults to 1.
-Map allSuitesJson({int count}) {
+Map<String, Object> allSuitesJson({int count}) {
   return {'type': 'allSuites', 'count': count ?? 1};
 }
 
@@ -59,7 +62,7 @@ Map allSuitesJson({int count}) {
 /// begun running.
 ///
 /// The [platform] defaults to `"vm"`, the [path] defaults to `"test.dart"`.
-Map suiteJson(int id, {String platform, String path}) {
+Map<String, Object> suiteJson(int id, {String platform, String path}) {
   return {
     'type': 'suite',
     'suite': {
@@ -79,7 +82,7 @@ Map suiteJson(int id, {String platform, String path}) {
 ///
 /// The [testCount] parameter indicates the number of tests in the group. It
 /// defaults to 1.
-Map groupJson(int id,
+Map<String, Object> groupJson(int id,
     {String name,
     int suiteID,
     int parentID,
@@ -117,7 +120,7 @@ Map groupJson(int id,
 /// [skip] is `true`, the test is expected to be marked as skipped without a
 /// reason. If it's a [String], the test is expected to be marked as skipped
 /// with that reason.
-Map testStartJson(int id, String name,
+Map<String, Object> testStartJson(int id, String name,
     {int suiteID,
     Iterable<int> groupIDs,
     int line,
@@ -177,7 +180,7 @@ Matcher printJson(int id, dynamic /*String|Matcher*/ message, {String type}) {
 ///
 /// The [isFailure] parameter indicates whether the error was a [TestFailure] or
 /// not.
-Map errorJson(int id, String error, {bool isFailure = false}) {
+Map<String, Object> errorJson(int id, String error, {bool isFailure = false}) {
   return {
     'type': 'error',
     'testID': id,
@@ -195,7 +198,7 @@ Map errorJson(int id, String error, {bool isFailure = false}) {
 /// The [hidden] parameter indicates whether the test should not be displayed
 /// after finishing. The [skipped] parameter indicates whether the test was
 /// skipped.
-Map testDoneJson(int id,
+Map<String, Object> testDoneJson(int id,
     {String result, bool hidden = false, bool skipped = false}) {
   result ??= 'success';
   return {
@@ -209,10 +212,11 @@ Map testDoneJson(int id,
 
 /// Returns the event emitted by the JSON reporter indicating that the entire
 /// run finished.
-Map doneJson({bool success = true}) => {'type': 'done', 'success': success};
+Map<String, Object> doneJson({bool success = true}) =>
+    {'type': 'done', 'success': success};
 
 /// Returns the serialized metadata corresponding to [skip].
-Map metadataJson({skip}) {
+Map<String, Object> metadataJson({skip}) {
   if (skip == true) {
     return {'skip': true, 'skipReason': null};
   } else if (skip is String) {

--- a/pkgs/test/test/runner/signal_test.dart
+++ b/pkgs/test/test/runner/signal_test.dart
@@ -260,7 +260,7 @@ Future<TestProcess> _runTest(List<String> args, {bool forwardStdio = false}) =>
         environment: {'_UNITTEST_TEMP_DIR': _tempDir},
         forwardStdio: forwardStdio);
 
-Future signalAndQuit(TestProcess test) async {
+Future<void> signalAndQuit(TestProcess test) async {
   test.signal(ProcessSignal.sigterm);
   await test.shouldExit();
   await expectLater(test.stderr, emitsDone);

--- a/pkgs/test/test/runner/test_on_test.dart
+++ b/pkgs/test/test/runner/test_on_test.dart
@@ -178,7 +178,7 @@ void main() {
 /// Each of [suiteTestOn], [groupTestOn], and [testTestOn] is a platform
 /// selector that's suite-, group-, and test-level respectively. If [loadable]
 /// is `false`, the test file will be made unloadable on the Dart VM.
-Future _writeTestFile(String filename,
+Future<void> _writeTestFile(String filename,
     {String suiteTestOn,
     String groupTestOn,
     String testTestOn,

--- a/pkgs/test/test/utils.dart
+++ b/pkgs/test/test/utils.dart
@@ -147,10 +147,10 @@ void expectTestFailed(LiveTest liveTest, message) {
 /// is called at some later time.
 ///
 /// [stopBlocking] is passed the return value of [test].
-Future expectTestBlocks(
+Future<void> expectTestBlocks(
     dynamic Function() test, dynamic Function(dynamic) stopBlocking) async {
   LiveTest liveTest;
-  Future future;
+  Future<void> future;
   liveTest = createTest(() {
     var value = test();
     future = pumpEventQueue().then((_) {
@@ -171,7 +171,7 @@ Future expectTestBlocks(
 ///
 /// This is typically used to run multiple tests where later tests make
 /// assertions about the results of previous ones.
-Future expectTestsPass(void Function() body) async {
+Future<void> expectTestsPass(void Function() body) async {
   var engine = declareEngine(body);
   var success = await engine.run();
 

--- a/pkgs/test/tool/host.dart
+++ b/pkgs/test/tool/host.dart
@@ -52,7 +52,7 @@ external set _jsApi(_JSApi api);
 final _iframes = <int, IFrameElement>{};
 
 /// Subscriptions created for each loaded test suite, indexed by the suite id.
-final _subscriptions = <int, List<StreamSubscription>>{};
+final _subscriptions = <int, List<StreamSubscription<void>>>{};
 
 /// The URL for the current page.
 final _currentUrl = Uri.parse(window.location.href);
@@ -164,7 +164,7 @@ void main() {
 
 /// Creates a [MultiChannel] connection to the server, using a [WebSocket] as
 /// the underlying protocol.
-MultiChannel _connectToServer() {
+MultiChannel<dynamic> _connectToServer() {
   // The `managerUrl` query parameter contains the WebSocket URL of the remote
   // [BrowserManager] with which this communicates.
   var webSocket = WebSocket(_currentUrl.queryParameters['managerUrl']);
@@ -184,7 +184,7 @@ MultiChannel _connectToServer() {
 /// a [MessageChannel].
 ///
 /// [id] identifies the suite loaded in this iframe.
-StreamChannel _connectToIframe(String url, int id) {
+StreamChannel<dynamic> _connectToIframe(String url, int id) {
   var iframe = IFrameElement();
   _iframes[id] = iframe;
   iframe.src = url;
@@ -198,7 +198,7 @@ StreamChannel _connectToIframe(String url, int id) {
   // message to us. This ensures that no messages get dropped on the floor.
   var readyCompleter = Completer();
 
-  var subscriptions = <StreamSubscription>[];
+  var subscriptions = <StreamSubscription<void>>[];
   _subscriptions[id] = subscriptions;
 
   subscriptions.add(window.onMessage.listen((message) {

--- a/pkgs/test_core/lib/src/runner/platform.dart
+++ b/pkgs/test_core/lib/src/runner/platform.dart
@@ -41,7 +41,7 @@ abstract class PlatformPlugin {
   /// associated with this plugin in [new Loader]'s `plugins` parameter.
   // TODO(grouma) - Remove this method from the API as no platforms implement
   // it.
-  StreamChannel loadChannel(String path, SuitePlatform platform);
+  StreamChannel<dynamic> loadChannel(String path, SuitePlatform platform);
 
   /// Loads the runner suite for the test file at [path] using [platform], with
   /// [suiteConfig] encoding the suite-specific configuration.

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -38,7 +38,7 @@ class VMPlatform extends PlatformPlugin {
   VMPlatform();
 
   @override
-  StreamChannel loadChannel(String path, SuitePlatform platform) =>
+  StreamChannel<dynamic> loadChannel(String path, SuitePlatform platform) =>
       throw UnimplementedError();
 
   @override


### PR DESCRIPTION
This mostly means adding a type argument to a function which returns "Future",
or a field which is ambiguously a "StreamSubscription" or a "Completer".

If you write `Future f = Future<int>.value(7)`, you have just created a
`Future<dynamic>`. The strict-raw-types analysis option helps here.

This CL does not enable strict-raw-types in analysis_options because the other packages need CLs too, and I didn't want this to be too big.