### PR TITLE
Replace references to IFrameListener

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.17.13-dev
+
 ## 1.17.12
 
 * Support the latest `test_core`.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.17.12
+version: 1.17.13-dev
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test

--- a/pkgs/test/tool/host.dart
+++ b/pkgs/test/tool/host.dart
@@ -84,7 +84,7 @@ final _currentUrl = Uri.parse(window.location.href);
 ///      ┃                         │                          ┃
 ///      ┃         ┌──────────MultiChannel┬─────────┐         ┃
 ///      ┃         │          │     │     │         │         ┃
-///      ┃   IframeListener  test  test  test  running test   ┃
+///      ┃   RemoteListener  test  test  test  running test   ┃
 ///      ┃                                                    ┃
 ///      ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 ///
@@ -93,9 +93,9 @@ final _currentUrl = Uri.parse(window.location.href);
 /// receive messages like "load a suite at this URL", and the rest are
 /// connected to each test suite's iframe via a [MessageChannel].
 ///
-/// Each iframe then has its own [MultiChannel] which takes its
-/// [MessageChannel] connection and splits it again. One connection is used for
-/// the [IframeListener], which sends messages like "here are all the tests in
+/// Each iframe runs a `RemoteListener` which creates its own [MultiChannel] on
+/// top of the [MessageChannel] connection. One connection is used for
+/// the `RemoteListener`, which sends messages like "here are all the tests in
 /// this suite". The rest are used for each test, receiving messages like
 /// "start running". A new connection is also created whenever a test begins
 /// running to send status messages about its progress.

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.4.3-dev
+
 ## 0.4.2
 
 * Re-use the cached dill file from previous runs on subsequent runs.

--- a/pkgs/test_core/lib/scaffolding.dart
+++ b/pkgs/test_core/lib/scaffolding.dart
@@ -38,8 +38,8 @@ Declarer? _globalDeclarer;
 /// Gets the declarer for the current scope.
 ///
 /// When using the runner, this returns the [Zone]-scoped declarer that's set by
-/// [IsolateListener] or [IframeListener]. If the test file is run directly,
-/// this returns [_globalDeclarer] (and sets it up on the first call).
+/// [RemoteListener]. If the test file is run directly, this returns
+/// [_globalDeclarer] (and sets it up on the first call).
 Declarer get _declarer {
   var declarer = Declarer.current;
   if (declarer != null) return declarer;

--- a/pkgs/test_core/lib/src/runner/runner_test.dart
+++ b/pkgs/test_core/lib/src/runner/runner_test.dart
@@ -27,7 +27,7 @@ class RunnerTest extends Test {
   @override
   final Trace? trace;
 
-  /// The channel used to communicate with the test's [IframeListener].
+  /// The channel used to communicate with the test's `RemoteListener`.
   final MultiChannel _channel;
 
   RunnerTest(this.name, this.metadata, this.trace, this._channel);

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.2
+version: 0.4.3-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
The class was removed in dc2fbc50c04ca7f593290a2a4a43f227dba4847a and
replaced with `RemoteListener`.