### PR TITLE
Drop two unnecessary getters in Configuration

### DIFF
--- a/pkgs/test_core/lib/src/runner/configuration.dart
+++ b/pkgs/test_core/lib/src/runner/configuration.dart
@@ -55,12 +55,11 @@ class Configuration {
   final bool? _pauseAfterLoad;
 
   /// Whether to run browsers in their respective debug modes
-  bool get debug => pauseAfterLoad || (_debug ?? false) || _coverage != null;
+  bool get debug => pauseAfterLoad || (_debug ?? false) || coverage != null;
   final bool? _debug;
 
   /// The output folder for coverage gathering
-  String? get coverage => _coverage;
-  final String? _coverage;
+  final String? coverage;
 
   /// The path to the file from which to load more configuration information.
   ///
@@ -149,11 +148,10 @@ class Configuration {
   final Set<String> chosenPresets;
 
   /// The set of tags that have been declared in any way in this configuration.
-  Set<String> get knownTags => _knownTags ??= UnmodifiableSetView({
-        ...suiteDefaults.knownTags,
-        for (var configuration in presets.values) ...configuration.knownTags
-      });
-  Set<String>? _knownTags;
+  late final Set<String> knownTags = UnmodifiableSetView({
+    ...suiteDefaults.knownTags,
+    for (var configuration in presets.values) ...configuration.knownTags
+  });
 
   /// Configuration presets.
   ///
@@ -350,7 +348,7 @@ class Configuration {
       String? dart2jsPath,
       String? reporter,
       Map<String, String>? fileReporters,
-      String? coverage,
+      this.coverage,
       int? pubServePort,
       int? concurrency,
       this.shardIndex,
@@ -376,7 +374,6 @@ class Configuration {
         _dart2jsPath = dart2jsPath,
         _reporter = reporter,
         fileReporters = fileReporters ?? {},
-        _coverage = coverage,
         pubServeUrl = pubServePort == null
             ? null
             : Uri.parse('http://localhost:$pubServePort'),
@@ -505,7 +502,7 @@ class Configuration {
         dart2jsPath: other._dart2jsPath ?? _dart2jsPath,
         reporter: other._reporter ?? _reporter,
         fileReporters: mergeMaps(fileReporters, other.fileReporters),
-        coverage: other._coverage ?? _coverage,
+        coverage: other.coverage ?? coverage,
         pubServePort: (other.pubServeUrl ?? pubServeUrl)?.port,
         concurrency: other._concurrency ?? _concurrency,
         shardIndex: other.shardIndex ?? shardIndex,


### PR DESCRIPTION
Using the smallest pattern possible, rather than matching surround
fields, helps readability because the things that behave differently
look different.

Use a public final field over a private final with a public getter for
`coverage`. This is different from other getters in this class in that
it doesn't do null defaulting.

Use a `late final` over `??=` for lazy initialization of the `knownTags`
field. This is different from the `_knownPreset` use case, which
sometimes needs to be set an on an instance directly instead of falling
through to the default initializing expression.