### PR TITLE
Stop treating `/packages/` specially

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.20.2-dev
 
 * Drop `dart2js-path` command line argument.
+* Allow loading tests under a path with the directory named `packages`.
 
 ## 1.20.1
 

--- a/pkgs/test/test/runner/loader_test.dart
+++ b/pkgs/test/test/runner/loader_test.dart
@@ -90,12 +90,6 @@ void main() {
           completion(isEmpty));
     });
 
-    test('ignores files in packages/ directories', () async {
-      await d.dir('packages', [d.file('a_test.dart', _tests)]).create();
-      expect(_loader.loadDir(d.sandbox, SuiteConfiguration.empty).toList(),
-          completion(isEmpty));
-    });
-
     test("ignores files that don't end in _test.dart", () async {
       await d.file('test.dart', _tests).create();
       expect(_loader.loadDir(d.sandbox, SuiteConfiguration.empty).toList(),

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Remove wait for VM platform isolate exits.
 * Drop `dart2jsPath` configuration support.
+* Allow loading tests under a path with the directory named `packages`.
 
 ## 0.4.11
 

--- a/pkgs/test_core/lib/src/runner/loader.dart
+++ b/pkgs/test_core/lib/src/runner/loader.dart
@@ -140,9 +140,7 @@ class Loader {
   Stream<LoadSuite> loadDir(String dir, SuiteConfiguration suiteConfig) {
     return StreamGroup.merge(
         Directory(dir).listSync(recursive: true).map((entry) {
-      if (entry is! File ||
-          !_config.filename.matches(p.basename(entry.path)) ||
-          p.split(entry.path).contains('packages')) {
+      if (entry is! File || !_config.filename.matches(p.basename(entry.path))) {
         return Stream.empty();
       }
 


### PR DESCRIPTION
Fixes #1667

The special treatment of `packages` as a directory name was from when
`pub` would create a directory with that name under the package root. I
think the intention was to avoid loading in tests from the packages pub
downloaded.

There are still cases where a directory named `packages` is created and
treated specially by Dart tooling, but those use cases are limited to
the web and should no longer have their `test` directories retained.