### PR TITLE
prep to release

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.18.0-dev
+## 1.18.0
 
 * Add configuration to disallow duplicate test and group names. See the
   [docs][allow_duplicate_test_names] for more information.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.18.0-dev
+version: 1.18.0
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -32,8 +32,8 @@ dependencies:
   webkit_inspection_protocol: ^1.0.0
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.5.0
-  test_core: 0.5.0
+  test_api: 0.4.4
+  test_core: 0.4.3
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.4-dev
+## 0.4.4
 
 * Allow disabling duplicate test or group names in the `Declarer`.
 

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.4.4-dev
+version: 0.4.4
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.3-dev
+## 0.4.3
 
 * Add an option to disallow duplicate test or group names in `directRunTests`.
 * Add configuration to disallow duplicate test and group names by default. See

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.3-dev
+version: 0.4.3
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
Releases the dropping of the package:pedantic dependency as well as the allow_duplicate_test_names configuration.