### PR TITLE
resume running tests on windows

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -38,16 +38,16 @@ jobs:
       - name: mono_repo self validate
         run: pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; Dart dev; PKGS: integration_tests/nnbd_opted_in, integration_tests/nnbd_opted_out, pkgs/test, pkgs/test_api, pkgs/test_core; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`"
+    name: "analyze_and_format; linux; Dart dev; PKGS: pkgs/test_core, integration_tests/nnbd_opted_out, pkgs/test, integration_tests/nnbd_opted_in, pkgs/test_api; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_in-integration_tests/nnbd_opted_out-pkgs/test-pkgs/test_api-pkgs/test_core;commands:dartfmt-dartanalyzer"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test_core-integration_tests/nnbd_opted_out-pkgs/test-integration_tests/nnbd_opted_in-pkgs/test_api;commands:dartfmt-dartanalyzer"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_in-integration_tests/nnbd_opted_out-pkgs/test-pkgs/test_api-pkgs/test_core
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test_core-integration_tests/nnbd_opted_out-pkgs/test-integration_tests/nnbd_opted_in-pkgs/test_api
             os:ubuntu-latest;pub-cache-hosted;dart:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -56,18 +56,18 @@ jobs:
           sdk: dev
       - id: checkout
         uses: actions/checkout@v2
-      - id: integration_tests_nnbd_opted_in_pub_upgrade
-        name: "integration_tests/nnbd_opted_in; pub upgrade --no-precompile"
+      - id: pkgs_test_core_pub_upgrade
+        name: "pkgs/test_core; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: integration_tests/nnbd_opted_in
+        working-directory: pkgs/test_core
         run: pub upgrade --no-precompile
-      - name: "integration_tests/nnbd_opted_in; dartfmt -n --set-exit-if-changed ."
-        if: "always() && steps.integration_tests_nnbd_opted_in_pub_upgrade.conclusion == 'success'"
-        working-directory: integration_tests/nnbd_opted_in
+      - name: "pkgs/test_core; dartfmt -n --set-exit-if-changed ."
+        if: "always() && steps.pkgs_test_core_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test_core
         run: dartfmt -n --set-exit-if-changed .
-      - name: "integration_tests/nnbd_opted_in; dartanalyzer --fatal-infos --fatal-warnings ."
-        if: "always() && steps.integration_tests_nnbd_opted_in_pub_upgrade.conclusion == 'success'"
-        working-directory: integration_tests/nnbd_opted_in
+      - name: "pkgs/test_core; dartanalyzer --fatal-infos --fatal-warnings ."
+        if: "always() && steps.pkgs_test_core_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test_core
         run: dartanalyzer --fatal-infos --fatal-warnings .
       - id: integration_tests_nnbd_opted_out_pub_upgrade
         name: "integration_tests/nnbd_opted_out; pub upgrade --no-precompile"
@@ -95,6 +95,19 @@ jobs:
         if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/test
         run: dartanalyzer --fatal-infos --fatal-warnings .
+      - id: integration_tests_nnbd_opted_in_pub_upgrade
+        name: "integration_tests/nnbd_opted_in; pub upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_in
+        run: pub upgrade --no-precompile
+      - name: "integration_tests/nnbd_opted_in; dartfmt -n --set-exit-if-changed ."
+        if: "always() && steps.integration_tests_nnbd_opted_in_pub_upgrade.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_in
+        run: dartfmt -n --set-exit-if-changed .
+      - name: "integration_tests/nnbd_opted_in; dartanalyzer --fatal-infos --fatal-warnings ."
+        if: "always() && steps.integration_tests_nnbd_opted_in_pub_upgrade.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_in
+        run: dartanalyzer --fatal-infos --fatal-warnings .
       - id: pkgs_test_api_pub_upgrade
         name: "pkgs/test_api; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -108,30 +121,17 @@ jobs:
         if: "always() && steps.pkgs_test_api_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/test_api
         run: dartanalyzer --fatal-infos --fatal-warnings .
-      - id: pkgs_test_core_pub_upgrade
-        name: "pkgs/test_core; pub upgrade --no-precompile"
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test_core
-        run: pub upgrade --no-precompile
-      - name: "pkgs/test_core; dartfmt -n --set-exit-if-changed ."
-        if: "always() && steps.pkgs_test_core_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test_core
-        run: dartfmt -n --set-exit-if-changed .
-      - name: "pkgs/test_core; dartanalyzer --fatal-infos --fatal-warnings ."
-        if: "always() && steps.pkgs_test_core_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test_core
-        run: dartanalyzer --fatal-infos --fatal-warnings .
   job_003:
-    name: "unit_test; Dart dev; PKG: integration_tests/nnbd_opted_in; `pub run test -p chrome,vm,node`"
+    name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_in;commands:test"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test;commands:command_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_in
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test
             os:ubuntu-latest;pub-cache-hosted;dart:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -140,82 +140,62 @@ jobs:
           sdk: dev
       - id: checkout
         uses: actions/checkout@v2
-      - id: integration_tests_nnbd_opted_in_pub_upgrade
-        name: "integration_tests/nnbd_opted_in; pub upgrade --no-precompile"
+      - id: pkgs_test_pub_upgrade
+        name: "pkgs/test; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: integration_tests/nnbd_opted_in
+        working-directory: pkgs/test
         run: pub upgrade --no-precompile
-      - name: "integration_tests/nnbd_opted_in; pub run test -p chrome,vm,node"
-        if: "always() && steps.integration_tests_nnbd_opted_in_pub_upgrade.conclusion == 'success'"
-        working-directory: integration_tests/nnbd_opted_in
-        run: "pub run test -p chrome,vm,node"
+      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0"
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0"
     needs:
       - job_001
       - job_002
   job_004:
-    name: "unit_test; Dart dev; PKG: integration_tests/nnbd_opted_out; `pub run test -p chrome,vm,node`"
-    runs-on: ubuntu-latest
+    name: "unit_test; windows; Dart dev; PKG: integration_tests/nnbd_opted_out; `pub run test -p chrome,vm,node`"
+    runs-on: windows-latest
     steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_out;commands:test"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_out
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
       - uses: dart-lang/setup-dart@v1.0
         with:
           sdk: dev
       - id: checkout
         uses: actions/checkout@v2
       - id: integration_tests_nnbd_opted_out_pub_upgrade
-        name: "integration_tests/nnbd_opted_out; pub upgrade --no-precompile"
+        name: "integration_tests/nnbd_opted_out; pub.bat upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: integration_tests/nnbd_opted_out
-        run: pub upgrade --no-precompile
+        run: pub.bat upgrade --no-precompile
       - name: "integration_tests/nnbd_opted_out; pub run test -p chrome,vm,node"
         if: "always() && steps.integration_tests_nnbd_opted_out_pub_upgrade.conclusion == 'success'"
         working-directory: integration_tests/nnbd_opted_out
-        run: "pub run test -p chrome,vm,node"
+        run: "pub.bat run test -p chrome,vm,node"
     needs:
       - job_001
       - job_002
   job_005:
-    name: "unit_test; Dart stable; PKG: integration_tests/nnbd_opted_in; `pub run test -p chrome,vm,node`"
-    runs-on: ubuntu-latest
+    name: "unit_test; windows; Dart dev; PKG: integration_tests/nnbd_opted_in; `pub run test -p chrome,vm,node`"
+    runs-on: windows-latest
     steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:integration_tests/nnbd_opted_in;commands:test"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:integration_tests/nnbd_opted_in
-            os:ubuntu-latest;pub-cache-hosted;dart:stable
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
       - uses: dart-lang/setup-dart@v1.0
         with:
-          sdk: stable
+          sdk: dev
       - id: checkout
         uses: actions/checkout@v2
       - id: integration_tests_nnbd_opted_in_pub_upgrade
-        name: "integration_tests/nnbd_opted_in; pub upgrade --no-precompile"
+        name: "integration_tests/nnbd_opted_in; pub.bat upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: integration_tests/nnbd_opted_in
-        run: pub upgrade --no-precompile
+        run: pub.bat upgrade --no-precompile
       - name: "integration_tests/nnbd_opted_in; pub run test -p chrome,vm,node"
         if: "always() && steps.integration_tests_nnbd_opted_in_pub_upgrade.conclusion == 'success'"
         working-directory: integration_tests/nnbd_opted_in
-        run: "pub run test -p chrome,vm,node"
+        run: "pub.bat run test -p chrome,vm,node"
     needs:
       - job_001
       - job_002
   job_006:
-    name: "unit_test; Dart stable; PKG: integration_tests/nnbd_opted_out; `pub run test -p chrome,vm,node`"
+    name: "unit_test; linux; Dart stable; PKG: integration_tests/nnbd_opted_out; `pub run test -p chrome,vm,node`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -246,29 +226,92 @@ jobs:
       - job_001
       - job_002
   job_007:
-    name: "unit_test; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0`"
+    name: "unit_test; linux; Dart stable; PKG: integration_tests/nnbd_opted_in; `pub run test -p chrome,vm,node`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test;commands:command_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:integration_tests/nnbd_opted_in;commands:test"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:integration_tests/nnbd_opted_in
+            os:ubuntu-latest;pub-cache-hosted;dart:stable
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: stable
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: integration_tests_nnbd_opted_in_pub_upgrade
+        name: "integration_tests/nnbd_opted_in; pub upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_in
+        run: pub upgrade --no-precompile
+      - name: "integration_tests/nnbd_opted_in; pub run test -p chrome,vm,node"
+        if: "always() && steps.integration_tests_nnbd_opted_in_pub_upgrade.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_in
+        run: "pub run test -p chrome,vm,node"
+    needs:
+      - job_001
+      - job_002
+  job_008:
+    name: "unit_test; windows; Dart stable; PKG: integration_tests/nnbd_opted_out; `pub run test -p chrome,vm,node`"
+    runs-on: windows-latest
+    steps:
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: stable
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: integration_tests_nnbd_opted_out_pub_upgrade
+        name: "integration_tests/nnbd_opted_out; pub.bat upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_out
+        run: pub.bat upgrade --no-precompile
+      - name: "integration_tests/nnbd_opted_out; pub run test -p chrome,vm,node"
+        if: "always() && steps.integration_tests_nnbd_opted_out_pub_upgrade.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_out
+        run: "pub.bat run test -p chrome,vm,node"
+    needs:
+      - job_001
+      - job_002
+  job_009:
+    name: "unit_test; windows; Dart stable; PKG: integration_tests/nnbd_opted_in; `pub run test -p chrome,vm,node`"
+    runs-on: windows-latest
+    steps:
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: stable
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: integration_tests_nnbd_opted_in_pub_upgrade
+        name: "integration_tests/nnbd_opted_in; pub.bat upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_in
+        run: pub.bat upgrade --no-precompile
+      - name: "integration_tests/nnbd_opted_in; pub run test -p chrome,vm,node"
+        if: "always() && steps.integration_tests_nnbd_opted_in_pub_upgrade.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_in
+        run: "pub.bat run test -p chrome,vm,node"
+    needs:
+      - job_001
+      - job_002
+  job_010:
+    name: "unit_test; windows; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0`"
+    runs-on: windows-latest
+    steps:
       - uses: dart-lang/setup-dart@v1.0
         with:
           sdk: dev
       - id: checkout
         uses: actions/checkout@v2
       - id: pkgs_test_pub_upgrade
