### PR TITLE
add a special exit code, 79, used when no tests were found

### DIFF
--- a/pkgs/test/test/runner/compact_reporter_test.dart
+++ b/pkgs/test/test/runner/compact_reporter_test.dart
@@ -18,7 +18,7 @@ void main() {
 
     var test = await runTest(['test.dart'], reporter: 'compact');
     expect(test.stdout, emitsThrough(contains('No tests ran.')));
-    await test.shouldExit(1);
+    await test.shouldExit(79);
   });
 
   test('runs several successful tests and reports when each completes', () {

--- a/pkgs/test/test/runner/configuration/custom_platform_test.dart
+++ b/pkgs/test/test/runner/configuration/custom_platform_test.dart
@@ -437,7 +437,7 @@ void main() {
 
           test = await runTest(['-p', 'chrome', 'test.dart']);
           expect(test.stdout, emitsThrough(contains('No tests ran.')));
-          await test.shouldExit(1);
+          await test.shouldExit(79);
         }, tags: 'chrome');
 
         test('that counts as its parent', () async {

--- a/pkgs/test/test/runner/configuration/tags_test.dart
+++ b/pkgs/test/test/runner/configuration/tags_test.dart
@@ -33,11 +33,11 @@ void main() {
 
     var test = await runTest(['--exclude-tag', 'foo', 'test.dart']);
     expect(test.stdout, emitsThrough(contains('No tests ran.')));
-    await test.shouldExit(1);
+    await test.shouldExit(79);
 
     test = await runTest(['--exclude-tag', 'bar', 'test.dart']);
     expect(test.stdout, emitsThrough(contains('No tests ran.')));
-    await test.shouldExit(1);
+    await test.shouldExit(79);
 
     test = await runTest(['test.dart']);
     expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));

--- a/pkgs/test/test/runner/configuration/top_level_test.dart
+++ b/pkgs/test/test/runner/configuration/top_level_test.dart
@@ -282,7 +282,7 @@ void main() {
               "Warning: this package doesn't support running tests on the Dart "
               'VM.'));
       expect(test.stdout, emitsThrough(contains('No tests ran.')));
-      await test.shouldExit(1);
+      await test.shouldExit(79);
     });
 
     test('warns about the OS when some OSes are supported', () async {
@@ -302,7 +302,7 @@ void main() {
           emits("Warning: this package doesn't support running tests on "
               '${currentOS.name}.'));
       expect(test.stdout, emitsThrough(contains('No tests ran.')));
-      await test.shouldExit(1);
+      await test.shouldExit(79);
     });
 
     test('warns about browsers in general when no browsers are supported',
@@ -323,7 +323,7 @@ void main() {
           emits(
               "Warning: this package doesn't support running tests on browsers."));
       expect(test.stdout, emitsThrough(contains('No tests ran.')));
-      await test.shouldExit(1);
+      await test.shouldExit(79);
     });
 
     test(
@@ -347,7 +347,7 @@ void main() {
           emits("Warning: this package doesn't support running tests on Chrome "
               'or Firefox.'));
       expect(test.stdout, emitsThrough(contains('No tests ran.')));
-      await test.shouldExit(1);
+      await test.shouldExit(79);
     });
   });
 

--- a/pkgs/test/test/runner/expanded_reporter_test.dart
+++ b/pkgs/test/test/runner/expanded_reporter_test.dart
@@ -18,7 +18,7 @@ void main() {
 
     var test = await runTest(['test.dart']);
     expect(test.stdout, emitsThrough(contains('No tests ran.')));
-    await test.shouldExit(1);
+    await test.shouldExit(79);
   });
 
   test('runs several successful tests and reports when each completes', () {

--- a/pkgs/test/test/runner/name_test.dart
+++ b/pkgs/test/test/runner/name_test.dart
@@ -76,7 +76,7 @@ void main() {
           test.stderr,
           emitsThrough(
               contains('No tests match regular expression "no match".')));
-      await test.shouldExit(exit_codes.data);
+      await test.shouldExit(exit_codes.noTestsRan);
     });
 
     test("doesn't filter out load exceptions", () async {
@@ -152,7 +152,7 @@ void main() {
 
       var test = await runTest(['--plain-name', 'no match', 'test.dart']);
       expect(test.stderr, emitsThrough(contains('No tests match "no match".')));
-      await test.shouldExit(exit_codes.data);
+      await test.shouldExit(exit_codes.noTestsRan);
     });
   });
 

