### PR TITLE
Disable stack trace chaining by default

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.16.8
 
 * Fix an issue where coverage collection could hang on Chrome. 
+* Disable stack trace chaining by default. It can be re-enabled by explicitly
+  passing the `--chain-stack-traces` flag.
 
 ## 1.16.7
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.3.0
-  test_core: 0.3.18
+  test_core: 0.3.19
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -92,7 +92,6 @@ Running Tests:
                                       especially for asynchronous code. It may be useful to disable
                                       to provide improved test performance but at the cost of
                                       debuggability.
-                                      (defaults to on)
     --no-retry                        Don't rerun tests that have retry set.
     --test-randomize-ordering-seed    Use the specified seed to randomize the execution order of test cases.
                                       Must be a 32bit unsigned integer or "random".
@@ -389,25 +388,25 @@ $_usage''');
   });
 
   group('runs failing tests', () {
-    test('defaults to chaining stack traces', () async {
+    test('respects the chain-stack-traces flag', () async {
       await d.file('test.dart', _asyncFailure).create();
 
-      var test = await runTest(['test.dart']);
+      var test = await runTest(['test.dart', '--chain-stack-traces']);
       expect(test.stdout, emitsThrough(contains('asynchronous gap')));
       await test.shouldExit(1);
     });
 
-    test('respects the chain-stack-traces flag', () async {
+    test('defaults to not chaining stack traces', () async {
       await d.file('test.dart', _asyncFailure).create();
 
-      var test = await runTest(['test.dart', '--no-chain-stack-traces']);
+      var test = await runTest(['test.dart']);
       expect(
           test.stdout,
           containsInOrder([
             '00:00 +0: failure',
             '00:00 +0 -1: failure [E]',
             'oh no',
-            'test.dart 8:7  main.<fn>',
+            'test.dart 8:7   main.<fn>.<fn>',
           ]));
       await test.shouldExit(1);
     });

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.19
+
+* Disable stack trace chaining by default.
+
 ## 0.3.18
 
 * Update `spawnHybridCode` to default to the current packages language version.

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -102,7 +102,7 @@ final ArgParser _parser = (() {
           'especially for asynchronous code. It may be useful to disable\n'
           'to provide improved test performance but at the cost of\n'
           'debuggability.',
-      defaultsTo: true);
+      defaultsTo: false);
   parser.addFlag('no-retry',
       help: "Don't rerun tests that have retry set.",
       defaultsTo: false,

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.18
+version: 0.3.19
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
Closes #1358

Stack trace chaining has a negative impact on performance, and the VM
has improved async stack trace chaining by default so the value has
dropped significantly on the VM platform. Despite the value on the web,
it will still be better for the majority of users and use cases to run
tests faster by default, and allow for the `--chain-stack-traces` flag
which can be used when debugging a failure is the explicit goal.