-        name: "pkgs/test; pub upgrade --no-precompile"
+        name: "pkgs/test; pub.bat upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: pkgs/test
-        run: pub upgrade --no-precompile
+        run: pub.bat upgrade --no-precompile
       - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0"
         if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/test
@@ -276,8 +319,8 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_008:
-    name: "unit_test; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0`"
+  job_011:
+    name: "unit_test; linux; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -307,8 +350,29 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_009:
-    name: "unit_test; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 1`"
+  job_012:
+    name: "unit_test; windows; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0`"
+    runs-on: windows-latest
+    steps:
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: stable
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: pkgs_test_pub_upgrade
+        name: "pkgs/test; pub.bat upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: pub.bat upgrade --no-precompile
+      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0"
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0"
+    needs:
+      - job_001
+      - job_002
+  job_013:
+    name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -338,8 +402,29 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_010:
-    name: "unit_test; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 1`"
+  job_014:
+    name: "unit_test; windows; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 1`"
+    runs-on: windows-latest
+    steps:
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: dev
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: pkgs_test_pub_upgrade
+        name: "pkgs/test; pub.bat upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: pub.bat upgrade --no-precompile
+      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 1"
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 1"
+    needs:
+      - job_001
+      - job_002
+  job_015:
+    name: "unit_test; linux; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -369,8 +454,29 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_011:
-    name: "unit_test; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2`"
+  job_016:
+    name: "unit_test; windows; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 1`"
+    runs-on: windows-latest
+    steps:
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: stable
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: pkgs_test_pub_upgrade
+        name: "pkgs/test; pub.bat upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: pub.bat upgrade --no-precompile
+      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 1"
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 1"
+    needs:
+      - job_001
+      - job_002
+  job_017:
+    name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -400,8 +506,29 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_012:
-    name: "unit_test; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2`"
+  job_018:
+    name: "unit_test; windows; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2`"
+    runs-on: windows-latest
+    steps:
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: dev
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: pkgs_test_pub_upgrade
+        name: "pkgs/test; pub.bat upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: pub.bat upgrade --no-precompile
+      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2"
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2"
+    needs:
+      - job_001
+      - job_002
+  job_019:
+    name: "unit_test; linux; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -431,30 +558,41 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_013:
-    name: "unit_test; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3`"
-    runs-on: ubuntu-latest
+  job_020:
+    name: "unit_test; windows; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2`"
+    runs-on: windows-latest
     steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