--- a/pkgs/test/test/runner/shard_test.dart
+++ b/pkgs/test/test/runner/shard_test.dart
@@ -143,7 +143,7 @@ void main() {
     var test =
         await runTest(['test.dart', '--shard-index=1', '--total-shards=3']);
     expect(test.stdout, emitsThrough('No tests ran.'));
-    await test.shouldExit(1);
+    await test.shouldExit(79);
   });
 
   group('reports an error if', () {

--- a/pkgs/test/test/runner/tag_test.dart
+++ b/pkgs/test/test/runner/tag_test.dart
@@ -72,7 +72,7 @@ void main() {
     test('prints no warnings when all tags are specified', () async {
       var test = await runTest(['--tags=a,b,c', 'test.dart']);
       expect(test.stdout, emitsThrough(contains('No tests ran.')));
-      await test.shouldExit(1);
+      await test.shouldExit(79);
     });
   });
 
@@ -110,7 +110,7 @@ void main() {
 
       var test = await runTest(['--exclude-tags=a', 'test.dart']);
       expect(test.stdout, emits('No tests ran.'));
-      await test.shouldExit(1);
+      await test.shouldExit(79);
     });
 
     test('allows unused tags', () async {
@@ -182,7 +182,7 @@ void main() {
 
     var test = await runTest(['-x', 'a', 'test.dart']);
     expect(test.stdout, emitsThrough(contains('No tests ran')));
-    await test.shouldExit(1);
+    await test.shouldExit(79);
   });
 
   group('warning formatting', () {

--- a/pkgs/test/test/runner/test_on_test.dart
+++ b/pkgs/test/test/runner/test_on_test.dart
@@ -45,7 +45,7 @@ void main() {
 
       var test = await runTest(['--platform', 'chrome', 'vm_test.dart']);
       expect(test.stdout, emitsThrough(contains('No tests ran.')));
-      await test.shouldExit(1);
+      await test.shouldExit(79);
     }, tags: 'chrome');
 
     test('runs a test suite on a matching operating system', () async {
@@ -63,7 +63,7 @@ void main() {
 
       var test = await runTest(['os_test.dart']);
       expect(test.stdout, emitsThrough(contains('No tests ran.')));
-      await test.shouldExit(1);
+      await test.shouldExit(79);
     });
 
     test('only loads matching files when loading as a group', () async {
@@ -95,7 +95,7 @@ void main() {
 
       var test = await runTest(['browser_test.dart']);
       expect(test.stdout, emitsThrough(contains('No tests ran.')));
-      await test.shouldExit(1);
+      await test.shouldExit(79);
     });
 
     test('runs a browser group on a browser', () async {
@@ -111,7 +111,7 @@ void main() {
 
       var test = await runTest(['--platform', 'chrome', 'vm_test.dart']);
       expect(test.stdout, emitsThrough(contains('No tests ran.')));
-      await test.shouldExit(1);
+      await test.shouldExit(79);
     }, tags: 'chrome');
   });
 
@@ -129,7 +129,7 @@ void main() {
 
       var test = await runTest(['browser_test.dart']);
       expect(test.stdout, emitsThrough(contains('No tests ran.')));
-      await test.shouldExit(1);
+      await test.shouldExit(79);
     });
 
     test('runs a browser test on a browser', () async {
@@ -145,7 +145,7 @@ void main() {
 
       var test = await runTest(['--platform', 'chrome', 'vm_test.dart']);
       expect(test.stdout, emitsThrough(contains('No tests ran.')));
-      await test.shouldExit(1);
+      await test.shouldExit(79);
     }, tags: 'chrome');
   });
 
@@ -165,7 +165,7 @@ void main() {
 
       var test = await runTest(['vm_test.dart']);
       expect(test.stdout, emitsThrough(contains('No tests ran.')));
-      await test.shouldExit(1);
+      await test.shouldExit(79);
     });
 
     test("doesn't runs the test if the group doesn't match", () async {
@@ -174,7 +174,7 @@ void main() {
 
       var test = await runTest(['vm_test.dart']);
       expect(test.stdout, emitsThrough(contains('No tests ran.')));
-      await test.shouldExit(1);
+      await test.shouldExit(79);
     });
 
     test("doesn't runs the test if the test doesn't match", () async {
@@ -183,7 +183,7 @@ void main() {
 
       var test = await runTest(['vm_test.dart']);
       expect(test.stdout, emitsThrough(contains('No tests ran.')));
-      await test.shouldExit(1);
+      await test.shouldExit(79);
     });
   });
 }

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -5,6 +5,8 @@
   canceled early.
 * Don't log the --test-randomization-ordering-seed if using the json reporter.
 * Add a new exit code, 79, which is used when no tests were ran.
