### PR TITLE
Disable stack trace chains by default - for real

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,10 +1,13 @@
-## 1.16.9-dev
+## 1.16.9
+
+* Disable stack trace chaining by default. It can be re-enabled by explicitly
+  passing the `--chain-stack-traces` flag.
 
 ## 1.16.8
 
 * Fix an issue where coverage collection could hang on Chrome. 
-* Disable stack trace chaining by default. It can be re-enabled by explicitly
-  passing the `--chain-stack-traces` flag.
+* ~~Disable stack trace chaining by default. It can be re-enabled by explicitly
+  passing the `--chain-stack-traces` flag.~~
 
 ## 1.16.7
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.16.9-dev
+version: 1.16.9
 description: A full featured library for writing and running Dart tests.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
 

--- a/pkgs/test/test/runner/compact_reporter_test.dart
+++ b/pkgs/test/test/runner/compact_reporter_test.dart
@@ -414,7 +414,7 @@ void main() {
 }
 
 Future<void> _expectReport(String tests, String expected,
-    {List<String>? args}) async {
+    {List<String> args = const []}) async {
   await d.file('test.dart', '''
     import 'dart:async';
 
@@ -425,7 +425,7 @@ $tests
     }
   ''').create();
 
-  var test = await runTest(['test.dart', if (args != null) ...args],
+  var test = await runTest(['test.dart', '--chain-stack-traces', ...args],
       reporter: 'compact');
   await test.shouldExit();
 

--- a/pkgs/test/test/runner/expanded_reporter_test.dart
+++ b/pkgs/test/test/runner/expanded_reporter_test.dart
@@ -317,7 +317,7 @@ void main() {
 }
 
 Future<void> _expectReport(String tests, String expected,
-    {List<String>? args}) async {
+    {List<String> args = const []}) async {
   await d.file('test.dart', '''
     import 'dart:async';
 
@@ -328,7 +328,7 @@ $tests
     }
   ''').create();
 
-  var test = await runTest(['test.dart', if (args != null) ...args]);
+  var test = await runTest(['test.dart', '--chain-stack-traces', ...args]);
   await test.shouldExit();
 
   var stdoutLines = await test.stdoutStream().toList();

--- a/pkgs/test/test/runner/json_file_reporter_test.dart
+++ b/pkgs/test/test/runner/json_file_reporter_test.dart
@@ -109,7 +109,7 @@ Future<void> _expectReports(
     String stdoutExpected,
     List<List<Object /*Map|Matcher*/ >> jsonFileExpected,
     Map<Object, Object> jsonFileDone,
-    {List<String>? args}) async {
+    {List<String> args = const []}) async {
   await d.file('test.dart', '''
     import 'dart:async';
 
@@ -120,7 +120,7 @@ $tests
     }
   ''').create();
 
-  var test = await runTest(['test.dart', ...?args],
+  var test = await runTest(['test.dart', '--chain-stack-traces', ...args],
       // Write to a file within a dir that doesn't yet exist to verify that the
       // file is created recursively.
       fileReporter: 'json:reports/tests.json');

--- a/pkgs/test/test/runner/json_reporter_test.dart
+++ b/pkgs/test/test/runner/json_reporter_test.dart
@@ -593,7 +593,8 @@ import 'package:test/test.dart';
 
   await d.file('test.dart', testContent.toString()).create();
 
-  var test = await runTest(['test.dart', ...args], reporter: 'json');
+  var test = await runTest(['test.dart', '--chain-stack-traces', ...args],
+      reporter: 'json');
   await test.shouldExit();
 
   var stdoutLines = await test.stdoutStream().toList();

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -406,7 +406,7 @@ $_usage''');
             '00:00 +0: failure',
             '00:00 +0 -1: failure [E]',
             'oh no',
-            'test.dart 8:7   main.<fn>.<fn>',
+            'test.dart 8:7  main.<fn>.<fn>',
           ]));
       await test.shouldExit(1);
     });

--- a/pkgs/test/test/utils.dart
+++ b/pkgs/test/test/utils.dart
@@ -101,7 +101,7 @@ Matcher isApplicationException(message) =>
 
 /// Returns a local [LiveTest] that runs [body].
 LiveTest createTest(dynamic Function() body) {
-  var test = LocalTest('test', Metadata(), body);
+  var test = LocalTest('test', Metadata(chainStackTraces: true), body);
   var suite = Suite(Group.root([test]), suitePlatform);
   return test.load(suite);
 }

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.3.1-dev
+## 0.3.1
 
 * Add examples to `throwsA` and make top-level `throws...` matchers refer to it.
+* Disable stack trace chaining by default.
 
 ## 0.3.0
 

--- a/pkgs/test_api/lib/src/backend/invoker.dart
+++ b/pkgs/test_api/lib/src/backend/invoker.dart
@@ -333,7 +333,8 @@ class Invoker {
     _controller.addError(error, stackTrace!);
     zone.run(() => _outstandingCallbacks.complete());
 
-    if (!liveTest.test.metadata.chainStackTraces) {
+    if (!liveTest.test.metadata.chainStackTraces &&
+        !liveTest.suite.isLoadSuite) {
       _printsOnFailure.add('Consider enabling the flag chain-stack-traces to '
           'receive more detailed exceptions.\n'
           "For example, 'pub run test --chain-stack-traces'.");

--- a/pkgs/test_api/lib/src/backend/metadata.dart
+++ b/pkgs/test_api/lib/src/backend/metadata.dart
@@ -41,7 +41,7 @@ class Metadata {
   final bool? _verboseTrace;
 
   /// Whether to chain stack traces.
-  bool get chainStackTraces => _chainStackTraces ?? true;
+  bool get chainStackTraces => _chainStackTraces ?? _verboseTrace ?? false;
   final bool? _chainStackTraces;
 
   /// The user-defined tags attached to the test or suite.

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.3.1-dev
+version: 0.3.1
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 

--- a/pkgs/test_api/test/backend/invoker_test.dart
+++ b/pkgs/test_api/test/backend/invoker_test.dart
@@ -427,7 +427,10 @@ void main() {
     test('A test can be timed out', () {
       var liveTest = _localTest(() {
         Invoker.current!.addOutstandingCallback();
-      }, metadata: Metadata(timeout: Timeout(Duration(milliseconds: 100))))
+      },
+              metadata: Metadata(
+                  chainStackTraces: true,
+                  timeout: Timeout(Duration(milliseconds: 100))))
           .load(suite);
 
       expectStates(liveTest, [
@@ -550,6 +553,6 @@ void main() {
 }
 
 LocalTest _localTest(dynamic Function() body, {Metadata? metadata}) {
-  metadata ??= Metadata();
+  metadata ??= Metadata(chainStackTraces: true);
   return LocalTest('test', metadata, body);
 }

--- a/pkgs/test_api/test/utils.dart
+++ b/pkgs/test_api/test/utils.dart
@@ -99,7 +99,7 @@ Matcher isApplicationException(message) =>
 
 /// Returns a local [LiveTest] that runs [body].
 LiveTest createTest(dynamic Function() body) {
-  var test = LocalTest('test', Metadata(), body);
+  var test = LocalTest('test', Metadata(chainStackTraces: true), body);
   var suite = Suite(Group.root([test]), suitePlatform);
   return test.load(suite);
 }

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,8 +1,10 @@
-## 0.3.20-dev
+## 0.3.20
+
+* Disable stack trace chaining by default.
 
 ## 0.3.19
 
-* Disable stack trace chaining by default.
+* ~~Disable stack trace chaining by default.~~
 
 ## 0.3.18
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,10 +1,10 @@
 name: test_core
-version: 0.3.20-dev
+version: 0.3.20
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+ sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   analyzer: ^1.0.0


### PR DESCRIPTION
Changing the default in the arg parser did not change the runner
behavior, and the test that changed was a false positive for the
behavior difference.

Change the default for `chainStackTraces` in the `Metadata` class which
is the real owner of the defaults. Enable stack trace chaining by
default when using `--verbose-trace`, otherwise default to off.

Remove the extra failure output about enabling stack trace chaining for
load "test" failures since they often have no stack trace.

The output is still very verbose - this commit does not reduce the
output to only once at the end of the tests, but that is something we
should consider doing.

Enable stack trace chaining in some tests where the output is checked in
the test.