### PR TITLE
Re-export some libraries from prior locations

### DIFF
--- a/pkgs/test_api/lib/src/frontend/async_matcher.dart
+++ b/pkgs/test_api/lib/src/frontend/async_matcher.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@deprecated
+library test_api.src.frontend.async_matcher;
+
+// Temporary re-export to reduce churn in flutter_test.
+export '../expect/async_matcher.dart';

--- a/pkgs/test_api/lib/src/frontend/expect.dart
+++ b/pkgs/test_api/lib/src/frontend/expect.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@deprecated
+library test_api.src.frontend.expect;
+
+// Temporary re-export to avoid churn in analyzer tests.
+export '../expect/expect.dart';


### PR DESCRIPTION
We cannot update `flutter_test` imports until after we publish, but this
package needs to land internally before then. Re-export some
implementation libraries that are imported from `src` from `analyzer`
tests and from `flutter_test`.