+      - uses: dart-lang/setup-dart@v1.0
         with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test;commands:command_3"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
+          sdk: stable
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: pkgs_test_pub_upgrade
+        name: "pkgs/test; pub.bat upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: pub.bat upgrade --no-precompile
+      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2"
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2"
+    needs:
+      - job_001
+      - job_002
+  job_021:
+    name: "unit_test; windows; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3`"
+    runs-on: windows-latest
+    steps:
       - uses: dart-lang/setup-dart@v1.0
         with:
           sdk: dev
       - id: checkout
         uses: actions/checkout@v2
       - id: pkgs_test_pub_upgrade
-        name: "pkgs/test; pub upgrade --no-precompile"
+        name: "pkgs/test; pub.bat upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: pkgs/test
-        run: pub upgrade --no-precompile
+        run: pub.bat upgrade --no-precompile
       - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3"
         if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/test
@@ -462,8 +600,8 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_014:
-    name: "unit_test; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3`"
+  job_022:
+    name: "unit_test; linux; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -493,8 +631,29 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_015:
-    name: "unit_test; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4`"
+  job_023:
+    name: "unit_test; windows; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3`"
+    runs-on: windows-latest
+    steps:
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: stable
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: pkgs_test_pub_upgrade
+        name: "pkgs/test; pub.bat upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: pub.bat upgrade --no-precompile
+      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3"
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3"
+    needs:
+      - job_001
+      - job_002
+  job_024:
+    name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -524,8 +683,29 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_016:
-    name: "unit_test; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4`"
+  job_025:
+    name: "unit_test; windows; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4`"
+    runs-on: windows-latest
+    steps:
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: dev
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: pkgs_test_pub_upgrade
+        name: "pkgs/test; pub.bat upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: pub.bat upgrade --no-precompile
+      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4"
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4"
+    needs:
+      - job_001
+      - job_002
+  job_026:
+    name: "unit_test; linux; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -555,8 +735,91 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_017:
-    name: "unit_test; Dart dev; PKG: pkgs/test_api; `pub run test --preset travis -x browser`"
+  job_027:
+    name: "unit_test; windows; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4`"
+    runs-on: windows-latest
+    steps:
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: stable
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: pkgs_test_pub_upgrade
+        name: "pkgs/test; pub.bat upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: pub.bat upgrade --no-precompile
+      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4"
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4"
+    needs:
+      - job_001
+      - job_002
+  job_028:
+    name: "unit_test; linux; Dart dev; PKG: integration_tests/nnbd_opted_in; `pub run test -p chrome,vm,node`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_in;commands:test"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_in
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: dev
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: integration_tests_nnbd_opted_in_pub_upgrade
+        name: "integration_tests/nnbd_opted_in; pub upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_in
+        run: pub upgrade --no-precompile
+      - name: "integration_tests/nnbd_opted_in; pub run test -p chrome,vm,node"
+        if: "always() && steps.integration_tests_nnbd_opted_in_pub_upgrade.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_in
+        run: "pub run test -p chrome,vm,node"
+    needs:
+      - job_001
+      - job_002
+  job_029:
+    name: "unit_test; linux; Dart dev; PKG: integration_tests/nnbd_opted_out; `pub run test -p chrome,vm,node`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_out;commands:test"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_out
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: dev
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: integration_tests_nnbd_opted_out_pub_upgrade
+        name: "integration_tests/nnbd_opted_out; pub upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_out
+        run: pub upgrade --no-precompile
+      - name: "integration_tests/nnbd_opted_out; pub run test -p chrome,vm,node"
+        if: "always() && steps.integration_tests_nnbd_opted_out_pub_upgrade.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_out
+        run: "pub run test -p chrome,vm,node"
+    needs:
+      - job_001
+      - job_002
+  job_030:
+    name: "unit_test; linux; Dart dev; PKG: pkgs/test_api; `pub run test --preset travis -x browser`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -586,8 +849,8 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_018:
-    name: "unit_test; Dart stable; PKG: pkgs/test_api; `pub run test --preset travis -x browser`"
+  job_031:
+    name: "unit_test; linux; Dart stable; PKG: pkgs/test_api; `pub run test --preset travis -x browser`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -617,7 +880,38 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_019:
+  job_032:
+    name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test;commands:command_3"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: dev
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: pkgs_test_pub_upgrade
+        name: "pkgs/test; pub upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: pub upgrade --no-precompile
+      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3"
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3"
+    needs:
+      - job_001
+      - job_002
+  job_033:
     name: Notify failure
     runs-on: ubuntu-latest
     if: "(github.event_name == 'push' || github.event_name == 'schedule') && failure()"
