### PR TITLE
Expand null safe constraints

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.16.0-nullsafety.18
+
+* Expand upper bound constraints for some null safe migrated packages.
+
 ## 1.16.0-nullsafety.17
 
 * Support the latest shelf release (`1.x.x`).

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.16.0-nullsafety.17
+version: 1.16.0-nullsafety.18
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
@@ -8,34 +8,41 @@ environment:
 
 dependencies:
   analyzer: '>=0.36.0 <0.42.0'
-  async: '>=2.5.0-nullsafety <2.5.0'
-  boolean_selector: '>=2.1.0-nullsafety <2.1.0'
+  async: ^2.5.0-nullsafety
+  boolean_selector: ^2.1.0-nullsafety
   coverage: '>=0.13.4 <0.16.0'
   http_multi_server: ^2.0.0
   io: ^0.3.0
-  js: '>=0.6.3-nullsafety <0.6.3'
+  js: ^0.6.3-nullsafety
   node_preamble: ^1.3.0
-  package_config: ^1.9.0
-  path: '>=1.8.0-nullsafety <1.8.0'
-  pedantic: '>=1.10.0-nullsafety <1.10.0'
-  pool: '>=1.5.0-nullsafety <1.5.0'
+  package_config: ">=1.9.0 <3.0.0"
+  path: ^1.8.0-nullsafety
+  pedantic: ^1.10.0-nullsafety
+  pool: ^1.5.0-nullsafety
   shelf: '>=0.7.0 <2.0.0'
   shelf_packages_handler: ">=1.0.0 <3.0.0"
   shelf_static: ^0.2.6
   shelf_web_socket: ^0.2.0
-  source_span: '>=1.8.0-nullsafety <1.8.0'
-  stack_trace: '>=1.10.0-nullsafety <1.10.0'
-  stream_channel: '>=2.1.0-nullsafety <2.1.0'
-  typed_data: '>=1.3.0-nullsafety <1.3.0'
+  source_span: ^1.8.0-nullsafety
+  stack_trace: ^1.10.0-nullsafety
+  stream_channel: ^2.1.0-nullsafety
+  typed_data: ^1.3.0-nullsafety
   web_socket_channel: ^1.0.0
   webkit_inspection_protocol: ">=0.5.0 <0.8.0"
   yaml: ">=2.0.0 <4.0.0"
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.2.19-nullsafety.6
-  test_core: 0.3.12-nullsafety.15
+  test_api: 0.2.19-nullsafety.7
+  test_core: 0.3.12-nullsafety.16
 
 dev_dependencies:
   fake_async: ^1.0.0
   shelf_test_handler: ^1.0.0
   test_descriptor: ^1.0.0
   test_process: ^1.0.0
+
+dependency_overrides:
+  test_core:
+    path: ../test_core
+  test_api:
+    path: ../test_api
+  package_config: 2.0.0-nullsafety.0

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -45,4 +45,3 @@ dependency_overrides:
     path: ../test_core
   test_api:
     path: ../test_api
-  package_config: 2.0.0-nullsafety.0

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.19-nullsafety.7
+
+* Expand upper bound constraints for some null safe migrated packages.
+
 ## 0.2.19-nullsafety.6
 
 * Fix `spawnHybridUri` to respect language versioning of the spawned uri.

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -7,23 +7,23 @@ environment:
   sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
