### PR TITLE
Determine encoding of source files used for coverage

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.21.1
 
-* Fix a bug loading sources and source maps while parsing coverage information
-  from chrome.
+* Fix a bug loading JS sources with non-utf8 content while parsing coverage
+  information from chrome.
 
 ## 1.21.0
 

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.21.1
+
+* Fix a bug loading sources and source maps while parsing coverage information
+  from chrome.
+
 ## 1.21.0
 
 * Allow analyzer version `4.x`.

--- a/pkgs/test/lib/src/runner/browser/chrome.dart
+++ b/pkgs/test/lib/src/runner/browser/chrome.dart
@@ -194,11 +194,22 @@ Future<WipConnection> _connect(
 }
 
 extension on HttpClient {
+  Encoding determineEncoding(HttpHeaders headers) {
+    final contentType = headers.contentType?.charset;
+    /// Using the `charset` property of the `contentType` if available.
+    /// If it's unavailable or if the encoding name is unknown, [latin1] is used by default, 
+    /// as per [RFC 2616][].
+    ///
+    /// [RFC 2616]: http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html
+    return Encoding.getByName(contentType) ?? latin1;
+  }
+
   Future<String?> getString(String url) async {
     final request = await getUrl(Uri.parse(url));
     final response = await request.close();
     if (response.statusCode != HttpStatus.ok) return null;
     var bytes = [await for (var chunk in response) ...chunk];
-    return utf8.decode(bytes);
+    final encoding = determineEncoding(response.headers);
+    return encoding.decode(bytes);
   }
 }

--- a/pkgs/test/lib/src/runner/browser/chrome.dart
+++ b/pkgs/test/lib/src/runner/browser/chrome.dart
@@ -196,8 +196,9 @@ Future<WipConnection> _connect(
 extension on HttpClient {
   Encoding determineEncoding(HttpHeaders headers) {
     final contentType = headers.contentType?.charset;
+
     /// Using the `charset` property of the `contentType` if available.
-    /// If it's unavailable or if the encoding name is unknown, [latin1] is used by default, 
+    /// If it's unavailable or if the encoding name is unknown, [latin1] is used by default,
     /// as per [RFC 2616][].
     ///
     /// [RFC 2616]: http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.21.0
+version: 1.21.1
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/blob/master/pkgs/test


### PR DESCRIPTION
After upgrade past version 1.15.7 of the test package I was no longer able to collect code coverage.

After working with several of my teammates we tracked down that it was due to a non utf-8 character in one of the javascript sources that are being used by our browser tests.

It looks like this got introduced with the move away from the http package because it looks like it was handling that type of problem [here](https://github.com/dart-lang/http/blob/69d6064dd92470ed7ccd50a808fc789ee7716fe8/lib/src/response.dart#L20-L28).

```
RangeError (index): Invalid value: Not in inclusive range 0..335531: 335532
dart:core                                            List.[]=
package:coverage/src/chrome.dart 137:21              _offsetCoverage
package:coverage/src/chrome.dart 48:28               parseChromeCoverage
package:test/src/runner/browser/chrome.dart 111:20   Chrome.gatherCoverage
package:test_core/src/runner/runner_suite.dart 79:8  RunnerSuite.gatherCoverage
package:test_core/src/runner/coverage.dart 16:18     writeCoverage
package:test_core/src/runner/engine.dart 270:36      Engine.run.<fn>.<fn>

This is an unexpected error. Please file an issue at http://github.com/dart-lang/test
with the stack trace and instructions for reproducing the error.
Unhandled exception:
RangeError (index): Invalid value: Not in inclusive range 0..335531: 335532
#0      List._setIndexed (dart:core-patch/array.dart:118:64)
#1      List.[]= (dart:core-patch/array.dart:114:5)
#2      _offsetCoverage (package:coverage/src/chrome.dart:137:21)
#3      parseChromeCoverage (package:coverage/src/chrome.dart:48:28)
<asynchronous suspension>
#4      Chrome.gatherCoverage (package:test/src/runner/browser/chrome.dart:111:20)
<asynchronous suspension>
#5      RunnerSuite.gatherCoverage (package:test_core/src/runner/runner_suite.dart:79:8)
<asynchronous suspension>
#6      writeCoverage (package:test_core/src/runner/coverage.dart:16:18)
<asynchronous suspension>
#7      Engine.run.<anonymous closure>.<anonymous closure> (package:test_core/src/runner/engine.dart:270:36)
<asynchronous suspension>


```