@@ -647,3 +941,17 @@ jobs:
       - job_016
       - job_017
       - job_018
+      - job_019
+      - job_020
+      - job_021
+      - job_022
+      - job_023
+      - job_024
+      - job_025
+      - job_026
+      - job_027
+      - job_028
+      - job_029
+      - job_030
+      - job_031
+      - job_032

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -38,16 +38,16 @@ jobs:
       - name: mono_repo self validate
         run: pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; linux; Dart dev; PKGS: pkgs/test_core, integration_tests/nnbd_opted_out, pkgs/test, integration_tests/nnbd_opted_in, pkgs/test_api; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`"
+    name: "analyze_and_format; linux; Dart dev; PKGS: integration_tests/nnbd_opted_in, integration_tests/nnbd_opted_out, pkgs/test, pkgs/test_api, pkgs/test_core; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test_core-integration_tests/nnbd_opted_out-pkgs/test-integration_tests/nnbd_opted_in-pkgs/test_api;commands:dartfmt-dartanalyzer"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_in-integration_tests/nnbd_opted_out-pkgs/test-pkgs/test_api-pkgs/test_core;commands:dartfmt-dartanalyzer"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test_core-integration_tests/nnbd_opted_out-pkgs/test-integration_tests/nnbd_opted_in-pkgs/test_api
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_in-integration_tests/nnbd_opted_out-pkgs/test-pkgs/test_api-pkgs/test_core
             os:ubuntu-latest;pub-cache-hosted;dart:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -56,18 +56,18 @@ jobs:
           sdk: dev
       - id: checkout
         uses: actions/checkout@v2
-      - id: pkgs_test_core_pub_upgrade
-        name: "pkgs/test_core; pub upgrade --no-precompile"
+      - id: integration_tests_nnbd_opted_in_pub_upgrade
+        name: "integration_tests/nnbd_opted_in; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test_core
+        working-directory: integration_tests/nnbd_opted_in
         run: pub upgrade --no-precompile
-      - name: "pkgs/test_core; dartfmt -n --set-exit-if-changed ."
-        if: "always() && steps.pkgs_test_core_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test_core
+      - name: "integration_tests/nnbd_opted_in; dartfmt -n --set-exit-if-changed ."
+        if: "always() && steps.integration_tests_nnbd_opted_in_pub_upgrade.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_in
         run: dartfmt -n --set-exit-if-changed .
-      - name: "pkgs/test_core; dartanalyzer --fatal-infos --fatal-warnings ."
-        if: "always() && steps.pkgs_test_core_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test_core
+      - name: "integration_tests/nnbd_opted_in; dartanalyzer --fatal-infos --fatal-warnings ."
+        if: "always() && steps.integration_tests_nnbd_opted_in_pub_upgrade.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_in
         run: dartanalyzer --fatal-infos --fatal-warnings .
       - id: integration_tests_nnbd_opted_out_pub_upgrade
         name: "integration_tests/nnbd_opted_out; pub upgrade --no-precompile"
@@ -95,19 +95,6 @@ jobs:
         if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/test
         run: dartanalyzer --fatal-infos --fatal-warnings .
-      - id: integration_tests_nnbd_opted_in_pub_upgrade
-        name: "integration_tests/nnbd_opted_in; pub upgrade --no-precompile"
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: integration_tests/nnbd_opted_in
-        run: pub upgrade --no-precompile
-      - name: "integration_tests/nnbd_opted_in; dartfmt -n --set-exit-if-changed ."
-        if: "always() && steps.integration_tests_nnbd_opted_in_pub_upgrade.conclusion == 'success'"
-        working-directory: integration_tests/nnbd_opted_in
-        run: dartfmt -n --set-exit-if-changed .
-      - name: "integration_tests/nnbd_opted_in; dartanalyzer --fatal-infos --fatal-warnings ."
-        if: "always() && steps.integration_tests_nnbd_opted_in_pub_upgrade.conclusion == 'success'"
-        working-directory: integration_tests/nnbd_opted_in
-        run: dartanalyzer --fatal-infos --fatal-warnings .
       - id: pkgs_test_api_pub_upgrade
         name: "pkgs/test_api; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -121,17 +108,30 @@ jobs:
         if: "always() && steps.pkgs_test_api_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/test_api
         run: dartanalyzer --fatal-infos --fatal-warnings .
+      - id: pkgs_test_core_pub_upgrade
+        name: "pkgs/test_core; pub upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test_core
+        run: pub upgrade --no-precompile
+      - name: "pkgs/test_core; dartfmt -n --set-exit-if-changed ."
+        if: "always() && steps.pkgs_test_core_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test_core
+        run: dartfmt -n --set-exit-if-changed .
+      - name: "pkgs/test_core; dartanalyzer --fatal-infos --fatal-warnings ."
+        if: "always() && steps.pkgs_test_core_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test_core
+        run: dartanalyzer --fatal-infos --fatal-warnings .
   job_003:
-    name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0`"
+    name: "unit_test; linux; Dart dev; PKG: integration_tests/nnbd_opted_in; `pub run test -p chrome,vm,node`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test;commands:command_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_in;commands:test"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_in
             os:ubuntu-latest;pub-cache-hosted;dart:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -140,36 +140,46 @@ jobs:
           sdk: dev
       - id: checkout
         uses: actions/checkout@v2
