### PR TITLE
Better exception for markTestSkipped outside test

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.18.3-dev
+
+* Give a better exception when using `markTestSkipped` outside of a test.
+
 ## 1.18.2
 
 * Publish with the `host.dart.js` file.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.18.2
+version: 1.18.3-dev
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -32,8 +32,8 @@ dependencies:
   webkit_inspection_protocol: ^1.0.0
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.4.5
-  test_core: 0.4.5
+  test_api: 0.4.6
+  test_core: 0.4.6
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.6-dev
+
+* Give a better exception when using `markTestSkipped` outside of a test.
+
 ## 0.4.5
 
 * Add defaulting for older test backends that don't pass a configuration for

--- a/pkgs/test_api/lib/src/scaffolding/utils.dart
+++ b/pkgs/test_api/lib/src/scaffolding/utils.dart
@@ -34,13 +34,7 @@ void registerException(Object error,
 /// [print], each individual message passed to [printOnFailure] will be
 /// separated by a blank line.
 void printOnFailure(String message) {
-  var invoker = Invoker.current;
-  if (invoker == null) {
-    throw StateError(
-        'There is no current invoker. Please make sure that you are making the '
-        'call inside a test zone.');
-  }
-  return invoker.printOnFailure(message);
+  _currentInvoker.printOnFailure(message);
 }
 
 /// Marks the current test as skipped.
@@ -48,4 +42,10 @@ void printOnFailure(String message) {
 /// A skipped test may still fail if any exception is thrown, including uncaught
 /// asynchronous errors. If the entire test should be skipped `return` from the
 /// test body after marking it as skipped.
-void markTestSkipped(String message) => Invoker.current!.skip(message);
+void markTestSkipped(String message) => _currentInvoker..skip(message);
+
+Invoker get _currentInvoker =>
+    Invoker.current ??
+    (throw StateError(
+        'There is no current invoker. Please make sure that you are making the '
+        'call inside a test zone.'));

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.4.5
+version: 0.4.6-dev
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.6-dev
+
+* Support the latest `test_api`.
+
 ## 0.4.5
 
 * Use newer analyzer APIs.

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.5
+version: 0.4.6-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
@@ -30,7 +30,7 @@ dependencies:
   # matcher is tightly constrained by test_api
   matcher: any
   # Use an exact version until the test_api package is stable.
-  test_api: 0.4.5
+  test_api: 0.4.6
 
 dev_dependencies:
   lints: ^1.0.0


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/91432

Pull out a `_currentInvoker` utility to share the exception fallback
behavior between `printOnFailure` and `markTestSkipped`.