### PR TITLE
Remove duplicate private constructor

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.4.3-dev
+
 ## 0.4.2
 
 * Re-use the cached dill file from previous runs on subsequent runs.

--- a/pkgs/test_core/lib/src/runner/runner_test.dart
+++ b/pkgs/test_core/lib/src/runner/runner_test.dart
@@ -32,8 +32,6 @@ class RunnerTest extends Test {
 
   RunnerTest(this.name, this.metadata, this.trace, this._channel);
 
-  RunnerTest._(this.name, this.metadata, this.trace, this._channel);
-
   @override
   LiveTest load(Suite suite, {Iterable<Group>? groups}) {
     late final LiveTestController controller;
@@ -103,6 +101,6 @@ class RunnerTest extends Test {
   @override
   Test? forPlatform(SuitePlatform platform) {
     if (!metadata.testOn.evaluate(platform)) return null;
-    return RunnerTest._(name, metadata.forPlatform(platform), trace, _channel);
+    return RunnerTest(name, metadata.forPlatform(platform), trace, _channel);
   }
 }

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.2
+version: 0.4.3-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
These constructors became identical in #650 so we can drop the private
copy altogether.