### PR TITLE
Remove references to fixed SDK issues

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.3.13-dev
+
 ## 0.3.12
 
 * Stable null safety release.

--- a/pkgs/test_core/lib/src/runner/runner_suite.dart
+++ b/pkgs/test_core/lib/src/runner/runner_suite.dart
@@ -81,13 +81,8 @@ class RunnerSuite extends Suite {
   ///
   /// Result is suitable for input to the coverage formatters provided by
   /// `package:coverage`.
-  Future<Map<String, dynamic>> gatherCoverage() async {
-    // TODO(https://github.com/dart-lang/sdk/issues/41108): Remove cast
-    var coverage =
-        // ignore: unnecessary_cast
-        await _controller._gatherCoverage?.call() as Map<String, dynamic>?;
-    return coverage ?? {};
-  }
+  Future<Map<String, dynamic>> gatherCoverage() async =>
+      (await _controller._gatherCoverage?.call()) ?? {};
 }
 
 /// A class that exposes and controls a [RunnerSuite].

--- a/pkgs/test_core/lib/src/runner/suite.dart
+++ b/pkgs/test_core/lib/src/runner/suite.dart
@@ -287,7 +287,6 @@ class SuiteConfiguration {
         dart2jsArgs: dart2jsArgs?.toList() ?? this.dart2jsArgs,
         precompiledPath: precompiledPath ?? this.precompiledPath,
         patterns: patterns ?? this.patterns,
-        // TODO(https://github.com/dart-lang/sdk/issues/41114): Remove cast
         runtimes: runtimes ?? _runtimes,
         includeTags: includeTags ?? this.includeTags,
         excludeTags: excludeTags ?? this.excludeTags,

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.12
+version: 0.3.13-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
Remove extra casts that were used to work around bugs in the SDK. In one
case the cast had already been removed but the comment remained.