### PR TITLE
fix handling of null remote exception messages

### DIFF
--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0-dev
+
+* **Breaking** `TestException.message` is now nullable.
+  * Fixes handling of `null` messages in remote exceptions.
+
 ## 0.2.20
 
 * Fix some strong null safety mode errors in the original migration.

--- a/pkgs/test_api/lib/src/frontend/expect.dart
+++ b/pkgs/test_api/lib/src/frontend/expect.dart
@@ -11,12 +11,12 @@ import 'async_matcher.dart';
 
 /// An exception thrown when a test assertion fails.
 class TestFailure {
-  final String message;
+  final String? message;
 
   TestFailure(this.message);
 
   @override
-  String toString() => message;
+  String toString() => message.toString();
 }
 
 /// The type used for functions that can be used to build up error reports

--- a/pkgs/test_api/lib/src/util/remote_exception.dart
+++ b/pkgs/test_api/lib/src/util/remote_exception.dart
@@ -17,7 +17,7 @@ class RemoteException implements Exception {
   ///
   /// If the original exception was a plain string, this will contain that
   /// string.
-  final String message;
+  final String? message;
 
   /// The value of the original exception's `runtimeType.toString()`.
   final String type;
@@ -63,7 +63,7 @@ class RemoteException implements Exception {
 
   /// Deserializes the exception portion of [serialized].
   static RemoteException _deserializeException(serialized) {
-    final message = serialized['message'] as String;
+    final message = serialized['message'] as String?;
     final type = serialized['type'] as String;
     final toString = serialized['toString'] as String;
 
@@ -86,6 +86,6 @@ class RemoteException implements Exception {
 /// It's important to preserve [TestFailure]-ness, because tests have different
 /// results depending on whether an exception was a failure or an error.
 class _RemoteTestFailure extends RemoteException implements TestFailure {
-  _RemoteTestFailure(String message, String type, String toString)
+  _RemoteTestFailure(String? message, String type, String toString)
       : super._(message, type, toString);
 }

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.2.21-dev
+version: 0.3.0-dev
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.2.20
+version: 0.2.21-dev
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 


### PR DESCRIPTION
Once this lands internally we can send another pr to publish new versions of test_core and test to allow this version.