### PR TITLE
Use URI class over manual string manipulation

### DIFF
--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -81,7 +81,8 @@ class VMPlatform extends PlatformPlugin {
       var isolateID = Service.getIsolateID(isolate)!;
 
       var libraryPath = p.toUri(p.absolute(path)).toString();
-      client = await vmServiceConnectUri(_wsUriFor(info.serverUri.toString()));
+      var serverUri = info.serverUri!;
+      client = await vmServiceConnectUri(_wsUriFor(serverUri).toString());
       var isolateNumber = int.parse(isolateID.split('/').last);
       isolateRef = (await client.getVM())
           .isolates!
@@ -90,8 +91,7 @@ class VMPlatform extends PlatformPlugin {
       var libraryRef = (await client.getIsolate(isolateRef.id!))
           .libraries!
           .firstWhere((library) => library.uri == libraryPath);
-      var url = _observatoryUrlFor(
-          info.serverUri.toString(), isolateRef.id!, libraryRef.id!);
+      var url = _observatoryUrlFor(serverUri, isolateRef.id!, libraryRef.id!);
       environment = VMEnvironment(url, isolateRef, client);
     }
 
@@ -227,9 +227,12 @@ Future<Isolate> _spawnPubServeIsolate(
   }
 }
 
-String _wsUriFor(String observatoryUrl) =>
-    "ws:${observatoryUrl.split(':').sublist(1).join(':')}ws";
+Uri _wsUriFor(Uri observatoryUrl) =>
+    observatoryUrl.replace(scheme: 'ws').resolve('ws');
 
-Uri _observatoryUrlFor(String base, String isolateId, String id) =>
-    Uri.parse('$base#/inspect?isolateId=${Uri.encodeQueryComponent(isolateId)}&'
-        'objectId=${Uri.encodeQueryComponent(id)}');
+Uri _observatoryUrlFor(Uri base, String isolateId, String id) {
+  var inspectUri = Uri(
+      path: '/inspect',
+      queryParameters: {'isolateId': isolateId, 'objectId': id});
+  return base.replace(fragment: inspectUri.toString());
+}

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -230,9 +230,7 @@ Future<Isolate> _spawnPubServeIsolate(
 Uri _wsUriFor(Uri observatoryUrl) =>
     observatoryUrl.replace(scheme: 'ws').resolve('ws');
 
-Uri _observatoryUrlFor(Uri base, String isolateId, String id) {
-  var inspectUri = Uri(
-      path: '/inspect',
-      queryParameters: {'isolateId': isolateId, 'objectId': id});
-  return base.replace(fragment: inspectUri.toString());
-}
+Uri _observatoryUrlFor(Uri base, String isolateId, String id) => base.replace(
+    fragment: Uri(
+        path: '/inspect',
+        queryParameters: {'isolateId': isolateId, 'objectId': id}).toString());


### PR DESCRIPTION
Avoid building URIs manually with brittle Strings. This also makes it
more clear that the Observatory URI is embedding a path and query string
into the fragment, instead of letting it look like part of the URI
itself.

Pull out `serverUri` as a separate variable and use `!` immediately. If
a null shows up this would be a more clear failure than trying to later
treat the string`'null'` as a URI.