### PR TITLE
Migrate a ??= getter to a late final field

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.4.11-dev
+
 ## 0.4.10
 
 * Update `analyzer` constraint to `>=2.14.0 <3.0.0`.

--- a/pkgs/test_core/lib/src/runner/configuration.dart
+++ b/pkgs/test_core/lib/src/runner/configuration.dart
@@ -191,10 +191,11 @@ class Configuration {
   /// All preset names that are known to be valid.
   ///
   /// This includes presets that have already been resolved.
-  late final Set<String> knownPresets = UnmodifiableSetView({
-    ...presets.keys,
-    for (var configuration in presets.values) ...configuration.knownPresets
-  });
+  Set<String> get knownPresets => _knownPresets ??= UnmodifiableSetView({
+        ...presets.keys,
+        for (var configuration in presets.values) ...configuration.knownPresets
+      });
+  Set<String>? _knownPresets;
 
   /// Whether to use the original `data:` URI isolate spawning strategy for VM
   /// tests.

--- a/pkgs/test_core/lib/src/runner/configuration.dart
+++ b/pkgs/test_core/lib/src/runner/configuration.dart
@@ -191,11 +191,10 @@ class Configuration {
   /// All preset names that are known to be valid.
   ///
   /// This includes presets that have already been resolved.
-  Set<String> get knownPresets => _knownPresets ??= UnmodifiableSetView({
-        ...presets.keys,
-        for (var configuration in presets.values) ...configuration.knownPresets
-      });
-  Set<String>? _knownPresets;
+  late final Set<String> knownPresets = UnmodifiableSetView({
+    ...presets.keys,
+    for (var configuration in presets.values) ...configuration.knownPresets
+  });
 
   /// Whether to use the original `data:` URI isolate spawning strategy for VM
   /// tests.

--- a/pkgs/test_core/lib/src/runner/suite.dart
+++ b/pkgs/test_core/lib/src/runner/suite.dart
@@ -125,15 +125,14 @@ class SuiteConfiguration {
   final Metadata _metadata;
 
   /// The set of tags that have been declared in any way in this configuration.
-  Set<String> get knownTags => _knownTags ??= UnmodifiableSetView({
-        ...includeTags.variables,
-        ...excludeTags.variables,
-        ..._metadata.tags,
-        for (var selector in tags.keys) ...selector.variables,
-        for (var configuration in tags.values) ...configuration.knownTags,
-        for (var configuration in onPlatform.values) ...configuration.knownTags,
-      });
-  Set<String>? _knownTags;
+  late final Set<String> knownTags = UnmodifiableSetView({
+    ...includeTags.variables,
+    ...excludeTags.variables,
+    ..._metadata.tags,
+    for (var selector in tags.keys) ...selector.variables,
+    for (var configuration in tags.values) ...configuration.knownTags,
+    for (var configuration in onPlatform.values) ...configuration.knownTags,
+  });
 
   /// Only run tests that originate from this line in a test file.
   final int? line;

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.10
+version: 0.4.11-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
This field was initialized lazily manually because it needs to refer
to other fields on `this`. Using a `late final` field with an
initializing expression is a more terse way to express this than an
additional private field.