### PR TITLE
Extend timeout for launching browsers

### DIFF
--- a/pkgs/test/lib/src/runner/browser/browser.dart
+++ b/pkgs/test/lib/src/runner/browser/browser.dart
@@ -70,10 +70,8 @@ abstract class Browser {
 
       void drainOutput(Stream<List<int>> stream) {
         try {
-          _ioSubscriptions.add(stream.listen((bytes) {
-            print('From Browser: ' + utf8.decode(bytes));
-            output.addAll(bytes);
-          }, cancelOnError: true));
+          _ioSubscriptions
+              .add(stream.listen(output.addAll, cancelOnError: true));
         } on StateError catch (_) {}
       }
 

--- a/pkgs/test/lib/src/runner/browser/browser.dart
+++ b/pkgs/test/lib/src/runner/browser/browser.dart
@@ -70,8 +70,10 @@ abstract class Browser {
 
       void drainOutput(Stream<List<int>> stream) {
         try {
-          _ioSubscriptions
-              .add(stream.listen(output.addAll, cancelOnError: true));
+          _ioSubscriptions.add(stream.listen((bytes) {
+            print('From Browser: ' + utf8.decode(bytes));
+            output.addAll(bytes);
+          }, cancelOnError: true));
         } on StateError catch (_) {}
       }
 

--- a/pkgs/test/lib/src/runner/browser/browser.dart
+++ b/pkgs/test/lib/src/runner/browser/browser.dart
@@ -52,6 +52,8 @@ abstract class Browser {
   /// Standard IO streams for the underlying browser process.
   final _ioSubscriptions = <StreamSubscription<List<int>>>[];
 
+  final output = Uint8Buffer();
+
   /// Creates a new browser.
   ///
   /// This is intended to be called by subclasses. They pass in [startBrowser],
@@ -66,7 +68,6 @@ abstract class Browser {
       var process = await startBrowser();
       _processCompleter.complete(process);
 
-      var output = Uint8Buffer();
       void drainOutput(Stream<List<int>> stream) {
         try {
           _ioSubscriptions

--- a/pkgs/test/lib/src/runner/browser/browser_manager.dart
+++ b/pkgs/test/lib/src/runner/browser/browser_manager.dart
@@ -127,7 +127,7 @@ class BrowserManager {
       completer.completeError(error, stackTrace);
     });
 
-    return completer.future.timeout(Duration(seconds: 30), onTimeout: () {
+    return completer.future.timeout(Duration(seconds: 45), onTimeout: () {
       browser.close();
       throw ApplicationException(
           'Timed out waiting for ${runtime.name} to connect.\n'

--- a/pkgs/test/lib/src/runner/browser/browser_manager.dart
+++ b/pkgs/test/lib/src/runner/browser/browser_manager.dart
@@ -131,7 +131,7 @@ class BrowserManager {
       browser.close();
       throw ApplicationException(
           'Timed out waiting for ${runtime.name} to connect.\n'
-          'Browser output: ${browser.output}');
+          'Browser output: ${utf8.decode(browser.output)}');
     });
   }
 

--- a/pkgs/test/lib/src/runner/browser/browser_manager.dart
+++ b/pkgs/test/lib/src/runner/browser/browser_manager.dart
@@ -130,7 +130,8 @@ class BrowserManager {
     return completer.future.timeout(Duration(seconds: 30), onTimeout: () {
       browser.close();
       throw ApplicationException(
-          'Timed out waiting for ${runtime.name} to connect.');
+          'Timed out waiting for ${runtime.name} to connect.\n'
+          'Browser output: ${browser.output}');
     });
   }
 

--- a/pkgs/test/lib/src/runner/browser/chrome.dart
+++ b/pkgs/test/lib/src/runner/browser/chrome.dart
@@ -49,7 +49,7 @@ class Chrome extends Browser {
         var args = [
           '--user-data-dir=$dir',
           url.toString(),
-          '--enable-logging=stderr',
+          if (Platform.isLinux) '--enable-logging=stderr',
           '--v=1',
           '--disable-extensions',
           '--disable-popup-blocking',

--- a/pkgs/test/lib/src/runner/browser/chrome.dart
+++ b/pkgs/test/lib/src/runner/browser/chrome.dart
@@ -49,6 +49,8 @@ class Chrome extends Browser {
         var args = [
           '--user-data-dir=$dir',
           url.toString(),
+          '--enable-logging=stderr',
+          '--v=1',
           '--disable-extensions',
           '--disable-popup-blocking',
           '--bwsi',


### PR DESCRIPTION
Towards #1616

If the process had started but the web page never loaded and connected
the websocket back to the runner we hit a timeout.

- Extend the timeout to see if it reduces the incidence of this failure.
- Add verbose logging flags when launching chrome on linux.
- Store the output from the browser and include it in the timeout message.