### PR TITLE
Remove an erroneous _outstandingCallbackZone

### DIFF
--- a/pkgs/test_api/lib/src/backend/invoker.dart
+++ b/pkgs/test_api/lib/src/backend/invoker.dart
@@ -369,8 +369,6 @@ class Invoker {
     Chain.capture(() {
       _guardIfGuarded(() {
         runZoned(() async {
-          _outstandingCallbackZones.add(Zone.current);
-
           // Run the test asynchronously so that the "running" state change
           // has a chance to hit its event handler(s) before the test produces
           // an error. If an error is emitted before the first state change is


### PR DESCRIPTION
I missed this call in #1270

Since there is no longer a `_counterKey` in the zone values for this
call to `runZoned` it doesn't make sense for it to be stored in the list
of zones that have async counters.