### PR TITLE
Update matcher dependency and prepare to publish

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 1.17.11-dev
+## 1.17.11
+
+* Use the latest `package:matcher`.
+  * Change many argument types from `dynamic` to `Object?`.
+  * Fix `stringContainsInOrder` to account for repetitions and empty strings.
+    * **Note**: This may break some existing tests, as the behavior does change.
 
 ## 1.17.10
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.17.11-dev
+version: 1.17.11
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -33,7 +33,7 @@ dependencies:
   webkit_inspection_protocol: ^1.0.0
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.4.2
+  test_api: 0.4.3
   test_core: 0.4.1
 
 dev_dependencies:

--- a/pkgs/test/test/runner/json_reporter_utils.dart
+++ b/pkgs/test/test/runner/json_reporter_utils.dart
@@ -22,13 +22,12 @@ Future<void> expectJsonReport(
     Map<Object, Object> done) async {
   // Ensure the output is of the same length, including start, done and all
   // suites messages.
-  expect(
-      outputLines.length, equals(expected.fold(3, (int a, m) => a + m.length)),
+  expect(outputLines.length,
+      equals(expected.fold<int>(3, (int a, m) => a + m.length)),
       reason: 'Expected $outputLines to match $expected.');
 
-  dynamic decodeLine(String l) => jsonDecode(l)
-    ..remove('time')
-    ..remove('stackTrace');
+  dynamic decodeLine(String l) =>
+      jsonDecode(l)..remove('time')..remove('stackTrace');
 
   // Should contain all suites message.
   expect(outputLines.map(decodeLine), containsAll([allSuitesJson()]));

--- a/pkgs/test/test/runner/json_reporter_utils.dart
+++ b/pkgs/test/test/runner/json_reporter_utils.dart
@@ -26,8 +26,9 @@ Future<void> expectJsonReport(
       equals(expected.fold<int>(3, (int a, m) => a + m.length)),
       reason: 'Expected $outputLines to match $expected.');
 
-  dynamic decodeLine(String l) =>
-      jsonDecode(l)..remove('time')..remove('stackTrace');
+  dynamic decodeLine(String l) => jsonDecode(l)
+    ..remove('time')
+    ..remove('stackTrace');
 
   // Should contain all suites message.
   expect(outputLines.map(decodeLine), containsAll([allSuitesJson()]));

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3
+
+* Use the latest `package:matcher`.
+
 ## 0.4.2
 
 * Update `analyzer` constraint to `>=1.5.0 <3.0.0`.

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.4.2
+version: 0.4.3
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 
@@ -19,7 +19,7 @@ dependencies:
 
   # Use a tight version constraint to ensure that a constraint on matcher
   # properly constrains all features it provides.
-  matcher: '>=0.12.10 <0.12.11'
+  matcher: '>=0.12.11 <0.12.12'
 
 dev_dependencies:
   analyzer: '>=1.5.0 <3.0.0'

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 0.4.1-dev
+## 0.4.1
+
+* Use the latest `package:matcher`.
 
 ## 0.4.0
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.1-dev
+version: 0.4.1
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
@@ -31,7 +31,7 @@ dependencies:
   # matcher is tightly constrained by test_api
   matcher: any
   # Use an exact version until the test_api package is stable.
-  test_api: 0.4.2
+  test_api: 0.4.3
 
 dependency_overrides:
   test_api:


### PR DESCRIPTION
Copy the changelog from `matcher` into `test` since this is where most
users will see it.