### PR TITLE
Remove dependency on shelf_test_handler

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.17.13-dev
+
 ## 1.17.12
 
 * Support the latest `test_core`.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.17.12
+version: 1.17.13-dev
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -39,7 +39,6 @@ dependencies:
 dev_dependencies:
   fake_async: ^1.0.0
   glob: ^2.0.0
-  shelf_test_handler: ^2.0.0
   test_descriptor: ^2.0.0
   test_process: ^2.0.0
 

--- a/pkgs/test/test/runner/browser/code_server.dart
+++ b/pkgs/test/test/runner/browser/code_server.dart
@@ -3,25 +3,26 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:collection';
 
+import 'package:test_api/hooks.dart';
 import 'package:http_multi_server/http_multi_server.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf_io.dart' as shelf_io;
-import 'package:shelf_test_handler/shelf_test_handler.dart';
 import 'package:shelf_web_socket/shelf_web_socket.dart';
+import 'package:test/test.dart' show printOnFailure, TestFailure;
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 /// A class that serves Dart and/or JS code and receives WebSocket connections.
 class CodeServer {
-  /// The handler for [_server].
-  final ShelfTestHandler _handler;
+  final _Handler _handler;
 
   /// The URL of the server (including the port).
   final Uri url;
 
   static Future<CodeServer> start() async {
     var server = await HttpMultiServer.loopback(0);
-    var handler = ShelfTestHandler();
+    var handler = _Handler(Zone.current.handleUncaughtError);
     shelf_io.serveRequests(server, (request) {
       if (request.method == 'GET' && request.url.path == 'favicon.ico') {
         return shelf.Response.notFound(null);
@@ -87,4 +88,80 @@ main() async {
     _handler.expect('GET', '/', webSocketHandler(completer.complete));
     return completer.future;
   }
+}
+
+/// A [shelf.Handler] that handles requests as specified by [expect].
+class _Handler {
+  /// A callback called whenever an unexpected exception is thrown.
+  ///
+  /// This is used over throwing errors directly since the request handler might
+  /// not be running in the same error zone as the test.
+  void Function(Object, StackTrace) _onError;
+
+  /// The queue of expected requests to this handler.
+  final _expectations = Queue<_Expectation>();
+
+  /// Creates a new handler that handles requests using handlers provided by
+  /// [expect].
+  _Handler(this._onError);
+
+  /// Expects that a single HTTP request with the given [method] and [path] will
+  /// be made to [this].
+  ///
+  /// The [path] should be root-relative; that is, it shuld start with "/".
+  ///
+  /// When a matching request is made, [handler] is used to handle that request.
+  ///
+  /// If this is called multiple times, the requests are expected to occur in
+  /// the same order.
+  void expect(String method, String path, shelf.Handler handler) {
+    _expectations.add(_Expectation(method, path, handler));
+  }
+
+  /// The implementation of [shelf.Handler].
+  FutureOr<shelf.Response> call(shelf.Request request) async {
+    const description = 'ShelfTesthandler';
+    var requestInfo = '${request.method} /${request.url}';
+    printOnFailure('[$description] $requestInfo');
+
+    try {
+      if (_expectations.isEmpty) {
+        throw TestFailure(
+            '$description received unexpected request $requestInfo.');
+      }
+
+      var expectation = _expectations.removeFirst();
+      if ((expectation.method != null &&
+              expectation.method != request.method) ||
+          (expectation.path != '/${request.url.path}' &&
+              expectation.path != null)) {
+        var message = '$description received unexpected request $requestInfo.';
+        if (expectation.method != null) {
+          message += '\nExpected ${expectation.method} ${expectation.path}.';
+        }
+        throw TestFailure(message);
+      }
+
+      return await expectation.handler(request);
+    } on shelf.HijackException catch (_) {
+      rethrow;
+    } catch (error, stackTrace) {
+      _onError(error, stackTrace);
+      return shelf.Response.internalServerError(body: '$error');
+    }
+  }
+}
+
+/// A single expectation for an HTTP request sent to a [_Handler].
+class _Expectation {
+  /// The expected request method, or [null] if this allows any requests.
+  final String? method;
+
+  /// The expected request path, or [null] if this allows any requests.
+  final String? path;
+
+  /// The handler to use for requests that match this expectation.
+  final shelf.Handler handler;
+
+  _Expectation(this.method, this.path, this.handler);
 }

--- a/pkgs/test/test/runner/browser/code_server.dart
+++ b/pkgs/test/test/runner/browser/code_server.dart
@@ -96,7 +96,7 @@ class _Handler {
   ///
   /// This is used over throwing errors directly since the request handler might
   /// not be running in the same error zone as the test.
-  void Function(Object, StackTrace) _onError;
+  final void Function(Object, StackTrace) _onError;
 
   /// The queue of expected requests to this handler.
   final _expectations = Queue<_Expectation>();


### PR DESCRIPTION
Closes #1277

Inline the parts of the package that are used in the single testing
library that uses them. Remove unused functionality and where possible
make things private.