### PR TITLE
Use trusted types for script URL

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Add an `--ignore-timeouts` command line flag, which disables all timeouts
   for all tests. This can be useful when debugging, so tests don't time out
   during debug sessions.
+* Create a trusted types policy when available for assigning the script URL for
+  web tests.
 
 ## 1.19.5
 

--- a/pkgs/test/lib/dart.js
+++ b/pkgs/test/lib/dart.js
@@ -52,7 +52,14 @@ if (link.href == '') {
 
 var script = document.createElement('script');
 
-script.src = link.href + '.browser_test.dart.js';
+if (typeof trustedTypes !== 'undefined') {
+  const sanitizer = trustedTypes.createPolicy('dart#test', {
+    createScriptURL: (input) => input + '.browser_test.dart.js'
+  });
+  script.src = sanitizer.createScriptURL(link.href);
+} else {
+  script.src = link.href + '.browser_test.dart.js';
+}
 
 script.onerror = function(event) {
   var message = "Failed to load script at " + script.src +


### PR DESCRIPTION
Create a policy which appends the test extensions to the URL.
This does not make the script safer, but it does limit the security risk
to the code inside the `createPolicy` call which, in theory, should be
easier to review.