### PR TITLE
Reformat with the latest dartfmt

### DIFF
--- a/pkgs/test_core/lib/src/executable.dart
+++ b/pkgs/test_core/lib/src/executable.dart
@@ -62,9 +62,9 @@ Future<void> _execute(List<String> args) async {
   final _signals = Platform.isWindows
       ? ProcessSignal.sigint.watch()
       : Platform.isFuchsia // Signals don't exist on Fuchsia.
-      ? Stream.empty()
-      : StreamGroup.merge(
-          [ProcessSignal.sigterm.watch(), ProcessSignal.sigint.watch()]);
+          ? Stream.empty()
+          : StreamGroup.merge(
+              [ProcessSignal.sigterm.watch(), ProcessSignal.sigint.watch()]);
 
   Configuration configuration;
   try {

--- a/pkgs/test_core/lib/src/runner/configuration/reporters.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/reporters.dart
@@ -52,8 +52,8 @@ final _allReporters = <String, ReporterDetails>{
 final defaultReporter = inTestTests
     ? 'expanded'
     : canUseSpecialChars
-    ? 'compact'
-    : 'expanded';
+        ? 'compact'
+        : 'expanded';
 
 /// **Do not call this function without express permission from the test package
 /// authors**.


### PR DESCRIPTION
Returns to the previous style for nested ternary conditional
expressions.