### PR TITLE
Fix implicit null returns

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.4.12-dev
+
 ## 0.4.11
 
 * Update `vm_service` constraint to `>=6.0.0 <9.0.0`.

--- a/pkgs/test_core/lib/src/runner/configuration/load.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/load.dart
@@ -6,7 +6,6 @@ import 'dart:io';
 
 import 'package:boolean_selector/boolean_selector.dart';
 import 'package:glob/glob.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:source_span/source_span.dart';
 import 'package:test_api/scaffolding.dart' // ignore: deprecated_member_use
@@ -648,8 +647,7 @@ class _ConfigurationLoader {
   }
 
   /// Throws a [SourceSpanFormatException] with [message] about [field].
-  @alwaysThrows
-  void _error(String message, String field) {
+  Never _error(String message, String field) {
     throw SourceSpanFormatException(
         message, _document.nodes[field]!.span, _source);
   }

--- a/pkgs/test_core/lib/src/runner/util/iterable_set.dart
+++ b/pkgs/test_core/lib/src/runner/util/iterable_set.dart
@@ -36,6 +36,7 @@ class IterableSet<E> with SetMixin<E>, UnmodifiableSetMixin<E> {
     for (var e in _base) {
       if (e == element) return e;
     }
+    return null;
   }
 
   @override

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.11
+version: 0.4.12-dev
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
Recent Dart SDK versions surface an analyzer diagnostic for functions
which use an implicit return at the end for the `null` case.

Migrate from `@alwaysThrows` to a `Never` return type to correct flow
analysis.

Add an explicit `return null` in one method.