### PR TITLE
Replace use of deprecated AnalysisSession methods

### DIFF
--- a/pkgs/test_api/test/import_restrictions_test.dart
+++ b/pkgs/test_api/test/import_restrictions_test.dart
@@ -9,6 +9,7 @@ import 'dart:isolate';
 import 'package:analyzer/dart/analysis/analysis_context.dart';
 import 'package:analyzer/dart/analysis/context_builder.dart';
 import 'package:analyzer/dart/analysis/context_locator.dart';
+import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:glob/glob.dart';
 import 'package:glob/list_local_fs.dart';
@@ -128,7 +129,7 @@ class _ImportCheck {
   Future<Set<Uri>> _findImports(Uri uri, String restrictToPackage) async {
     var path = await _pathForUri(uri);
     var analysisSession = _context.currentSession;
-    var parseResult = analysisSession.getParsedUnit(path);
+    var parseResult = analysisSession.getParsedUnit2(path) as ParsedUnitResult;
     assert(parseResult.content.isNotEmpty,
         'Tried to read an invalid library $uri');
     return parseResult.unit.directives


### PR DESCRIPTION
The goal of the changes to AnalysisSession is to make it easier to
understand when the result is valid, and when it is not. Previously
sometimes we throw an exception, sometimes return a result that returns
nulls, sometimes return a result that is not valid, so its getters
throw.

Since the result was previously assumed to be valid, continue making the
same assumption explicitly by immediately casting the result.