### PR TITLE
allow analyzer 4.x, and prepare to publish

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 1.21.0-dev
+## 1.21.0
 
+* Allow analyzer version `4.x`.
 * Add a `github` reporter option for use with GitHub Actions.
 * Make the `github` test reporter the default when we detect we're running on
   GitHub Actions.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.21.0-dev
+version: 1.21.0
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=2.0.0 <4.0.0'
+  analyzer: '>=2.0.0 <5.0.0'
   async: ^2.5.0
   boolean_selector: ^2.1.0
   collection: ^1.15.0
@@ -33,7 +33,7 @@ dependencies:
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.4.9
-  test_core: 0.4.11
+  test_core: 0.4.12
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   matcher: '>=0.12.11 <0.12.12'
 
 dev_dependencies:
-  analyzer: '>=2.1.0 <4.0.0'
+  analyzer: '>=2.1.0 <5.0.0'
   fake_async: ^1.2.0
   glob: ^2.0.0
   graphs: ^2.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,9 +1,9 @@
-## 0.4.12-dev
+## 0.4.12
 
 * Remove wait for VM platform isolate exits.
 * Drop `dart2jsPath` configuration support.
 * Allow loading tests under a path with the directory named `packages`.
-* Require analyzer version `3.3.0`.
+* Require analyzer version `3.3.0`, and allow version `4.x`.
 
 ## 0.4.11
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.12-dev
+version: 0.4.12
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 
@@ -7,7 +7,7 @@ environment:
  sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=3.3.0 <4.0.0'
+  analyzer: '>=3.3.0 <5.0.0'
   async: ^2.5.0
   args: ^2.0.0
   boolean_selector: ^2.1.0


### PR DESCRIPTION
Note that `test_api` does not need a version bump, as it has no public dep on analyzer