### PR TITLE
Add an extension to pause VM isolates after tests

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * Add an `--ignore-timeouts` command line flag, which disables all timeouts
   for all tests.
+* Experimental: Add a VM service extension `ext.test.pauseAfterTests` which
+  configures VM platform tests to pause for debugging after tests are run,
+  before the test isolates are killed.
 
 ## 0.4.9
 

--- a/pkgs/test_core/lib/src/bootstrap/vm.dart
+++ b/pkgs/test_core/lib/src/bootstrap/vm.dart
@@ -2,14 +2,25 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:developer';
 import 'dart:isolate';
 
 import 'package:stream_channel/isolate_channel.dart';
+import 'package:stream_channel/stream_channel.dart';
 
 import 'package:test_core/src/runner/plugin/remote_platform_helpers.dart';
 
 /// Bootstraps a vm test to communicate with the test runner.
 void internalBootstrapVmTest(Function Function() getMain, SendPort sendPort) {
-  var channel = serializeSuite(getMain);
-  IsolateChannel<Object?>.connectSend(sendPort).pipe(channel);
+  var platformChannel =
+      MultiChannel(IsolateChannel<Object?>.connectSend(sendPort));
+  var testControlChannel = platformChannel.virtualChannel()
+    ..pipe(serializeSuite(getMain));
+  platformChannel.sink.add(testControlChannel.id);
+
+  platformChannel.stream.forEach((message) {
+    assert(message == 'debug');
+    debugger(message: 'Paused by test runner');
+    platformChannel.sink.add('done');
+  });
 }

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:developer';
 import 'dart:io';
 import 'dart:isolate';
@@ -11,6 +12,7 @@ import 'package:async/async.dart';
 import 'package:coverage/coverage.dart';
 import 'package:path/path.dart' as p;
 import 'package:stream_channel/isolate_channel.dart';
+import 'package:stream_channel/stream_channel.dart';
 import 'package:test_api/backend.dart'; // ignore: deprecated_member_use
 import 'package:test_core/src/runner/vm/test_compiler.dart';
 import 'package:vm_service/vm_service.dart' hide Isolate;
@@ -28,6 +30,8 @@ import '../../util/package_config.dart';
 import '../package_version.dart';
 import 'environment.dart';
 
+var _shouldPauseAfterTests = false;
+
 /// A platform that loads tests in isolates spawned within this Dart process.
 class VMPlatform extends PlatformPlugin {
   /// The test runner configuration.
@@ -42,6 +46,8 @@ class VMPlatform extends PlatformPlugin {
   Future<RunnerSuite?> load(String path, SuitePlatform platform,
       SuiteConfiguration suiteConfig, Map<String, Object?> message) async {
     assert(platform.runtime == Runtime.vm);
+
+    _setupPauseAfterTests();
 
     var receivePort = ReceivePort();
     var onExitPort = ReceivePort();
@@ -63,8 +69,15 @@ class VMPlatform extends PlatformPlugin {
 
     VmService? client;
     StreamSubscription<Event>? eventSub;
-    var channel = IsolateChannel.connectReceive(receivePort)
-        .transformStream(StreamTransformer.fromHandlers(handleDone: (sink) {
+    var outerChannel = MultiChannel(IsolateChannel.connectReceive(receivePort));
+    var outerQueue = StreamQueue(outerChannel.stream);
+    var channelId = (await outerQueue.next) as int;
+    var channel = outerChannel.virtualChannel(channelId).transformStream(
+        StreamTransformer.fromHandlers(handleDone: (sink) async {
+      if (_shouldPauseAfterTests) {
+        outerChannel.sink.add('debug');
+        await outerQueue.next;
+      }
       receivePort.close();
       onExitPort.close();
       isolate!.kill();
@@ -234,3 +247,13 @@ Uri _observatoryUrlFor(Uri base, String isolateId, String id) => base.replace(
     fragment: Uri(
         path: '/inspect',
         queryParameters: {'isolateId': isolateId, 'objectId': id}).toString());
+
+var _hasRegistered = false;
+void _setupPauseAfterTests() {
+  if (_hasRegistered) return;
+  _hasRegistered = true;
+  registerExtension('ext.test.pauseAfterTests', (_, __) async {
+    _shouldPauseAfterTests = true;
+    return ServiceExtensionResponse.result(jsonEncode({}));
+  });
+}

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -69,6 +69,9 @@ class VMPlatform extends PlatformPlugin {
 
     VmService? client;
     StreamSubscription<Event>? eventSub;
+    // Typical test interaction will go across `channel`, `outerChannel` adds
+    // additional communication directly between the test bootstrapping and this
+    // platform to enable pausing after tests for debugging.
     var outerChannel = MultiChannel(IsolateChannel.connectReceive(receivePort));
     var outerQueue = StreamQueue(outerChannel.stream);
     var channelId = (await outerQueue.next) as int;


### PR DESCRIPTION
Enables use cases like checking memory usage after a test has run.

This is primarily aimed at an internal use case, if it turns out to be
more widely useful we can better document it. For now it is considered
experimental.

Add a separate channel for communication between the VM platform and the
test isolate bootstrapping. Use a virtual channel for the existing
communication between the `RemoteListener` and the test control helper.
The only messages that are sent across this channel for now are a signal
from the platform to the isolate to pause, and a signal back indicating
that the pause is complete and the isolate can be killed.

Register a service extension (once globally) when loading a test for the
VM platform. The setting is global, which may need to be changed if we
extend this to support external use cases. Internal tests only ever run
a single test suite, so it makes no difference whether the setting is
global.