### PR TITLE
Use hasLength matcher

### DIFF
--- a/pkgs/test/test/runner/json_reporter_utils.dart
+++ b/pkgs/test/test/runner/json_reporter_utils.dart
@@ -22,9 +22,8 @@ Future<void> expectJsonReport(
     Map<Object, Object> done) async {
   // Ensure the output is of the same length, including start, done and all
   // suites messages.
-  expect(outputLines.length,
-      equals(expected.fold<int>(3, (int a, m) => a + m.length)),
-      reason: 'Expected $outputLines to match $expected.');
+  expect(outputLines,
+      hasLength(expected.fold<int>(3, (int a, m) => a + m.length)));
 
   dynamic decodeLine(String l) => jsonDecode(l)
     ..remove('time')


### PR DESCRIPTION
Use a semantically meaningful matcher so the error output is more useful
than seeing two unequal ints. Drop the reason message since the "actual"
output now includes everything we would have wanted from the message.