### PR TITLE
Initial implementation of package:checks

### DIFF
--- a/pkgs/checks/README.md
+++ b/pkgs/checks/README.md
@@ -1,0 +1,47 @@
+# Trying Checks as a Preview
+
+1.  Add a git dependency on this package:
+
+    ```
+    dev_dependencies:
+      checks:
+        git:
+          url: git@github.com:dart-lang/test.git
+          path: pkgs/checks
+          ref: checks
+    ```
+
+1.  Add an import to `package:checks/checks.dart`.
+
+1.  Replace the existing `package:test/test.dart` import with
+    `package:test/scaffolding.dart`.
+
+1.  For an incremental migration within the test, add an import to
+    `package:test/expect.dart`. Remove it to surface errors in tests that stil
+    need to be migrated, or keep it in so the tests work without being fully
+    migrated.
+
+1.  Migrate the test cases.
+
+# Migrating from Matchers
+
+Replace calls to `expect` with a call to `checkThat` passing the first argument.
+When a direct replacement is available, change the second argument from calling
+a function returning a Matcher, to calling the extension method on the `Check`.
+
+When a non-matcher argument is used for the expected value, it would have been
+wrapped with `equals` automatically. See below, `.equals` may not always be the
+correct replacement in `package:checks`.
+
+```dart
+expect(actual, expected);
+checkThat(actual).equals(expected);
+// or maybe
+checkThat(actual).deepEquals(expected);
+```
+
+## Differences in behavior from matcher
+
+- The `equals` Matcher performed a deep equality check on collections.
+  `.equals()` check will only correspon to [operator ==] so some tests may need
+  to replace `.equals()` with `.deepEquals()`. **TODO: implement `deepEquals`**

--- a/pkgs/checks/README.md
+++ b/pkgs/checks/README.md
@@ -17,7 +17,7 @@
     `package:test/scaffolding.dart`.
 
 1.  For an incremental migration within the test, add an import to
-    `package:test/expect.dart`. Remove it to surface errors in tests that stil
+    `package:test/expect.dart`. Remove it to surface errors in tests that still
     need to be migrated, or keep it in so the tests work without being fully
     migrated.
 
@@ -43,5 +43,5 @@ checkThat(actual).deepEquals(expected);
 ## Differences in behavior from matcher
 
 - The `equals` Matcher performed a deep equality check on collections.
-  `.equals()` check will only correspon to [operator ==] so some tests may need
+  `.equals()` check will only correspond to [operator ==] so some tests may need
   to replace `.equals()` with `.deepEquals()`. **TODO: implement `deepEquals`**

--- a/pkgs/checks/README.md
+++ b/pkgs/checks/README.md
@@ -8,7 +8,9 @@
         git:
           url: git@github.com:dart-lang/test.git
           path: pkgs/checks
