### PR TITLE
Drop some unused functions

### DIFF
--- a/pkgs/test_api/lib/src/expect/async_matcher.dart
+++ b/pkgs/test_api/lib/src/expect/async_matcher.dart
@@ -14,8 +14,6 @@ import 'expect.dart';
 /// returned future completes, and [expect] returns a future that completes when
 /// the returned future completes so that tests can wait for it.
 abstract class AsyncMatcher extends Matcher {
-  const AsyncMatcher();
-
   /// Returns `null` if this matches [item], or a [String] description of the
   /// failure if it doesn't match.
   ///

--- a/pkgs/test_api/lib/src/expect/async_matcher.dart
+++ b/pkgs/test_api/lib/src/expect/async_matcher.dart
@@ -14,6 +14,8 @@ import 'expect.dart';
 /// returned future completes, and [expect] returns a future that completes when
 /// the returned future completes so that tests can wait for it.
 abstract class AsyncMatcher extends Matcher {
+  const AsyncMatcher();
+
   /// Returns `null` if this matches [item], or a [String] description of the
   /// failure if it doesn't match.
   ///

--- a/pkgs/test_api/test/utils.dart
+++ b/pkgs/test_api/test/utils.dart
@@ -89,14 +89,6 @@ Matcher throwsTestFailure(message) => throwsA(isTestFailure(message));
 Matcher isTestFailure(message) => const TypeMatcher<TestFailure>()
     .having((e) => e.message, 'message', message);
 
-/// Returns a matcher that matches a [ApplicationException] with the given
-/// [message].
-///
-/// [message] can be a string or a [Matcher].
-Matcher isApplicationException(message) =>
-    const TypeMatcher<ApplicationException>()
-        .having((e) => e.message, 'message', message);
-
 /// Returns a local [LiveTest] that runs [body].
 LiveTest createTest(dynamic Function() body) {
   var test = LocalTest('test', Metadata(chainStackTraces: true), body);
@@ -195,7 +187,3 @@ Engine declareEngine(void Function() body, {bool runSkipped = false}) {
         suitePlatform)
   ]);
 }
-
-/// Returns a [RunnerSuite] with a default environment and configuration.
-RunnerSuite runnerSuite(Group root) => RunnerSuite(
-    const PluginEnvironment(), SuiteConfiguration.empty, root, suitePlatform);

--- a/pkgs/test_api/test/utils.dart
+++ b/pkgs/test_api/test/utils.dart
@@ -14,7 +14,6 @@ import 'package:test_api/src/backend/runtime.dart';
 import 'package:test_api/src/backend/state.dart';
 import 'package:test_api/src/backend/suite.dart';
 import 'package:test_api/src/backend/suite_platform.dart';
-import 'package:test_core/src/runner/application_exception.dart';
 import 'package:test_core/src/runner/engine.dart';
 import 'package:test_core/src/runner/plugin/environment.dart';
 import 'package:test_core/src/runner/suite.dart';

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.3.26-dev
+
 ## 0.3.25
 
 * Support the latest vm_service release (`7.0.0`).

