### PR TITLE
Use the root zone to handle expectAsync callbacks

### DIFF
--- a/pkgs/test_api/lib/src/expect/expect_async.dart
+++ b/pkgs/test_api/lib/src/expect/expect_async.dart
@@ -96,7 +96,8 @@ class _ExpectedFunction<T> {
     }
 
     if (isDone != null || minExpected > 0) {
-      var completer = _expectationSatisfied = Completer<void>();
+      var completer = _expectationSatisfied =
+          Zone.root.run<Completer<void>>(() => Completer<void>());
       _test.mustWaitFor(completer.future);
       _complete = false;
     } else {

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -25,6 +25,7 @@ dev_dependencies:
   pedantic: ^1.10.0
   test: any
   test_core: any
+  fake_async: ^1.2.0
 
 dependency_overrides:
   test:

--- a/pkgs/test_api/test/frontend/expect_async_test.dart
+++ b/pkgs/test_api/test/frontend/expect_async_test.dart
@@ -4,9 +4,10 @@
 
 import 'dart:async';
 
+import 'package:fake_async/fake_async.dart';
+import 'package:test/test.dart';
 import 'package:test_api/src/backend/live_test.dart';
 import 'package:test_api/src/backend/state.dart';
-import 'package:test/test.dart';
 
 import '../utils.dart';
 
@@ -312,6 +313,16 @@ void main() {
     var liveTest = await runTestBody(() {
       var callback = expectAsync0(() {});
       Zone.root.run(callback);
+    });
+    expectTestPassed(liveTest);
+  });
+
+  test('may be called in a FakeAsync zone that does not run further', () async {
+    var liveTest = await runTestBody(() {
+      FakeAsync().run((_) {
+        var callback = expectAsync0(() {});
+        callback();
+      });
     });
     expectTestPassed(liveTest);
   });


### PR DESCRIPTION
Previously the call to `Invoker.current.removeOutstandingCallbacks`
happened synchronously when the callback was called. After the change to
use `testHandle.mustWaitFor(Future)` the callback would no longer be
called in a `FakeAsync` zone that does not have any further async
progression. Creating the `Completer` in the root zone avoid this issue.