+  * Previously you would have gotten either exit code 1 or 65 (65 if you had
+    provided a test name regex).
 * When no tests were ran but tags were provided, list the tag configuration.
 
 ## 0.3.29

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Report incomplete tests as errors in the JSON reporter when the run is
   canceled early.
 * Don't log the --test-randomization-ordering-seed if using the json reporter.
+* Add a new exit code, 79, which is used when no tests were ran.
+* When no tests were ran but tags were provided, list the tag configuration.
 
 ## 0.3.29
 

--- a/pkgs/test_core/lib/src/executable.dart
+++ b/pkgs/test_core/lib/src/executable.dart
@@ -10,6 +10,7 @@ import 'package:path/path.dart' as p;
 import 'package:source_span/source_span.dart';
 import 'package:stack_trace/stack_trace.dart';
 import 'package:test_api/src/backend/util/pretty_print.dart'; // ignore: implementation_imports
+import 'package:test_core/src/runner/no_tests_found_exception.dart';
 
 import 'runner/application_exception.dart';
 import 'runner/configuration.dart';
@@ -155,6 +156,9 @@ Future<void> _execute(List<String> args) async {
   } on FormatException catch (error) {
     stderr.writeln(error.message);
     exitCode = exit_codes.data;
+  } on NoTestsFoundException catch (error) {
+    stderr.writeln(error.message);
+    exitCode = exit_codes.noTestsRan;
   } catch (error, stackTrace) {
     stderr.writeln(getErrorMessage(error));
     stderr.writeln(Trace.from(stackTrace).terse);

--- a/pkgs/test_core/lib/src/runner.dart
+++ b/pkgs/test_core/lib/src/runner.dart
@@ -18,7 +18,6 @@ import 'package:test_api/src/backend/test.dart'; // ignore: implementation_impor
 import 'package:test_api/src/backend/util/pretty_print.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/reporter/multiplex.dart';
 
-import 'runner/application_exception.dart';
 import 'runner/no_tests_found_exception.dart';
 import 'runner/configuration.dart';
 import 'runner/configuration/reporters.dart';
@@ -143,10 +142,10 @@ class Runner {
                 (pattern) => pattern is RegExp
                     ? 'regular expression "${pattern.pattern}"'
                     : '"$pattern"'));
