### PR TITLE
Revert import removals

### DIFF
--- a/pkgs/test_api/lib/src/backend/metadata.dart
+++ b/pkgs/test_api/lib/src/backend/metadata.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:collection';
+
 import 'package:boolean_selector/boolean_selector.dart';
 import 'package:collection/collection.dart';
 

--- a/pkgs/test_api/lib/src/frontend/async_matcher.dart
+++ b/pkgs/test_api/lib/src/frontend/async_matcher.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:matcher/matcher.dart';
 
 import '../backend/invoker.dart';

--- a/pkgs/test_api/lib/src/frontend/expect.dart
+++ b/pkgs/test_api/lib/src/frontend/expect.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:matcher/matcher.dart';
 
 import '../backend/closed_exception.dart';

--- a/pkgs/test_api/lib/src/frontend/future_matchers.dart
+++ b/pkgs/test_api/lib/src/frontend/future_matchers.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:matcher/matcher.dart';
 
 import '../utils.dart';

--- a/pkgs/test_api/lib/src/frontend/stream_matcher.dart
+++ b/pkgs/test_api/lib/src/frontend/stream_matcher.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:async/async.dart';
 import 'package:matcher/matcher.dart';
 

--- a/pkgs/test_api/lib/src/frontend/stream_matchers.dart
+++ b/pkgs/test_api/lib/src/frontend/stream_matchers.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:async/async.dart';
 import 'package:matcher/matcher.dart';
 

--- a/pkgs/test_api/lib/src/frontend/utils.dart
+++ b/pkgs/test_api/lib/src/frontend/utils.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
 /// Returns a [Future] that completes after the [event loop][] has run the given
 /// number of [times] (20 by default).
 ///

--- a/pkgs/test_api/test/frontend/expect_test.dart
+++ b/pkgs/test_api/test/frontend/expect_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:test/test.dart';
 
 import '../utils.dart';

--- a/pkgs/test_api/test/frontend/never_called_test.dart
+++ b/pkgs/test_api/test/frontend/never_called_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:term_glyph/term_glyph.dart' as glyph;
 import 'package:test/test.dart';
 

--- a/pkgs/test_api/test/frontend/tear_down_all_test.dart
+++ b/pkgs/test_api/test/frontend/tear_down_all_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:async/async.dart';
 import 'package:test/test.dart';
 

--- a/pkgs/test_api/test/utils.dart
+++ b/pkgs/test_api/test/utils.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:collection';
 
 import 'package:test_api/src/backend/declarer.dart';


### PR DESCRIPTION
Reverts https://github.com/dart-lang/test/commit/ce2a16c16f282acd6d1a2566c5dd64e70ea2f080 and https://github.com/dart-lang/test/commit/841254aaf24714f65cc5ab6e1755b60ad11c4453 for the stable release.

These changes never landed in a previous release and we want to ensure there are no code differences between the last null safety pre-release and stable.

These can be re-landed after publishing stable.