### PR TITLE
Wait for isolate exits from VM platform

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.19.4-dev
+
+* Wait for paused VM platform isolates before shutdown.
+
 ## 1.19.3
 
 * Remove duplicate logging of suggestion to enable the `chain-stack-traces`

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.19.3
+version: 1.19.4-dev
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -33,7 +33,7 @@ dependencies:
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.4.7
-  test_core: 0.4.8
+  test_core: 0.4.9
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.9-dev
+
+* Wait for paused VM platform isolates before shutdown.
+
 ## 0.4.8
 
 * Add logging about enabling stack trace chaining to the compact and expanded

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -71,6 +71,7 @@ class VMPlatform extends PlatformPlugin {
     var channel = IsolateChannel.connectReceive(receivePort)
         .transformStream(StreamTransformer.fromHandlers(handleDone: (sink) {
       receivePort.close();
+      onExitPort.close();
       isolate!.kill();
       eventSub?.cancel();
       client?.dispose();

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -55,8 +55,10 @@ class VMPlatform extends PlatformPlugin {
       isolate = await _spawnIsolate(
           path, receivePort.sendPort, suiteConfig.metadata,
           onExit: onExitPort.sendPort);
-      if (isolate == null) return null;
-
+      if (isolate == null) {
+        onExitPort.close();
+        return null;
+      }
       _isolateExits.add(Result.capture(onExitPort.first));
     } catch (error) {
       receivePort.close();

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -52,12 +52,12 @@ class VMPlatform extends PlatformPlugin {
     Isolate? isolate;
     try {
       var onExitPort = ReceivePort();
-      _isolateExits.add(Result.capture(onExitPort.first));
       isolate = await _spawnIsolate(
           path, receivePort.sendPort, suiteConfig.metadata,
           onExit: onExitPort.sendPort);
       if (isolate == null) return null;
-      isolate.addOnExitListener(onExitPort.sendPort);
+
+      _isolateExits.add(Result.capture(onExitPort.first));
     } catch (error) {
       receivePort.close();
       rethrow;

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.8
+version: 0.4.9-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
Internally the test runner is run with
`--mark-main-isolate-as-system-isolate`, so when the main isolate exits
any paused-at-exit non-system isolates are also closed. This makes it
impossible to keep a debugger attached to, for instance, example the
state of the heap following the tests.

Wait for all started isolates to exit when closing the VM platform so
that the outer "system" isolate doesn't forcibly close them before they
are done.