### PR TITLE
Drop explicit diagnostic upgrades

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,13 +3,6 @@ analyzer:
   strong-mode:
     implicit-casts: false
   errors:
-    # Remove noise from workspace diagnostics lists
-    todo: ignore
-    # Upgrade lints to errors that will break Google3
-    unused_element: error
-    unused_import: error
-    unused_local_variable: error
-    dead_code: error
     # There are a number of deprecated members used through this package
     deprecated_member_use_from_same_package: ignore
   enable-experiment:


### PR DESCRIPTION
The upgrades to `error` are no longer necessary because we run the
analyzer with the `--fatal-infos` flag.

The ignore for TODO is no longer necessary because the analysis server
allows configuring whether to show TODO as diagnostics.