### PR TITLE
dont log the --test-randomization-ordering-seed if using the json reporter

### DIFF
--- a/pkgs/test/test/runner/configuration/randomize_order_test.dart
+++ b/pkgs/test/test/runner/configuration/randomize_order_test.dart
@@ -80,10 +80,9 @@ void main() {
         ['test.dart', '--test-randomize-ordering-seed=random', '-r', 'json']);
     expect(
         test.stdout,
-        emitsInAnyOrder([
-          isNot((contains(
-              'Shuffling test order with --test-randomize-ordering-seed'))),
-        ]));
+        isNot(emitsInAnyOrder([
+          contains('Shuffling test order with --test-randomize-ordering-seed'),
+        ])));
     await test.shouldExit(0);
   });
 

--- a/pkgs/test/test/runner/configuration/randomize_order_test.dart
+++ b/pkgs/test/test/runner/configuration/randomize_order_test.dart
@@ -74,6 +74,17 @@ void main() {
               'Shuffling test order with --test-randomize-ordering-seed=0'))
         ]));
     await test.shouldExit(0);
+
+    // Doesn't log about shuffling with the json reporter
+    test = await runTest(
+        ['test.dart', '--test-randomize-ordering-seed=random', '-r', 'json']);
+    expect(
+        test.stdout,
+        emitsInAnyOrder([
+          isNot((contains(
+              'Shuffling test order with --test-randomize-ordering-seed'))),
+        ]));
+    await test.shouldExit(0);
   });
 
   test('shuffles each suite with the same seed', () async {

--- a/pkgs/test/test/runner/configuration/randomize_order_test.dart
+++ b/pkgs/test/test/runner/configuration/randomize_order_test.dart
@@ -78,11 +78,7 @@ void main() {
     // Doesn't log about shuffling with the json reporter
     test = await runTest(
         ['test.dart', '--test-randomize-ordering-seed=random', '-r', 'json']);
-    expect(
-        test.stdout,
-        isNot(emitsInAnyOrder([
-          contains('Shuffling test order with --test-randomize-ordering-seed'),
-        ])));
+    expect(test.stdout, neverEmits(contains('Shuffling test order')));
     await test.shouldExit(0);
   });
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Remove support for `FORCE_TEST_EXIT`.
 * Report incomplete tests as errors in the JSON reporter when the run is
   canceled early.
+* Don't log the --test-randomization-ordering-seed if using the json reporter.
 
 ## 0.3.29
 

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -223,12 +223,18 @@ class _Parser {
       }
     }
 
+    var reporter = _ifParsed('reporter') as String?;
+
     var testRandomizeOrderingSeed =
         _parseOption('test-randomize-ordering-seed', (value) {
       var seed = value == 'random'
           ? Random().nextInt(4294967295)
           : int.parse(value).toUnsigned(32);
-      print('Shuffling test order with --test-randomize-ordering-seed=$seed');
+
+      // TODO(#1547): Less hacky way of not breaking the json reporter
+      if (reporter != 'json') {
+        print('Shuffling test order with --test-randomize-ordering-seed=$seed');
+      }
 
       return seed;
     });
@@ -251,7 +257,7 @@ class _Parser {
         dart2jsPath: _ifParsed('dart2js-path'),
         dart2jsArgs: _ifParsed('dart2js-args'),
         precompiledPath: _ifParsed('precompiled'),
-        reporter: _ifParsed('reporter'),
+        reporter: reporter,
         fileReporters: _parseFileReporterOption(),
         coverage: _ifParsed('coverage'),
         pubServePort: _parseOption('pub-serve', int.parse),


### PR DESCRIPTION
Fixes https://github.com/dart-lang/test/issues/1545

This is hacky but we don't have a good solution right now, added a TODO and filed an issue though.