### PR TITLE
Add test for opted in package with opted out test

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -38,16 +38,16 @@ jobs:
       - name: mono_repo self validate
         run: pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; Dart dev; PKGS: integration_tests/nnbd_opted_out, pkgs/test, pkgs/test_api, pkgs/test_core; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`"
+    name: "analyze_and_format; Dart dev; PKGS: integration_tests/nnbd_opted_in, integration_tests/nnbd_opted_out, pkgs/test, pkgs/test_api, pkgs/test_core; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_out-pkgs/test-pkgs/test_api-pkgs/test_core;commands:dartfmt-dartanalyzer"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_in-integration_tests/nnbd_opted_out-pkgs/test-pkgs/test_api-pkgs/test_core;commands:dartfmt-dartanalyzer"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_out-pkgs/test-pkgs/test_api-pkgs/test_core
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_in-integration_tests/nnbd_opted_out-pkgs/test-pkgs/test_api-pkgs/test_core
             os:ubuntu-latest;pub-cache-hosted;dart:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -56,6 +56,19 @@ jobs:
           sdk: dev
       - id: checkout
         uses: actions/checkout@v2
+      - id: integration_tests_nnbd_opted_in_pub_upgrade
+        name: "integration_tests/nnbd_opted_in; pub upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_in
+        run: pub upgrade --no-precompile
+      - name: "integration_tests/nnbd_opted_in; dartfmt -n --set-exit-if-changed ."
+        if: "always() && steps.integration_tests_nnbd_opted_in_pub_upgrade.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_in
+        run: dartfmt -n --set-exit-if-changed .
+      - name: "integration_tests/nnbd_opted_in; dartanalyzer --fatal-infos --fatal-warnings ."
+        if: "always() && steps.integration_tests_nnbd_opted_in_pub_upgrade.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_in
+        run: dartanalyzer --fatal-infos --fatal-warnings .
       - id: integration_tests_nnbd_opted_out_pub_upgrade
         name: "integration_tests/nnbd_opted_out; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -109,6 +122,37 @@ jobs:
         working-directory: pkgs/test_core
         run: dartanalyzer --fatal-infos --fatal-warnings .
   job_003:
+    name: "unit_test; Dart dev; PKG: integration_tests/nnbd_opted_in; `pub run test -p chrome,vm,node`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_in;commands:test"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_in
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: dev
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: integration_tests_nnbd_opted_in_pub_upgrade
+        name: "integration_tests/nnbd_opted_in; pub upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_in
+        run: pub upgrade --no-precompile
+      - name: "integration_tests/nnbd_opted_in; pub run test -p chrome,vm,node"
+        if: "always() && steps.integration_tests_nnbd_opted_in_pub_upgrade.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_in
+        run: "pub run test -p chrome,vm,node"
+    needs:
+      - job_001
+      - job_002
+  job_004:
     name: "unit_test; Dart dev; PKG: integration_tests/nnbd_opted_out; `pub run test -p chrome,vm,node`"
     runs-on: ubuntu-latest
     steps:
@@ -139,7 +183,38 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_004:
+  job_005:
+    name: "unit_test; Dart stable; PKG: integration_tests/nnbd_opted_in; `pub run test -p chrome,vm,node`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:integration_tests/nnbd_opted_in;commands:test"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:integration_tests/nnbd_opted_in
+            os:ubuntu-latest;pub-cache-hosted;dart:stable
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: stable
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: integration_tests_nnbd_opted_in_pub_upgrade
+        name: "integration_tests/nnbd_opted_in; pub upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_in
+        run: pub upgrade --no-precompile
+      - name: "integration_tests/nnbd_opted_in; pub run test -p chrome,vm,node"
+        if: "always() && steps.integration_tests_nnbd_opted_in_pub_upgrade.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_in
+        run: "pub run test -p chrome,vm,node"
+    needs:
+      - job_001
+      - job_002
+  job_006:
     name: "unit_test; Dart stable; PKG: integration_tests/nnbd_opted_out; `pub run test -p chrome,vm,node`"
     runs-on: ubuntu-latest
     steps:
@@ -170,7 +245,7 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_005:
+  job_007:
     name: "unit_test; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: ubuntu-latest
     steps:
@@ -201,7 +276,7 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_006:
+  job_008:
     name: "unit_test; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: ubuntu-latest
     steps:
@@ -232,7 +307,7 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_007:
+  job_009:
     name: "unit_test; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: ubuntu-latest
     steps:
@@ -263,7 +338,7 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_008:
+  job_010:
     name: "unit_test; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: ubuntu-latest
     steps:
@@ -294,7 +369,7 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_009:
+  job_011:
     name: "unit_test; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: ubuntu-latest
     steps:
@@ -325,7 +400,7 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_010:
+  job_012:
     name: "unit_test; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: ubuntu-latest
     steps:
@@ -356,7 +431,7 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_011:
+  job_013:
     name: "unit_test; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3`"
     runs-on: ubuntu-latest
     steps:
@@ -387,7 +462,7 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_012:
+  job_014:
     name: "unit_test; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3`"
     runs-on: ubuntu-latest
     steps:
@@ -418,7 +493,7 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_013:
+  job_015:
     name: "unit_test; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4`"
     runs-on: ubuntu-latest
     steps:
@@ -449,7 +524,7 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_014:
+  job_016:
     name: "unit_test; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4`"
     runs-on: ubuntu-latest
     steps:
@@ -480,7 +555,7 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_015:
+  job_017:
     name: "unit_test; Dart dev; PKG: pkgs/test_api; `pub run test --preset travis -x browser`"
     runs-on: ubuntu-latest
     steps:
@@ -511,7 +586,7 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_016:
+  job_018:
     name: "unit_test; Dart stable; PKG: pkgs/test_api; `pub run test --preset travis -x browser`"
     runs-on: ubuntu-latest
     steps:
@@ -542,7 +617,7 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_017:
+  job_019:
     name: Notify failure
     runs-on: ubuntu-latest
     if: "(github.event_name == 'push' || github.event_name == 'schedule') && failure()"
@@ -570,3 +645,5 @@ jobs:
       - job_014
       - job_015
       - job_016
+      - job_017
+      - job_018

--- a/integration_tests/nnbd_opted_in/mono_pkg.yaml
+++ b/integration_tests/nnbd_opted_in/mono_pkg.yaml
@@ -1,0 +1,13 @@
+dart:
+  - dev
+  - stable
+
+stages:
+    - analyze_and_format:
+      - group:
+        - dartfmt: sdk
+        - dartanalyzer: --fatal-infos --fatal-warnings .
+        dart:
+        - dev
+    - unit_test:
+      - test: -p chrome,vm,node

--- a/integration_tests/nnbd_opted_in/pubspec.yaml
+++ b/integration_tests/nnbd_opted_in/pubspec.yaml
@@ -1,0 +1,12 @@
+name: nnbd_opted_in
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+dev_dependencies:
+  test: any
+dependency_overrides:
+  test:
+    path: ../../pkgs/test
+  test_api:
+    path: ../../pkgs/test_api
+  test_core:
+    path: ../../pkgs/test_core

--- a/integration_tests/nnbd_opted_in/test/opted_in_test.dart
+++ b/integration_tests/nnbd_opted_in/test/opted_in_test.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+void main() {
+  test('sound behavior', () async {
+    expect(() => null as int, throwsA(anything));
+  });
+}

--- a/integration_tests/nnbd_opted_in/test/opted_out_test.dart
+++ b/integration_tests/nnbd_opted_in/test/opted_out_test.dart
@@ -1,0 +1,13 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// @dart=2.9
+
+import 'package:test/test.dart';
+
+void main() {
+  test('unsound behavior', () async {
+    null as int;
+  });
+}

--- a/integration_tests/nnbd_opted_in/test/opted_out_test.dart
+++ b/integration_tests/nnbd_opted_in/test/opted_out_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.9
+// @dart=2.11
 
 import 'package:test/test.dart';
 


### PR DESCRIPTION
There is a bug with the frontend server usage where the first test that
runs determines the soundness for all other tests. If the first test is
opted in to null safety, all tests must be and an opted out test will
fail to load. If the first test is opted out of null safety, all tests
will run in unsound mode.

Add an integration test package which is opted in to null safety at the
package level and has one test opted out and one opted in. Both tests
will only pass if they are run with the expected soundness.