-          ref: checks
+          # Omit to try the latest, or pin to a commit to avoid
+          # breaking changes while the library is experimental.
+          ref: <sha>
     ```
 
 1.  Add an import to `package:checks/checks.dart`.

--- a/pkgs/checks/lib/checks.dart
+++ b/pkgs/checks/lib/checks.dart
@@ -1,0 +1,14 @@
+export 'src/checks.dart' show checkThat, Check;
+export 'src/extensions/async.dart' show ChainAsync, FutureChecks, StreamChecks;
+export 'src/extensions/core.dart'
+    show
+        BoolChecks,
+        EqualityChecks,
+        HasField,
+        NullabilityChecks,
+        StringChecks,
+        TypeChecks;
+export 'src/extensions/function.dart' show ThrowsCheck;
+export 'src/extensions/iterable.dart' show IterableChecks;
+export 'src/extensions/map.dart' show MapChecks;
+export 'src/extensions/math.dart' show NumChecks;

--- a/pkgs/checks/lib/context.dart
+++ b/pkgs/checks/lib/context.dart
@@ -1,0 +1,10 @@
+export 'src/checks.dart'
+    show
+        Check,
+        Context,
+        Extracted,
+        Rejection,
+        describe,
+        softCheck,
+        ContextExtension;
+export 'src/describe.dart' show literal, indent;

--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -59,7 +59,7 @@ Check<T> checkThat<T>(T value, {String? because}) => Check._(_TestContext._(
     fail: (m, _) => throw TestFailure(m),
     allowAsync: true));
 
-/// Checks whether [value] satifies all expectations invoked in [condition].
+/// Checks whether [value] satisfies all expectations invoked in [condition].
 ///
 /// Returns `null` if all expectations are satisfied, otherwise returns the
 /// [Rejection] for the first expectation that fails.
@@ -81,7 +81,7 @@ Rejection? softCheck<T>(T value, void Function(Check<T>) condition) {
 /// Creates a description of the expectations checked by [condition].
 ///
 /// The strings are individual lines of a description.
-/// The description of an expectation may be one or more adjactent lines.
+/// The description of an expectation may be one or more adjacent lines.
 ///
 /// Matches the "Expected: " lines in the output of a failure message if a value
 /// did not meet the last expectation in [condition], without the first labeled
@@ -116,7 +116,7 @@ abstract class Context<T> {
   ///
   /// The property that is asserted by this expectation is described by
   /// [clause]. Often this is a single statement like "equals <1>" or "is
-  /// greather than 10", but it may be multiple lines such as describing that an
+  /// greater than 10", but it may be multiple lines such as describing that an
   /// Iterable contains an element meeting a complex expectation. If any element
   /// in the returned iterable contains a newline it may cause problems with
   /// indentation in the output.
@@ -128,7 +128,7 @@ abstract class Context<T> {
   ///
   /// The property that is asserted by this expectation is described by
   /// [clause]. Often this is a single statement like "equals <1>" or "is
-  /// greather than 10", but it may be multiple lines such as describing that an
+  /// greater than 10", but it may be multiple lines such as describing that an
   /// Iterable contains an element meeting a complex expectation. If any element
   /// in the returned iterable contains a newline it may cause problems with
   /// indentation in the output.

--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -53,6 +53,7 @@ class Check<T> {
 /// ```
 Check<T> checkThat<T>(T value, {String? because}) => Check._(_TestContext._(
     value: _Present(value),
+    // TODO - switch between "a" and "an"
     label: 'a $T',
     reason: because,
     fail: (m, _) => throw TestFailure(m),

--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -40,7 +40,7 @@ class Check<T> {
   }
 }
 
-/// Returns a [Check] that can be used to validate expectations against [value].
+/// Creates a [Check] that can be used to validate expectations against [value].
 ///
 /// Expectations that are not satisfied throw a [TestFailure] to interrupt the
 /// currently running test and mark it as failed.

--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -1,0 +1,483 @@
+import 'dart:async';
+
+import 'package:test_api/hooks.dart';
+
+import 'describe.dart';
+
+/// A target for checking expectations against a value in a test.
+///
+/// A Check my have a real value, in which case the expectations can be
+/// validated or rejected; or it may be a placeholder, in which case
+/// expectations describe what would be checked but cannot be rejected.
+///
+/// Expectations are defined as extension methods specialized on the generic
+/// [T]. Expectations can use the [ContextExtension] to interact with the
+/// [Context] for this check.
+class Check<T> {
+  final Context<T> _context;
+  Check._(this._context);
+
+  /// Mark the currently running test as skipped and return a [Check] that will
+  /// ignore all expectations.
+  ///
+  /// Any expectations against the return value will not be checked and will not
+  /// be included in the "Expected" or "Actual" string representations of a
+  /// failure.
+  ///
+  /// ```dart
+  /// checkThat(actual)
+  ///     ..stillChecked()
+  ///     ..skip('reason the expectation is temporarily not met').notChecked();
+  /// ```
+  ///
+  /// If `skip` is used in a callback passed to `softCheck` or `describe` it
+  /// will still mark the test as skipped, even though failing the expectation
+  /// would not have otherwise caused the test to fail.
+  Check<T> skip(String message) {
+    TestHandle.current.markSkipped(message);
+    return Check._(_SkippedContext());
+  }
+}
+
+/// Returns a [Check] that can be used to validate expectations against [value].
+///
+/// Expectations that are not satisfied throw a [TestFailure] to interrupt the
+/// currently running test and mark it as failed.
+///
+/// If [because] is passed it will be included as a "Reason:" line in failure
+/// messages.
+///
+/// ```dart
+/// checkThat(actual).equals(expected);
+/// ```
+Check<T> checkThat<T>(T value, {String? because}) => Check._(_TestContext._(
+    value: _Present(value),
+    label: 'a $T',
+    reason: because,
+    fail: (m, _) => throw TestFailure(m),
+    allowAsync: true));
+
+/// Checks whether [value] satifies all expectations invoked in [condition].
+///
+/// Returns `null` if all expectations are satisfied, otherwise returns the
+/// [Rejection] for the first expectation that fails.
+///
+/// Asynchronous expectations are not allowed in [condition] and will cause a
+/// runtime error if they are used.
+Rejection? softCheck<T>(T value, void Function(Check<T>) condition) {
+  Rejection? rejection;
+  final check = Check<T>._(_TestContext._(
+      value: _Present(value),
+      fail: (_, r) {
+        rejection = r;
+      },
+      allowAsync: false));
+  condition(check);
+  return rejection;
+}
+
+/// Return a String describing the expectations checked by [condition].
+///
+/// Elements in the returned value are individual lines in the description. An
+/// expectation may be a single line, or multiple lines.
+///
+/// Matches the "Expected: " lines in the output of a failure message if a value
+/// did not meet the last expectation in [condition], without the first labeled
+/// line.
+Iterable<String> describe<T>(void Function(Check<T>) condition) {
+  final context = _TestContext<T>._(
+      value: _Absent(),
+      fail: (_, __) {
+        throw UnimplementedError();
+      },
+      allowAsync: false);
+  condition(Check._(context));
+  return context.expected.skip(1);
+}
+
+extension ContextExtension<T> on Check<T> {
+  /// The expectations and nesting context for this check.
+  Context<T> get context => _context;
+}
+
+/// The expectation and nesting context already applied to a [Check].
+///
+/// This is the surface of interaction for expectation extension method
+/// implementations.
+///
+/// `expect` and `expectAsync` can test the value and optionally reject it.
+/// `nest` and `nestAsync` can test the value, and also extract some other
+/// property from it for further checking.
+abstract class Context<T> {
+  /// Expect that [predicate] will not return a [Rejection] for the checked
+  /// value.
+  ///
+  /// The property that is asserted by this expectation is described by
+  /// [clause]. Often this is a single statement like "equals <1>" or "is
+  /// greather than 10", but it may be multiple lines such as describing that an
+  /// Iterable contains an element meeting a complex expectation. If any element
+  /// in the returned iterable contains a newline it may cause problems with
+  /// indentation in the output.
+  void expect(
+      Iterable<String> Function() clause, Rejection? Function(T) predicate);
+
+  /// Expect that [predicate] will not result in a [Rejection] for the checked
+  /// value.
+  ///
+  /// The property that is asserted by this expectation is described by
+  /// [clause]. Often this is a single statement like "equals <1>" or "is
+  /// greather than 10", but it may be multiple lines such as describing that an
+  /// Iterable contains an element meeting a complex expectation. If any element
+  /// in the returned iterable contains a newline it may cause problems with
+  /// indentation in the output.
+  ///
+  /// Some context may disallow asynchronous expectations, for instance in
+  /// [softCheck] which must synchronously check the value. In those contexts
+  /// this method will throw.
+  Future<void> expectAsync<R>(Iterable<String> Function() clause,
+      FutureOr<Rejection?> Function(T) predicate);
+
+  /// Extract a property from the value for further checking.
+  ///
+  /// If the property cannot be extracted, [extract] should return an
+  /// [Extracted.rejection] describing the problem. Otherwise it should return
+  /// an [Extracted.value].
+  ///
+  /// The [label] will be used preceding "that:" in a description. Expectations
+  /// applied to the returned [Check] will follow the label, indented by two
+  /// more spaces.
+  ///
+  /// If [atSameLevel] is true then [R] should be a subtype of [T], and a
+  /// returned [Extracted.value] should be the same instance as passed value.
+  /// This may be useful to refine the type for further checks. In this case the
+  /// label is used like a single line "clause" passed to [expect], and
+  /// expectations applied to the return [Check] will behave as if they were
+  /// applied to the Check for this context.
+  Check<R> nest<R>(String label, Extracted<R> Function(T) extract,
+      {bool atSameLevel = false});
+
+  /// Extract an asynchronous property from the value for further checking.
+  ///
+  /// If the property cannot be extracted, [extract] should return an
+  /// [Extracted.rejection] describing the problem. Otherwise it should return
+  /// an [Extracted.value].
+  ///
+  /// The [label] will be used preceding "that:" in a description. Expectations
+  /// applied to the returned [Check] will follow the label, indented by two
+  /// more spaces.
+  ///
+  /// Some context may disallow asynchronous expectations, for instance in
+  /// [softCheck] which must synchronously check the value. In those contexts
+  /// this method will throw.
+  Future<Check<R>> nestAsync<R>(
+      String label, FutureOr<Extracted<R>> Function(T) extract);
+}
+
+/// A property extracted from a value being checked, or a rejection.
+class Extracted<T> {
+  final Rejection? rejection;
+  final T? value;
+  Extracted.rejection({required String actual, Iterable<String>? which})
+      : this.rejection = Rejection(actual: actual, which: which),
+        this.value = null;
+  Extracted.value(this.value) : this.rejection = null;
+
+  Extracted._(this.rejection) : this.value = null;
+
+  Extracted<R> _map<R>(R Function(T) transform) {
+    if (rejection != null) return Extracted._(rejection);
+    return Extracted.value(transform(value as T));
+  }
+}
+
+abstract class _Value<T> {
+  R? apply<R extends FutureOr<Rejection?>>(R Function(T) callback);
+  Future<Extracted<_Value<R>>> mapAsync<R>(
+      FutureOr<Extracted<R>> Function(T) transform);
+  Extracted<_Value<R>> map<R>(Extracted<R> Function(T) transform);
+}
+
+class _Present<T> implements _Value<T> {
+  final T value;
+  _Present(this.value);
+
+  @override
+  R? apply<R extends FutureOr<Rejection?>>(R Function(T) c) => c(value);
+
+  @override
+  Future<Extracted<_Value<R>>> mapAsync<R>(
+      FutureOr<Extracted<R>> Function(T) transform) async {
+    final transformed = await transform(value);
+    return transformed._map((v) => _Present(v));
+  }
+
+  @override
+  Extracted<_Value<R>> map<R>(Extracted<R> Function(T) transform) =>
+      transform(value)._map((v) => _Present(v));
+}
+
+class _Absent<T> implements _Value<T> {
+  @override
+  R? apply<R extends FutureOr<Rejection?>>(R Function(T) c) => null;
+
+  @override
+  Future<Extracted<_Value<R>>> mapAsync<R>(
+          FutureOr<Extracted<R>> Function(T) transform) async =>
+      Extracted.value(_Absent<R>());
+
+  @override
+  Extracted<_Value<R>> map<R>(FutureOr<Extracted<R>> Function(T) transform) =>
+      Extracted.value(_Absent<R>());
+}
+
+class _TestContext<T> implements Context<T>, _ClauseDescription {
+  final _Value<T> _value;
+  final _TestContext<dynamic>? _parent;
+
+  final List<_ClauseDescription> _clauses;
+  final List<_TestContext> _aliases;
+
+  // The "a value" in "a value that:".
+  final String _label;
+  final String? _reason;
+
+  final void Function(String, Rejection?) _fail;
+
+  final bool _allowAsync;
+
+  _TestContext._({
+    required _Value<T> value,
+    required void Function(String, Rejection?) fail,
+    required bool allowAsync,
+    String? label,
+    String? reason,
+  })  : _value = value,
+        _label = label ?? '',
+        _reason = reason,
+        _fail = fail,
+        _allowAsync = allowAsync,
+        _parent = null,
+        _clauses = [],
+        _aliases = [];
+
+  _TestContext._alias(_TestContext original, this._value)
+      : _parent = original._parent,
+        _clauses = original._clauses,
+        _aliases = original._aliases,
+        _fail = original._fail,
+        _allowAsync = original._allowAsync,
+        // Properties that are never read from an aliased context
+        _label = '',
+        _reason = null;
+
+  _TestContext._child(this._value, this._label, _TestContext<dynamic> parent)
+      : _parent = parent,
+        _fail = parent._fail,
+        _allowAsync = parent._allowAsync,
+        _clauses = [],
+        _aliases = [],
+        // Properties that are never read from any context other than root
+        _reason = null;
+
+  @override
+  void expect(
+      Iterable<String> Function() clause, Rejection? Function(T) predicate) {
+    _clauses.add(_StringClause(clause));
+    final rejection = _value.apply(predicate);
+    if (rejection != null) {
+      _fail(_failure(rejection), rejection);
+    }
+  }
+
+  @override
+  Future<void> expectAsync<R>(Iterable<String> Function() clause,
+      FutureOr<Rejection?> Function(T) predicate) async {
+    if (!_allowAsync) {
+      throw StateError(
+          'Async expectations cannot be used in a synchronous check');
+    }
+    _clauses.add(_StringClause(clause));
+    final outstandingWork = TestHandle.current.markPending();
+    final rejection = await _value.apply(predicate);
+    outstandingWork.complete();
+    if (rejection == null) return;
+    _fail(_failure(rejection), rejection);
+  }
+
+  String _failure(Rejection rejection) {
+    final root = _root;
+    return [
+      ..._prefixFirst('Expected: ', root.expected),
+      ..._prefixFirst('Actual: ', root.actual(rejection, this)),
+      if (_reason != null) 'Reason: $_reason',
+    ].join('\n');
+  }
+
+  @override
+  Check<R> nest<R>(String label, Extracted<R> Function(T) extract,
+      {bool atSameLevel = false}) {
+    final result = _value.map(extract);
+    final rejection = result.rejection;
+    if (rejection != null) {
+      _clauses.add(_StringClause(() => [label]));
+      _fail(_failure(rejection), rejection);
+    }
+    final value = result.value ?? _Absent<R>();
+    final _TestContext<R> context;
+    if (atSameLevel) {
+      context = _TestContext._alias(this, value);
+      _aliases.add(context);
+      _clauses.add(_StringClause(() => [label]));
+    } else {
+      context = _TestContext._child(value, label, this);
+      _clauses.add(context);
+    }
+    return Check._(context);
+  }
+
+  @override
+  Future<Check<R>> nestAsync<R>(
+      String label, FutureOr<Extracted<R>> Function(T) extract) async {
+    if (!_allowAsync) {
+      throw StateError(
+          'Async expectations cannot be used in a synchronous check');
+    }
+    final outstandingWork = TestHandle.current.markPending();
+    final result = await _value.mapAsync(extract);
+    outstandingWork.complete();
+    final rejection = result.rejection;
+    if (rejection != null) {
+      _clauses.add(_StringClause(() => [label]));
+      _fail(_failure(rejection), rejection);
+    }
+    // TODO - does this need null fallback instead?
+    final value = result.value as _Value<R>;
+    final context = _TestContext<R>._child(value, label, this);
+    _clauses.add(context);
+    return Check._(context);
+  }
+
+  _TestContext get _root {
+    _TestContext<dynamic> current = this;
+    while (current._parent != null) {
+      current = current._parent!;
+    }
+    return current;
+  }
+
+  @override
+  Iterable<String> get expected {
+    assert(_clauses.isNotEmpty);
+    return [
+      '$_label that:',
+      for (var clause in _clauses) ...indent(clause.expected),
+    ];
+  }
+
+  @override
+  Iterable<String> actual(Rejection rejection, Context<dynamic> failedContext) {
+    if (identical(failedContext, this) || _aliases.contains(failedContext)) {
+      final which = rejection.which;
+      return [
+        if (_parent != null) '$_label that:',
+        '${_parent != null ? 'Actual: ' : ''}${rejection.actual}',
+        if (which != null && which.isNotEmpty) ..._prefixFirst('Which: ', which)
+      ];
+    } else {
+      return [
+        '$_label that:',
+        for (var clause in _clauses)
+          ...indent(clause.actual(rejection, failedContext))
+      ];
+    }
+  }
+}
+
+class _SkippedContext<T> implements Context<T> {
+  @override
+  void expect(
+      Iterable<String> Function() clause, Rejection? Function(T) predicate) {
+    // Ignore
+  }
+
+  @override
+  Future<void> expectAsync<R>(Iterable<String> Function() clause,
+      FutureOr<Rejection?> Function(T) predicate) async {
+    // Ignore
+  }
+
+  @override
+  Check<R> nest<R>(String label, Extracted<R> Function(T p1) extract,
+      {bool atSameLevel = false}) {
+    return Check._(_SkippedContext());
+  }
+
+  @override
+  Future<Check<R>> nestAsync<R>(
+      String label, FutureOr<Extracted<R>> Function(T p1) extract) async {
+    return Check._(_SkippedContext());
+  }
+}
+
+abstract class _ClauseDescription {
+  Iterable<String> get expected;
+  Iterable<String> actual(Rejection rejection, Context<dynamic> context);
+}
+
+class _StringClause implements _ClauseDescription {
+  final Iterable<String> Function() _expected;
+  @override
+  Iterable<String> get expected => _expected();
+  _StringClause(this._expected);
+  // Assumes this will never get called when it was this clause that failed
+  // because the TestContext that fails never inspect it's clauses and just
+  // prints the failed one.
+  // TODO: better way to model this?
+  @override
+  Iterable<String> actual(Rejection rejection, Context<dynamic> context) =>
+      expected;
+}
+
+/// A description of a value that failed an expectation.
+class Rejection {
+  /// A description of the actual value as it relates to the expectation.
+  ///
+  /// This may use [literal] to show a String representation of the value, or it
+  /// may be a description of a specific aspect of the value. For instance an
+  /// expectation that a Future completes to a value may describe the actual as
+  /// "A Future that completes to an error".
+  ///
+  /// This is printed following an "Actual: " label in the output of a failure
+  /// message. The message will be indented to the level of the expectation in
+  /// the description, and printed following the descriptions of any
+  /// expectations that have already passed.
+  final String actual;
+
+  /// A description of the way that [actual] failed to meet the expectation.
+  ///
+  /// An expectation can provide extra detail, or focus attention on a specific
+  /// part of the value. For instance when comparing multiple elements in a
+  /// collection, the rejection may describe that the value "has an unequal
+  /// value at index 3".
+  ///
+  /// Lines should be separate values in the iterable, if any element contains a
+  /// newline it may cause problems with indentation in the output.
+  ///
+  /// When provided, this is printed following a "Which: " label at the end of
+  /// the output for the failure message.
+  final Iterable<String>? which;
+
+  Rejection({required this.actual, this.which});
+}
+
+Iterable<String> _prefixFirst(String prefix, Iterable<String> lines) sync* {
+  var isFirst = true;
+  for (var line in lines) {
+    if (isFirst) {
+      yield '$prefix$line';
+      isFirst = false;
+    } else {
+      yield line;
+    }
+  }
+}

--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -1,3 +1,4 @@
+// TODO Add doc about how failure strings work.
 import 'dart:async';
 
 import 'package:test_api/hooks.dart';
@@ -76,10 +77,10 @@ Rejection? softCheck<T>(T value, void Function(Check<T>) condition) {
   return rejection;
 }
 
-/// Return a String describing the expectations checked by [condition].
+/// Creates a description of the expectations checked by [condition].
 ///
-/// Elements in the returned value are individual lines in the description. An
-/// expectation may be a single line, or multiple lines.
+/// The strings are individual lines of a description.
+/// The description of an expectation may be one or more adjactent lines.
 ///
 /// Matches the "Expected: " lines in the output of a failure message if a value
 /// did not meet the last expectation in [condition], without the first labeled
@@ -105,8 +106,8 @@ extension ContextExtension<T> on Check<T> {
 /// This is the surface of interaction for expectation extension method
 /// implementations.
 ///
-/// `expect` and `expectAsync` can test the value and optionally reject it.
-/// `nest` and `nestAsync` can test the value, and also extract some other
+/// The `expect` and `expectAsync` can test the value and optionally reject it.
+/// The `nest` and `nestAsync` can test the value, and also extract some other
 /// property from it for further checking.
 abstract class Context<T> {
   /// Expect that [predicate] will not return a [Rejection] for the checked

--- a/pkgs/checks/lib/src/describe.dart
+++ b/pkgs/checks/lib/src/describe.dart
@@ -1,0 +1,10 @@
+String literal(Object? o) {
+  if (o == null) return '<null>';
+  if (o is num || o is bool) return '<$o>';
+  // TODO Truncate long strings?
+  if (o is String) return '\'$o\'';
+  // TODO Truncate long collections?
+  return '$o';
+}
+
+Iterable<String> indent(Iterable<String> lines) => lines.map((l) => '  $l');

--- a/pkgs/checks/lib/src/describe.dart
+++ b/pkgs/checks/lib/src/describe.dart
@@ -1,8 +1,7 @@
 String literal(Object? o) {
-  if (o == null) return '<null>';
-  if (o is num || o is bool) return '<$o>';
+  if (o == null || o is num || o is bool) return '<$o>';
   // TODO Truncate long strings?
-  if (o is String) return '\'$o\'';
+  if (o is String) return "'$o'";
   // TODO Truncate long collections?
   return '$o';
 }

--- a/pkgs/checks/lib/src/extensions/async.dart
+++ b/pkgs/checks/lib/src/extensions/async.dart
@@ -1,0 +1,142 @@
+import 'dart:async';
+
+import 'package:async/async.dart';
+import 'package:checks/context.dart';
+
+extension FutureChecks<T> on Check<Future<T>> {
+  /// Expects that the Future completes to a value without throwing.
+  ///
+  /// Returns a Future that completes to a [Check<T>] on the result once the
+  /// Future completes.
+  ///
+  /// Fails if the Future completes as an error.
+  Future<Check<T>> completes() async {
+    return await context.nestAsync<T>('Completes to', (actual) async {
+      try {
+        return Extracted.value(await actual);
+      } catch (e) {
+        return Extracted.rejection(
+            actual: 'A future that completes as an error',
+            which: ['Threw ${literal(e)}']);
+      }
+    });
+  }
+
+  /// Expects that the Future completes as an error.
+  ///
+  /// Returns a Future that completes to a [Check<E>] on the error once the
+  /// Future completes as an error.
+  ///
+  /// Fails if the Future completes to a value.
+  Future<Check<E>> throws<E>() async {
+    return await context.nestAsync<E>('Completes as an error of type $E',
+        (actual) async {
+      try {
+        return Extracted.rejection(
+            actual: 'Completed to ${literal(await actual)}',
+            which: ['Did not throw']);
+      } catch (e) {
+        if (e is E) return Extracted.value(e as E);
+        return Extracted.rejection(
+            actual: 'Completed to error ${literal(e)}',
+            which: ['Is not an $E']);
+      }
+    });
+  }
+}
+
+/// Expectations on a [StreamQueue].
+///
+/// Streams should be wrapped in user test code so that any reuse of the same
+/// Stream, and the full Stream lifecycle, is explicit.
+extension StreamChecks<T> on Check<StreamQueue<T>> {
+  /// Expect that the Stream emits a value without first emitting an error.
+  ///
+  /// Returns a Future that completes to a [Check<T>] on the next event emitted
+  /// by the stream.
+  ///
+  /// Fails if the stream emits an error instead of a value, or closes without
+  /// emitting a value.
+  Future<Check<T>> emits() async {
+    return await context.nestAsync<T>('Emits a value', (actual) async {
+      if (!await actual.hasNext) {
+        return Extracted.rejection(
+            actual: 'an empty stream', which: ['did not emit any value']);
+      }
+      try {
+        return Extracted.value(await actual.next);
+      } catch (e) {
+        return Extracted.rejection(
+            actual: 'A stream with error ${literal(e)}',
+            which: ['emittid an error instead of a value']);
+      }
+    });
+  }
+
+  /// Expects that the Stream emits any number of events before emitting an
+  /// event that satisfies [condition].
+  ///
+  /// Returns a Future that completes after the Stream has emitted an even that
+  /// satisfies [condition].
+  ///
+  /// Fails if the Stream emits an error or closes before emitting a matching
+  /// event.
+  Future<void> emitsThrough(void Function(Check<T>) condition) async {
+    await context.expectAsync(
+        () => [
+              'Emits any values then a value that:',
+              ...indent(describe(condition))
+            ], (actual) async {
+      var count = 0;
+      await for (var emitted in actual.rest) {
+        if (softCheck(emitted, condition) == null) {
+          return null;
+        }
+        count++;
+      }
+      return Rejection(
+          actual: 'a stream',
+          which: ['ended after emitting $count elements with none matching']);
+    });
+  }
+
+  /// Expects that the Stream closes without emitting any even that satisfies
+  /// [condition].
+  ///
+  /// Returns a Future that completes after the Stream has closed.
+  ///
+  /// Fails if the Stream emits any even that satisfies [condition].
+  Future<void> neverEmits(void Function(Check<T>) condition) async {
+    await context.expectAsync(
+        () => ['Never emis a value that:', ...indent(describe(condition))],
+        (actual) async {
+      var count = 0;
+      await for (var emitted in actual.rest) {
+        if (softCheck(emitted, condition) == null) {
+          return Rejection(actual: 'a stream', which: [
+            'emitted ${literal(emitted)}',
+            if (count > 0) 'following $count other items'
+          ]);
+        }
+        count++;
+      }
+      return null;
+    });
+  }
+}
+
+extension ChainAsync<T> on Future<Check<T>> {
+  /// Checks the expectations in [condition] against the result of this Future.
+  ///
+  /// Extensions written on [Check] cannot be invoked on [Future<Check>]. This
+  /// method allows adding expectations for the value without awaiting it.
+  ///
+  /// ```dart
+  /// await checkThat(someFuture).completes().that((r) => r.equals('expected'));
+  /// // or, with the intermediate `await`:
+  /// (await checkThat(someFuture).completes()).equals('expected');
+  /// ```
+  Future<void> that(FutureOr<void> Function(Check<T>) condition) async {
+    await condition(await this);
+  }
+}

--- a/pkgs/checks/lib/src/extensions/async.dart
+++ b/pkgs/checks/lib/src/extensions/async.dart
@@ -4,12 +4,12 @@ import 'package:async/async.dart';
 import 'package:checks/context.dart';
 
 extension FutureChecks<T> on Check<Future<T>> {
-  /// Expects that the Future completes to a value without throwing.
+  /// Expects that the `Future` completes to a value without throwing.
   ///
-  /// Returns a Future that completes to a [Check<T>] on the result once the
-  /// Future completes.
+  /// Returns a future that completes to a [Check<T>] on the result once the
+  /// future completes.
   ///
-  /// Fails if the Future completes as an error.
+  /// Fails if the future completes as an error.
   Future<Check<T>> completes() async {
     return await context.nestAsync<T>('Completes to', (actual) async {
       try {
@@ -22,12 +22,12 @@ extension FutureChecks<T> on Check<Future<T>> {
     });
   }
 
-  /// Expects that the Future completes as an error.
+  /// Expects that the `Future` completes as an error.
   ///
-  /// Returns a Future that completes to a [Check<E>] on the error once the
-  /// Future completes as an error.
+  /// Returns a future that completes to a [Check<E>] on the error once the
+  /// future completes as an error.
   ///
-  /// Fails if the Future completes to a value.
+  /// Fails if the future completes to a value.
   Future<Check<E>> throws<E>() async {
     return await context.nestAsync<E>('Completes as an error of type $E',
         (actual) async {
@@ -48,12 +48,12 @@ extension FutureChecks<T> on Check<Future<T>> {
 /// Expectations on a [StreamQueue].
 ///
 /// Streams should be wrapped in user test code so that any reuse of the same
-/// Stream, and the full Stream lifecycle, is explicit.
+/// Stream, and the full stream lifecycle, is explicit.
 extension StreamChecks<T> on Check<StreamQueue<T>> {
-  /// Expect that the Stream emits a value without first emitting an error.
+  /// Expect that the `Stream` emits a value without first emitting an error.
   ///
-  /// Returns a Future that completes to a [Check<T>] on the next event emitted
-  /// by the stream.
+  /// Returns a `Future` that completes to a [Check<T>] on the next event
+  /// emitted by the stream.
   ///
   /// Fails if the stream emits an error instead of a value, or closes without
   /// emitting a value.
@@ -73,13 +73,13 @@ extension StreamChecks<T> on Check<StreamQueue<T>> {
     });
   }
 
-  /// Expects that the Stream emits any number of events before emitting an
+  /// Expects that the `Stream` emits any number of events before emitting an
   /// event that satisfies [condition].
   ///
-  /// Returns a Future that completes after the Stream has emitted an even that
-  /// satisfies [condition].
+  /// Returns a `Future` that completes after the stream has emitted an even
+  /// that satisfies [condition].
   ///
-  /// Fails if the Stream emits an error or closes before emitting a matching
+  /// Fails if the stream emits an error or closes before emitting a matching
   /// event.
   Future<void> emitsThrough(void Function(Check<T>) condition) async {
     await context.expectAsync(
@@ -100,12 +100,12 @@ extension StreamChecks<T> on Check<StreamQueue<T>> {
     });
   }
 
-  /// Expects that the Stream closes without emitting any even that satisfies
+  /// Expects that the `Stream` closes without emitting any even that satisfies
   /// [condition].
   ///
-  /// Returns a Future that completes after the Stream has closed.
+  /// Returns a `Future` that completes after the stream has closed.
   ///
-  /// Fails if the Stream emits any even that satisfies [condition].
+  /// Fails if the stream emits any even that satisfies [condition].
   Future<void> neverEmits(void Function(Check<T>) condition) async {
     await context.expectAsync(
         () => ['Never emis a value that:', ...indent(describe(condition))],
@@ -126,7 +126,8 @@ extension StreamChecks<T> on Check<StreamQueue<T>> {
 }
 
 extension ChainAsync<T> on Future<Check<T>> {
-  /// Checks the expectations in [condition] against the result of this Future.
+  /// Checks the expectations in [condition] against the result of this
+  /// `Future`.
   ///
   /// Extensions written on [Check] cannot be invoked on [Future<Check>]. This
   /// method allows adding expectations for the value without awaiting it.

--- a/pkgs/checks/lib/src/extensions/async.dart
+++ b/pkgs/checks/lib/src/extensions/async.dart
@@ -68,7 +68,7 @@ extension StreamChecks<T> on Check<StreamQueue<T>> {
       } catch (e) {
         return Extracted.rejection(
             actual: 'A stream with error ${literal(e)}',
-            which: ['emittid an error instead of a value']);
+            which: ['emitted an error instead of a value']);
       }
     });
   }
@@ -108,7 +108,7 @@ extension StreamChecks<T> on Check<StreamQueue<T>> {
   /// Fails if the stream emits any even that satisfies [condition].
   Future<void> neverEmits(void Function(Check<T>) condition) async {
     await context.expectAsync(
-        () => ['Never emis a value that:', ...indent(describe(condition))],
+        () => ['Never emits a value that:', ...indent(describe(condition))],
         (actual) async {
       var count = 0;
       await for (var emitted in actual.rest) {

--- a/pkgs/checks/lib/src/extensions/core.dart
+++ b/pkgs/checks/lib/src/extensions/core.dart
@@ -65,17 +65,13 @@ extension HasField<T> on Check<T> {
 
 extension BoolChecks on Check<bool> {
   void isTrue() {
-    context.expect(() => ['is true'], (actual) {
-      if (actual) return null;
-      return Rejection(actual: literal(actual));
-    });
+    context.expect(() => ['is true'],
+        (actual) => actual ? null : Rejection(actual: literal(actual)));
   }
 
   void isFalse() {
-    context.expect(() => ['is false'], (actual) {
-      if (!actual) return null;
-      return Rejection(actual: literal(actual));
-    });
+    context.expect(() => ['is false'],
+        (actual) => !actual ? null : Rejection(actual: literal(actual)));
   }
 }
 

--- a/pkgs/checks/lib/src/extensions/core.dart
+++ b/pkgs/checks/lib/src/extensions/core.dart
@@ -80,9 +80,7 @@ extension EqualityChecks<T> on Check<T> {
   void equals(T other) {
     context.expect(() => ['equals ${literal(other)}'], (actual) {
       if (actual == other) return null;
-      return Rejection(
-          actual: literal(actual),
-          which: ['is not equal according to `operator ==`']);
+      return Rejection(actual: literal(actual), which: ['are not equal']);
     });
   }
 

--- a/pkgs/checks/lib/src/extensions/core.dart
+++ b/pkgs/checks/lib/src/extensions/core.dart
@@ -1,0 +1,125 @@
+import 'package:checks/context.dart';
+
+extension TypeChecks on Check<Object?> {
+  /// Expects that the value is assignable to type [T].
+  ///
+  /// If the value is a [T], returns a [Check<T>] for further expectations.
+  Check<T> isA<T>() {
+    return context.nest<T>('is a $T', (actual) {
+      if (actual is! T) {
+        return Extracted.rejection(
+            actual: literal(actual), which: ['Is a ${actual.runtimeType}']);
+      }
+      return Extracted.value(actual);
+    }, atSameLevel: true);
+  }
+}
+
+extension HasField<T> on Check<T> {
+  /// Extracts a property of the value for further expectations.
+  ///
+  /// Sets up a clause that the value "has [name] that:" followed by any
+  /// expectations applied to the returned [Check].
+  Check<R> has<R>(R Function(T) extract, String name) {
+    return context.nest('has $name', (T value) {
+      try {
+        return Extracted.value(extract(value));
+      } catch (_) {
+        return Extracted.rejection(
+            actual: literal(value),
+            which: ['threw while trying to read property']);
+      }
+    });
+  }
+
+  /// Checks the expectations invoked in [condition] against this value.
+  ///
+  /// Use this method when it would otherwise not be possible to check multiple
+  /// properties of this value due to cascade notation already being used in a
+  /// way that would conflict.
+  ///
+  /// ```
+  /// checkThat(something)
+  ///   ..has((s) => s.foo, 'foo').equals(expectedFoo)
+  ///   ..has((s) => s.bar, 'bar').that((b) => b
+  ///     ..isLessThan(10)
+  ///     ..isGreaterThan(0));
+  /// ```
+  R that<R>(R Function(Check<T>) condition) => condition(this);
+
+  /// Check that the expectations invoked in [condition] are not satisfied by
+  /// this value.
+  ///
+  /// Asynchronous expectations are not allowed in [condition].
+  void not(void Function(Check<T>) condition) {
+    context.expect(() {
+      return ['is not a value that:', ...indent(describe(condition))];
+    }, (actual) {
+      if (softCheck(actual, condition) != null) return null;
+      return Rejection(
+          actual: literal(actual),
+          which: ['is a value that: ', ...indent(describe(condition))]);
+    });
+  }
+}
+
+extension BoolChecks on Check<bool> {
+  void isTrue() {
+    context.expect(() => ['is true'], (actual) {
+      if (actual) return null;
+      return Rejection(actual: literal(actual));
+    });
+  }
+
+  void isFalse() {
+    context.expect(() => ['is false'], (actual) {
+      if (!actual) return null;
+      return Rejection(actual: literal(actual));
+    });
+  }
+}
+
+extension EqualityChecks<T> on Check<T> {
+  /// Expects that the value is equal to [other] according to [operator ==].
+  void equals(T other) {
+    context.expect(() => ['equals ${literal(other)}'], (actual) {
+      if (actual == other) return null;
+      return Rejection(actual: literal(actual), which: ['is not equal']);
+    });
+  }
+
+  /// Expects that the value is [identical] to [other].
+  void identicalTo(T other) {
+    context.expect(() => ['is identical to ${literal(other)}'], (actual) {
+      if (identical(actual, other)) return null;
+      return Rejection(actual: literal(actual), which: ['is not identical']);
+    });
+  }
+}
+
+extension NullabilityChecks<T> on Check<T?> {
+  Check<T> isNotNull() {
+    return context.nest<T>('is not null', (actual) {
+      if (actual == null) return Extracted.rejection(actual: literal(actual));
+      return Extracted.value(actual);
+    }, atSameLevel: true);
+  }
+
+  void isNull() {
+    context.expect(() => const ['is null'], (actual) {
+      if (actual != null) return Rejection(actual: literal(actual));
+      return null;
+    });
+  }
+}
+
+extension StringChecks on Check<String> {
+  /// Expects that the value contains [pattern] according to [String.contains];
+  void contains(Pattern pattern) {
+    context.expect(() => ['contains $pattern'], (actual) {
+      if (actual.contains(pattern)) return null;
+      return Rejection(
+          actual: literal(actual), which: ['Does not contain $pattern']);
+    });
+  }
+}

--- a/pkgs/checks/lib/src/extensions/core.dart
+++ b/pkgs/checks/lib/src/extensions/core.dart
@@ -80,7 +80,9 @@ extension EqualityChecks<T> on Check<T> {
   void equals(T other) {
     context.expect(() => ['equals ${literal(other)}'], (actual) {
       if (actual == other) return null;
-      return Rejection(actual: literal(actual), which: ['is not equal']);
+      return Rejection(
+          actual: literal(actual),
+          which: ['is not equal according to `operator ==`']);
     });
   }
 

--- a/pkgs/checks/lib/src/extensions/function.dart
+++ b/pkgs/checks/lib/src/extensions/function.dart
@@ -1,0 +1,31 @@
+import 'package:checks/context.dart';
+
+extension ThrowsCheck<T> on Check<T Function()> {
+  /// Expects that a function throws synchronously when it is called.
+  ///
+  /// If the function synchronously throws a value of type [E], return a
+  /// [Check<E>] to check further expectations on the error.
+  ///
+  /// If the function does not throw synchronously, or if it throws an error
+  /// that is not of type [E], this expectation will fail.
+  ///
+  /// If this function is async and returns a [Future], this expectation will
+  /// fail. Instead invoke the function and check the expectation on the
+  /// returned [Future].
+  Check<E> throws<E>() {
+    return context.nest<E>('Completes as an error of type $E', (actual) {
+      try {
+        final result = actual();
+        return Extracted.rejection(
+          actual: 'Returned ${literal(result)}',
+          which: ['Did not throw'],
+        );
+      } catch (e) {
+        if (e is E) return Extracted.value(e as E);
+        return Extracted.rejection(
+            actual: 'Completed to error ${literal(e)}',
+            which: ['Is not an $E']);
+      }
+    });
+  }
+}

--- a/pkgs/checks/lib/src/extensions/iterable.dart
+++ b/pkgs/checks/lib/src/extensions/iterable.dart
@@ -38,9 +38,9 @@ extension IterableChecks<T> on Check<Iterable<T>> {
     });
   }
 
-  /// Expects that the iterable contains any element such that
+  /// Expects that the iterable contains at least on element such that
   /// [elementCondition] is satisfied.
-  void containsThat(void Function(Check<T>) elementCondition) {
+  void any(void Function(Check<T>) elementCondition) {
     context.expect(() {
       final conditionDescription = describe(elementCondition);
       assert(conditionDescription.isNotEmpty);

--- a/pkgs/checks/lib/src/extensions/iterable.dart
+++ b/pkgs/checks/lib/src/extensions/iterable.dart
@@ -1,0 +1,61 @@
+import 'package:checks/context.dart';
+
+import 'core.dart' show HasField;
+
+extension IterableChecks<T> on Check<Iterable<T>> {
+  Check<int> get length => has((l) => l.length, 'length');
+  Check<T> get first => has((l) => l.first, 'first element');
+  Check<T> get last => has((l) => l.last, 'last element');
+  Check<T> get single => has((l) => l.single, 'single element');
+
+  void isEmpty() {
+    context.expect(() => const ['is empty'], (actual) {
+      if (actual.isEmpty) return null;
+      return Rejection(actual: literal(actual), which: ['is not empty']);
+    });
+  }
+
+  void isNotEmpty() {
+    context.expect(() => const ['is not empty'], (actual) {
+      if (actual.isEmpty) return null;
+      return Rejection(actual: literal(actual), which: ['is not empty']);
+    });
+  }
+
+  /// Expects that the iterable contains [element] according to
+  /// [Iterable.contains].
+  void contains(T element) {
+    context.expect(() {
+      return [
+        'contains ${literal(element)}',
+      ];
+    }, (actual) {
+      if (actual.isEmpty) return Rejection(actual: 'an empty iterable');
+      if (actual.contains(element)) return null;
+      return Rejection(
+          actual: literal(actual),
+          which: ['does not contain ${literal(element)}']);
+    });
+  }
+
+  /// Expects that the iterable contains any element such that
+  /// [elementCondition] is satisfied.
+  void containsThat(void Function(Check<T>) elementCondition) {
+    context.expect(() {
+      final conditionDescription = describe(elementCondition);
+      assert(conditionDescription.isNotEmpty);
+      return [
+        'contains a value that:',
+        ...conditionDescription,
+      ];
+    }, (actual) {
+      if (actual.isEmpty) return Rejection(actual: 'an empty iterable');
+      for (var e in actual) {
+        if (softCheck(e, elementCondition) == null) return null;
+      }
+      return Rejection(
+          actual: '${literal(actual)}',
+          which: ['Contains no matching element']);
+    });
+  }
+}

--- a/pkgs/checks/lib/src/extensions/map.dart
+++ b/pkgs/checks/lib/src/extensions/map.dart
@@ -1,0 +1,71 @@
+import 'package:checks/context.dart';
+
+import 'core.dart' show HasField;
+
+extension MapChecks<K, V> on Check<Map<K, V>> {
+  Check<Iterable<MapEntry<K, V>>> get entries =>
+      has((m) => m.entries, 'entries');
+  Check<Iterable<K>> get keys => has((m) => m.keys, 'keys');
+  Check<Iterable<V>> get values => has((m) => m.values, 'values');
+  Check<int> get length => has((m) => m.length, 'length');
+
+  /// Expects that the map contains [key] according to [Map.containsKey].
+  void containsKey(K key) {
+    context.expect(() => ['contains key ${literal(key)}'], (actual) {
+      if (actual.containsKey(key)) return null;
+      return Rejection(
+          actual: literal(actual),
+          which: ['does not contain key ${literal(key)}']);
+    });
+  }
+
+  /// Expects that the map contains some key such that [keyCondition] is
+  /// satisfied.
+  void containsKeyThat(void Function(Check<K>) keyCondition) {
+    context.expect(() {
+      final conditionDescription = describe(keyCondition);
+      assert(conditionDescription.isNotEmpty);
+      return [
+        'contains a key that:',
+        ...conditionDescription,
+      ];
+    }, (actual) {
+      if (actual.isEmpty) return Rejection(actual: 'an empty map');
+      for (var k in actual.keys) {
+        if (softCheck(k, keyCondition) == null) return null;
+      }
+      return Rejection(
+          actual: '${literal(actual)}', which: ['Contains no matching key']);
+    });
+  }
+
+  /// Expects that the map contains [value] according to [Map.containsValue].
+  void containsValue(V value) {
+    context.expect(() => ['contains value ${literal(value)}'], (actual) {
+      if (actual.containsValue(value)) return null;
+      return Rejection(
+          actual: literal(actual),
+          which: ['does not contain value ${literal(value)}']);
+    });
+  }
+
+  /// Expects that the map contains some value such that [valueCondition] is
+  /// satisfied.
+  void containsValueThat(void Function(Check<V>) valueCondition) {
+    context.expect(() {
+      final conditionDescription = describe(valueCondition);
+      assert(conditionDescription.isNotEmpty);
+      return [
+        'contains a value that:',
+        ...conditionDescription,
+      ];
+    }, (actual) {
+      if (actual.isEmpty) return Rejection(actual: 'an empty map');
+      for (var v in actual.values) {
+        if (softCheck(v, valueCondition) == null) return null;
+      }
+      return Rejection(
+          actual: '${literal(actual)}', which: ['Contains no matching value']);
+    });
+  }
+}

--- a/pkgs/checks/lib/src/extensions/math.dart
+++ b/pkgs/checks/lib/src/extensions/math.dart
@@ -1,7 +1,7 @@
 import 'package:checks/context.dart';
 
 extension NumChecks on Check<num> {
-  void isGreaterThan(num other) {
+  void operator >(num other) {
     context.expect(() => ['is greater than ${literal(other)}'], (actual) {
       if (actual > other) return null;
       return Rejection(
@@ -10,7 +10,7 @@ extension NumChecks on Check<num> {
     });
   }
 
-  void isLessThan(num other) {
+  void operator <(num other) {
     context.expect(() => ['is less than ${literal(other)}'], (actual) {
       if (actual < other) return null;
       return Rejection(

--- a/pkgs/checks/lib/src/extensions/math.dart
+++ b/pkgs/checks/lib/src/extensions/math.dart
@@ -1,0 +1,21 @@
+import 'package:checks/context.dart';
+
+extension NumChecks on Check<num> {
+  void isGreaterThan(num other) {
+    context.expect(() => ['is greater than ${literal(other)}'], (actual) {
+      if (actual > other) return null;
+      return Rejection(
+          actual: literal(actual),
+          which: ['Is not greater than ${literal(other)}']);
+    });
+  }
+
+  void isLessThan(num other) {
+    context.expect(() => ['is less than ${literal(other)}'], (actual) {
+      if (actual < other) return null;
+      return Rejection(
+          actual: literal(actual),
+          which: ['Is not less than ${literal(other)}']);
+    });
+  }
+}

--- a/pkgs/checks/pubspec.yaml
+++ b/pkgs/checks/pubspec.yaml
@@ -1,0 +1,9 @@
+name: checks
+publish_to: none
+
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+
+dependencies:
+  async: ^2.8.0
+  test_api: ^0.4.0


### PR DESCRIPTION
Implements the core mechanics for defining and using expectations, along
with some basic expectations for core types. Many more expectation
extensions will be added, including `deepEquals` which is already called
out in the docs as necessary to replace the behavior of `equals` from
Matcher.

High level design:

A `Check` is the target for extension methods. It may hold a value (if
it came from `checkThat`) or it may be a placeholder for a value that
could be checked (if it came from `describe`). In test code only the
extensions are visible, to write an expectation a second import exposes
a `context` field on the check which gives access to defining the
expectations.

Each expectation is synchronous or asynchronous, and may be a simple
clause on the value, or may extract a property from the value for
further checking. These are `expect/Async`, and `nest/Async`
respectively.

`expect` and `expectAsync` will add a clause to the list of clause:

```
Expected: a value that:
  some clause from `expect` or `expectAsync`
  another clause from `expect` or `expectAsync`
```

`nest` and `nestAsync` will create a nested context which can have it's
own clauses

```
Expected: a value that:
  has some property extracted by a `nest` or `nestAsync` callback that:
    some clause from an expectation on the nested Check
```

When a failure happens, the clause that failed is replace by the
"Actual" description from the `Rejection`

```
Expected: a value that:
  some clause that will pass
  some clause that will fail
Actual: a value that:
  some clause that will pass
  Actual: The description of the failing value
```

Expectation extensions are written as small as possible, with the
intention that they can be put together in interesting ways. For
instance instead of a `hasLength(int length)` expectation, the `length`
is extracted and a `.equals` expectation can be used on the extracted
value.

```dart
// BAD
checkThat(someList).hasLength(10);
// GOOD
checkThat(someList).length.equals(10);
```

Whenever possible, a name that matches an API on the class is used to
correspond to exactly that behavior. For instance
`Check<Iterable>.contains` use `Iterable.contains` in the
implementation, while `Check<Iterable>.containsThat` takes a callback to
match with the Checks library instead.