--- a/pkgs/test_core/lib/src/runner/configuration.dart
+++ b/pkgs/test_core/lib/src/runner/configuration.dart
@@ -212,19 +212,6 @@ class Configuration {
   factory Configuration.load(String path, {bool global = false}) =>
       load(path, global: global);
 
-  /// Loads the configuration from YAML formatted [source].
-  ///
-  /// If [global] is `true`, this restricts the configuration file to only rules
-  /// that are supported globally.
-  ///
-  /// If [sourceUrl] is provided then that will be set as the source url for
-  /// the yaml document.
-  ///
-  /// Throws a [FormatException] if its contents are invalid.
-  factory Configuration.loadFromString(String source,
-          {bool global = false, Uri? sourceUrl}) =>
-      loadFromString(source, global: global, sourceUrl: sourceUrl);
-
   factory Configuration(
       {bool? help,
       String? customHtmlTemplatePath,

--- a/pkgs/test_core/lib/src/runner/configuration/load.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/load.dart
@@ -43,14 +43,6 @@ final _packageName =
 
 /// Loads configuration information from a YAML file at [path].
 ///
-/// See [loadFromString] for further documentation.
-Configuration load(String path, {bool global = false}) {
-  var source = File(path).readAsStringSync();
-  return loadFromString(source, global: global, sourceUrl: p.toUri(path));
-}
-
-/// Loads configuration information from YAML formatted [source].
-///
 /// If [global] is `true`, this restricts the configuration file to only rules
 /// that are supported globally.
 ///
@@ -58,9 +50,9 @@ Configuration load(String path, {bool global = false}) {
 /// the yaml document.
 ///
 /// Throws a [FormatException] if the configuration is invalid.
-Configuration loadFromString(String source,
-    {bool global = false, Uri? sourceUrl}) {
-  var document = loadYamlNode(source, sourceUrl: sourceUrl);
+Configuration load(String path, {bool global = false}) {
+  var source = File(path).readAsStringSync();
+  var document = loadYamlNode(source, sourceUrl: p.toUri(path));
 
   if (document.value == null) return Configuration.empty;
 

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -129,17 +129,6 @@ class Engine {
   Stream<RunnerSuite> get onSuiteAdded => _onSuiteAddedController.stream;
   final _onSuiteAddedController = StreamController<RunnerSuite>.broadcast();
 
-  /// All the currently-known suites that have run or are running.
-  ///
-  /// These are [LiveSuite]s, representing the in-progress state of each suite
-  /// as its component tests are being run.
-  ///
-  /// Note that unlike [addedSuites], for suites that are loaded using
-  /// [LoadSuite]s, both the [LoadSuite] and the suite it loads will eventually
-  /// be in this set.
-  Set<LiveSuite> get liveSuites => UnmodifiableSetView(_liveSuites);
-  final _liveSuites = <LiveSuite>{};
-
   /// A broadcast stream that emits each [LiveSuite] as it's loaded.
   ///
   /// Note that unlike [onSuiteAdded], for suites that are loaded using
@@ -491,7 +480,6 @@ class Engine {
   /// Add [liveSuite] and the information it exposes to the engine's
   /// informational streams and collections.
   void _addLiveSuite(LiveSuite liveSuite) {
-    _liveSuites.add(liveSuite);
     _onSuiteStartedController.add(liveSuite);
 
     _onTestStartedGroup.add(liveSuite.onTestStarted);

--- a/pkgs/test_core/lib/src/runner/live_suite.dart
+++ b/pkgs/test_core/lib/src/runner/live_suite.dart
@@ -17,17 +17,6 @@ abstract class LiveSuite {
   /// The suite that's being run.
   RunnerSuite get suite;
 
-  /// Whether the suite has completed.
-  ///
-  /// Note that even if this returns `true`, the suite may still be running code
-  /// asynchronously. A suite is considered complete once all of its tests are
-  /// complete, but it's possible for a test to continue running even after it's
-  /// been marked complete—see [LiveTest.isComplete] for details.
-  ///
-  /// The [isClosed] getter can be used to determine whether the suite and its
-  /// tests are guaranteed to emit no more events.
-  bool get isComplete;
-
   /// A [Future] that completes once the suite is complete.
   ///
   /// Note that even once this completes, the suite may still be running code

--- a/pkgs/test_core/lib/src/runner/live_suite_controller.dart
+++ b/pkgs/test_core/lib/src/runner/live_suite_controller.dart
@@ -22,9 +22,6 @@ class _LiveSuite extends LiveSuite {
   RunnerSuite get suite => _controller._suite;
 
   @override
-  bool get isComplete => _controller._isComplete;
-
-  @override
   Future get onComplete => _controller._onCompleteGroup.future;
 
   @override
@@ -62,8 +59,7 @@ class _LiveSuite extends LiveSuite {
 /// down, [close] should be called.
 class LiveSuiteController {
   /// The [LiveSuite] being controlled.
-  LiveSuite get liveSuite => _liveSuite;
-  late final LiveSuite _liveSuite;
+  late final liveSuite = _LiveSuite(this);
 
   /// The suite that's being run.
   final RunnerSuite _suite;
@@ -72,9 +68,6 @@ class LiveSuiteController {
   ///
   /// This contains all the futures from tests that are run in this suite.
   final _onCompleteGroup = FutureGroup();
-
-  /// Whether [_onCompleteGroup]'s future has fired.
-  var _isComplete = false;
 
   /// The completer that backs [LiveSuite.onClose].
   ///
@@ -103,13 +96,7 @@ class LiveSuiteController {
   /// Once this is called, the controller assumes responsibility for closing the
   /// suite. The caller should call [LiveSuiteController.close] rather than
   /// calling [RunnerSuite.close] directly.
-  LiveSuiteController(this._suite) {
-    _liveSuite = _LiveSuite(this);
-
-    _onCompleteGroup.future.then((_) {
-      _isComplete = true;
-    }, onError: (_) {});
-  }
+  LiveSuiteController(this._suite);
 
   /// Reports the status of [liveTest] through [liveSuite].
   ///

--- a/pkgs/test_core/lib/src/runner/load_suite.dart
+++ b/pkgs/test_core/lib/src/runner/load_suite.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:stack_trace/stack_trace.dart';
-import 'package:stream_channel/stream_channel.dart';
 import 'package:test_api/src/backend/group.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/invoker.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/metadata.dart'; // ignore: implementation_imports
@@ -203,10 +202,6 @@ class LoadSuite extends Suite implements RunnerSuite {
     filtered ??= Group.root([], metadata: metadata);
     return LoadSuite._filtered(this, filtered);
   }
-
-  @override
-  StreamChannel channel(String name) =>
-      throw UnsupportedError('LoadSuite.channel() is not supported.');
 
   @override
   Future close() async {}

--- a/pkgs/test_core/lib/src/runner/runner_suite.dart
+++ b/pkgs/test_core/lib/src/runner/runner_suite.dart
@@ -44,14 +44,6 @@ class RunnerSuite extends Suite {
   /// The event is `true` when debugging starts and `false` when it ends.
   Stream<bool> get onDebugging => _controller._onDebuggingController.stream;
 
-  /// Returns a channel that communicates with the remote suite.
-  ///
-  /// This connects to a channel created by code in the test worker calling the
-  /// `suiteChannel` argument from a `beforeLoad` callback to `serializeSuite`
-  /// with the same name.
-  /// It can be used used to send and receive any JSON-serializable object.
-  StreamChannel channel(String name) => _controller.channel(name);
-
   /// A shortcut constructor for creating a [RunnerSuite] that never goes into
   /// debugging mode and doesn't support suite channels.
   factory RunnerSuite(Environment environment, SuiteConfiguration config,

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.25
+version: 0.3.26-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
- Inline `loadFromString` into `load` and drop the extra `Configuration`
  constructor.
- `Engine.liveSuites` had no readers.
- Initialize `LiveSuiteController.liveSuite` with a `late final` to
  avoid an extra getter.
- `LiveSuiteController.isComplete` had no readers.
- `RunnerSuite.channel` had no callers.
- Various test utilities are likely remnants of the package split.