-      - id: pkgs_test_pub_upgrade
-        name: "pkgs/test; pub upgrade --no-precompile"
+      - id: integration_tests_nnbd_opted_in_pub_upgrade
+        name: "integration_tests/nnbd_opted_in; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test
+        working-directory: integration_tests/nnbd_opted_in
         run: pub upgrade --no-precompile
-      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0"
-        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0"
+      - name: "integration_tests/nnbd_opted_in; pub run test -p chrome,vm,node"
+        if: "always() && steps.integration_tests_nnbd_opted_in_pub_upgrade.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_in
+        run: "pub run test -p chrome,vm,node"
     needs:
       - job_001
       - job_002
   job_004:
-    name: "unit_test; windows; Dart dev; PKG: integration_tests/nnbd_opted_out; `pub run test -p chrome,vm,node`"
-    runs-on: windows-latest
+    name: "unit_test; linux; Dart dev; PKG: integration_tests/nnbd_opted_out; `pub run test -p chrome,vm,node`"
+    runs-on: ubuntu-latest
     steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_out;commands:test"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_out
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
       - uses: dart-lang/setup-dart@v1.0
         with:
           sdk: dev
       - id: checkout
         uses: actions/checkout@v2
       - id: integration_tests_nnbd_opted_out_pub_upgrade
-        name: "integration_tests/nnbd_opted_out; pub.bat upgrade --no-precompile"
+        name: "integration_tests/nnbd_opted_out; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: integration_tests/nnbd_opted_out
-        run: pub.bat upgrade --no-precompile
+        run: pub upgrade --no-precompile
       - name: "integration_tests/nnbd_opted_out; pub run test -p chrome,vm,node"
         if: "always() && steps.integration_tests_nnbd_opted_out_pub_upgrade.conclusion == 'success'"
         working-directory: integration_tests/nnbd_opted_out
-        run: "pub.bat run test -p chrome,vm,node"
+        run: "pub run test -p chrome,vm,node"
     needs:
       - job_001
       - job_002
@@ -195,33 +205,23 @@ jobs:
       - job_001
       - job_002
   job_006:
-    name: "unit_test; linux; Dart stable; PKG: integration_tests/nnbd_opted_out; `pub run test -p chrome,vm,node`"
-    runs-on: ubuntu-latest
+    name: "unit_test; windows; Dart dev; PKG: integration_tests/nnbd_opted_out; `pub run test -p chrome,vm,node`"
+    runs-on: windows-latest
     steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:integration_tests/nnbd_opted_out;commands:test"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:integration_tests/nnbd_opted_out
-            os:ubuntu-latest;pub-cache-hosted;dart:stable
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
       - uses: dart-lang/setup-dart@v1.0
         with:
-          sdk: stable
+          sdk: dev
       - id: checkout
         uses: actions/checkout@v2
       - id: integration_tests_nnbd_opted_out_pub_upgrade
-        name: "integration_tests/nnbd_opted_out; pub upgrade --no-precompile"
+        name: "integration_tests/nnbd_opted_out; pub.bat upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: integration_tests/nnbd_opted_out
-        run: pub upgrade --no-precompile
+        run: pub.bat upgrade --no-precompile
       - name: "integration_tests/nnbd_opted_out; pub run test -p chrome,vm,node"
         if: "always() && steps.integration_tests_nnbd_opted_out_pub_upgrade.conclusion == 'success'"
         working-directory: integration_tests/nnbd_opted_out
-        run: "pub run test -p chrome,vm,node"
+        run: "pub.bat run test -p chrome,vm,node"
     needs:
       - job_001
       - job_002
@@ -257,23 +257,33 @@ jobs:
       - job_001
       - job_002
   job_008:
-    name: "unit_test; windows; Dart stable; PKG: integration_tests/nnbd_opted_out; `pub run test -p chrome,vm,node`"
-    runs-on: windows-latest
+    name: "unit_test; linux; Dart stable; PKG: integration_tests/nnbd_opted_out; `pub run test -p chrome,vm,node`"
+    runs-on: ubuntu-latest
     steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:integration_tests/nnbd_opted_out;commands:test"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:integration_tests/nnbd_opted_out
+            os:ubuntu-latest;pub-cache-hosted;dart:stable
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
       - uses: dart-lang/setup-dart@v1.0
         with:
           sdk: stable
       - id: checkout
         uses: actions/checkout@v2
       - id: integration_tests_nnbd_opted_out_pub_upgrade
-        name: "integration_tests/nnbd_opted_out; pub.bat upgrade --no-precompile"
+        name: "integration_tests/nnbd_opted_out; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: integration_tests/nnbd_opted_out
-        run: pub.bat upgrade --no-precompile
+        run: pub upgrade --no-precompile
       - name: "integration_tests/nnbd_opted_out; pub run test -p chrome,vm,node"
         if: "always() && steps.integration_tests_nnbd_opted_out_pub_upgrade.conclusion == 'success'"
         working-directory: integration_tests/nnbd_opted_out
-        run: "pub.bat run test -p chrome,vm,node"
+        run: "pub run test -p chrome,vm,node"
     needs:
       - job_001
       - job_002
