### PR TITLE
reuse incremental dill files when possible

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.17.12
+
+* Support the latest `test_core`.
+* Re-use the cached dill file from previous runs on subsequent runs.
+
 ## 1.17.11
 
 * Use the latest `package:matcher`.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.17.11
+version: 1.17.12
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -34,7 +34,7 @@ dependencies:
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.4.3
-  test_core: 0.4.1
+  test_core: 0.4.2
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -247,10 +247,15 @@ $_usage''');
 
       expect(
           test.stdout,
-          containsInOrder([
-            '-1: loading test.dart [E]',
-            "Error: Getter not found: 'main'",
-          ]));
+          emitsThrough(
+            contains('-1: loading test.dart [E]'),
+          ));
+      expect(
+          test.stdout,
+          emitsThrough(anyOf([
+            contains("Error: Getter not found: 'main'"),
+            contains("Error: Undefined name 'main'"),
+          ])));
 
       await test.shouldExit(1);
     });

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2
+
+* Re-use the cached dill file from previous runs on subsequent runs.
+
 ## 0.4.1
 
 * Use the latest `package:matcher`.

--- a/pkgs/test_core/lib/src/runner/vm/test_compiler.dart
+++ b/pkgs/test_core/lib/src/runner/vm/test_compiler.dart
@@ -105,7 +105,6 @@ class _TestCompilerForLanguageVersion {
   Future<CompilationResponse> _compile(Uri mainUri) async {
     _compileNumber++;
     if (_closeMemo.hasRun) return CompilationResponse._wasShutdown;
-    var firstCompile = false;
     CompileResult? compilerOutput;
     final tempFile = File(p.join(_outputDillDirectory.path, 'test.dart'))
       ..writeAsStringSync(_generateEntrypoint(mainUri));
@@ -117,7 +116,6 @@ class _TestCompilerForLanguageVersion {
           await testCache.copy(_outputDill.path);
         }
         compilerOutput = await _createCompiler(tempFile.uri);
-        firstCompile = true;
       } else {
         compilerOutput =
             await _frontendServerClient!.compile(<Uri>[tempFile.uri]);

--- a/pkgs/test_core/lib/src/runner/vm/test_compiler.dart
+++ b/pkgs/test_core/lib/src/runner/vm/test_compiler.dart
@@ -106,9 +106,13 @@ class _TestCompilerForLanguageVersion {
     CompileResult? compilerOutput;
     final tempFile = File(p.join(_outputDillDirectory.path, 'test.dart'))
       ..writeAsStringSync(_generateEntrypoint(mainUri));
+    final testCache = File(_dillCachePath);
 
     try {
       if (_frontendServerClient == null) {
+        if (await testCache.exists()) {
+          await testCache.copy(_outputDill.path);
+        }
         compilerOutput = await _createCompiler(tempFile.uri);
         firstCompile = true;
       } else {
@@ -134,7 +138,6 @@ class _TestCompilerForLanguageVersion {
     final outputFile = File(outputPath);
     final kernelReadyToRun =
         await outputFile.copy('${tempFile.path}_$_compileNumber.dill');
-    final testCache = File(_dillCachePath);
     // Keep the cache file up-to-date and use the size of the kernel file
     // as an approximation for how many packages are included. Larger files
     // are prefered, since re-using more packages will reduce the number of

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.1
+version: 0.4.2
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
We were already caching this but weren't actually using it on subsequent runs 🤦‍♂️ . I also optimized it a bit to only copy the dill file once inside `dispose` instead of updating it repeatedly whenever we see a larger file.

This takes our `test_api` test runs from ~9 seconds to ~4 seconds.

Related to https://github.com/dart-lang/test/issues/1567.