### PR TITLE
Fix[test_api]: printOnFailure check current invoker

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.17.6
+
+* Give a better error when `printOnFailure` is called from outside a test
+  zone.
+
 ## 1.17.5
 
 * Support the latest vm_service release (`7.0.0`).

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.17.5
+version: 1.17.6
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -33,8 +33,8 @@ dependencies:
   webkit_inspection_protocol: ^1.0.0
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.4.0
-  test_core: 0.3.25
+  test_api: 0.4.1
+  test_core: 0.3.26
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 0.4.1-dev
+## 0.4.1
+
+* Give a better error when `printOnFailure` is called from outside a test
+  zone.
 
 ## 0.4.0
 

--- a/pkgs/test_api/lib/src/scaffolding/utils.dart
+++ b/pkgs/test_api/lib/src/scaffolding/utils.dart
@@ -37,7 +37,8 @@ void printOnFailure(String message) {
   var invoker = Invoker.current;
   if (invoker == null) {
     throw Exception(
-        'There is no current invoker. Please make sure that you are making the call inside a test zone.');
+        'There is no current invoker. Please make sure that you are making the '
+        'call inside a test zone.');
   }
   return invoker.printOnFailure(message);
 }

--- a/pkgs/test_api/lib/src/scaffolding/utils.dart
+++ b/pkgs/test_api/lib/src/scaffolding/utils.dart
@@ -33,7 +33,14 @@ void registerException(Object error,
 /// without cluttering the output for successful tests. Note that unlike
 /// [print], each individual message passed to [printOnFailure] will be
 /// separated by a blank line.
-void printOnFailure(String message) => Invoker.current!.printOnFailure(message);
+void printOnFailure(String message) {
+  var invoker = Invoker.current;
+  if (invoker == null) {
+    throw Exception(
+        'There is no current invoker. Please make sure that you are making the call inside a test zone.');
+  }
+  return invoker.printOnFailure(message);
+}
 
 /// Marks the current test as skipped.
 ///

--- a/pkgs/test_api/lib/src/scaffolding/utils.dart
+++ b/pkgs/test_api/lib/src/scaffolding/utils.dart
@@ -36,7 +36,7 @@ void registerException(Object error,
 void printOnFailure(String message) {
   var invoker = Invoker.current;
   if (invoker == null) {
-    throw Exception(
+    throw StateError(
         'There is no current invoker. Please make sure that you are making the '
         'call inside a test zone.');
   }

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.4.1-dev
+version: 0.4.1
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 0.3.26-dev
+## 0.3.26
+
+* Give a better error when `printOnFailure` is called from outside a test
+  zone.
 
 ## 0.3.25
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.26-dev
+version: 0.3.26
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
@@ -31,7 +31,7 @@ dependencies:
   # matcher is tightly constrained by test_api
   matcher: any
   # Use an exact version until the test_api package is stable.
-  test_api: 0.4.0
+  test_api: 0.4.1
 
 dependency_overrides:
   test_api:


### PR DESCRIPTION
Closes #1340

This PR adds a check within `printOnFailure ` and throw an exception if there is no current invoker.

Please let me know if you want me to add some tests to check the behavior of the function.