### PR TITLE
Fix example for null safety

### DIFF
--- a/pkgs/test/README.md
+++ b/pkgs/test/README.md
@@ -122,8 +122,8 @@ fails, to ensure that it has a chance to clean up after itself.
 import 'package:test/test.dart';
 
 void main() {
-  HttpServer server;
-  Uri url;
+  late HttpServer server;
+  late Uri url;
   setUp(() async {
     server = await HttpServer.bind('localhost', 0);
     url = Uri.parse('http://${server.address.host}:${server.port}');


### PR DESCRIPTION
The Dart compiler can't detect that the variable is set in setUp before
it's used.  Mark them late to let the compiler know that they'll be set.