### PR TITLE
add --ignore-timeouts flag

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.20.0-dev
+
+* Add an `--ignore-timeouts` command line flag, which disables all timeouts
+  for all tests. This can be useful when debugging, so tests don't time out
+  during debug sessions.
+
 ## 1.19.4
 
 * Wait for paused VM platform isolates before shutdown.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.19.4
+version: 1.20.0-dev
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -32,8 +32,8 @@ dependencies:
   webkit_inspection_protocol: ^1.0.0
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.4.8
-  test_core: 0.4.9
+  test_api: 0.4.9
+  test_core: 0.4.10
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test/test/utils.dart
+++ b/pkgs/test/test/utils.dart
@@ -289,6 +289,7 @@ Configuration configuration(
         Map<String, CustomRuntime>? defineRuntimes,
         bool? noRetry,
         bool? useDataIsolateStrategy,
+        bool? ignoreTimeouts,
 
         // Suite-level configuration
         bool? allowDuplicateTestNames,
@@ -340,6 +341,7 @@ Configuration configuration(
         defineRuntimes: defineRuntimes,
         noRetry: noRetry,
         useDataIsolateStrategy: useDataIsolateStrategy,
+        ignoreTimeouts: ignoreTimeouts,
         allowDuplicateTestNames: allowDuplicateTestNames,
         allowTestRandomization: allowTestRandomization,
         jsTrace: jsTrace,

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.9-dev
+
+* Add `ignoreTimeouts` option to the `Declarer`, which disables all timeouts
+  for all tests.
+
 ## 0.4.8
 
 * `TestFailure` implements `Exception` for compatibility with

--- a/pkgs/test_api/lib/src/backend/declarer.dart
+++ b/pkgs/test_api/lib/src/backend/declarer.dart
@@ -112,6 +112,9 @@ class Declarer {
   /// `null`.
   final Set<String>? _seenNames;
 
+  /// Whether or not timeouts should be ignored.
+  final bool ignoreTimeouts;
+
   /// Creates a new declarer for the root group.
   ///
   /// This is the implicit group that exists outside of any calls to `group()`.
@@ -139,6 +142,7 @@ class Declarer {
     String? fullTestName,
     // TODO: Change the default https://github.com/dart-lang/test/issues/1571
     bool allowDuplicateTestNames = true,
+    bool ignoreTimeouts = false,
   }) : this._(
             null,
             null,
@@ -148,7 +152,8 @@ class Declarer {
             null,
             noRetry,
             fullTestName,
-            allowDuplicateTestNames ? null : <String>{});
+            allowDuplicateTestNames ? null : <String>{},
+            ignoreTimeouts);
 
   Declarer._(
     this._parent,
@@ -160,6 +165,7 @@ class Declarer {
     this._noRetry,
     this._fullTestName,
     this._seenNames,
+    this.ignoreTimeouts,
   );
 
   /// Runs [body] with this declarer as [Declarer.current].
@@ -260,7 +266,8 @@ class Declarer {
         trace,
         _noRetry,
         _fullTestName,
-        _seenNames);
+        _seenNames,
+        ignoreTimeouts);
     declarer.declare(() {
       // Cast to dynamic to avoid the analyzer complaining about us using the
       // result of a void method.

--- a/pkgs/test_api/lib/src/backend/invoker.dart
+++ b/pkgs/test_api/lib/src/backend/invoker.dart
@@ -268,7 +268,7 @@ class Invoker {
   /// Each heartbeat resets the timeout timer. This helps ensure that
   /// long-running tests that still make progress don't time out.
   void heartbeat() {
-    if (liveTest.isComplete) return;
+    if (liveTest.isComplete || Declarer.current!.ignoreTimeouts) return;
     if (_timeoutTimer != null) _timeoutTimer!.cancel();
 
     const defaultTimeout = Duration(seconds: 30);

--- a/pkgs/test_api/lib/src/backend/remote_listener.dart
+++ b/pkgs/test_api/lib/src/backend/remote_listener.dart
@@ -108,6 +108,7 @@ class RemoteListener {
           // TODO: Change to non-nullable https://github.com/dart-lang/test/issues/1591
           allowDuplicateTestNames:
               message['allowDuplicateTestNames'] as bool? ?? true,
+          ignoreTimeouts: message['ignoreTimeouts'] as bool? ?? false,
         );
         StackTraceFormatter.current!.configure(
             except: _deserializeSet(message['foldTraceExcept'] as List),

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.4.8
+version: 0.4.9-dev
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 

--- a/pkgs/test_api/test/utils.dart
+++ b/pkgs/test_api/test/utils.dart
@@ -174,8 +174,10 @@ List<GroupEntry> declare(
   void Function() body, {
   // TODO: Change the default https://github.com/dart-lang/test/issues/1571
   bool allowDuplicateTestNames = true,
+  bool ignoreTimeouts = false,
 }) {
-  var declarer = Declarer(allowDuplicateTestNames: allowDuplicateTestNames)
+  var declarer = Declarer(
+      allowDuplicateTestNames: allowDuplicateTestNames, ignoreTimeouts: false)
     ..declare(body);
   return declarer.build().entries;
 }

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.10
+
+* Add an `--ignore-timeouts` command line flag, which disables all timeouts
+  for all tests.
+
 ## 0.4.9
 
 * Wait for paused VM platform isolates before shutdown.

--- a/pkgs/test_core/lib/src/runner/configuration.dart
+++ b/pkgs/test_core/lib/src/runner/configuration.dart
@@ -220,6 +220,9 @@ class Configuration {
   /// The same seed will shuffle the tests in the same way every time.
   final int? testRandomizeOrderingSeed;
 
+  final bool? _ignoreTimeouts;
+  bool get ignoreTimeouts => _ignoreTimeouts ?? false;
+
   /// Returns the current configuration, or a default configuration if no
   /// current configuration is set.
   ///
@@ -285,6 +288,7 @@ class Configuration {
       required bool? noRetry,
       required bool? useDataIsolateStrategy,
       required int? testRandomizeOrderingSeed,
+      required bool? ignoreTimeouts,
 
       // Suite-level configuration
       required bool? allowDuplicateTestNames,
@@ -337,6 +341,7 @@ class Configuration {
         noRetry: noRetry,
         useDataIsolateStrategy: useDataIsolateStrategy,
         testRandomizeOrderingSeed: testRandomizeOrderingSeed,
+        ignoreTimeouts: ignoreTimeouts,
         suiteDefaults: SuiteConfiguration(
             allowDuplicateTestNames: allowDuplicateTestNames,
             allowTestRandomization: allowTestRandomization,
@@ -395,9 +400,11 @@ class Configuration {
           Map<String, CustomRuntime>? defineRuntimes,
           bool? noRetry,
           bool? useDataIsolateStrategy,
-          bool? allowDuplicateTestNames,
+          int? testRandomizeOrderingSeed,
+          bool? ignoreTimeouts,
 
           // Suite-level configuration
+          bool? allowDuplicateTestNames,
           bool? allowTestRandomization,
           bool? jsTrace,
           bool? runSkipped,
@@ -409,7 +416,6 @@ class Configuration {
           BooleanSelector? excludeTags,
           Map<BooleanSelector, SuiteConfiguration>? tags,
           Map<PlatformSelector, SuiteConfiguration>? onPlatform,
-          int? testRandomizeOrderingSeed,
 
           // Test-level configuration
           Timeout? timeout,
@@ -446,6 +452,8 @@ class Configuration {
           defineRuntimes: defineRuntimes,
           noRetry: noRetry,
           useDataIsolateStrategy: useDataIsolateStrategy,
+          testRandomizeOrderingSeed: testRandomizeOrderingSeed,
+          ignoreTimeouts: ignoreTimeouts,
           allowDuplicateTestNames: allowDuplicateTestNames,
           allowTestRandomization: allowTestRandomization,
           jsTrace: jsTrace,
@@ -458,7 +466,6 @@ class Configuration {
           excludeTags: excludeTags,
           tags: tags,
           onPlatform: onPlatform,
-          testRandomizeOrderingSeed: testRandomizeOrderingSeed,
           timeout: timeout,
           verboseTrace: verboseTrace,
           chainStackTraces: chainStackTraces,
@@ -513,6 +520,7 @@ class Configuration {
         noRetry: null,
         useDataIsolateStrategy: null,
         testRandomizeOrderingSeed: null,
+        ignoreTimeouts: null,
         allowDuplicateTestNames: null,
         allowTestRandomization: null,
         runSkipped: null,
@@ -580,6 +588,7 @@ class Configuration {
         noRetry: null,
         useDataIsolateStrategy: null,
         testRandomizeOrderingSeed: null,
+        ignoreTimeouts: null,
         jsTrace: null,
         runSkipped: null,
         dart2jsArgs: null,
@@ -642,6 +651,7 @@ class Configuration {
         noRetry: null,
         useDataIsolateStrategy: null,
         testRandomizeOrderingSeed: null,
+        ignoreTimeouts: null,
         allowDuplicateTestNames: null,
         allowTestRandomization: null,
         jsTrace: null,
@@ -705,6 +715,7 @@ class Configuration {
           noRetry: null,
           useDataIsolateStrategy: null,
           testRandomizeOrderingSeed: null,
+          ignoreTimeouts: null,
           allowDuplicateTestNames: null,
           allowTestRandomization: null,
           jsTrace: null,
@@ -770,6 +781,7 @@ class Configuration {
       required bool? noRetry,
       required bool? useDataIsolateStrategy,
       required this.testRandomizeOrderingSeed,
+      required bool? ignoreTimeouts,
       required SuiteConfiguration? suiteDefaults})
       : _help = help,
         _version = version,
@@ -794,10 +806,9 @@ class Configuration {
         defineRuntimes = _map(defineRuntimes),
         _noRetry = noRetry,
         _useDataIsolateStrategy = useDataIsolateStrategy,
-        suiteDefaults = pauseAfterLoad == true
-            ? suiteDefaults?.change(timeout: Timeout.none) ??
-                SuiteConfiguration.timeout(Timeout.none)
-            : suiteDefaults ?? SuiteConfiguration.empty {
+        _ignoreTimeouts =
+            pauseAfterLoad == true ? ignoreTimeouts ?? true : ignoreTimeouts,
+        suiteDefaults = suiteDefaults ?? SuiteConfiguration.empty {
     if (_filename != null && _filename!.context.style != p.style) {
       throw ArgumentError(
           "filename's context must match the current operating system, was "
@@ -845,6 +856,7 @@ class Configuration {
         noRetry: null,
         useDataIsolateStrategy: null,
         testRandomizeOrderingSeed: null,
+        ignoreTimeouts: null,
       );
 
   /// Returns an unmodifiable copy of [input].
@@ -961,6 +973,7 @@ class Configuration {
             other._useDataIsolateStrategy ?? _useDataIsolateStrategy,
         testRandomizeOrderingSeed:
             other.testRandomizeOrderingSeed ?? testRandomizeOrderingSeed,
+        ignoreTimeouts: other._ignoreTimeouts ?? ignoreTimeouts,
         suiteDefaults: suiteDefaults.merge(other.suiteDefaults));
     result = result._resolvePresets();
 
@@ -1000,6 +1013,8 @@ class Configuration {
       Map<String, CustomRuntime>? defineRuntimes,
       bool? noRetry,
       bool? useDataIsolateStrategy,
+      int? testRandomizeOrderingSeed,
+      bool? ignoreTimeouts,
 
       // Suite-level configuration
       bool? allowDuplicateTestNames,
@@ -1013,7 +1028,6 @@ class Configuration {
       BooleanSelector? excludeTags,
       Map<BooleanSelector, SuiteConfiguration>? tags,
       Map<PlatformSelector, SuiteConfiguration>? onPlatform,
-      int? testRandomizeOrderingSeed,
 
       // Test-level configuration
       Timeout? timeout,
@@ -1053,6 +1067,7 @@ class Configuration {
             useDataIsolateStrategy ?? _useDataIsolateStrategy,
         testRandomizeOrderingSeed:
             testRandomizeOrderingSeed ?? this.testRandomizeOrderingSeed,
+        ignoreTimeouts: ignoreTimeouts ?? _ignoreTimeouts,
         suiteDefaults: suiteDefaults.change(
             allowDuplicateTestNames: allowDuplicateTestNames,
             jsTrace: jsTrace,

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -88,9 +88,11 @@ final ArgParser _parser = (() {
   parser.addOption('timeout',
       help: 'The default test timeout. For example: 15s, 2x, none',
       defaultsTo: '30s');
+  parser.addFlag('--ignore-timeouts',
+      help: 'Ignore all timeouts (useful if debugging)', negatable: false);
   parser.addFlag('pause-after-load',
       help: 'Pause for debugging before any tests execute.\n'
-          'Implies --concurrency=1, --debug, and --timeout=none.\n'
+          'Implies --concurrency=1, --debug, and --ignore-timeouts.\n'
           'Currently only supported for browser tests.',
       negatable: false);
   parser.addFlag('debug',
@@ -312,6 +314,7 @@ class _Parser {
         noRetry: _ifParsed('no-retry'),
         useDataIsolateStrategy: _ifParsed('use-data-isolate-strategy'),
         testRandomizeOrderingSeed: testRandomizeOrderingSeed,
+        ignoreTimeouts: _ifParsed('ignore-timeouts'),
         // Config that isn't supported on the command line
         addTags: null,
         allowTestRandomization: null,

--- a/pkgs/test_core/lib/src/runner/plugin/platform_helpers.dart
+++ b/pkgs/test_core/lib/src/runner/plugin/platform_helpers.dart
@@ -62,6 +62,7 @@ RunnerSuiteController deserializeSuite(
     'foldTraceExcept': Configuration.current.foldTraceExcept.toList(),
     'foldTraceOnly': Configuration.current.foldTraceOnly.toList(),
     'allowDuplicateTestNames': suiteConfig.allowDuplicateTestNames,
+    'ignoreTimeouts': Configuration.current.ignoreTimeouts,
     ...(message as Map<String, dynamic>),
   });
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.9
+version: 0.4.10-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
@@ -30,7 +30,7 @@ dependencies:
   # matcher is tightly constrained by test_api
   matcher: any
   # Use an exact version until the test_api package is stable.
-  test_api: 0.4.8
+  test_api: 0.4.9
 
 dev_dependencies:
   lints: ^1.0.0


### PR DESCRIPTION
Closes https://github.com/dart-lang/test/issues/1634

This was a bit awkard to plumb through, I ended up just sticking it on the declarer and accessing that through the invoker.

I also changed the `--pause-after-load` behavior slightly so that it implies this new flag instead of `--timeout=none`. This flag more reliably achieves the desired result (not timeouts) as it won't be overridden by local test config.

Will see about adding a test if this LGTY.