### PR TITLE
Separate out utilities from io required libraries

### DIFF
--- a/pkgs/test/lib/src/runner/browser/browser.dart
+++ b/pkgs/test/lib/src/runner/browser/browser.dart
@@ -6,11 +6,10 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:typed_data/typed_data.dart';
 import 'package:pedantic/pedantic.dart';
-
 import 'package:test_core/src/runner/application_exception.dart'; // ignore: implementation_imports
-import 'package:test_core/src/util/dart.dart'; // ignore: implementation_imports
+import 'package:test_core/src/util/errors.dart'; // ignore: implementation_imports
+import 'package:typed_data/typed_data.dart';
 
 /// An interface for running browser instances.
 ///

--- a/pkgs/test/lib/src/runner/browser/platform.dart
+++ b/pkgs/test/lib/src/runner/browser/platform.dart
@@ -27,7 +27,7 @@ import 'package:test_core/src/runner/platform.dart'; // ignore: implementation_i
 import 'package:test_core/src/runner/plugin/customizable_platform.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/runner_suite.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/suite.dart'; // ignore: implementation_imports
-import 'package:test_core/src/util/dart.dart'; // ignore: implementation_imports
+import 'package:test_core/src/util/errors.dart'; // ignore: implementation_imports
 import 'package:test_core/src/util/io.dart'; // ignore: implementation_imports
 import 'package:test_core/src/util/package_config.dart'; // ignore: implementation_imports
 import 'package:test_core/src/util/stack_trace_mapper.dart'; // ignore: implementation_imports

--- a/pkgs/test/lib/src/runner/node/platform.dart
+++ b/pkgs/test/lib/src/runner/node/platform.dart
@@ -3,8 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:async/async.dart';
 import 'package:node_preamble/preamble.dart' as preamble;
@@ -12,8 +12,6 @@ import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
 import 'package:pedantic/pedantic.dart';
 import 'package:stream_channel/stream_channel.dart';
-import 'package:yaml/yaml.dart';
-
 import 'package:test_api/src/backend/runtime.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/suite_platform.dart'; // ignore: implementation_imports
 import 'package:test_api/src/util/stack_trace_mapper.dart'; // ignore: implementation_imports
@@ -28,14 +26,15 @@ import 'package:test_core/src/runner/plugin/environment.dart'; // ignore: implem
 import 'package:test_core/src/runner/plugin/platform_helpers.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/runner_suite.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/suite.dart'; // ignore: implementation_imports
-import 'package:test_core/src/util/dart.dart'; // ignore: implementation_imports
+import 'package:test_core/src/util/errors.dart'; // ignore: implementation_imports
 import 'package:test_core/src/util/io.dart'; // ignore: implementation_imports
 import 'package:test_core/src/util/package_config.dart'; // ignore: implementation_imports
 import 'package:test_core/src/util/pair.dart'; // ignore: implementation_imports
 import 'package:test_core/src/util/stack_trace_mapper.dart'; // ignore: implementation_imports
+import 'package:yaml/yaml.dart';
 
-import '../executable_settings.dart';
 import '../../util/package_map.dart';
+import '../executable_settings.dart';
 
 /// A platform that loads tests in Node.js processes.
 class NodePlatform extends PlatformPlugin

--- a/pkgs/test_core/lib/src/direct_run.dart
+++ b/pkgs/test_core/lib/src/direct_run.dart
@@ -20,7 +20,7 @@ import 'runner/reporter.dart';
 import 'runner/reporter/expanded.dart';
 import 'runner/runner_suite.dart';
 import 'runner/suite.dart';
-import 'util/io.dart';
+import 'util/os.dart';
 import 'util/print_sink.dart';
 
 /// Runs all unskipped test cases declared in [testMain].

--- a/pkgs/test_core/lib/src/executable.dart
+++ b/pkgs/test_core/lib/src/executable.dart
@@ -15,7 +15,7 @@ import 'runner.dart';
 import 'runner/application_exception.dart';
 import 'runner/configuration.dart';
 import 'runner/version.dart';
-import 'util/dart.dart';
+import 'util/errors.dart';
 import 'util/exit_codes.dart' as exit_codes;
 import 'util/io.dart';
 

--- a/pkgs/test_core/lib/src/runner/configuration/load.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/load.dart
@@ -9,14 +9,13 @@ import 'package:glob/glob.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:source_span/source_span.dart';
-import 'package:yaml/yaml.dart';
-
 import 'package:test_api/src/backend/operating_system.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/platform_selector.dart'; // ignore: implementation_imports
 import 'package:test_api/src/frontend/timeout.dart'; // ignore: implementation_imports
 import 'package:test_api/src/utils.dart'; // ignore: implementation_imports
