### PR TITLE
Fix/broken docs link

### DIFF
--- a/pkgs/test/doc/configuration.md
+++ b/pkgs/test/doc/configuration.md
@@ -172,7 +172,7 @@ platforms that match the selector. It's often used with
 [specific tags](#configuring-tags) to ensure that certain features will only be
 tested on supported platforms.
 
-[platform selectors]: https://github.com/dart-lang/test/blob/master/README.md#platform-selectors
+[platform selectors]: https://github.com/dart-lang/test/tree/master/pkgs/test#platform-selectors
 
 ```yaml
 tags:

--- a/pkgs/test_api/lib/src/scaffolding/test_structure.dart
+++ b/pkgs/test_api/lib/src/scaffolding/test_structure.dart
@@ -42,7 +42,7 @@ Declarer get _declarer => Zone.current[#test.declarer] as Declarer;
 /// If [retry] is passed, the test will be retried the provided number of times
 /// before being marked as a failure.
 ///
-/// [configuring tags]: https://github.com/dart-lang/test/blob/master/doc/package_config.md#configuring-tags
+/// [configuring tags]: https://github.com/dart-lang/test/blob/master/pkgs/test/doc/configuration.md#configuring-tags
 ///
 /// [onPlatform] allows tests to be configured on a platform-by-platform
 /// basis. It's a map from strings that are parsed as [PlatformSelector]s to
@@ -120,7 +120,7 @@ void test(description, dynamic Function() body,
 /// [package configuration file][configuring tags]. The parameter can be an
 /// [Iterable] of tag names, or a [String] representing a single tag.
 ///
-/// [configuring tags]: https://github.com/dart-lang/test/blob/master/doc/package_config.md#configuring-tags
+/// [configuring tags]: https://github.com/dart-lang/test/blob/master/pkgs/test/doc/configuration.md#configuring-tags
 ///
 /// [onPlatform] allows groups to be configured on a platform-by-platform
 /// basis. It's a map from strings that are parsed as [PlatformSelector]s to

--- a/pkgs/test_core/lib/scaffolding.dart
+++ b/pkgs/test_core/lib/scaffolding.dart
@@ -102,7 +102,7 @@ Declarer get _declarer {
 /// If [retry] is passed, the test will be retried the provided number of times
 /// before being marked as a failure.
 ///
-/// [configuring tags]: https://github.com/dart-lang/test/blob/master/doc/package_config.md#configuring-tags
+/// [configuring tags]: https://github.com/dart-lang/test/blob/master/pkgs/test/doc/configuration.md#configuring-tags
 ///
 /// [onPlatform] allows tests to be configured on a platform-by-platform
 /// basis. It's a map from strings that are parsed as [PlatformSelector]s to
@@ -180,7 +180,7 @@ void test(description, dynamic Function() body,
 /// [package configuration file][configuring tags]. The parameter can be an
 /// [Iterable] of tag names, or a [String] representing a single tag.
 ///
-/// [configuring tags]: https://github.com/dart-lang/test/blob/master/doc/package_config.md#configuring-tags
+/// [configuring tags]: https://github.com/dart-lang/test/blob/master/pkgs/test/doc/configuration.md#configuring-tags
 ///
 /// [onPlatform] allows groups to be configured on a platform-by-platform
 /// basis. It's a map from strings that are parsed as [PlatformSelector]s to


### PR DESCRIPTION
This PR fixes docs broken links for 
- configuration tags [from](https://github.com/dart-lang/test/blob/master/doc/package_config.md#configuring-tags) [to](https://github.com/dart-lang/test/blob/master/pkgs/test/doc/configuration.md#tags)
- platform selector [from](https://github.com/dart-lang/test/blob/master/README.md#platform-selectors) [to](https://github.com/dart-lang/test/tree/master/pkgs/test#platform-selectors)

closes #1555
