### PR TITLE
prep to release the latest test_api

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.16.7
+
+* Update `test_core` and `test_api` deps.
+
 ## 1.16.6
 
 * Complete the migration to null safety.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.16.6
+version: 1.16.7
 description: A full featured library for writing and running Dart tests.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
 
@@ -32,8 +32,8 @@ dependencies:
   webkit_inspection_protocol: ^1.0.0
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.2.20
-  test_core: 0.3.17
+  test_api: 0.3.0
+  test_core: 0.3.18
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0-dev
+## 0.3.0
 
 * **Breaking** `TestException.message` is now nullable.
   * Fixes handling of `null` messages in remote exceptions.

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.3.0-dev
+version: 0.3.0
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.18
+
+* Update to the latest `test_api`.
+
 ## 0.3.17
 
 * Complete the null safety migration.

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.17
+version: 0.3.18
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
@@ -30,7 +30,7 @@ dependencies:
   # matcher is tightly constrained by test_api
   matcher: any
   # Use an exact version until the test_api package is stable.
-  test_api: 0.2.20
+  test_api: 0.3.0
 
 dependency_overrides:
   test_api:


### PR DESCRIPTION
Also release a new test_core and test that depend on it.

Fixes an issue when `Error`s are serialized as remote exceptions. We now allow an empty message and properly de-serialize it.