### PR TITLE
Remove the isolate exit waits

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.12-dev
+
+* Remove wait for VM platform isolate exits.
+
 ## 0.4.11
 
 * Update `vm_service` constraint to `>=6.0.0 <9.0.0`.

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.11
+version: 0.4.12-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
These turned out not to accomplish very much and they have been
superseded by the `pauseAfterTests` VM service extension.