### PR TITLE
More target split fixes

### DIFF
--- a/pkgs/test_api/lib/src/remote_listener.dart
+++ b/pkgs/test_api/lib/src/remote_listener.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export 'backend/remote_listener.dart' show RemoteListener;

--- a/pkgs/test_core/lib/src/runner/load_suite.dart
+++ b/pkgs/test_core/lib/src/runner/load_suite.dart
@@ -14,7 +14,7 @@ import 'package:test_api/src/backend/suite.dart'; // ignore: implementation_impo
 import 'package:test_api/src/backend/suite_platform.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/test.dart'; // ignore: implementation_imports
 // ignore: deprecated_member_use
-import 'package:test_api/test_api.dart' show Timeout;
+import 'package:test_api/scaffolding.dart' show Timeout;
 
 import '../util/async.dart';
 import '../util/io_stub.dart' if (dart.library.io) '../util/io.dart';


### PR DESCRIPTION
Avoid importing `test_api/test_api.dart` from `test_core` except in
`test_core.dart` which re-exports it. This allows a separate
`test_core:scaffolding` target with limited transitive dependencies.

Add back `test_api/lib/src/remote_listener.dart` to reduce churn.