### PR TITLE
move log about enabling stack trace chaining to the reporters

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.19.3
+
+* Remove duplicate logging of suggestion to enable the `chain-stack-traces`
+  flag, a single log will now appear at the end.
+
 ## 1.19.2
 
 * Republish with missing JS file for browser tests.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.19.2
+version: 1.19.3
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -32,7 +32,7 @@ dependencies:
   webkit_inspection_protocol: ^1.0.0
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.4.6
+  test_api: 0.4.7
   test_core: 0.4.8
 
 dev_dependencies:

--- a/pkgs/test/test/runner/compact_reporter_test.dart
+++ b/pkgs/test/test/runner/compact_reporter_test.dart
@@ -413,10 +413,24 @@ void main() {
           +2: All tests passed!''', args: ['--run-skipped']);
     });
   });
+
+  test('Directs users to enable stack trace chaining if disabled', () async {
+    await _expectReport(
+        '''test('failure 1', () => throw TestFailure('oh no'));''', '''
+        +0: loading test.dart
+        +0: failure 1
+        +0 -1: failure 1 [E]
+          oh no
+          test.dart 6:25  main.<fn>
+        +0 -1: Some tests failed.
+        Consider enabling the flag chain-stack-traces to receive more detailed exceptions.
+        For example, 'dart test --chain-stack-traces'.''',
+        chainStackTraces: false);
+  });
 }
 
 Future<void> _expectReport(String tests, String expected,
-    {List<String> args = const []}) async {
+    {List<String> args = const [], bool chainStackTraces = true}) async {
   await d.file('test.dart', '''
     import 'dart:async';
 
@@ -427,8 +441,11 @@ $tests
     }
   ''').create();
 
-  var test = await runTest(['test.dart', '--chain-stack-traces', ...args],
-      reporter: 'compact');
+  var test = await runTest([
+    'test.dart',
+    if (chainStackTraces) '--chain-stack-traces',
+    ...args,
+  ], reporter: 'compact');
   await test.shouldExit();
 
   var stdoutLines = await test.stdout.rest.toList();

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.7
+
+* Remove logging about enabling the chain-stack-traces flag from the invoker.
+
 ## 0.4.6
 
 * Give a better exception when using `markTestSkipped` outside of a test.

--- a/pkgs/test_api/lib/src/backend/invoker.dart
+++ b/pkgs/test_api/lib/src/backend/invoker.dart
@@ -348,13 +348,6 @@ class Invoker {
     _controller.addError(error, stackTrace!);
     zone.run(() => _outstandingCallbacks.complete());
 
-    if (!liveTest.test.metadata.chainStackTraces &&
-        !liveTest.suite.isLoadSuite) {
-      _printsOnFailure.add('Consider enabling the flag chain-stack-traces to '
-          'receive more detailed exceptions.\n'
-          "For example, 'dart test --chain-stack-traces'.");
-    }
-
     if (_printsOnFailure.isNotEmpty) {
       print(_printsOnFailure.join('\n\n'));
       _printsOnFailure.clear();

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.4.6
+version: 0.4.7
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 

--- a/pkgs/test_api/test/backend/invoker_test.dart
+++ b/pkgs/test_api/test/backend/invoker_test.dart
@@ -524,25 +524,6 @@ void main() {
     });
   });
 
-  group('chainStackTraces', () {
-    test(
-        'if disabled, directs users to run with the flag enabled when '
-        'failures occur', () {
-      expect(() async {
-        var liveTest = _localTest(() {
-          expect(true, isFalse);
-        }, metadata: Metadata(chainStackTraces: false))
-            .load(suite);
-        liveTest.onError.listen(expectAsync1((_) {}, count: 1));
-
-        await liveTest.run();
-      },
-          prints('Consider enabling the flag chain-stack-traces to '
-              'receive more detailed exceptions.\n'
-              "For example, 'dart test --chain-stack-traces'.\n"));
-    });
-  });
-
   group('printOnFailure:', () {
     test("doesn't print anything if the test succeeds", () {
       expect(() async {

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 0.4.8-dev
+## 0.4.8
+
+* Add logging about enabling stack trace chaining to the compact and expanded
+  reporters (moved from the invoker). This will now only be logged once after
+  all tests have ran.
 
 ## 0.4.7
 

--- a/pkgs/test_core/lib/src/runner/reporter/compact.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/compact.dart
@@ -220,6 +220,8 @@ class CompactReporter implements Reporter {
   void _onStateChange(LiveTest liveTest, State state) {
     if (state.status != Status.complete) return;
 
+    // Errors are printed in [onError]; no need to print them here as well.
+    if (state.result == Result.failure) return;
     if (state.result == Result.error) return;
 
     // Always display the name of the oldest active test, unless testing

--- a/pkgs/test_core/lib/src/runner/reporter/expanded.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/expanded.dart
@@ -81,6 +81,10 @@ class ExpandedReporter implements Reporter {
   /// Whether the reporter is paused.
   var _paused = false;
 
+  // Whether a notice should be logged about enabling stack trace chaining at
+  // the end of all tests running.
+  var _shouldPrintStackTraceChainingNotice = false;
+
   /// The set of all subscriptions to various streams.
   final _subscriptions = <StreamSubscription>{};
 
@@ -197,6 +201,11 @@ class ExpandedReporter implements Reporter {
 
   /// A callback called when [liveTest] throws [error].
   void _onError(LiveTest liveTest, error, StackTrace stackTrace) {
+    if (!liveTest.test.metadata.chainStackTraces &&
+        !liveTest.suite.isLoadSuite) {
+      _shouldPrintStackTraceChainingNotice = true;
+    }
+
     if (liveTest.state.status != Status.complete) return;
 
     _progressLine(_description(liveTest), suffix: ' $_bold$_red[E]$_noColor');
@@ -240,6 +249,14 @@ class ExpandedReporter implements Reporter {
       _progressLine('All tests skipped.');
     } else {
       _progressLine('All tests passed!');
+    }
+
+    if (_shouldPrintStackTraceChainingNotice) {
+      _sink
+        ..writeln('')
+        ..writeln('Consider enabling the flag chain-stack-traces to '
+            'receive more detailed exceptions.\n'
+            "For example, 'dart test --chain-stack-traces'.");
     }
   }
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.8-dev
+version: 0.4.8
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
@@ -30,7 +30,7 @@ dependencies:
   # matcher is tightly constrained by test_api
   matcher: any
   # Use an exact version until the test_api package is stable.
-  test_api: 0.4.6
+  test_api: 0.4.7
 
 dev_dependencies:
   lints: ^1.0.0


### PR DESCRIPTION
Fixes https://github.com/dart-lang/test/issues/1505

Alternatively we could remove this log entirely, but this is one fairly easy solution. 