### PR TITLE
migrate back to ConstructorName.type from ConstructorName.type2

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Remove wait for VM platform isolate exits.
 * Drop `dart2jsPath` configuration support.
 * Allow loading tests under a path with the directory named `packages`.
+* Require analyzer version `3.3.0`.
 
 ## 0.4.11
 

--- a/pkgs/test_core/lib/src/runner/parse_metadata.dart
+++ b/pkgs/test_core/lib/src/runner/parse_metadata.dart
@@ -220,7 +220,7 @@ class _Parser {
       for (var expression in expressions) {
         if (expression is InstanceCreationExpression) {
           var className = _resolveConstructor(
-                  expression.constructorName.type2.name,
+                  expression.constructorName.type.name,
                   expression.constructorName.name)
               .first;
 
@@ -356,7 +356,7 @@ class _Parser {
 
   String? _findConstructornameFromInstantiation(
       InstanceCreationExpression constructor, String className) {
-    var pair = _resolveConstructor(constructor.constructorName.type2.name,
+    var pair = _resolveConstructor(constructor.constructorName.type.name,
         constructor.constructorName.name);
     var actualClassName = pair.first;
     var constructorName = pair.last;

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
  sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=2.4.0 <4.0.0'
+  analyzer: '>=3.3.0 <4.0.0'
   async: ^2.5.0
   args: ^2.0.0
   boolean_selector: ^2.1.0


### PR DESCRIPTION
The `type2` api is now deprecated, breaking our CI. This requires a bump in analyzer min version, but we don't need to publish right away.