### PR TITLE
Allow stdin to be injected

### DIFF
--- a/pkgs/test/lib/src/executable.dart
+++ b/pkgs/test/lib/src/executable.dart
@@ -11,7 +11,12 @@ import 'package:test_api/src/backend/runtime.dart'; // ignore: implementation_im
 import 'runner/node/platform.dart';
 import 'runner/browser/platform.dart';
 
-void main(List<String> args) async {
+/// Entrypoint to the test executable.
+///
+/// [stdin] should be provided as a broadcast stream if this function is
+/// intended to be called multiple times in the same process, or if there are
+/// other accesses to `stdin` from `dart:io` outside this method.
+Future<void> main(List<String> args, {Stream<List<int>> stdin}) async {
   registerPlatformPlugin([Runtime.nodeJS], () => NodePlatform());
   registerPlatformPlugin([
     Runtime.chrome,
@@ -21,5 +26,5 @@ void main(List<String> args) async {
     Runtime.internetExplorer
   ], () => BrowserPlatform.start());
 
-  await executable.main(args);
+  await executable.main(args, stdin: stdin);
 }

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -8,7 +8,6 @@ import 'dart:core' as core;
 import 'dart:core';
 import 'dart:io';
 
-import 'package:async/async.dart';
 import 'package:path/path.dart' as p;
 import 'package:test_api/src/backend/operating_system.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/runtime.dart'; // ignore: implementation_imports
@@ -48,18 +47,6 @@ final currentOS = OperatingSystem.findByIoName(Platform.operatingSystem);
 SuitePlatform currentPlatform(Runtime runtime) => SuitePlatform(runtime,
     os: runtime.isBrowser ? OperatingSystem.none : currentOS,
     inGoogle: inGoogle);
-
-/// A queue of lines of standard input.
-///
-/// Also returns an empty stream for Fuchsia since Fuchsia components can't
-/// access stdin.
-StreamQueue<String> get stdinLines => _stdinLines ??= StreamQueue(
-    Platform.isFuchsia ? Stream<String>.empty() : lineSplitter.bind(stdin));
-
-StreamQueue<String>? _stdinLines;
-
-/// Call cancel on [stdinLines], but only if it's been accessed previously.
-void cancelStdinLines() => _stdinLines?.cancel(immediate: true);
 
 /// Whether this is being run as a subprocess in the test package's own tests.
 bool inTestTests = Platform.environment['_DART_TEST_TESTING'] == 'true';


### PR DESCRIPTION
`stdin` is a global property from `dart:io` that returns a single consumer stream which can only be listened to once. This creates problems when different libraries need to access stdin as part of the same process, without coordination. Listening on `stdin` more than once will cause a `StateError`.

As such, instead of reading `stdin` from `dart:io` and saving a handle to it globally, accept it as a `Stream<List<int>>`, and pass it through to where it is needed. This will allow dependents on this library, such as the Flutter Tools to provide a broadcast stream that can be managed by the respective libraries independently. 
