### PR TITLE
Improve the error message for hybridMain functions

### DIFF
--- a/pkgs/test/test/runner/hybrid_test.dart
+++ b/pkgs/test/test/runner/hybrid_test.dart
@@ -47,6 +47,34 @@ void main() {
       ''').stream.toList(), completion(equals([1, 2, 3])));
     });
 
+    test('allows a first parameter with type StreamChannel<Object?>', () {
+      expect(spawnHybridCode('''
+        import "package:stream_channel/stream_channel.dart";
+
+        void hybridMain(StreamChannel<Object?> channel) {
+          channel.sink..add(1)..add(2)..add(null)..close();
+        }
+      ''').stream.toList(), completion(equals([1, 2, null])));
+    });
+
+    test('gives a good error when the StreamChannel type is not supported', () {
+      expect(
+          spawnHybridCode('''
+        import "package:stream_channel/stream_channel.dart";
+
+        void hybridMain(StreamChannel<Object> channel) {
+          channel.sink..add(1)..add(2)..add(3)..close();
+        }
+      ''').stream,
+          emitsError(isA<Exception>().having(
+              (e) => e.toString(),
+              'toString',
+              contains(
+                  'The first parameter to the top-level hybridMain() must be a '
+                  'StreamChannel<dynamic> or StreamChannel<Object?>. More specific '
+                  'types such as StreamChannel<Object> are not supported.'))));
+    });
+
     test('can use dart:io even when run from a browser', () async {
       var path = p.join(d.sandbox, 'test.dart');
       await d.file('test.dart', '''

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,11 +1,12 @@
 ## 0.3.20-dev
 
 * Disable stack trace chaining by default.
-
 * Change the default way VM tests are launched and ran to greatly speed up
   loading performance.
   * You can force the old strategy with `--use-data-isolate-strategy` flag if
     you run into issues, but please also file a bug.
+* Improve the error message for `hybridMain` functions with an incompatible
+  StreamChannel parameter type.
 
 ## 0.3.19
 

--- a/pkgs/test_core/lib/src/runner/hybrid_listener.dart
+++ b/pkgs/test_core/lib/src/runner/hybrid_listener.dart
@@ -54,8 +54,17 @@ void listen(Function Function() getMain, List data) {
         return;
       } else if (main is! Function(StreamChannel) &&
           main is! Function(StreamChannel, Never)) {
-        _sendError(channel,
-            'Top-level hybridMain() function must take one or two arguments.');
+        if (main is Function(StreamChannel<Never>) ||
+            main is Function(StreamChannel<Never>, Never)) {
+          _sendError(
+              channel,
+              'The first parameter to the top-level hybridMain() must be a '
+              'StreamChannel<dynamic> or StreamChannel<Object?>. More specific '
+              'types such as StreamChannel<Object> are not supported.');
+        } else {
+          _sendError(channel,
+              'Top-level hybridMain() function must take one or two arguments.');
+        }
         return;
       }
 


### PR DESCRIPTION
Mention explicitly that the first parameter must be a `StreamChannel<dynamic>` or a `StreamChannel<Object?>`.

Proposed resolution to https://github.com/dart-lang/test/issues/1469.