+import 'package:yaml/yaml.dart';
 
-import '../../util/dart.dart';
+import '../../util/errors.dart';
 import '../../util/io.dart';
 import '../../util/pretty_print.dart';
 import '../configuration.dart';

--- a/pkgs/test_core/lib/src/runner/load_exception.dart
+++ b/pkgs/test_core/lib/src/runner/load_exception.dart
@@ -4,7 +4,7 @@
 
 import 'package:source_span/source_span.dart';
 
-import '../util/dart.dart';
+import '../util/errors.dart';
 
 class LoadException implements Exception {
   final String path;

--- a/pkgs/test_core/lib/src/util/dart.dart
+++ b/pkgs/test_core/lib/src/util/dart.dart
@@ -68,14 +68,3 @@ SourceSpan? contextualizeSpan(
 
   return file.span(start, contextRunes.offset);
 }
-
-/// A regular expression to match the exception prefix that some exceptions'
-/// [Object.toString] values contain.
-final _exceptionPrefix = RegExp(r'^([A-Z][a-zA-Z]*)?(Exception|Error): ');
-
-/// Get a string description of an exception.
-///
-/// Many exceptions include the exception class name at the beginning of their
-/// [toString], so we remove that if it exists.
-String getErrorMessage(error) =>
-    error.toString().replaceFirst(_exceptionPrefix, '');

--- a/pkgs/test_core/lib/src/util/errors.dart
+++ b/pkgs/test_core/lib/src/util/errors.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// A regular expression to match the exception prefix that some exceptions'
+/// [Object.toString] values contain.
+final _exceptionPrefix = RegExp(r'^([A-Z][a-zA-Z]*)?(Exception|Error): ');
+
+/// Get a string description of an exception.
+///
+/// Many exceptions include the exception class name at the beginning of their
+/// [toString], so we remove that if it exists.
+String getErrorMessage(error) =>
+    error.toString().replaceFirst(_exceptionPrefix, '');

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -216,27 +216,3 @@ Future<Uri> getRemoteDebuggerUrl(Uri base) async {
     return base;
   }
 }
-
-/// Directories that are specific to OS X.
-///
-/// This is used to try to distinguish OS X and Linux in [currentOSGuess].
-final _macOSDirectories = {
-  '/Applications',
-  '/Library',
-  '/Network',
-  '/System',
-  '/Users',
-};
-
-/// Returns the best guess for the current operating system without using
-/// `dart:io`.
-///
-/// This is useful for running test files directly and skipping tests as
-/// appropriate. The only OS-specific information we have is the current path,
-/// which we try to use to figure out the OS.
-final OperatingSystem currentOSGuess = (() {
-  if (p.style == p.Style.url) return OperatingSystem.none;
-  if (p.style == p.Style.windows) return OperatingSystem.windows;
-  if (_macOSDirectories.any(p.current.startsWith)) return OperatingSystem.macOS;
-  return OperatingSystem.linux;
-})();

--- a/pkgs/test_core/lib/src/util/os.dart
+++ b/pkgs/test_core/lib/src/util/os.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:path/path.dart' as p;
+import 'package:test_api/src/backend/operating_system.dart'; // ignore: implementation_imports
+
+/// Directories that are specific to OS X.
+///
+/// This is used to try to distinguish OS X and Linux in [currentOSGuess].
+final _macOSDirectories = {
+  '/Applications',
+  '/Library',
+  '/Network',
+  '/System',
+  '/Users',
+};
+
+/// Returns the best guess for the current operating system without using
+/// `dart:io`.
+///
+/// This is useful for running test files directly and skipping tests as
+/// appropriate. The only OS-specific information we have is the current path,
+/// which we try to use to figure out the OS.
+final OperatingSystem currentOSGuess = (() {
+  if (p.style == p.Style.url) return OperatingSystem.none;
+  if (p.style == p.Style.windows) return OperatingSystem.windows;
+  if (_macOSDirectories.any(p.current.startsWith)) return OperatingSystem.macOS;
+  return OperatingSystem.linux;
+})();

--- a/pkgs/test_core/lib/test_core.dart
+++ b/pkgs/test_core/lib/test_core.dart
@@ -22,7 +22,7 @@ import 'src/runner/reporter/expanded.dart';
 import 'src/runner/runner_suite.dart';
 import 'src/runner/suite.dart';
 import 'src/util/async.dart';
-import 'src/util/io.dart';
+import 'src/util/os.dart';
 import 'src/util/print_sink.dart';
 
 export 'package:matcher/matcher.dart';


### PR DESCRIPTION
Move out utilities which are imported from files which need to avoid
imports to `dart:io` or `dart:isolate`.