### PR TITLE
forward language experiments args from the runner executable to the frontend server compiler

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.17.3
+
+* Forward experiment args from the runner executable to the compiler with the
+  new vm test loading strategy.
+
 ## 1.17.2
 
 * Fix a windows issue with the new loading strategy.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.17.2
+version: 1.17.3
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -34,7 +34,7 @@ dependencies:
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.4.0
-  test_core: 0.3.22
+  test_core: 0.3.23
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.23
+
+* Forward experiment args from the runner executable to the compiler with the
+  new vm test loading strategy.
+
 ## 0.3.22
 
 * Fix a windows issue with the new loading strategy.

--- a/pkgs/test_core/lib/src/runner/compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/compiler_pool.dart
@@ -11,6 +11,7 @@ import 'package:pool/pool.dart';
 
 import '../util/io.dart';
 import '../util/package_config.dart';
+import '../util/dart.dart';
 import 'configuration.dart';
 import 'suite.dart';
 
@@ -63,7 +64,7 @@ class CompilerPool {
         if (Platform.isWindows) dart2jsPath += '.bat';
 
         var args = [
-          for (var experiment in _enabledExperiments)
+          for (var experiment in enabledExperiments)
             '--enable-experiment=$experiment',
           '--enable-asserts',
           wrapperPath,
@@ -140,23 +141,3 @@ class CompilerPool {
     });
   }
 }
-
-/// Parses and returns the currently enabled experiments from
-/// [Platform.executableArguments].
-final List<String> _enabledExperiments = () {
-  var experiments = <String>[];
-  var itr = Platform.executableArguments.iterator;
-  while (itr.moveNext()) {
-    var arg = itr.current;
-    if (arg == '--enable-experiment') {
-      if (!itr.moveNext()) break;
-      experiments.add(itr.current);
-    } else if (arg.startsWith('--enable-experiment=')) {
-      var parts = arg.split('=');
-      if (parts.length == 2) {
-        experiments.addAll(parts[1].split(','));
-      }
-    }
-  }
-  return experiments;
-}();

--- a/pkgs/test_core/lib/src/runner/vm/test_compiler.dart
+++ b/pkgs/test_core/lib/src/runner/vm/test_compiler.dart
@@ -7,7 +7,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:async/async.dart';
-import 'package:package_config/package_config_types.dart';
 import 'package:path/path.dart' as p;
 import 'package:pool/pool.dart';
 import 'package:test_api/backend.dart'; // ignore: deprecated_member_use

--- a/pkgs/test_core/lib/src/util/dart.dart
+++ b/pkgs/test_core/lib/src/util/dart.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:io';
 import 'dart:isolate';
 
 import 'package:analyzer/dart/ast/ast.dart';
@@ -68,3 +69,23 @@ SourceSpan? contextualizeSpan(
 
   return file.span(start, contextRunes.offset);
 }
+
+/// Parses and returns the currently enabled experiments from
+/// [Platform.executableArguments].
+final List<String> enabledExperiments = () {
+  var experiments = <String>[];
+  var itr = Platform.executableArguments.iterator;
+  while (itr.moveNext()) {
+    var arg = itr.current;
+    if (arg == '--enable-experiment') {
+      if (!itr.moveNext()) break;
+      experiments.add(itr.current);
+    } else if (arg.startsWith('--enable-experiment=')) {
+      var parts = arg.split('=');
+      if (parts.length == 2) {
+        experiments.addAll(parts[1].split(','));
+      }
+    }
+  }
+  return experiments;
+}();

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.22
+version: 0.3.23
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
@@ -13,7 +13,7 @@ dependencies:
   boolean_selector: ^2.1.0
   collection: ^1.15.0
   coverage: ^1.0.0
-  frontend_server_client: ^2.0.0
+  frontend_server_client: ^2.1.0
   glob: ^2.0.0
   io: ^1.0.0
   meta: ^1.3.0


### PR DESCRIPTION
This brings back the old behavior we got automatically with the data isolate loading strategy. I also added  a test to validate we don't break this in the future, which also covers the already implemented behavior for web.

Fixes https://github.com/dart-lang/sdk/issues/45835