### PR TITLE
update test_core and test to allow latest published deps

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.16.5-dev
+
+* Expand several deps to allow the latest versions.
+
 ## 1.16.4
 
 * Update `test_core` dependency to `0.3.14`.

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.16.5-dev
+## 1.16.5
 
 * Expand several deps to allow the latest versions.
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.16.5-dev
+version: 1.16.5
 description: A full featured library for writing and running Dart tests.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,42 +1,42 @@
 name: test
-version: 1.16.4
+version: 1.16.5-dev
 description: A full featured library for writing and running Dart tests.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
   analyzer: '>=0.39.5 <2.0.0'
   async: ^2.5.0
   boolean_selector: ^2.1.0
   coverage: '>=0.13.4 <0.16.0'
-  http_multi_server: ^2.0.0
-  io: ^0.3.0
+  http_multi_server: '>=2.0.0 <4.0.0'
+  io: '>=0.3.0 <2.0.0'
   js: ^0.6.3
   node_preamble: ^1.3.0
-  package_config: ">=1.9.0 <3.0.0"
+  package_config: '>=1.9.0 <3.0.0'
   path: ^1.8.0
   pedantic: ^1.10.0
   pool: ^1.5.0
   shelf: '>=0.7.0 <2.0.0'
-  shelf_packages_handler: ">=1.0.0 <3.0.0"
-  shelf_static: ^0.2.6
-  shelf_web_socket: ^0.2.0
+  shelf_packages_handler: '>=1.0.0 <4.0.0'
+  shelf_static: '>=0.2.6 <2.0.0'
+  shelf_web_socket: '>=0.2.0 <2.0.0'
   source_span: ^1.8.0
   stack_trace: ^1.10.0
   stream_channel: ^2.1.0
   typed_data: ^1.3.0
   web_socket_channel: '>=1.0.0 <3.0.0'
-  webkit_inspection_protocol: ">=0.5.0 <0.8.0"
-  yaml: ">=2.0.0 <4.0.0"
+  webkit_inspection_protocol: '>=0.5.0 <0.8.0'
+  yaml: '>=2.0.0 <4.0.0'
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.2.19
-  test_core: 0.3.14
+  test_core: 0.3.15
 
 dev_dependencies:
   fake_async: ^1.0.0
-  shelf_test_handler: ^1.0.0
+  shelf_test_handler: ^2.0.0
   test_descriptor: ^2.0.0
   test_process: '>=1.0.0 <3.0.0'
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   analyzer: '>=0.39.5 <2.0.0'
   async: ^2.5.0
   boolean_selector: ^2.1.0
-  coverage: '>=0.13.4 <0.16.0'
+  coverage: '>=0.13.4 <2.0.0'
   http_multi_server: '>=2.0.0 <4.0.0'
   io: '>=0.3.0 <2.0.0'
   js: ^0.6.3
@@ -28,7 +28,7 @@ dependencies:
   stream_channel: ^2.1.0
   typed_data: ^1.3.0
   web_socket_channel: '>=1.0.0 <3.0.0'
-  webkit_inspection_protocol: '>=0.5.0 <0.8.0'
+  webkit_inspection_protocol: '>=0.5.0 <2.0.0'
   yaml: '>=2.0.0 <4.0.0'
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.2.19

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -23,9 +23,7 @@ dependencies:
   matcher: '>=0.12.10 <0.12.11'
 
 dev_dependencies:
-  pedantic: ^1.10.0-nullsafety
-  test_descriptor: ^1.0.0
-  test_process: ^1.0.0
+  pedantic: ^1.10.0
   test: any
   test_core: any
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.3.15-dev
 
+* Allow package:io version 1.0.0.
+
 ## 0.3.14
 
 * Handle issue closing `stdin` during shutdown.

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.15-dev
+## 0.3.15
 
 * Allow package:io version 1.0.0.
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   args: '>=1.4.0 <3.0.0'
   boolean_selector: ^2.1.0
   collection: ^1.15.0
-  coverage: '>=0.13.3 <0.16.0'
+  coverage: '>=0.13.3 <2.0.0'
   glob: '>=1.0.0 <3.0.0'
   io: '>=0.3.0 <2.0.0'
   meta: ^1.3.0

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.15-dev
+version: 0.3.15
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -4,19 +4,19 @@ description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
   analyzer: '>=0.39.5 <2.0.0'
   async: ^2.5.0
-  args: ">=1.4.0 <3.0.0"
+  args: '>=1.4.0 <3.0.0'
   boolean_selector: ^2.1.0
   collection: ^1.15.0
-  coverage: ">=0.13.3 <0.16.0"
-  glob: ">=1.0.0 <3.0.0"
-  io: ^0.3.0
+  coverage: '>=0.13.3 <0.16.0'
+  glob: '>=1.0.0 <3.0.0'
+  io: '>=0.3.0 <2.0.0'
   meta: ^1.3.0
-  package_config: ">=1.9.2 <3.0.0"
+  package_config: '>=1.9.2 <3.0.0'
   path: ^1.8.0
   pedantic: ^1.10.0
   pool: ^1.5.0
@@ -26,7 +26,7 @@ dependencies:
   stack_trace: ^1.10.0
   stream_channel: ^2.1.0
   vm_service: '>=1.0.0 <7.0.0'
-  yaml: ">=2.0.0 <4.0.0"
+  yaml: '>=2.0.0 <4.0.0'
   # matcher is tightly constrained by test_api
   matcher: any
   # Use an exact version until the test_api package is stable.


### PR DESCRIPTION
Also removes some unused deps from test_api, and unified quote style in pubspecs.

Waiting to publish until we can update node_preamble (or may just add that here if it lands soon and then remove the dev).

Then we can finish the migration to null safety after that 🎉 