### PR TITLE
Remove a stale TODO and diagnostic ignore

### DIFF
--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.4.10-dev
+
 ## 0.4.9
 
 * Add `ignoreTimeouts` option to `Suite`, which disables all timeouts for all

--- a/pkgs/test_api/lib/src/expect/expect.dart
+++ b/pkgs/test_api/lib/src/expect/expect.dart
@@ -62,9 +62,6 @@ Future expectLater(actual, matcher, {String? reason, skip}) =>
     _expect(actual, matcher, reason: reason, skip: skip);
 
 /// The implementation of [expect] and [expectLater].
-///
-// TODO: why is this necessary? Is @alwaysThrows not working in NNBD?
-// ignore: body_might_complete_normally
 Future _expect(actual, matcher,
     {String? reason, skip, bool verbose = false, ErrorFormatter? formatter}) {
   final test = TestHandle.current;

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.4.9
+version: 0.4.10-dev
 description: A library for writing Dart tests.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_api
 


### PR DESCRIPTION
The `fail` method was updated with a return type of `Never` and does not
use `@alwaysThrows` anymore. This diagnostic is no longer present and
does not need to be ignored.