### PR TITLE
Document testRandomizeOrderingSeed on Engine ctor

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.17.11-dev
+
 ## 1.17.10
 
 * Report incomplete tests as errors in the JSON reporter when the run is

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.17.10
+version: 1.17.11-dev
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -34,7 +34,7 @@ dependencies:
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.4.2
-  test_core: 0.4.0
+  test_core: 0.4.1
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.4.1-dev
+
 ## 0.4.0
 
 * **BREAKING**: All parameters to the `SuiteConfiguration` and `Configuration`

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -198,8 +198,6 @@ class Engine {
   /// `false` to `true`.
   Stream get onIdle => _group.onIdle;
 
-  // TODO(nweiz): Use interface libraries to take a Configuration even when
-  // dart:io is unavailable.
   /// Creates an [Engine] that will run all tests provided via [suiteSink].
   ///
   /// [concurrency] controls how many suites are loaded and ran at once, and

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -204,6 +204,13 @@ class Engine {
   ///
   /// [concurrency] controls how many suites are loaded and ran at once, and
   /// defaults to 1.
+  ///
+  /// [testRandomizeOrderingSeed] configures test case shuffling within each
+  /// test suite.
+  /// Any non-zero value will enable shuffling using this value as a seed.
+  /// Omitting this argument or passing `0` disables shuffling.
+  ///
+  /// [coverage] specifies a directory to output coverage information.
   Engine({int? concurrency, String? coverage, this.testRandomizeOrderingSeed})
       : _runPool = Pool(concurrency ?? 1),
         _coverage = coverage {

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.0
+version: 0.4.1-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
Add a description of the named arguments `testRandomizeOrderingSeed` and
`coverage` to the doc comment for the `Engine` constructor.