### PR TITLE
Log to stdout from chrome

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.19.5-dev
+
+* Try to get more logging from `chrome` on windows to diagnose intermittent
+  failures.
+
 ## 1.19.4
 
 * Wait for paused VM platform isolates before shutdown.

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.19.5-dev
+## 1.19.5
 
 * Try to get more logging from `chrome` on windows to diagnose intermittent
   failures.

--- a/pkgs/test/lib/src/runner/browser/chrome.dart
+++ b/pkgs/test/lib/src/runner/browser/chrome.dart
@@ -49,7 +49,7 @@ class Chrome extends Browser {
         var args = [
           '--user-data-dir=$dir',
           url.toString(),
-          if (Platform.isLinux) '--enable-logging=stderr',
+          '--enable-logging=stdout',
           '--v=1',
           '--disable-extensions',
           '--disable-popup-blocking',

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.19.4
+version: 1.19.5-dev
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.19.5-dev
+version: 1.19.5
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test


### PR DESCRIPTION
Log to `stdout` instead of `stderr` so that it works on windows and we
can (hopefully) get more useful output.