@@ -299,19 +309,50 @@ jobs:
       - job_001
       - job_002
   job_010:
-    name: "unit_test; windows; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0`"
+    name: "unit_test; windows; Dart stable; PKG: integration_tests/nnbd_opted_out; `pub run test -p chrome,vm,node`"
     runs-on: windows-latest
     steps:
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: stable
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: integration_tests_nnbd_opted_out_pub_upgrade
+        name: "integration_tests/nnbd_opted_out; pub.bat upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_out
+        run: pub.bat upgrade --no-precompile
+      - name: "integration_tests/nnbd_opted_out; pub run test -p chrome,vm,node"
+        if: "always() && steps.integration_tests_nnbd_opted_out_pub_upgrade.conclusion == 'success'"
+        working-directory: integration_tests/nnbd_opted_out
+        run: "pub.bat run test -p chrome,vm,node"
+    needs:
+      - job_001
+      - job_002
+  job_011:
+    name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test;commands:command_0"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
       - uses: dart-lang/setup-dart@v1.0
         with:
           sdk: dev
       - id: checkout
         uses: actions/checkout@v2
       - id: pkgs_test_pub_upgrade
-        name: "pkgs/test; pub.bat upgrade --no-precompile"
+        name: "pkgs/test; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: pkgs/test
-        run: pub.bat upgrade --no-precompile
+        run: pub upgrade --no-precompile
       - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0"
         if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/test
@@ -319,7 +360,7 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_011:
+  job_012:
     name: "unit_test; linux; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: ubuntu-latest
     steps:
@@ -343,27 +384,6 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: pkgs/test
         run: pub upgrade --no-precompile
-      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0"
-        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0"
-    needs:
-      - job_001
-      - job_002
-  job_012:
-    name: "unit_test; windows; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0`"
-    runs-on: windows-latest
-    steps:
-      - uses: dart-lang/setup-dart@v1.0
-        with:
-          sdk: stable
-      - id: checkout
-        uses: actions/checkout@v2
-      - id: pkgs_test_pub_upgrade
-        name: "pkgs/test; pub.bat upgrade --no-precompile"
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: pub.bat upgrade --no-precompile
       - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 0"
         if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/test
@@ -403,27 +423,6 @@ jobs:
       - job_001
       - job_002
   job_014:
-    name: "unit_test; windows; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 1`"
-    runs-on: windows-latest
-    steps:
-      - uses: dart-lang/setup-dart@v1.0
-        with:
-          sdk: dev
-      - id: checkout
-        uses: actions/checkout@v2
-      - id: pkgs_test_pub_upgrade
-        name: "pkgs/test; pub.bat upgrade --no-precompile"
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: pub.bat upgrade --no-precompile
-      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 1"
-        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 1"
-    needs:
-      - job_001
-      - job_002
-  job_015:
     name: "unit_test; linux; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: ubuntu-latest
     steps:
@@ -454,28 +453,7 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_016:
-    name: "unit_test; windows; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 1`"
-    runs-on: windows-latest
-    steps:
-      - uses: dart-lang/setup-dart@v1.0
-        with:
-          sdk: stable
-      - id: checkout
-        uses: actions/checkout@v2
-      - id: pkgs_test_pub_upgrade
-        name: "pkgs/test; pub.bat upgrade --no-precompile"
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: pub.bat upgrade --no-precompile
-      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 1"
-        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 1"
-    needs:
-      - job_001
-      - job_002
-  job_017:
+  job_015:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: ubuntu-latest
     steps:
@@ -506,28 +484,7 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_018:
-    name: "unit_test; windows; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2`"
-    runs-on: windows-latest
-    steps:
-      - uses: dart-lang/setup-dart@v1.0
-        with:
-          sdk: dev
-      - id: checkout
-        uses: actions/checkout@v2
-      - id: pkgs_test_pub_upgrade
-        name: "pkgs/test; pub.bat upgrade --no-precompile"
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: pub.bat upgrade --no-precompile
-      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2"
-        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2"
-    needs:
-      - job_001
-      - job_002
-  job_019:
+  job_016:
     name: "unit_test; linux; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: ubuntu-latest
     steps:
