### PR TITLE
drop new constants from test_api and usages from test_core, re-publish test_core

### DIFF
--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.4.9
-  test_core: 0.4.12
+  test_core: 0.4.13
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_api/lib/src/backend/declarer.dart
+++ b/pkgs/test_api/lib/src/backend/declarer.dart
@@ -14,9 +14,6 @@ import 'invoker.dart';
 import 'metadata.dart';
 import 'test.dart';
 
-const setUpAllName = '(setUpAll)';
-const tearDownAllName = '(tearDownAll)';
-
 /// A class that manages the state of tests as they're declared.
 ///
 /// A nested tree of Declarers tracks the current group, set-up, and tear-down
@@ -360,7 +357,7 @@ class Declarer {
   Test? get _setUpAll {
     if (_setUpAlls.isEmpty) return null;
 
-    return LocalTest(_prefix(setUpAllName), _metadata.change(timeout: _timeout),
+    return LocalTest(_prefix('(setUpAll)'), _metadata.change(timeout: _timeout),
         () {
       return runZoned(
           () => Future.forEach<Function>(_setUpAlls, (setUp) => setUp()),
@@ -377,7 +374,7 @@ class Declarer {
     if (_setUpAlls.isEmpty && _tearDownAlls.isEmpty) return null;
 
     return LocalTest(
-        _prefix(tearDownAllName), _metadata.change(timeout: _timeout), () {
+        _prefix('(tearDownAll)'), _metadata.change(timeout: _timeout), () {
       return runZoned(() => Invoker.current!.runTearDowns(_tearDownAlls),
           // Make the declarer visible to running scaffolds so they can add to
           // the declarer's `tearDownAll()` list.

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 0.4.12
+## 0.4.13
+
+* Re-publish changes from 0.4.12.
+* Stop relying on setUpAllName and tearDownAllName constants from test_api.
+
+## 0.4.12 (retracted)
 
 * Remove wait for VM platform isolate exits.
 * Drop `dart2jsPath` configuration support.

--- a/pkgs/test_core/lib/src/runner/reporter/github.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/github.dart
@@ -9,7 +9,6 @@ import 'dart:async';
 import 'package:test_api/src/backend/live_test.dart';
 import 'package:test_api/src/backend/message.dart';
 import 'package:test_api/src/backend/state.dart';
-import 'package:test_api/src/backend/declarer.dart';
 import 'package:test_api/src/backend/util/pretty_print.dart';
 
 import '../engine.dart';
@@ -112,8 +111,8 @@ class GithubReporter implements Reporter {
     final failed = errors.isNotEmpty;
     final loadSuite = test.suite is LoadSuite;
     final synthetic = loadSuite ||
-        test.individualName == setUpAllName ||
-        test.individualName == tearDownAllName;
+        test.individualName == '(setUpAll)' ||
+        test.individualName == '(tearDownAll)';
 
     // Mark this test as having completed.
     _completedTests.add(test);

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.12
+version: 0.4.13
 description: A basic library for writing tests and running them on the VM.
 homepage: https://github.com/dart-lang/test/blob/master/pkgs/test_core
 


### PR DESCRIPTION
It turns out test_core did rely on some changes in test_api that weren't documented in the changelog, I yanked version 0.4.12, and this will re-publish it as 0.4.13.

We don't want to do a release in test_api because flutter users won't pick up that version for a long time (on stable at least), so this removes the reliance on those new apis as well.