### PR TITLE
Update 'analyzer' constraints to include '2.0.0'.

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Report incomplete tests as errors in the JSON reporter when the run is
   canceled early.
+* Update `analyzer` constraint to `>=1.0.0 <3.0.0`.
 
 ## 1.17.9
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  analyzer: ^1.0.0
+  analyzer: '>=1.0.0 <3.0.0'
   async: ^2.5.0
   boolean_selector: ^2.1.0
   collection: ^1.15.0
@@ -33,7 +33,7 @@ dependencies:
   webkit_inspection_protocol: ^1.0.0
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.4.1
+  test_api: 0.4.2-dev
   test_core: 0.4.0
 
 dev_dependencies:

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2-dev
+
+* Update `analyzer` constraint to `>=1.5.0 <3.0.0`.
+
 ## 0.4.1
 
 * Give a better error when `printOnFailure` is called from outside a test

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.4.1
+version: 0.4.2-dev
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 
@@ -22,7 +22,7 @@ dependencies:
   matcher: '>=0.12.10 <0.12.11'
 
 dev_dependencies:
-  analyzer: ^1.5.0
+  analyzer: '>=1.5.0 <3.0.0'
   fake_async: ^1.2.0
   glob: ^2.0.0
   graphs: ^2.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -11,6 +11,7 @@
   * Previously you would have gotten either exit code 1 or 65 (65 if you had
     provided a test name regex).
 * When no tests were ran but tags were provided, list the tag configuration.
+* Update `analyzer` constraint to `>=1.0.0 <3.0.0`.
 
 ## 0.3.29
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  analyzer: ^1.0.0
+  analyzer: '>=1.0.0 <3.0.0'
   async: ^2.5.0
   args: ^2.0.0
   boolean_selector: ^2.1.0
@@ -31,7 +31,7 @@ dependencies:
   # matcher is tightly constrained by test_api
   matcher: any
   # Use an exact version until the test_api package is stable.
-  test_api: 0.4.1
+  test_api: 0.4.2-dev
 
 dependency_overrides:
   test_api:


### PR DESCRIPTION
This also removes `-dev` from `test_core` and `test`, and increments `test_api` to `0.4.2` with anticipation that we will publish. If there is a reason not to publish, I can revert these version changes.