@@ -558,329 +515,7 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_020:
-    name: "unit_test; windows; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2`"
-    runs-on: windows-latest
-    steps:
-      - uses: dart-lang/setup-dart@v1.0
-        with:
-          sdk: stable
-      - id: checkout
-        uses: actions/checkout@v2
-      - id: pkgs_test_pub_upgrade
-        name: "pkgs/test; pub.bat upgrade --no-precompile"
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: pub.bat upgrade --no-precompile
-      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2"
-        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 2"
-    needs:
-      - job_001
-      - job_002
-  job_021:
-    name: "unit_test; windows; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3`"
-    runs-on: windows-latest
-    steps:
-      - uses: dart-lang/setup-dart@v1.0
-        with:
-          sdk: dev
-      - id: checkout
-        uses: actions/checkout@v2
-      - id: pkgs_test_pub_upgrade
-        name: "pkgs/test; pub.bat upgrade --no-precompile"
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: pub.bat upgrade --no-precompile
-      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3"
-        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3"
-    needs:
-      - job_001
-      - job_002
-  job_022:
-    name: "unit_test; linux; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkgs/test;commands:command_3"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkgs/test
-            os:ubuntu-latest;pub-cache-hosted;dart:stable
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: dart-lang/setup-dart@v1.0
-        with:
-          sdk: stable
-      - id: checkout
-        uses: actions/checkout@v2
-      - id: pkgs_test_pub_upgrade
-        name: "pkgs/test; pub upgrade --no-precompile"
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: pub upgrade --no-precompile
-      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3"
-        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3"
-    needs:
-      - job_001
-      - job_002
-  job_023:
-    name: "unit_test; windows; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3`"
-    runs-on: windows-latest
-    steps:
-      - uses: dart-lang/setup-dart@v1.0
-        with:
-          sdk: stable
-      - id: checkout
-        uses: actions/checkout@v2
-      - id: pkgs_test_pub_upgrade
-        name: "pkgs/test; pub.bat upgrade --no-precompile"
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: pub.bat upgrade --no-precompile
-      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3"
-        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3"
-    needs:
-      - job_001
-      - job_002
-  job_024:
-    name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test;commands:command_4"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: dart-lang/setup-dart@v1.0
-        with:
-          sdk: dev
-      - id: checkout
-        uses: actions/checkout@v2
-      - id: pkgs_test_pub_upgrade
-        name: "pkgs/test; pub upgrade --no-precompile"
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: pub upgrade --no-precompile
-      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4"
-        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4"
-    needs:
-      - job_001
-      - job_002
-  job_025:
-    name: "unit_test; windows; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4`"
-    runs-on: windows-latest
-    steps:
-      - uses: dart-lang/setup-dart@v1.0
-        with:
-          sdk: dev
-      - id: checkout
-        uses: actions/checkout@v2
-      - id: pkgs_test_pub_upgrade
-        name: "pkgs/test; pub.bat upgrade --no-precompile"
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: pub.bat upgrade --no-precompile
-      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4"
-        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4"
-    needs:
-      - job_001
-      - job_002
-  job_026:
-    name: "unit_test; linux; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkgs/test;commands:command_4"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkgs/test
-            os:ubuntu-latest;pub-cache-hosted;dart:stable
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: dart-lang/setup-dart@v1.0
-        with:
-          sdk: stable
-      - id: checkout
-        uses: actions/checkout@v2
-      - id: pkgs_test_pub_upgrade
-        name: "pkgs/test; pub upgrade --no-precompile"
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: pub upgrade --no-precompile
-      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4"
-        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4"
-    needs:
-      - job_001
-      - job_002
-  job_027:
-    name: "unit_test; windows; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4`"
-    runs-on: windows-latest
-    steps:
-      - uses: dart-lang/setup-dart@v1.0
-        with:
-          sdk: stable
-      - id: checkout
-        uses: actions/checkout@v2
-      - id: pkgs_test_pub_upgrade
-        name: "pkgs/test; pub.bat upgrade --no-precompile"
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: pub.bat upgrade --no-precompile
-      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4"
-        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test
-        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4"
-    needs:
-      - job_001
-      - job_002
-  job_028:
-    name: "unit_test; linux; Dart dev; PKG: integration_tests/nnbd_opted_in; `pub run test -p chrome,vm,node`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_in;commands:test"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_in
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: dart-lang/setup-dart@v1.0
-        with:
-          sdk: dev
-      - id: checkout
-        uses: actions/checkout@v2
-      - id: integration_tests_nnbd_opted_in_pub_upgrade
-        name: "integration_tests/nnbd_opted_in; pub upgrade --no-precompile"
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: integration_tests/nnbd_opted_in
-        run: pub upgrade --no-precompile
-      - name: "integration_tests/nnbd_opted_in; pub run test -p chrome,vm,node"
-        if: "always() && steps.integration_tests_nnbd_opted_in_pub_upgrade.conclusion == 'success'"
-        working-directory: integration_tests/nnbd_opted_in
-        run: "pub run test -p chrome,vm,node"
-    needs:
-      - job_001
-      - job_002
-  job_029:
-    name: "unit_test; linux; Dart dev; PKG: integration_tests/nnbd_opted_out; `pub run test -p chrome,vm,node`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_out;commands:test"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:integration_tests/nnbd_opted_out
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: dart-lang/setup-dart@v1.0
-        with:
-          sdk: dev
-      - id: checkout
-        uses: actions/checkout@v2
-      - id: integration_tests_nnbd_opted_out_pub_upgrade
-        name: "integration_tests/nnbd_opted_out; pub upgrade --no-precompile"
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: integration_tests/nnbd_opted_out
-        run: pub upgrade --no-precompile
-      - name: "integration_tests/nnbd_opted_out; pub run test -p chrome,vm,node"
-        if: "always() && steps.integration_tests_nnbd_opted_out_pub_upgrade.conclusion == 'success'"
-        working-directory: integration_tests/nnbd_opted_out
-        run: "pub run test -p chrome,vm,node"
-    needs:
-      - job_001
-      - job_002
-  job_030:
-    name: "unit_test; linux; Dart dev; PKG: pkgs/test_api; `pub run test --preset travis -x browser`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test_api;commands:command_5"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test_api
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: dart-lang/setup-dart@v1.0
-        with:
-          sdk: dev
-      - id: checkout
-        uses: actions/checkout@v2
-      - id: pkgs_test_api_pub_upgrade
-        name: "pkgs/test_api; pub upgrade --no-precompile"
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test_api
-        run: pub upgrade --no-precompile
-      - name: "pkgs/test_api; pub run test --preset travis -x browser"
-        if: "always() && steps.pkgs_test_api_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test_api
-        run: pub run test --preset travis -x browser
-    needs:
-      - job_001
-      - job_002
-  job_031:
-    name: "unit_test; linux; Dart stable; PKG: pkgs/test_api; `pub run test --preset travis -x browser`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkgs/test_api;commands:command_5"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkgs/test_api
-            os:ubuntu-latest;pub-cache-hosted;dart:stable
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: dart-lang/setup-dart@v1.0
-        with:
-          sdk: stable
-      - id: checkout
-        uses: actions/checkout@v2
-      - id: pkgs_test_api_pub_upgrade
-        name: "pkgs/test_api; pub upgrade --no-precompile"
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test_api
-        run: pub upgrade --no-precompile
-      - name: "pkgs/test_api; pub run test --preset travis -x browser"
-        if: "always() && steps.pkgs_test_api_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test_api
-        run: pub run test --preset travis -x browser
-    needs:
-      - job_001
-      - job_002
-  job_032:
+  job_017:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3`"
     runs-on: ubuntu-latest
     steps:
@@ -911,7 +546,162 @@ jobs:
     needs:
       - job_001
       - job_002
-  job_033:
+  job_018:
+    name: "unit_test; linux; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkgs/test;commands:command_3"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkgs/test
+            os:ubuntu-latest;pub-cache-hosted;dart:stable
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: stable
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: pkgs_test_pub_upgrade
+        name: "pkgs/test; pub upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: pub upgrade --no-precompile
+      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3"
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 3"
+    needs:
+      - job_001
+      - job_002
+  job_019:
+    name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test;commands:command_4"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: dev
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: pkgs_test_pub_upgrade
+        name: "pkgs/test; pub upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: pub upgrade --no-precompile
+      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4"
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4"
+    needs:
+      - job_001
+      - job_002
+  job_020:
+    name: "unit_test; linux; Dart stable; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkgs/test;commands:command_4"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkgs/test
+            os:ubuntu-latest;pub-cache-hosted;dart:stable
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: stable
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: pkgs_test_pub_upgrade
+        name: "pkgs/test; pub upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: pub upgrade --no-precompile
+      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4"
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+        run: "xvfb-run -s \"-screen 0 1024x768x24\" pub run test --preset travis --total-shards 5 --shard-index 4"
+    needs:
+      - job_001
+      - job_002
+  job_021:
+    name: "unit_test; linux; Dart dev; PKG: pkgs/test_api; `pub run test --preset travis -x browser`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test_api;commands:command_5"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:pkgs/test_api
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: dev
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: pkgs_test_api_pub_upgrade
+        name: "pkgs/test_api; pub upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test_api
+        run: pub upgrade --no-precompile
+      - name: "pkgs/test_api; pub run test --preset travis -x browser"
+        if: "always() && steps.pkgs_test_api_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test_api
+        run: pub run test --preset travis -x browser
+    needs:
+      - job_001
+      - job_002
+  job_022:
+    name: "unit_test; linux; Dart stable; PKG: pkgs/test_api; `pub run test --preset travis -x browser`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkgs/test_api;commands:command_5"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:stable;packages:pkgs/test_api
+            os:ubuntu-latest;pub-cache-hosted;dart:stable
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: stable
+      - id: checkout
+        uses: actions/checkout@v2
+      - id: pkgs_test_api_pub_upgrade
+        name: "pkgs/test_api; pub upgrade --no-precompile"
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test_api
+        run: pub upgrade --no-precompile
+      - name: "pkgs/test_api; pub run test --preset travis -x browser"
+        if: "always() && steps.pkgs_test_api_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test_api
+        run: pub run test --preset travis -x browser
+    needs:
+      - job_001
+      - job_002
+  job_023:
     name: Notify failure
     runs-on: ubuntu-latest
     if: "(github.event_name == 'push' || github.event_name == 'schedule') && failure()"
@@ -945,13 +735,3 @@ jobs:
       - job_020
       - job_021
       - job_022
-      - job_023
-      - job_024
-      - job_025
-      - job_026
-      - job_027
-      - job_028
-      - job_029
-      - job_030
-      - job_031
-      - job_032

--- a/integration_tests/nnbd_opted_in/mono_pkg.yaml
+++ b/integration_tests/nnbd_opted_in/mono_pkg.yaml
@@ -11,3 +11,6 @@ stages:
         - dev
     - unit_test:
       - test: -p chrome,vm,node
+        os:
+        - linux
+        - windows

--- a/integration_tests/nnbd_opted_out/mono_pkg.yaml
+++ b/integration_tests/nnbd_opted_out/mono_pkg.yaml
@@ -11,3 +11,6 @@ stages:
         - dev
     - unit_test:
       - test: -p chrome,vm,node
+        os:
+        - linux
+        - windows

--- a/pkgs/test/mono_pkg.yaml
+++ b/pkgs/test/mono_pkg.yaml
@@ -1,9 +1,6 @@
 dart:
   - dev
   - stable
-os:
-- linux
-- windows
 
 stages:
     - analyze_and_format:
@@ -12,8 +9,6 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
         dart:
         - dev
-        os:
-        - linux
     - unit_test:
       - command: xvfb-run -s "-screen 0 1024x768x24" pub run test --preset travis --total-shards 5 --shard-index 0
       - command: xvfb-run -s "-screen 0 1024x768x24" pub run test --preset travis --total-shards 5 --shard-index 1

--- a/pkgs/test/mono_pkg.yaml
+++ b/pkgs/test/mono_pkg.yaml
@@ -1,6 +1,9 @@
 dart:
   - dev
   - stable
+os:
+- linux
+- windows
 
 stages:
     - analyze_and_format:
@@ -9,6 +12,8 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
         dart:
         - dev
+        os:
+        - linux
     - unit_test:
       - command: xvfb-run -s "-screen 0 1024x768x24" pub run test --preset travis --total-shards 5 --shard-index 0
       - command: xvfb-run -s "-screen 0 1024x768x24" pub run test --preset travis --total-shards 5 --shard-index 1

--- a/pkgs/test_api/mono_pkg.yaml
+++ b/pkgs/test_api/mono_pkg.yaml
@@ -12,3 +12,6 @@ stages:
   - unit_test:
     - group:
       - command: pub run test --preset travis -x browser
+        os:
+        - linux
+        - windows


### PR DESCRIPTION
~Enables all tests on windows, I may disable some of the tests after I see what the CI looks like.~

Enabled windows testing for test_api and integration tests, windows tests still failing for package:test due to xvfb issues. If/once we resolve that we can add those back also.