### PR TITLE
Update year in example copyright blurb

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ new tests, use the existing tests as a guideline for what they should look like.
 Before you send your pull request, make sure all the tests pass! To run all the
 tests, you'll need:
 
-* [NodeJS][https://nodejs.org/]
+* [NodeJS](https://nodejs.org/])
 
 Once you have this, just run `pub run test`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,17 +37,15 @@ new tests, use the existing tests as a guideline for what they should look like.
 Before you send your pull request, make sure all the tests pass! To run all the
 tests, you'll need:
 
-* [PhantomJS][] version 2.0.0 or higher.
+* [NodeJS]: https://nodejs.org/
 
-[PhantomJS]: http://phantomjs.org/
-
-Once you have these, just run `pub run test`.
+Once you have this, just run `pub run test`.
 
 ### File headers
 
 All files in the project must start with the following header.
 
-    // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+    // Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
     // for details. All rights reserved. Use of this source code is governed by a
     // BSD-style license that can be found in the LICENSE file.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,15 +31,13 @@ this repository.
 [pr]: https://help.github.com/articles/creating-a-pull-request/
 
 Functional changes will require tests to be added or changed. The tests live in
-the `test/` directory, and are run with `pub run test`. If you need to create
-new tests, use the existing tests as a guideline for what they should look like.
+the `test/` directory for each package, and are run with `pub run test`. If you
+need to create new tests, use the existing tests as a guideline for what they
+should look like.
 
-Before you send your pull request, make sure all the tests pass! To run all the
-tests, you'll need:
-
-* [NodeJS](https://nodejs.org/)
-
-Once you have this, just run `pub run test`.
+You can run all additional presubmit checks locally if you wish, by using the
+`mono_repo` tool. From the root of the repository, run
+`pub global run mono_repo presubmit`.
 
 ### File headers
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ new tests, use the existing tests as a guideline for what they should look like.
 Before you send your pull request, make sure all the tests pass! To run all the
 tests, you'll need:
 
-* [NodeJS](https://nodejs.org/])
+* [NodeJS](https://nodejs.org/)
 
 Once you have this, just run `pub run test`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ new tests, use the existing tests as a guideline for what they should look like.
 Before you send your pull request, make sure all the tests pass! To run all the
 tests, you'll need:
 
-* [NodeJS]: https://nodejs.org/
+* [NodeJS][https://nodejs.org/]
 
 Once you have this, just run `pub run test`.
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/test/issues/1498

I would remove the sentence about the AUTHORS file but I don't want to touch the substance of the blurb even though its obviously not providing value right now.