-  async: '>=2.5.0-nullsafety <2.5.0'
-  boolean_selector: ">=2.1.0-nullsafety <2.1.0"
-  collection: '>=1.15.0-nullsafety <1.15.0'
-  meta: '>=1.3.0-nullsafety <1.3.0'
-  path: '>=1.8.0-nullsafety <1.8.0'
-  source_span: '>=1.8.0-nullsafety <1.8.0'
-  stack_trace: '>=1.10.0-nullsafety <1.10.0'
-  stream_channel: '>=2.1.0-nullsafety <2.1.0'
-  string_scanner: '>=1.1.0-nullsafety <1.1.0'
-  term_glyph: '>=1.2.0-nullsafety <1.2.0'
+  async: ^2.5.0-nullsafety
+  boolean_selector: ^2.1.0-nullsafety
+  collection: ^1.15.0-nullsafety
+  meta: ^1.3.0-nullsafety
+  path: ^1.8.0-nullsafety
+  source_span: ^1.8.0-nullsafety
+  stack_trace: ^1.10.0-nullsafety
+  stream_channel: ^2.1.0-nullsafety
+  string_scanner: ^1.1.0-nullsafety
+  term_glyph: ^1.2.0-nullsafety
 
   # Use a tight version constraint to ensure that a constraint on matcher
   # properly constrains all features it provides.
   matcher: '>=0.12.10-nullsafety <0.12.10'
 
 dev_dependencies:
-  pedantic: '>=1.10.0-nullsafety <1.10.0'
+  pedantic: ^1.10.0-nullsafety
   test_descriptor: ^1.0.0
   test_process: ^1.0.0
   test: any

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.12-nullsafety.16
+
+* Expand upper bound constraints for some null safe migrated packages.
+
 ## 0.3.12-nullsafety.15
 
 * Support the latest vm_service release (`6.x.x`).

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -35,4 +35,3 @@ dependencies:
 dependency_overrides:
   test_api:
     path: ../test_api
-  package_config: 2.0.0-nullsafety.0

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.12-nullsafety.15
+version: 0.3.12-nullsafety.16
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
@@ -8,30 +8,31 @@ environment:
 
 dependencies:
   analyzer: ">=0.39.5 <0.42.0"
-  async: '>=2.5.0-nullsafety <2.5.0'
+  async: ^2.5.0-nullsafety
   args: ">=1.4.0 <3.0.0"
-  boolean_selector: ">=2.1.0-nullsafety <2.1.0"
-  collection: '>=1.15.0-nullsafety <1.15.0'
+  boolean_selector: ^2.1.0-nullsafety
+  collection: ^1.15.0-nullsafety
   coverage: ">=0.13.3 <0.16.0"
   glob: ">=1.0.0 <3.0.0"
   io: ^0.3.0
-  meta: '>=1.3.0-nullsafety <1.3.0'
-  package_config: ^1.9.2
-  path: '>=1.8.0-nullsafety <1.8.0'
-  pedantic: '>=1.10.0-nullsafety <1.10.0'
-  pool: '>=1.5.0-nullsafety <1.5.0'
-  source_map_stack_trace: '>=2.1.0-nullsafety <2.1.0'
-  source_maps: '>=0.10.10-nullsafety <0.10.10'
-  source_span: '>=1.8.0-nullsafety <1.8.0'
-  stack_trace: '>=1.10.0-nullsafety <1.10.0'
-  stream_channel: ">=2.1.0-nullsafety <2.1.0"
+  meta: ^1.3.0-nullsafety
+  package_config: ">=1.9.2 <3.0.0"
+  path: ^1.8.0-nullsafety
+  pedantic: ^1.10.0-nullsafety
+  pool: ^1.5.0-nullsafety
+  source_map_stack_trace: ^2.1.0-nullsafety
+  source_maps: ^0.10.10-nullsafety
+  source_span: ^1.8.0-nullsafety
+  stack_trace: ^1.10.0-nullsafety
+  stream_channel: ^2.1.0-nullsafety
   vm_service: '>=1.0.0 <7.0.0'
   yaml: ">=2.0.0 <4.0.0"
   # matcher is tightly constrained by test_api
   matcher: any
   # Use an exact version until the test_api package is stable.
-  test_api: 0.2.19-nullsafety.6
+  test_api: 0.2.19-nullsafety.7
 
 dependency_overrides:
   test_api:
     path: ../test_api
+  package_config: 2.0.0-nullsafety.0


### PR DESCRIPTION
Change all constraints with an upper bound which prevents the stable
version for null safety into caret constraints which allow them.

Expand constraint on `package_config` to allow `2.x`.