### PR TITLE
Bump test_api version in pubspec

### DIFF
--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.2.19-nullsafety.6
+version: 0.2.19-nullsafety.7
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 


### PR DESCRIPTION
This was missed in https://github.com/dart-lang/test/pull/1417