### PR TITLE
Use a set literal for knownTags

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.4.3-dev
+
 ## 0.4.2
 
 * Re-use the cached dill file from previous runs on subsequent runs.

--- a/pkgs/test_core/lib/src/runner/suite.dart
+++ b/pkgs/test_core/lib/src/runner/suite.dart
@@ -114,31 +114,15 @@ class SuiteConfiguration {
   final Metadata _metadata;
 
   /// The set of tags that have been declared in any way in this configuration.
-  Set<String> get knownTags {
-    if (_knownTags != null) return _knownTags!;
-
-    var known = includeTags.variables.toSet()
-      ..addAll(excludeTags.variables)
-      ..addAll(_metadata.tags);
-
-    for (var selector in tags.keys) {
-      known.addAll(selector.variables);
-    }
-
-    for (var configuration in _children) {
-      known.addAll(configuration.knownTags);
-    }
-
-    return _knownTags = UnmodifiableSetView(known);
-  }
-
+  Set<String> get knownTags => _knownTags ??= UnmodifiableSetView({
+        ...includeTags.variables,
+        ...excludeTags.variables,
+        ..._metadata.tags,
+        for (var selector in tags.keys) ...selector.variables,
+        for (var configuration in tags.values) ...configuration.knownTags,
+        for (var configuration in onPlatform.values) ...configuration.knownTags,
+      });
   Set<String>? _knownTags;
-
-  /// All child configurations that may be selected under various circumstances.
-  Iterable<SuiteConfiguration> get _children sync* {
-    yield* tags.values;
-    yield* onPlatform.values;
-  }
 
   factory SuiteConfiguration(
       {required bool? allowTestRandomization,

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.2
+version: 0.4.3-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
Using a set literal with spreads over `.addAll` calls allows the entire
set to collapse to a single expression which lets us use `??=`.

Drop the `_children` getter since it's only used on one place and the
name is not more clear than the implementation.