-            throw ApplicationException('No tests match $patterns.');
+            throw NoTestsFoundException('No tests match $patterns.');
           } else if (_config.suiteDefaults.includeTags != BooleanSelector.all ||
               _config.suiteDefaults.excludeTags != BooleanSelector.none) {
-            throw ApplicationException(
+            throw NoTestsFoundException(
                 'No tests match the requested tag selectors:\n'
                 '  include: "${_config.suiteDefaults.includeTags}"\n'
                 '  exclude: "${_config.suiteDefaults.excludeTags}"');

--- a/pkgs/test_core/lib/src/runner.dart
+++ b/pkgs/test_core/lib/src/runner.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:async/async.dart';
+import 'package:boolean_selector/boolean_selector.dart';
 // ignore: deprecated_member_use
 import 'package:test_api/backend.dart'
     show PlatformSelector, Runtime, SuitePlatform;
@@ -18,6 +19,7 @@ import 'package:test_api/src/backend/util/pretty_print.dart'; // ignore: impleme
 import 'package:test_core/src/runner/reporter/multiplex.dart';
 
 import 'runner/application_exception.dart';
+import 'runner/no_tests_found_exception.dart';
 import 'runner/configuration.dart';
 import 'runner/configuration/reporters.dart';
 import 'runner/debugger.dart';
@@ -135,14 +137,22 @@ class Runner {
 
         if (_engine.passed.isEmpty &&
             _engine.failed.isEmpty &&
-            _engine.skipped.isEmpty &&
-            _config.suiteDefaults.patterns.isNotEmpty) {
-          var patterns = toSentence(_config.suiteDefaults.patterns.map(
-              (pattern) => pattern is RegExp
-                  ? 'regular expression "${pattern.pattern}"'
-                  : '"$pattern"'));
-
-          throw ApplicationException('No tests match $patterns.');
+            _engine.skipped.isEmpty) {
+          if (_config.suiteDefaults.patterns.isNotEmpty) {
+            var patterns = toSentence(_config.suiteDefaults.patterns.map(
+                (pattern) => pattern is RegExp
+                    ? 'regular expression "${pattern.pattern}"'
+                    : '"$pattern"'));
+            throw ApplicationException('No tests match $patterns.');
+          } else if (_config.suiteDefaults.includeTags != BooleanSelector.all ||
+              _config.suiteDefaults.excludeTags != BooleanSelector.none) {
+            throw ApplicationException(
+                'No tests match the requested tag selectors:\n'
+                '  include: "${_config.suiteDefaults.includeTags}"\n'
+                '  exclude: "${_config.suiteDefaults.excludeTags}"');
+          } else {
+            throw NoTestsFoundException('No tests were found.');
+          }
         }
 
         return (success ?? false) &&

--- a/pkgs/test_core/lib/src/runner/no_tests_found_exception.dart
+++ b/pkgs/test_core/lib/src/runner/no_tests_found_exception.dart
@@ -1,0 +1,13 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// An expected exception thrown when there were no tests found to run.
+class NoTestsFoundException implements Exception {
+  final String message;
+
+  NoTestsFoundException(this.message);
+
+  @override
+  String toString() => message;
+}

--- a/pkgs/test_core/lib/src/util/exit_codes.dart
+++ b/pkgs/test_core/lib/src/util/exit_codes.dart
@@ -54,3 +54,6 @@ const noPerm = 77;
 
 /// Something was unconfigured or mis-configured.
 const config = 78;
+
+/// No tests were ran.
+const noTestsRan = 79;


### PR DESCRIPTION
Fixes https://github.com/dart-lang/test/issues/1546

I will update the tests and things if we decide this is a fine route to go. I simply used the next exit code in the sequence of special exit codes we have.

I also added some special logging for tags, similar to what existed for the name patterns. It will list the tag configuration, if one was provided.

~~Both of these end up with a different exit code, 65, which indicates some sort of data error in the input (this was used previously when you provided a name regex and there were no matches). I am not sure if we want to also re-use that exit code for the case where there simply weren't any tests.~~ All of these cases now use exit code 79.

We also may want to specialize for additional configuration like platforms? Not sure how deep that rabbit hole goes.