### PR TITLE
Remove a reference to a very old SDK version

### DIFF
--- a/pkgs/test_core/lib/src/runner/debugger.dart
+++ b/pkgs/test_core/lib/src/runner/debugger.dart
@@ -140,8 +140,7 @@ class _Debugger {
         if (runtime.isDartVM) {
           var url = _suite.environment.observatoryUrl;
           if (url == null) {
-            print("${yellow}Observatory URL not found. Make sure you're using "
-                '${runtime.name} 1.11 or later.$noColor');
+            print('${yellow}Observatory URL not found.$noColor');
           } else {
             print('Observatory URL: $bold$url$noColor');
           }


### PR DESCRIPTION
This version of the test package will never run with Dart 1.11 so the
message will never apply.