### PR TITLE
Prepare to publish again

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 1.18.2-dev
+## 1.18.2
+
+* Publish with the `host.dart.js` file.
 
 ## 1.18.1
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.18.2-dev
+version: 1.18.2
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -33,7 +33,7 @@ dependencies:
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.4.5
-  test_core: 0.4.5-dev
+  test_core: 0.4.5
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 0.4.5-dev
+## 0.4.5
+
+* Use newer analyzer APIs.
 
 ## 0.4.4
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.5-dev
+version: 0.4.5
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
Fixes #1594

We need to publish with an older SDK to work around changes to how pub
finds ignored files.