### PR TITLE
Move testRandomizeOrderingSeed to global level

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.17.8-dev
+
+* Fix a bug where a tag level configuration would cause test suites with that
+  tag to ignore the `--test-randomize-ordering-seed` argument.
+
 ## 1.17.7
 
 * Support the latest `test_core`.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.17.7
+version: 1.17.8-dev
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -34,7 +34,7 @@ dependencies:
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.4.1
-  test_core: 0.3.27
+  test_core: 0.3.28
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test/test/runner/configuration/configuration_test.dart
+++ b/pkgs/test/test/runner/configuration/configuration_test.dart
@@ -27,6 +27,7 @@ void main() {
         expect(merged.pubServeUrl, isNull);
         expect(merged.shardIndex, isNull);
         expect(merged.totalShards, isNull);
+        expect(merged.testRandomizeOrderingSeed, isNull);
         expect(merged.paths, equals(['test']));
       });
 
@@ -44,6 +45,7 @@ void main() {
             pubServePort: 1234,
             shardIndex: 3,
             totalShards: 10,
+            testRandomizeOrderingSeed: 123,
             paths: ['bar']).merge(Configuration());
 
         expect(merged.help, isTrue);
@@ -58,6 +60,7 @@ void main() {
         expect(merged.pubServeUrl!.port, equals(1234));
         expect(merged.shardIndex, equals(3));
         expect(merged.totalShards, equals(10));
+        expect(merged.testRandomizeOrderingSeed, 123);
         expect(merged.paths, equals(['bar']));
       });
 
@@ -75,6 +78,7 @@ void main() {
             pubServePort: 1234,
             shardIndex: 3,
             totalShards: 10,
+            testRandomizeOrderingSeed: 123,
             paths: ['bar']));
 
         expect(merged.help, isTrue);
@@ -89,6 +93,7 @@ void main() {
         expect(merged.pubServeUrl!.port, equals(1234));
         expect(merged.shardIndex, equals(3));
         expect(merged.totalShards, equals(10));
+        expect(merged.testRandomizeOrderingSeed, 123);
         expect(merged.paths, equals(['bar']));
       });
 
@@ -108,6 +113,7 @@ void main() {
             pubServePort: 1234,
             shardIndex: 2,
             totalShards: 4,
+            testRandomizeOrderingSeed: 0,
             paths: ['bar']);
         var newer = Configuration(
             help: false,
@@ -122,6 +128,7 @@ void main() {
             pubServePort: 5678,
             shardIndex: 3,
             totalShards: 10,
+            testRandomizeOrderingSeed: 123,
             paths: ['blech']);
         var merged = older.merge(newer);
 
@@ -137,6 +144,7 @@ void main() {
         expect(merged.pubServeUrl!.port, equals(5678));
         expect(merged.shardIndex, equals(3));
         expect(merged.totalShards, equals(10));
+        expect(merged.testRandomizeOrderingSeed, 123);
         expect(merged.paths, equals(['blech']));
       });
     });

--- a/pkgs/test/test/runner/configuration/suite_test.dart
+++ b/pkgs/test/test/runner/configuration/suite_test.dart
@@ -20,7 +20,6 @@ void main() {
         expect(merged.runSkipped, isFalse);
         expect(merged.precompiledPath, isNull);
         expect(merged.runtimes, equals([Runtime.vm.identifier]));
-        expect(merged.testRandomizeOrderingSeed, null);
       });
 
       test("if only the old configuration's is defined, uses it", () {
@@ -42,13 +41,11 @@ void main() {
             jsTrace: true,
             runSkipped: true,
             precompiledPath: '/tmp/js',
-            testRandomizeOrderingSeed: 1234,
             runtimes: [RuntimeSelection(Runtime.chrome.identifier)]));
 
         expect(merged.jsTrace, isTrue);
         expect(merged.runSkipped, isTrue);
         expect(merged.precompiledPath, equals('/tmp/js'));
-        expect(merged.testRandomizeOrderingSeed, 1234);
         expect(merged.runtimes, equals([Runtime.chrome.identifier]));
       });
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.28-dev
+
+* Fix a bug where a tag level configuration would cause test suites with that
+  tag to ignore the `--test-randomize-ordering-seed` argument.
+
 ## 0.3.27
 
 * Restore the `Configuration.loadFromString` constructor.

