### PR TITLE
Correct docs for the Retry annotation

### DIFF
--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.4.1-dev
+
 ## 0.4.0
 
 * Add libraries `scaffolding.dart`, and `expect.dart` to allow importing as

--- a/pkgs/test_api/lib/src/backend/configuration/retry.dart
+++ b/pkgs/test_api/lib/src/backend/configuration/retry.dart
@@ -6,13 +6,13 @@ import 'package:meta/meta_meta.dart';
 
 /// An annotation for marking a test suite to be retried.
 ///
-/// A test with retries enabled will be re-run if it fails for a reason
-/// other than [TestFailure].
+/// A suite-level retry configuration will enable retries for every test in the
+/// suite, unless the group or test is configured with a more specific retry.
 @Target({TargetKind.library})
 class Retry {
-  /// The number of times the test will be retried.
+  /// The number of times the tests in the suite will be retried.
   final int count;
 
-  /// Marks a test to be retried.
+  /// Marks all tests in a test suite to be retried.
   const Retry(this.count);
 }

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.4.0
+version: 0.4.1-dev
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 


### PR DESCRIPTION
Fixes #1529

Drop mention of `TestFailure` - there is no distinction between the
types of exceptions which are thrown.

Correct the phrasing to avoid making it seem like the annotation can be
applied to a single test - as an annotation it can only be applied to
the test suite, and for individual groups or tests a named argument is
used instead.