### PR TITLE
update json reporter docs for null safety, add `time` field to `AllSuitesEvent`

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.17.8-dev
+
+* Update json reporter docs with updated nullability annotations and
+  descriptions.
+
 ## 1.17.7
 
 * Support the latest `test_core`.

--- a/pkgs/test/doc/json_reporter.md
+++ b/pkgs/test/doc/json_reporter.md
@@ -99,7 +99,9 @@ class StartEvent extends Event {
   String protocolVersion;
 
   // The version of the test runner being used.
-  String runnerVersion;
+  //
+  // This is null if for some reason the version couldn't be loaded.
+  String? runnerVersion;
 
   // The pid of the VM process running the tests.
   int pid;
@@ -151,11 +153,11 @@ class DebugEvent extends Event {
 
   /// The HTTP URL for the Dart Observatory, or `null` if the Observatory isn't
   /// available for this suite.
-  String observatory;
+  String? observatory;
 
   /// The HTTP URL for the remote debugger for this suite's host page, or `null`
   /// if no remote debugger is available for this suite.
-  String remoteDebugger;
+  String? remoteDebugger;
 }
 ```
 
@@ -316,7 +318,10 @@ class DoneEvent extends Event {
   String type = "done";
 
   // Whether all tests succeeded (or were skipped).
-  bool success;
+  //
+  // Will be `null` if the test runner was close before all tests completed
+  // running.
+  bool? success;
 }
 ```
 
@@ -343,30 +348,30 @@ class Test {
   List<int> groupIDs;
 
   // The (1-based) line on which the test was defined, or `null`.
-  int line;
+  int? line;
 
   // The (1-based) column on which the test was defined, or `null`.
-  int column;
+  int? column;
 
   // The URL for the file in which the test was defined, or `null`.
-  String url;
+  String? url;
 
   // The (1-based) line in the original test suite from which the test
   // originated.
   //
   // Will only be present if `root_url` is different from `url`.
-  int root_line;
+  int? root_line;
 
   // The (1-based) line on in the original test suite from which the test
   // originated.
   //
   // Will only be present if `root_url` is different from `url`.
-  int root_column;
+  int? root_column;
 
   // The URL for the original test suite in which the test was defined.
   //
   // Will only be present if different from `url`.
-  String root_url;
+  String? root_url;
 
   // This field is deprecated and should not be used.
   Metadata metadata;
@@ -394,10 +399,10 @@ class Suite {
   int id;
 
   // The platform on which the suite is running.
-  String? platform;
+  String platform;
 
-  // The path to the suite's file.
-  String path;
+  // The path to the suite's file, or `null` if that path is unknown.
+  String? path;
 }
 ```
 
@@ -418,7 +423,7 @@ class Group {
   int id;
 
   // The name of the group, including prefixes from any containing groups.
-  String? name;
+  String name;
 
   // The ID of the suite containing this group.
   int suiteID;
@@ -430,13 +435,13 @@ class Group {
   int testCount;
 
   // The (1-based) line on which the group was defined, or `null`.
-  int line;
+  int? line;
 
   // The (1-based) column on which the group was defined, or `null`.
-  int column;
+  int? column;
 
   // The URL for the file in which the group was defined, or `null`.
-  String url;
+  String? url;
 
   // This field is deprecated and should not be used.
   Metadata metadata;
@@ -460,6 +465,8 @@ and may be a `package:` URL.
 ```
 class Metadata {
   bool skip;
+
+  // The reason the tests was skipped, or `null` if it wasn't skipped.
   String? skipReason;
 }
 ```

--- a/pkgs/test/doc/json_reporter.md
+++ b/pkgs/test/doc/json_reporter.md
@@ -114,7 +114,7 @@ test runner has started running.
 ### AllSuitesEvent
 
 ```
-class AllSuitesEvent {
+class AllSuitesEvent extends Event {
   String type = "allSuites";
 
   /// The total number of suites that will be loaded.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.17.7
+version: 1.17.8-dev
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -34,7 +34,7 @@ dependencies:
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.4.1
-  test_core: 0.3.27
+  test_core: 0.3.28-dev
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.3.28-dev
+
 ## 0.3.27
 
 * Restore the `Configuration.loadFromString` constructor.

--- a/pkgs/test_core/lib/src/runner/reporter/json.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/json.dart
@@ -76,7 +76,10 @@ class JsonReporter implements Reporter {
     _subscriptions.add(_engine.success.asStream().listen(_onDone));
 
     _subscriptions.add(_engine.onSuiteAdded.listen(null, onDone: () {
-      _emit('allSuites', {'count': _engine.addedSuites.length});
+      _emit('allSuites', {
+        'count': _engine.addedSuites.length,
+        'time': _stopwatch.elapsed.inMilliseconds
+      });
     }));
 
     _emit('start',

--- a/pkgs/test_core/lib/src/runner/reporter/json.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/json.dart
@@ -126,7 +126,7 @@ class JsonReporter implements Reporter {
     // Don't emit groups for load suites. They're always empty and they provide
     // unnecessary clutter.
     var groupIDs = liveTest.suite is LoadSuite
-        ? []
+        ? <int>[]
         : _idsForGroups(liveTest.groups, liveTest.suite);
 
     var suiteConfig = _configFor(liveTest.suite);

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.27
+version: 0.3.28-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/test/issues/1537
Fixes https://github.com/dart-lang/test/issues/1536

Note that this does add an extra `time` field to the `allSuites` event. That shouldn't be breaking though.