### PR TITLE
Prepare to publish test_api for stable null safety

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.16.0-nullsafety.19
+
+* Use the `test_api` for stable null safety.
+
 ## 1.16.0-nullsafety.18
 
 * Expand upper bound constraints for some null safe migrated packages.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.16.0-nullsafety.18
+version: 1.16.0-nullsafety.19
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
@@ -8,31 +8,31 @@ environment:
 
 dependencies:
   analyzer: '>=0.36.0 <0.42.0'
-  async: ^2.5.0-nullsafety
-  boolean_selector: ^2.1.0-nullsafety
+  async: ^2.5.0
+  boolean_selector: ^2.1.0
   coverage: '>=0.13.4 <0.16.0'
   http_multi_server: ^2.0.0
   io: ^0.3.0
   js: ^0.6.3-nullsafety
   node_preamble: ^1.3.0
   package_config: ">=1.9.0 <3.0.0"
-  path: ^1.8.0-nullsafety
+  path: ^1.8.0
   pedantic: ^1.10.0-nullsafety
   pool: ^1.5.0-nullsafety
   shelf: '>=0.7.0 <2.0.0'
   shelf_packages_handler: ">=1.0.0 <3.0.0"
   shelf_static: ^0.2.6
   shelf_web_socket: ^0.2.0
-  source_span: ^1.8.0-nullsafety
-  stack_trace: ^1.10.0-nullsafety
+  source_span: ^1.8.0
+  stack_trace: ^1.10.0
   stream_channel: ^2.1.0-nullsafety
   typed_data: ^1.3.0-nullsafety
   web_socket_channel: ^1.0.0
   webkit_inspection_protocol: ">=0.5.0 <0.8.0"
   yaml: ">=2.0.0 <4.0.0"
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.2.19-nullsafety.7
-  test_core: 0.3.12-nullsafety.16
+  test_api: 0.2.19
+  test_core: 0.3.12-nullsafety.17
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.19
+
+* Stable release for null safety.
+
 ## 0.2.19-nullsafety.7
 
 * Expand upper bound constraints for some null safe migrated packages.

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.2.19-nullsafety.7
+version: 0.2.19
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 
@@ -7,20 +7,20 @@ environment:
   sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
-  async: ^2.5.0-nullsafety
-  boolean_selector: ^2.1.0-nullsafety
-  collection: ^1.15.0-nullsafety
-  meta: ^1.3.0-nullsafety
-  path: ^1.8.0-nullsafety
-  source_span: ^1.8.0-nullsafety
-  stack_trace: ^1.10.0-nullsafety
-  stream_channel: ^2.1.0-nullsafety
-  string_scanner: ^1.1.0-nullsafety
-  term_glyph: ^1.2.0-nullsafety
+  async: ^2.5.0
+  boolean_selector: ^2.1.0
+  collection: ^1.15.0
+  meta: ^1.3.0
+  path: ^1.8.0
+  source_span: ^1.8.0
+  stack_trace: ^1.10.0
+  stream_channel: ^2.1.0
+  string_scanner: ^1.1.0
+  term_glyph: ^1.2.0
 
   # Use a tight version constraint to ensure that a constraint on matcher
   # properly constrains all features it provides.
-  matcher: '>=0.12.10-nullsafety <0.12.10'
+  matcher: '>=0.12.10 <0.12.11'
 
 dev_dependencies:
   pedantic: ^1.10.0-nullsafety

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.12-nullsafety.17
+
+* Use the `test_api` for stable null safety.
+
 ## 0.3.12-nullsafety.16
 
 * Expand upper bound constraints for some null safe migrated packages.

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.12-nullsafety.16
+version: 0.3.12-nullsafety.17
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
@@ -8,29 +8,29 @@ environment:
 
 dependencies:
   analyzer: ">=0.39.5 <0.42.0"
-  async: ^2.5.0-nullsafety
+  async: ^2.5.0
   args: ">=1.4.0 <3.0.0"
-  boolean_selector: ^2.1.0-nullsafety
-  collection: ^1.15.0-nullsafety
+  boolean_selector: ^2.1.0
+  collection: ^1.15.0
   coverage: ">=0.13.3 <0.16.0"
   glob: ">=1.0.0 <3.0.0"
   io: ^0.3.0
-  meta: ^1.3.0-nullsafety
+  meta: ^1.3.0
   package_config: ">=1.9.2 <3.0.0"
-  path: ^1.8.0-nullsafety
+  path: ^1.8.0
   pedantic: ^1.10.0-nullsafety
   pool: ^1.5.0-nullsafety
   source_map_stack_trace: ^2.1.0-nullsafety
   source_maps: ^0.10.10-nullsafety
-  source_span: ^1.8.0-nullsafety
-  stack_trace: ^1.10.0-nullsafety
+  source_span: ^1.8.0
+  stack_trace: ^1.10.0
   stream_channel: ^2.1.0-nullsafety
   vm_service: '>=1.0.0 <7.0.0'
   yaml: ">=2.0.0 <4.0.0"
   # matcher is tightly constrained by test_api
   matcher: any
   # Use an exact version until the test_api package is stable.
-  test_api: 0.2.19-nullsafety.7
+  test_api: 0.2.19
 
 dependency_overrides:
   test_api:


### PR DESCRIPTION
- Drop the `-nullsafety` prerelease suffix from the version.
- Bump to the stable versions for all normal dependencies.
- Bump to the stable versions for all `test_api` dependencies from
  `test` and `test_core`.

Only `test_api` is going stable for now. `test` and `test_core` will go
to stable after the remainder of their dependencies go stable.