### PR TITLE
Revert "add --ignore-timeouts flag (#1635)"

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,9 +1,3 @@
-## 1.20.0-dev
-
-* Add an `--ignore-timeouts` command line flag, which disables all timeouts
-  for all tests. This can be useful when debugging, so tests don't time out
-  during debug sessions.
-
 ## 1.19.4
 
 * Wait for paused VM platform isolates before shutdown.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.20.0-dev
+version: 1.19.4
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -32,8 +32,8 @@ dependencies:
   webkit_inspection_protocol: ^1.0.0
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.4.9
-  test_core: 0.4.10
+  test_api: 0.4.8
+  test_core: 0.4.9
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -82,9 +82,8 @@ Running Tests:
     --pub-serve=<port>                The port of a pub serve instance serving "test/".
     --timeout                         The default test timeout. For example: 15s, 2x, none
                                       (defaults to "30s")
-    --ignore-timeouts                 Ignore all timeouts (useful if debugging)
     --pause-after-load                Pause for debugging before any tests execute.
-                                      Implies --concurrency=1, --debug, and --ignore-timeouts.
+                                      Implies --concurrency=1, --debug, and --timeout=none.
                                       Currently only supported for browser tests.
     --debug                           Run the VM and Chrome tests in debug mode.
     --coverage=<directory>            Gather coverage and output it to the specified directory.

--- a/pkgs/test/test/runner/timeout_test.dart
+++ b/pkgs/test/test/runner/timeout_test.dart
@@ -162,24 +162,4 @@ void main() {
             ['Test timed out after 0 seconds.', '-1: Some tests failed.']));
     await test.shouldExit(1);
   });
-
-  test('are ignored with --ignore-timeouts', () async {
-    await d.file('test.dart', '''
-@Timeout(const Duration(seconds: 0))
-
-import 'dart:async';
-
-import 'package:test/test.dart';
-
-void main() {
-  test("timeout", () async {
-    await Future.delayed(Duration(milliseconds: 10));
-  });
-}
-''').create();
-
-    var test = await runTest(['test.dart', '--ignore-timeouts']);
-    expect(test.stdout, containsInOrder(['+1: All tests passed!']));
-    await test.shouldExit(0);
-  });
 }

--- a/pkgs/test/test/utils.dart
+++ b/pkgs/test/test/utils.dart
@@ -109,7 +109,7 @@ Matcher isApplicationException(message) =>
 /// Returns a local [LiveTest] that runs [body].
 LiveTest createTest(dynamic Function() body) {
   var test = LocalTest('test', Metadata(chainStackTraces: true), body);
-  var suite = Suite(Group.root([test]), suitePlatform, ignoreTimeouts: false);
+  var suite = Suite(Group.root([test]), suitePlatform);
   return test.load(suite);
 }
 
