### PR TITLE
Make testRandomizeOrderingSeed public on Engine

### DIFF
--- a/pkgs/test_core/lib/src/runner.dart
+++ b/pkgs/test_core/lib/src/runner.dart
@@ -76,7 +76,7 @@ class Runner {
         var engine = Engine(
             concurrency: config.concurrency,
             coverage: config.coverage,
-            randomizeOrderingSeed: config.testRandomizeOrderingSeed);
+            testRandomizeOrderingSeed: config.testRandomizeOrderingSeed);
 
         var sinks = <IOSink>[];
         Reporter createFileReporter(String reporterName, String filepath) {

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -204,10 +204,10 @@ class Engine {
   ///
   /// [concurrency] controls how many suites are loaded and ran at once, and
   /// defaults to 1.
-  Engine({int? concurrency, String? coverage, int? randomizeOrderingSeed})
+  Engine({int? concurrency, String? coverage, int? testRandomizeOrderingSeed})
       : _runPool = Pool(concurrency ?? 1),
         _coverage = coverage,
-        testRandomizeOrderingSeed = randomizeOrderingSeed {
+        testRandomizeOrderingSeed = testRandomizeOrderingSeed {
     _group.future.then((_) {
       _onTestStartedGroup.close();
       _onSuiteStartedController.close();

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -73,7 +73,7 @@ class Engine {
   ///
   /// If null or zero no shuffling will occur.
   /// The same seed will shuffle the tests in the same way every time.
-  int? _testRandomizeOrderingSeed;
+  int? testRandomizeOrderingSeed;
 
   /// A pool that limits the number of test suites running concurrently.
   final Pool _runPool;
@@ -207,7 +207,7 @@ class Engine {
   Engine({int? concurrency, String? coverage, int? randomizeOrderingSeed})
       : _runPool = Pool(concurrency ?? 1),
         _coverage = coverage,
-        _testRandomizeOrderingSeed = randomizeOrderingSeed {
+        testRandomizeOrderingSeed = randomizeOrderingSeed {
     _group.future.then((_) {
       _onTestStartedGroup.close();
       _onSuiteStartedController.close();
@@ -308,9 +308,9 @@ class Engine {
       if (!_closed && setUpAllSucceeded) {
         // shuffle the group entries
         var entries = group.entries.toList();
-        if (_testRandomizeOrderingSeed != null &&
-            _testRandomizeOrderingSeed! > 0) {
-          entries.shuffle(Random(_testRandomizeOrderingSeed));
+        if (testRandomizeOrderingSeed != null &&
+            testRandomizeOrderingSeed! > 0) {
+          entries.shuffle(Random(testRandomizeOrderingSeed));
         }
 
         for (var entry in entries) {

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -204,10 +204,9 @@ class Engine {
   ///
   /// [concurrency] controls how many suites are loaded and ran at once, and
   /// defaults to 1.
-  Engine({int? concurrency, String? coverage, int? testRandomizeOrderingSeed})
+  Engine({int? concurrency, String? coverage, this.testRandomizeOrderingSeed})
       : _runPool = Pool(concurrency ?? 1),
-        _coverage = coverage,
-        testRandomizeOrderingSeed = testRandomizeOrderingSeed {
+        _coverage = coverage {
     _group.future.then((_) {
       _onTestStartedGroup.close();
       _onSuiteStartedController.close();


### PR DESCRIPTION
One internal reporter needs this information.