--- a/pkgs/test_core/lib/src/runner.dart
+++ b/pkgs/test_core/lib/src/runner.dart
@@ -73,8 +73,10 @@ class Runner {
 
   /// Creates a new runner based on [configuration].
   factory Runner(Configuration config) => config.asCurrent(() {
-        var engine =
-            Engine(concurrency: config.concurrency, coverage: config.coverage);
+        var engine = Engine(
+            concurrency: config.concurrency,
+            coverage: config.coverage,
+            randomizeOrderingSeed: config.testRandomizeOrderingSeed);
 
         var sinks = <IOSink>[];
         Reporter createFileReporter(String reporterName, String filepath) {

--- a/pkgs/test_core/lib/src/runner/configuration.dart
+++ b/pkgs/test_core/lib/src/runner/configuration.dart
@@ -191,6 +191,12 @@ class Configuration {
   /// The default suite-level configuration.
   final SuiteConfiguration suiteDefaults;
 
+  /// The seed used to generate randomess for test case shuffling.
+  ///
+  /// If null or zero no shuffling will occur.
+  /// The same seed will shuffle the tests in the same way every time.
+  final int? testRandomizeOrderingSeed;
+
   /// Returns the current configuration, or a default configuration if no
   /// current configuration is set.
   ///
@@ -305,6 +311,7 @@ class Configuration {
         defineRuntimes: defineRuntimes,
         noRetry: noRetry,
         useDataIsolateStrategy: useDataIsolateStrategy,
+        testRandomizeOrderingSeed: testRandomizeOrderingSeed,
         suiteDefaults: SuiteConfiguration(
             jsTrace: jsTrace,
             runSkipped: runSkipped,
@@ -316,7 +323,6 @@ class Configuration {
             excludeTags: excludeTags,
             tags: tags,
             onPlatform: onPlatform,
-            testRandomizeOrderingSeed: testRandomizeOrderingSeed,
 
             // Test-level configuration
             timeout: timeout,
@@ -368,6 +374,7 @@ class Configuration {
       Map<String, CustomRuntime>? defineRuntimes,
       bool? noRetry,
       bool? useDataIsolateStrategy,
+      this.testRandomizeOrderingSeed,
       SuiteConfiguration? suiteDefaults})
       : _help = help,
         customHtmlTemplatePath = customHtmlTemplatePath,
@@ -529,6 +536,8 @@ class Configuration {
         noRetry: other._noRetry ?? _noRetry,
         useDataIsolateStrategy:
             other._useDataIsolateStrategy ?? _useDataIsolateStrategy,
+        testRandomizeOrderingSeed:
+            other.testRandomizeOrderingSeed ?? testRandomizeOrderingSeed,
         suiteDefaults: suiteDefaults.merge(other.suiteDefaults));
     result = result._resolvePresets();
 
@@ -625,7 +634,6 @@ class Configuration {
             excludeTags: excludeTags,
             tags: tags,
             onPlatform: onPlatform,
-            testRandomizeOrderingSeed: testRandomizeOrderingSeed,
             timeout: timeout,
             verboseTrace: verboseTrace,
             chainStackTraces: chainStackTraces,

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -69,6 +69,12 @@ class Engine {
   /// The coverage output directory.
   String? _coverage;
 
+  /// The seed used to generate randomess for test case shuffling.
+  ///
+  /// If null or zero no shuffling will occur.
+  /// The same seed will shuffle the tests in the same way every time.
+  int? _testRandomizeOrderingSeed;
+
   /// A pool that limits the number of test suites running concurrently.
   final Pool _runPool;
 
@@ -198,9 +204,10 @@ class Engine {
   ///
   /// [concurrency] controls how many suites are loaded and ran at once, and
   /// defaults to 1.
-  Engine({int? concurrency, String? coverage})
+  Engine({int? concurrency, String? coverage, int? randomizeOrderingSeed})
       : _runPool = Pool(concurrency ?? 1),
-        _coverage = coverage {
+        _coverage = coverage,
+        _testRandomizeOrderingSeed = randomizeOrderingSeed {
     _group.future.then((_) {
       _onTestStartedGroup.close();
       _onSuiteStartedController.close();
@@ -301,9 +308,9 @@ class Engine {
       if (!_closed && setUpAllSucceeded) {
         // shuffle the group entries
         var entries = group.entries.toList();
-        if (suiteConfig.testRandomizeOrderingSeed != null &&
-            suiteConfig.testRandomizeOrderingSeed! > 0) {
-          entries.shuffle(Random(suiteConfig.testRandomizeOrderingSeed));
+        if (_testRandomizeOrderingSeed != null &&
+            _testRandomizeOrderingSeed! > 0) {
+          entries.shuffle(Random(_testRandomizeOrderingSeed));
         }
 
         for (var entry in entries) {

--- a/pkgs/test_core/lib/src/runner/suite.dart
+++ b/pkgs/test_core/lib/src/runner/suite.dart
@@ -86,11 +86,6 @@ class SuiteConfiguration {
   /// configuration fields, but that isn't enforced.
   final Map<PlatformSelector, SuiteConfiguration> onPlatform;
 
-  /// The seed with which to shuffle the test order.
-  /// Default value is null if not provided and will not change the test order.
-  /// The same seed will shuffle the tests in the same way every time.
-  final int? testRandomizeOrderingSeed;
-
   /// The global test metadata derived from this configuration.
   Metadata get metadata {
     if (tags.isEmpty && onPlatform.isEmpty) return _metadata;
@@ -140,7 +135,6 @@ class SuiteConfiguration {
       BooleanSelector? excludeTags,
       Map<BooleanSelector, SuiteConfiguration>? tags,
       Map<PlatformSelector, SuiteConfiguration>? onPlatform,
-      int? testRandomizeOrderingSeed,
 
       // Test-level configuration
       Timeout? timeout,
@@ -162,7 +156,6 @@ class SuiteConfiguration {
         excludeTags: excludeTags,
         tags: tags,
         onPlatform: onPlatform,
-        testRandomizeOrderingSeed: testRandomizeOrderingSeed,
         metadata: Metadata(
             timeout: timeout,
             verboseTrace: verboseTrace,
@@ -190,7 +183,6 @@ class SuiteConfiguration {
       BooleanSelector? excludeTags,
       Map<BooleanSelector, SuiteConfiguration>? tags,
       Map<PlatformSelector, SuiteConfiguration>? onPlatform,
-      int? testRandomizeOrderingSeed,
       Metadata? metadata})
       : _jsTrace = jsTrace,
         _runSkipped = runSkipped,
@@ -201,7 +193,6 @@ class SuiteConfiguration {
         excludeTags = excludeTags ?? BooleanSelector.none,
         tags = _map(tags),
         onPlatform = _map(onPlatform),
-        testRandomizeOrderingSeed = testRandomizeOrderingSeed,
         _metadata = metadata ?? Metadata.empty;
 
   /// Creates a new [SuiteConfiguration] that takes its configuration from
@@ -250,8 +241,6 @@ class SuiteConfiguration {
         excludeTags: excludeTags.union(other.excludeTags),
         tags: _mergeConfigMaps(tags, other.tags),
         onPlatform: _mergeConfigMaps(onPlatform, other.onPlatform),
-        testRandomizeOrderingSeed:
-            other.testRandomizeOrderingSeed ?? testRandomizeOrderingSeed,
         metadata: metadata.merge(other.metadata));
     return config._resolveTags();
   }
@@ -271,7 +260,6 @@ class SuiteConfiguration {
       BooleanSelector? excludeTags,
       Map<BooleanSelector, SuiteConfiguration>? tags,
       Map<PlatformSelector, SuiteConfiguration>? onPlatform,
-      int? testRandomizeOrderingSeed,
 
       // Test-level configuration
       Timeout? timeout,
@@ -293,8 +281,6 @@ class SuiteConfiguration {
         excludeTags: excludeTags ?? this.excludeTags,
         tags: tags ?? this.tags,
         onPlatform: onPlatform ?? this.onPlatform,
-        testRandomizeOrderingSeed:
-            testRandomizeOrderingSeed ?? testRandomizeOrderingSeed,
         metadata: _metadata.change(
             timeout: timeout,
             verboseTrace: verboseTrace,

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.3.27
+version: 0.3.28-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
Resolves an issue discovered in #1539

This configuration was attached to the `SuiteConfig` likely because that
was the easiest way to communicate it through to the `Engine` where
required. This introduced a bug where a more specific `SuiteConfig` for
a tag configured in `dart_test.yaml` would always override the apparent
configuration for those suites with the default, which is unshuffled.
There was no indication when this happeened.

Remove `testRandomizedOrderingSeed` form the `SuiteCConfiguration` class
entirely instead of trying to track down where the inconsistency slips
in.