### PR TITLE
udpate test_core dep in test

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.16.2
+
+* Update `test_core` dependency to `0.3.13`.
+
 ## 1.16.1
 
 * Allow the latest analyzer `1.0.0`.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.16.1
+version: 1.16.2
 description: A full featured library for writing and running Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test
 
@@ -32,7 +32,7 @@ dependencies:
   yaml: ">=2.0.0 <4.0.0"
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.2.19
-  test_core: 0.3.12
+  test_core: 0.3.13
 
 dev_dependencies:
   fake_async: ^1.0.0


### PR DESCRIPTION
forgot to do this in 0.16.1 (hidden by dep overrides :( )