### PR TITLE
fix sdk root path on windows

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.17.2
+
+* Fix a windows issue with the new loading strategy.
+
 ## 1.17.1
 
 * Fix an issue where you couldn't have tests compiled in both sound and

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.17.1
+version: 1.17.2
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -34,7 +34,7 @@ dependencies:
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.4.0
-  test_core: 0.3.21
+  test_core: 0.3.22
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.22
+
+* Fix a windows issue with the new loading strategy.
+
 ## 0.3.21
 
 * Fix an issue where you couldn't have tests compiled in both sound and

--- a/pkgs/test_core/lib/src/runner/vm/test_compiler.dart
+++ b/pkgs/test_core/lib/src/runner/vm/test_compiler.dart
@@ -152,13 +152,12 @@ class _TestCompilerForLanguageVersion {
   Future<CompileResult?> _createCompiler(Uri testUri) async {
     final platformDill = 'lib/_internal/vm_platform_strong.dill';
     final sdkRoot =
-        Directory(p.relative(p.join(Platform.resolvedExecutable, '..', '..')))
-            .uri;
+        p.relative(p.dirname(p.dirname(Platform.resolvedExecutable)));
     var client = _frontendServerClient = await FrontendServerClient.start(
       testUri.toString(),
       _outputDill.path,
       platformDill,
-      sdkRoot: sdkRoot.path,
+      sdkRoot: sdkRoot,
       packagesJson: (await packageConfigUri).toFilePath(),
       printIncrementalDependencies: false,
     );

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.21
+version: 0.3.22
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/test/issues/1506

I couldn't repro this locally on my windows box but I am testing the fix on github CI over at [mono_repo #317](https://github.com/google/mono_repo.dart/pull/317).

Basically my assumption here is that the `uri` we were grabbing off of the `Directory` object had a mix of forward/backward slashes.