### PR TITLE
Remove a stale comment

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.19.1-dev
+
 ## 1.19.0
 
 * Support query parameters `name`, `full-name`, `line`, and `col` on test paths,

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.19.0
+version: 1.19.1-dev
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -33,7 +33,7 @@ dependencies:
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.4.6
-  test_core: 0.4.6
+  test_core: 0.4.7
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.4.7-dev
+
 ## 0.4.6
 
 * Support query parameters `name`, `full-name`, `line`, and `col` on test paths,

--- a/pkgs/test_core/lib/src/runner/debugger.dart
+++ b/pkgs/test_core/lib/src/runner/debugger.dart
@@ -29,8 +29,6 @@ CancelableOperation debug(
   _Debugger? debugger;
   var canceled = false;
   return CancelableOperation.fromFuture(() async {
-    // Make the underlying suite null so that the engine doesn't start running
-    // it immediately.
     engine.suiteSink.add(loadSuite.changeSuite((runnerSuite) {
       engine.pause();
       return runnerSuite;

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.6
+version: 0.4.7-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
The comment was intended to clarify the side effect returning null.
The null return was refactored to a call to `engine.pause()` which has a
name that conveys the meaning of the comment.