@@ -289,7 +289,6 @@ Configuration configuration(
         Map<String, CustomRuntime>? defineRuntimes,
         bool? noRetry,
         bool? useDataIsolateStrategy,
-        bool? ignoreTimeouts,
 
         // Suite-level configuration
         bool? allowDuplicateTestNames,
@@ -341,7 +340,6 @@ Configuration configuration(
         defineRuntimes: defineRuntimes,
         noRetry: noRetry,
         useDataIsolateStrategy: useDataIsolateStrategy,
-        ignoreTimeouts: ignoreTimeouts,
         allowDuplicateTestNames: allowDuplicateTestNames,
         allowTestRandomization: allowTestRandomization,
         jsTrace: jsTrace,

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 0.4.9-dev
-
-* Add `ignoreTimeouts` option to `Suite`, which disables all timeouts for all
-  tests in that suite.
-
 ## 0.4.8
 
 * `TestFailure` implements `Exception` for compatibility with

--- a/pkgs/test_api/lib/src/backend/invoker.dart
+++ b/pkgs/test_api/lib/src/backend/invoker.dart
@@ -270,7 +270,6 @@ class Invoker {
   void heartbeat() {
     if (liveTest.isComplete) return;
     if (_timeoutTimer != null) _timeoutTimer!.cancel();
-    if (liveTest.suite.ignoreTimeouts == true) return;
 
     const defaultTimeout = Duration(seconds: 30);
     var timeout = liveTest.test.metadata.timeout.apply(defaultTimeout);

--- a/pkgs/test_api/lib/src/backend/remote_listener.dart
+++ b/pkgs/test_api/lib/src/backend/remote_listener.dart
@@ -119,12 +119,9 @@ class RemoteListener {
 
         await declarer.declare(main);
 
-        var suite = Suite(
-          declarer.build(),
-          SuitePlatform.deserialize(message['platform'] as Object),
-          path: message['path'] as String,
-          ignoreTimeouts: message['ignoreTimeouts'] as bool? ?? false,
-        );
+        var suite = Suite(declarer.build(),
+            SuitePlatform.deserialize(message['platform'] as Object),
+            path: message['path'] as String);
 
         runZoned(() {
           Invoker.guard(

--- a/pkgs/test_api/lib/src/backend/suite.dart
+++ b/pkgs/test_api/lib/src/backend/suite.dart
@@ -26,16 +26,13 @@ class Suite {
   /// The top-level group for this test suite.
   final Group group;
 
-  /// Whether or not to ignore test timeouts.
-  final bool ignoreTimeouts;
-
   /// Creates a new suite containing [entires].
   ///
   /// If [platform] and/or [os] are passed, [group] is filtered to match that
   /// platform information.
   ///
   /// If [os] is passed without [platform], throws an [ArgumentError].
-  Suite(Group group, this.platform, {required this.ignoreTimeouts, this.path})
+  Suite(Group group, this.platform, {this.path})
       : group = _filterGroup(group, platform);
 
   /// Returns [entries] filtered according to [platform] and [os].
@@ -54,8 +51,7 @@ class Suite {
   Suite filter(bool Function(Test) callback) {
     var filtered = group.filter(callback);
     filtered ??= Group.root([], metadata: metadata);
-    return Suite(filtered, platform,
-        ignoreTimeouts: ignoreTimeouts, path: path);
+    return Suite(filtered, platform, path: path);
   }
 
   bool get isLoadSuite => false;

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.4.9-dev
+version: 0.4.8
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 

--- a/pkgs/test_api/test/backend/declarer_test.dart
+++ b/pkgs/test_api/test/backend/declarer_test.dart
@@ -17,7 +17,7 @@ late Suite _suite;
 
 void main() {
   setUp(() {
-    _suite = Suite(Group.root([]), suitePlatform, ignoreTimeouts: false);
+    _suite = Suite(Group.root([]), suitePlatform);
   });
 
   group('.test()', () {

--- a/pkgs/test_api/test/backend/invoker_test.dart
+++ b/pkgs/test_api/test/backend/invoker_test.dart
@@ -19,7 +19,7 @@ void main() {
   late Suite suite;
   setUp(() {
     lastState = null;
-    suite = Suite(Group.root([]), suitePlatform, ignoreTimeouts: false);
+    suite = Suite(Group.root([]), suitePlatform);
   });
 
   group('Invoker.current', () {
@@ -428,7 +428,8 @@ void main() {
         Invoker.current!.addOutstandingCallback();
       },
               metadata: Metadata(
-                  chainStackTraces: true, timeout: Timeout(Duration.zero)))
+                  chainStackTraces: true,
+                  timeout: Timeout(Duration(milliseconds: 100))))
           .load(suite);
 
       expectStates(liveTest, [
@@ -441,23 +442,6 @@ void main() {
           expect(lastState!.status, equals(Status.complete));
           expect(error, TypeMatcher<TimeoutException>());
         }
-      ]);
-
-      liveTest.run();
-    });
-
-    test('can be ignored', () {
-      suite = Suite(Group.root([]), suitePlatform, ignoreTimeouts: true);
-      var liveTest = _localTest(() async {
-        await Future.delayed(Duration(milliseconds: 10));
-      },
-              metadata: Metadata(
-                  chainStackTraces: true, timeout: Timeout(Duration.zero)))
-          .load(suite);
-
-      expectStates(liveTest, [
-        const State(Status.running, Result.success),
-        const State(Status.complete, Result.success)
       ]);
 
       liveTest.run();

--- a/pkgs/test_api/test/utils.dart
+++ b/pkgs/test_api/test/utils.dart
@@ -91,7 +91,7 @@ Matcher isTestFailure(message) => const TypeMatcher<TestFailure>()
 /// Returns a local [LiveTest] that runs [body].
 LiveTest createTest(dynamic Function() body) {
   var test = LocalTest('test', Metadata(chainStackTraces: true), body);
-  var suite = Suite(Group.root([test]), suitePlatform, ignoreTimeouts: false);
+  var suite = Suite(Group.root([test]), suitePlatform);
   return test.load(suite);
 }
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 0.4.10
-
-* Add an `--ignore-timeouts` command line flag, which disables all timeouts
-  for all tests.
-
 ## 0.4.9
 
 * Wait for paused VM platform isolates before shutdown.

--- a/pkgs/test_core/lib/src/runner/configuration.dart
+++ b/pkgs/test_core/lib/src/runner/configuration.dart
@@ -220,9 +220,6 @@ class Configuration {
   /// The same seed will shuffle the tests in the same way every time.
   final int? testRandomizeOrderingSeed;
 
-  final bool? _ignoreTimeouts;
-  bool get ignoreTimeouts => _ignoreTimeouts ?? false;
-
   /// Returns the current configuration, or a default configuration if no
   /// current configuration is set.
   ///
@@ -288,7 +285,6 @@ class Configuration {
       required bool? noRetry,
       required bool? useDataIsolateStrategy,
       required int? testRandomizeOrderingSeed,
-      required bool? ignoreTimeouts,
 
       // Suite-level configuration
       required bool? allowDuplicateTestNames,
@@ -341,7 +337,6 @@ class Configuration {
         noRetry: noRetry,
         useDataIsolateStrategy: useDataIsolateStrategy,
         testRandomizeOrderingSeed: testRandomizeOrderingSeed,
-        ignoreTimeouts: ignoreTimeouts,
         suiteDefaults: SuiteConfiguration(
             allowDuplicateTestNames: allowDuplicateTestNames,
             allowTestRandomization: allowTestRandomization,
@@ -400,11 +395,9 @@ class Configuration {
           Map<String, CustomRuntime>? defineRuntimes,
           bool? noRetry,
           bool? useDataIsolateStrategy,
-          int? testRandomizeOrderingSeed,
-          bool? ignoreTimeouts,
+          bool? allowDuplicateTestNames,
 
           // Suite-level configuration
-          bool? allowDuplicateTestNames,
           bool? allowTestRandomization,
           bool? jsTrace,
           bool? runSkipped,
@@ -416,6 +409,7 @@ class Configuration {
           BooleanSelector? excludeTags,
           Map<BooleanSelector, SuiteConfiguration>? tags,
           Map<PlatformSelector, SuiteConfiguration>? onPlatform,
+          int? testRandomizeOrderingSeed,
 
           // Test-level configuration
           Timeout? timeout,
@@ -452,8 +446,6 @@ class Configuration {
           defineRuntimes: defineRuntimes,
           noRetry: noRetry,
           useDataIsolateStrategy: useDataIsolateStrategy,
-          testRandomizeOrderingSeed: testRandomizeOrderingSeed,
-          ignoreTimeouts: ignoreTimeouts,
           allowDuplicateTestNames: allowDuplicateTestNames,
           allowTestRandomization: allowTestRandomization,
           jsTrace: jsTrace,
@@ -466,6 +458,7 @@ class Configuration {
           excludeTags: excludeTags,
           tags: tags,
           onPlatform: onPlatform,
+          testRandomizeOrderingSeed: testRandomizeOrderingSeed,
           timeout: timeout,
           verboseTrace: verboseTrace,
           chainStackTraces: chainStackTraces,
@@ -520,7 +513,6 @@ class Configuration {
         noRetry: null,
         useDataIsolateStrategy: null,
         testRandomizeOrderingSeed: null,
-        ignoreTimeouts: null,
         allowDuplicateTestNames: null,
         allowTestRandomization: null,
         runSkipped: null,
@@ -588,7 +580,6 @@ class Configuration {
         noRetry: null,
         useDataIsolateStrategy: null,
         testRandomizeOrderingSeed: null,
-        ignoreTimeouts: null,
         jsTrace: null,
         runSkipped: null,
         dart2jsArgs: null,
@@ -651,7 +642,6 @@ class Configuration {
         noRetry: null,
         useDataIsolateStrategy: null,
         testRandomizeOrderingSeed: null,
-        ignoreTimeouts: null,
         allowDuplicateTestNames: null,
         allowTestRandomization: null,
         jsTrace: null,
@@ -715,7 +705,6 @@ class Configuration {
           noRetry: null,
           useDataIsolateStrategy: null,
           testRandomizeOrderingSeed: null,
-          ignoreTimeouts: null,
           allowDuplicateTestNames: null,
           allowTestRandomization: null,
           jsTrace: null,
@@ -781,7 +770,6 @@ class Configuration {
       required bool? noRetry,
       required bool? useDataIsolateStrategy,
       required this.testRandomizeOrderingSeed,
-      required bool? ignoreTimeouts,
       required SuiteConfiguration? suiteDefaults})
       : _help = help,
         _version = version,
@@ -806,9 +794,10 @@ class Configuration {
         defineRuntimes = _map(defineRuntimes),
         _noRetry = noRetry,
         _useDataIsolateStrategy = useDataIsolateStrategy,
-        _ignoreTimeouts =
-            pauseAfterLoad == true ? ignoreTimeouts ?? true : ignoreTimeouts,
-        suiteDefaults = suiteDefaults ?? SuiteConfiguration.empty {
+        suiteDefaults = pauseAfterLoad == true
+            ? suiteDefaults?.change(timeout: Timeout.none) ??
+                SuiteConfiguration.timeout(Timeout.none)
+            : suiteDefaults ?? SuiteConfiguration.empty {
     if (_filename != null && _filename!.context.style != p.style) {
       throw ArgumentError(
           "filename's context must match the current operating system, was "
@@ -856,7 +845,6 @@ class Configuration {
         noRetry: null,
         useDataIsolateStrategy: null,
         testRandomizeOrderingSeed: null,
-        ignoreTimeouts: null,
       );
 
   /// Returns an unmodifiable copy of [input].
@@ -973,7 +961,6 @@ class Configuration {
             other._useDataIsolateStrategy ?? _useDataIsolateStrategy,
         testRandomizeOrderingSeed:
             other.testRandomizeOrderingSeed ?? testRandomizeOrderingSeed,
-        ignoreTimeouts: other._ignoreTimeouts ?? ignoreTimeouts,
         suiteDefaults: suiteDefaults.merge(other.suiteDefaults));
     result = result._resolvePresets();
 
@@ -1013,8 +1000,6 @@ class Configuration {
       Map<String, CustomRuntime>? defineRuntimes,
       bool? noRetry,
       bool? useDataIsolateStrategy,
-      int? testRandomizeOrderingSeed,
-      bool? ignoreTimeouts,
 
       // Suite-level configuration
       bool? allowDuplicateTestNames,
@@ -1028,6 +1013,7 @@ class Configuration {
       BooleanSelector? excludeTags,
       Map<BooleanSelector, SuiteConfiguration>? tags,
       Map<PlatformSelector, SuiteConfiguration>? onPlatform,
+      int? testRandomizeOrderingSeed,
 
       // Test-level configuration
       Timeout? timeout,
@@ -1067,7 +1053,6 @@ class Configuration {
             useDataIsolateStrategy ?? _useDataIsolateStrategy,
         testRandomizeOrderingSeed:
             testRandomizeOrderingSeed ?? this.testRandomizeOrderingSeed,
-        ignoreTimeouts: ignoreTimeouts ?? _ignoreTimeouts,
         suiteDefaults: suiteDefaults.change(
             allowDuplicateTestNames: allowDuplicateTestNames,
             jsTrace: jsTrace,

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -88,11 +88,9 @@ final ArgParser _parser = (() {
   parser.addOption('timeout',
       help: 'The default test timeout. For example: 15s, 2x, none',
       defaultsTo: '30s');
-  parser.addFlag('ignore-timeouts',
-      help: 'Ignore all timeouts (useful if debugging)', negatable: false);
   parser.addFlag('pause-after-load',
       help: 'Pause for debugging before any tests execute.\n'
-          'Implies --concurrency=1, --debug, and --ignore-timeouts.\n'
+          'Implies --concurrency=1, --debug, and --timeout=none.\n'
           'Currently only supported for browser tests.',
       negatable: false);
   parser.addFlag('debug',
@@ -314,7 +312,6 @@ class _Parser {
         noRetry: _ifParsed('no-retry'),
         useDataIsolateStrategy: _ifParsed('use-data-isolate-strategy'),
         testRandomizeOrderingSeed: testRandomizeOrderingSeed,
-        ignoreTimeouts: _ifParsed('ignore-timeouts'),
         // Config that isn't supported on the command line
         addTags: null,
         allowTestRandomization: null,

--- a/pkgs/test_core/lib/src/runner/load_suite.dart
+++ b/pkgs/test_core/lib/src/runner/load_suite.dart
@@ -18,7 +18,6 @@ import 'package:test_api/scaffolding.dart' show Timeout;
 import '../util/async.dart';
 import '../util/io_stub.dart' if (dart.library.io) '../util/io.dart';
 import '../util/pair.dart';
-import 'configuration.dart';
 import 'load_exception.dart';
 import 'plugin/environment.dart';
 import 'runner_suite.dart';
@@ -117,8 +116,7 @@ class LoadSuite extends Suite implements RunnerSuite {
       // If the test is forcibly closed, let it complete, since load tests don't
       // have timeouts.
       invoker.onClose.then((_) => invoker.removeOutstandingCallback());
-    }, completer.future,
-        path: path, ignoreTimeouts: Configuration.current.ignoreTimeouts);
+    }, completer.future, path: path);
   }
 
   /// A utility constructor for a load suite that just throws [exception].
@@ -145,27 +143,23 @@ class LoadSuite extends Suite implements RunnerSuite {
   }
 
   LoadSuite._(String name, this.config, SuitePlatform platform,
-      void Function() body, this._suiteAndZone,
-      {required bool ignoreTimeouts, String? path})
+      void Function() body, this._suiteAndZone, {String? path})
       : super(
             Group.root(
                 [LocalTest(name, Metadata(timeout: Timeout(_timeout)), body)]),
             platform,
-            path: path,
-            ignoreTimeouts: ignoreTimeouts);
+            path: path);
 
   /// A constructor used by [changeSuite].
   LoadSuite._changeSuite(LoadSuite old, this._suiteAndZone)
       : config = old.config,
-        super(old.group, old.platform,
-            path: old.path, ignoreTimeouts: old.ignoreTimeouts);
+        super(old.group, old.platform, path: old.path);
 
   /// A constructor used by [filter].
   LoadSuite._filtered(LoadSuite old, Group filtered)
       : config = old.config,
         _suiteAndZone = old._suiteAndZone,
-        super(old.group, old.platform,
-            path: old.path, ignoreTimeouts: old.ignoreTimeouts);
+        super(old.group, old.platform, path: old.path);
 
   /// Creates a new [LoadSuite] that's identical to this one, but that
   /// transforms [suite] once it's loaded.

--- a/pkgs/test_core/lib/src/runner/plugin/platform_helpers.dart
+++ b/pkgs/test_core/lib/src/runner/plugin/platform_helpers.dart
@@ -62,7 +62,6 @@ RunnerSuiteController deserializeSuite(
     'foldTraceExcept': Configuration.current.foldTraceExcept.toList(),
     'foldTraceOnly': Configuration.current.foldTraceOnly.toList(),
     'allowDuplicateTestNames': suiteConfig.allowDuplicateTestNames,
-    'ignoreTimeouts': Configuration.current.ignoreTimeouts,
     ...(message as Map<String, dynamic>),
   });
 

--- a/pkgs/test_core/lib/src/runner/runner_suite.dart
+++ b/pkgs/test_core/lib/src/runner/runner_suite.dart
@@ -11,7 +11,6 @@ import 'package:test_api/src/backend/suite.dart'; // ignore: implementation_impo
 import 'package:test_api/src/backend/suite_platform.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/test.dart'; // ignore: implementation_imports
 
-import 'configuration.dart';
 import 'environment.dart';
 import 'suite.dart';
 
@@ -59,8 +58,7 @@ class RunnerSuite extends Suite {
 
   RunnerSuite._(this._controller, Group group, SuitePlatform platform,
       {String? path})
-      : super(group, platform,
-            path: path, ignoreTimeouts: Configuration.current.ignoreTimeouts);
+      : super(group, platform, path: path);
 
   @override
   RunnerSuite filter(bool Function(Test) callback) {

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.10-dev
+version: 0.4.9
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
@@ -30,7 +30,7 @@ dependencies:
   # matcher is tightly constrained by test_api
   matcher: any
   # Use an exact version until the test_api package is stable.
-  test_api: 0.4.9
+  test_api: 0.4.8
 
 dev_dependencies:
   lints: ^1.0.0


### PR DESCRIPTION
This reverts commit bb4f7e85e0e490cae61bbd13245bbd6dd811263d.

This needs to be reverted because it breaks us internally due to the addition of the `configuration.dart` import to some files that previously didn't transitively import `dart:io`.