### PR TITLE
Switch from mustWaitFor to markPending

### DIFF
--- a/pkgs/test_api/lib/hooks.dart
+++ b/pkgs/test_api/lib/hooks.dart
@@ -48,7 +48,7 @@ class TestHandle {
   }
 
   /// Indicates that this test should not be considered done until the returned
-  /// [OutstandingWork] is marked as complete;
+  /// [OutstandingWork] is marked as complete.
   ///
   /// The test may time out before the outstanding work completes.
   OutstandingWork markPending() {

--- a/pkgs/test_api/lib/src/expect/expect.dart
+++ b/pkgs/test_api/lib/src/expect/expect.dart
@@ -106,11 +106,16 @@ Future _expect(actual, matcher,
     if (result is String) {
       fail(formatFailure(matcher, actual, result, reason: reason));
     } else if (result is Future) {
-      return test.mustWaitFor(result.then((realResult) {
+      final outstandingWork = test.markPending();
+      return result.then((realResult) {
         if (realResult == null) return;
         fail(formatFailure(matcher as Matcher, actual, realResult as String,
             reason: reason));
-      }));
+      }).whenComplete(() {
+        // Always remove this, in case the failure is caught and handled
+        // gracefully.
+        outstandingWork.complete();
+      });
     }
 
     return Future.sync(() {});

--- a/pkgs/test_api/lib/src/expect/expect_async.dart
+++ b/pkgs/test_api/lib/src/expect/expect_async.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:test_api/hooks.dart';
 
 import 'util/placeholder.dart';
@@ -67,7 +65,7 @@ class _ExpectedFunction<T> {
   /// Whether this function has been called the requisite number of times.
   late bool _complete;
 
-  Completer<void>? _expectationSatisfied;
+  OutstandingWork? _outstandingWork;
 
   /// Wraps [callback] in a function that asserts that it's called at least
   /// [minExpected] times and no more than [maxExpected] times.
@@ -96,8 +94,7 @@ class _ExpectedFunction<T> {
     }
 
     if (isDone != null || minExpected > 0) {
-      var completer = _expectationSatisfied = Completer<void>();
-      _test.mustWaitFor(completer.future);
+      _outstandingWork = _test.markPending();
       _complete = false;
     } else {
       _complete = true;
@@ -137,7 +134,7 @@ class _ExpectedFunction<T> {
     if (_callback is Function(Never)) return max1;
     if (_callback is Function()) return max0;
 
-    _expectationSatisfied?.complete();
+    _outstandingWork?.complete();
     throw ArgumentError(
         'The wrapped function has more than 6 required arguments');
   }
@@ -210,7 +207,7 @@ class _ExpectedFunction<T> {
     // Mark this callback as complete and remove it from the test case's
     // oustanding callback count; if that hits zero the test is done.
     _complete = true;
-    _expectationSatisfied?.complete();
+    _outstandingWork?.complete();
   }
 }
 

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   matcher: '>=0.12.10 <0.12.11'
 
 dev_dependencies:
+  fake_async: ^1.2.0
   pedantic: ^1.10.0
   test: any
   test_core: any

--- a/pkgs/test_api/test/frontend/expect_async_test.dart
+++ b/pkgs/test_api/test/frontend/expect_async_test.dart
@@ -4,9 +4,10 @@
 
 import 'dart:async';
 
+import 'package:fake_async/fake_async.dart';
+import 'package:test/test.dart';
 import 'package:test_api/src/backend/live_test.dart';
 import 'package:test_api/src/backend/state.dart';
-import 'package:test/test.dart';
 
 import '../utils.dart';
 
@@ -312,6 +313,16 @@ void main() {
     var liveTest = await runTestBody(() {
       var callback = expectAsync0(() {});
       Zone.root.run(callback);
+    });
+    expectTestPassed(liveTest);
+  });
+
+  test('may be called in a FakeAsync zone that does not run further', () async {
+    var liveTest = await runTestBody(() {
+      FakeAsync().run((_) {
+        var callback = expectAsync0(() {});
+        callback();
+      });
     });
     expectTestPassed(liveTest);
   });


### PR DESCRIPTION
The `mustWaitFor` API has tricky edges around futures created in a
`FakeAsync` zone. Return to a non-Future based API which abstracts the
trickiness around zones (other than that the `markPending` call must be
in the test zone, which is the case for all APIs) and errors.