### PR TITLE
Make the `message` argument a Map

### DIFF
--- a/pkgs/test/lib/src/runner/browser/browser_manager.dart
+++ b/pkgs/test/lib/src/runner/browser/browser_manager.dart
@@ -202,8 +202,8 @@ class BrowserManager {
   ///
   /// If [mapper] is passed, it's used to map stack traces for errors coming
   /// from this test suite.
-  Future<RunnerSuite> load(
-      String path, Uri url, SuiteConfiguration suiteConfig, Object message,
+  Future<RunnerSuite> load(String path, Uri url, SuiteConfiguration suiteConfig,
+      Map<String, Object?> message,
       {StackTraceMapper? mapper}) async {
     url = url.replace(
         fragment: Uri.encodeFull(jsonEncode({

--- a/pkgs/test/lib/src/runner/browser/platform.dart
+++ b/pkgs/test/lib/src/runner/browser/platform.dart
@@ -208,7 +208,7 @@ class BrowserPlatform extends PlatformPlugin
   /// Throws an [ArgumentError] if `platform.platform` isn't a browser.
   @override
   Future<RunnerSuite?> load(String path, SuitePlatform platform,
-      SuiteConfiguration suiteConfig, Object message) async {
+      SuiteConfiguration suiteConfig, Map<String, Object?> message) async {
     var browser = platform.runtime;
     assert(suiteConfig.runtimes.contains(browser.identifier));
 

--- a/pkgs/test/lib/src/runner/node/platform.dart
+++ b/pkgs/test/lib/src/runner/node/platform.dart
@@ -86,7 +86,7 @@ class NodePlatform extends PlatformPlugin
 
   @override
   Future<RunnerSuite> load(String path, SuitePlatform platform,
-      SuiteConfiguration suiteConfig, Object message) async {
+      SuiteConfiguration suiteConfig, Map<String, Object?> message) async {
     var pair = await _loadChannel(path, platform.runtime, suiteConfig);
     var controller = deserializeSuite(
         path, platform, suiteConfig, PluginEnvironment(), pair.first, message);

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.0-dev
+## 0.3.20-dev
 
 * Remove `suiteChannel`. This is now handled by an additional argument to the
   `beforeLoad` callback in `serializeSuite`.
@@ -9,8 +9,9 @@
     you run into issues, but please also file a bug.
 * Improve the error message for `hybridMain` functions with an incompatible
   StreamChannel parameter type.
-* **Breaking** change the `message` argument to `deserializeSuite` and
-  `PlatformPlugin.load` to `Map<String, Object?>`
+* Change the `message` argument to `PlatformPlugin.load` to `Map<String,
+  Object?>`. In an upcoming release this will be required as the type for this
+  argument when passed through to `deserializeSuite`.
 
 ## 0.3.19
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.20-dev
+## 0.4.0-dev
 
 * Remove `suiteChannel`. This is now handled by an additional argument to the
   `beforeLoad` callback in `serializeSuite`.
@@ -9,6 +9,8 @@
     you run into issues, but please also file a bug.
 * Improve the error message for `hybridMain` functions with an incompatible
   StreamChannel parameter type.
+* **Breaking** change the `message` argument to `deserializeSuite` and
+  `PlatformPlugin.load` to `Map<String, Object?>`
 
 ## 0.3.19
 

--- a/pkgs/test_core/lib/src/runner/platform.dart
+++ b/pkgs/test_core/lib/src/runner/platform.dart
@@ -55,7 +55,7 @@ abstract class PlatformPlugin {
   /// `platform_helpers.dart` to obtain a [RunnerSuiteController]. They must
   /// pass the opaque [message] parameter to the [deserializeSuite] call.
   Future<RunnerSuite?> load(String path, SuitePlatform platform,
-      SuiteConfiguration suiteConfig, Object message);
+      SuiteConfiguration suiteConfig, Map<String, Object?> message);
 
   Future closeEphemeral() async {}
 

--- a/pkgs/test_core/lib/src/runner/plugin/platform_helpers.dart
+++ b/pkgs/test_core/lib/src/runner/plugin/platform_helpers.dart
@@ -43,7 +43,7 @@ RunnerSuiteController deserializeSuite(
     SuiteConfiguration suiteConfig,
     Environment environment,
     StreamChannel<Object?> channel,
-    Map<String, Object?> message,
+    Object /*Map<String, Object?>*/ message,
     {Future<Map<String, dynamic>> Function()? gatherCoverage}) {
   var disconnector = Disconnector<Object?>();
   var suiteChannel = MultiChannel<Object?>(channel.transform(disconnector));
@@ -59,7 +59,7 @@ RunnerSuiteController deserializeSuite(
     'noRetry': Configuration.current.noRetry,
     'foldTraceExcept': Configuration.current.foldTraceExcept.toList(),
     'foldTraceOnly': Configuration.current.foldTraceOnly.toList(),
-    ...message,
+    ...(message as Map<String, dynamic>),
   });
 
   var completer = Completer<Group>();

--- a/pkgs/test_core/lib/src/runner/plugin/platform_helpers.dart
+++ b/pkgs/test_core/lib/src/runner/plugin/platform_helpers.dart
@@ -43,7 +43,7 @@ RunnerSuiteController deserializeSuite(
     SuiteConfiguration suiteConfig,
     Environment environment,
     StreamChannel<Object?> channel,
-    Object message,
+    Map<String, Object?> message,
     {Future<Map<String, dynamic>> Function()? gatherCoverage}) {
   var disconnector = Disconnector<Object?>();
   var suiteChannel = MultiChannel<Object?>(channel.transform(disconnector));
@@ -59,7 +59,8 @@ RunnerSuiteController deserializeSuite(
     'noRetry': Configuration.current.noRetry,
     'foldTraceExcept': Configuration.current.foldTraceExcept.toList(),
     'foldTraceOnly': Configuration.current.foldTraceOnly.toList(),
-  }..addAll(message as Map<String, dynamic>));
+    ...message,
+  });
 
   var completer = Completer<Group>();
 

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -47,7 +47,7 @@ class VMPlatform extends PlatformPlugin {
 
   @override
   Future<RunnerSuite?> load(String path, SuitePlatform platform,
-      SuiteConfiguration suiteConfig, Object message) async {
+      SuiteConfiguration suiteConfig, Map<String, Object?> message) async {
     assert(platform.runtime == Runtime.vm);
 
     var receivePort = ReceivePort();

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.0-dev
+version: 0.3.20-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.20-dev
+version: 0.4.0-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
Towards #1478

The argument to `PlatformPlugin.load` is always a `Map`. The intent is
always to pass it to `deserializeSuite`, where it is unconditionally
cast to `Map`. The loose `Object` argument type does not add any
capabilities.

Changing `PlatformPlugin.load` argument type is not likely to be
breaking since it is not intended for use from outside callers. Changing
the `deserializeSuite` argument is breaking for platform
implementations. Change `PlatformPlugin.load` now so implementations
can adjust before the change to `deserializeSuite`.