### PR TITLE
Tweak the phrasing for doc on file reporters

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.17.5-dev
+
 ## 1.17.4
 
 * Fix race condition between compilation of vm tests and the running of

--- a/pkgs/test/doc/json_reporter.md
+++ b/pkgs/test/doc/json_reporter.md
@@ -19,8 +19,8 @@ JSON reporter.
 
     pub run test --reporter json <path-to-test-file>
 
-You may also use the `--file-reporter` option to enable the JSON reporter such
-that it writes to a file instead of stdout.
+You may also use the `--file-reporter` option to enable the JSON reporter output
+to a file, in addition to another reporter writing to stdout.
 
     pub run test --file-reporter json:reports/tests.json <path-to-test-file>
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.17.4
+version: 1.17.5-dev
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -34,7 +34,7 @@ dependencies:
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.4.0
-  test_core: 0.3.24
+  test_core: 0.3.25
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -108,7 +108,7 @@ Output:
           [expanded] (default)        A separate line for each update.
           [json]                      A machine-readable format (see https://dart.dev/go/test-docs/json_reporter.md).
 
-    --file-reporter                   Set the reporter used to write test results to a file.
+    --file-reporter                   Enable an additional reporter writing test results to a file.
                                       Should be in the form <reporter>:<filepath>, Example: "json:reports/tests.json"
     --verbose-trace                   Emit stack traces with core library frames.
     --js-trace                        Emit raw JavaScript stack traces for browser tests.

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.3.25-dev
+
 ## 0.3.24
 
 * Fix race condition between compilation of vm tests and the running of
@@ -247,7 +249,7 @@
 ## 0.2.17
 
 * Add `file_reporters` configuration option and `--file-reporter` CLI option to
-  allow specifying a separate reporter that writes to a file instead of stdout.
+  allow specifying a separate reporter that writes to a file.
 
 ## 0.2.16
 

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -135,7 +135,7 @@ final ArgParser _parser = (() {
       allowed: reporterDescriptions.keys.toList(),
       allowedHelp: reporterDescriptions);
   parser.addOption('file-reporter',
-      help: 'Set the reporter used to write test results to a file.\n'
+      help: 'Enable an additional reporter writing test results to a file.\n'
           'Should be in the form <reporter>:<filepath>, '
           'Example: "json:reports/tests.json"');
   parser.addFlag('verbose-trace',

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.24
+version: 0.3.25-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
Towards #1521

The argument causes an output to a file in _addition_ to the output on
stdout. Avoid the word "instead" to avoid confusion that this argument
disables reporting on stdout.