### PR TITLE
make ignoreTimeouts param on Suite not required

### DIFF
--- a/pkgs/test_api/lib/src/backend/suite.dart
+++ b/pkgs/test_api/lib/src/backend/suite.dart
@@ -35,7 +35,7 @@ class Suite {
   /// platform information.
   ///
   /// If [os] is passed without [platform], throws an [ArgumentError].
-  Suite(Group group, this.platform, {required this.ignoreTimeouts, this.path})
+  Suite(Group group, this.platform, {this.ignoreTimeouts = false, this.path})
       : group = _filterGroup(group, platform);
 
   /// Returns [entries] filtered according to [platform] and [os].


### PR DESCRIPTION
This will ease the transition as flutter_test and some internal packages use this constructor.

We can move it back to required in a later release.