### PR TITLE
Restrict TestOn to library level

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.21.2-dev
 
+* Add `Target` to restrict `TestOn` annotation to library level.
+
 ## 1.21.1
 
 * Fix a bug loading JS sources with non-utf8 content while parsing coverage

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -32,8 +32,8 @@ dependencies:
   webkit_inspection_protocol: ^1.0.0
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.4.9
-  test_core: 0.4.13
+  test_api: 0.4.10
+  test_core: 0.4.14
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test/test/runner/retry_test.dart
+++ b/pkgs/test/test/runner/retry_test.dart
@@ -2,8 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:test/test.dart';
 @TestOn('vm')
+
+import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
 import '../io.dart';

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.4.10-dev
 
+* Add `Target` to restrict `TestOn` annotation to library level.
+
 ## 0.4.9
 
 * Add `ignoreTimeouts` option to `Suite`, which disables all timeouts for all

--- a/pkgs/test_api/lib/src/backend/configuration/test_on.dart
+++ b/pkgs/test_api/lib/src/backend/configuration/test_on.dart
@@ -2,11 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:meta/meta_meta.dart';
+
 /// An annotation indicating which platforms a test suite supports.
 ///
 /// For the full syntax of [expression], see [the README][].
 ///
 /// [the README]: https://github.com/dart-lang/test/tree/master/pkgs/test#platform-selectors
+@Target({TargetKind.library})
 class TestOn {
   /// The expression specifying the platform.
   final String expression;

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   # matcher is tightly constrained by test_api
   matcher: any
   # Use an exact version until the test_api package is stable.
-  test_api: 0.4.9
+  test_api: 0.4.10
 
 dev_dependencies:
   lints: '>=1.0.0 <3.0.0'


### PR DESCRIPTION
Closes https://github.com/dart-lang/sdk/issues/49071

Add a `Target` with the `TargetKind.library` so that the analyzer
understands that the annotation is logically applied to the library,
even when it is syntactically applied on an import. This fixes behavior
when sorting imports.
The same configuration was applied to other imports in #1345 and this
looks like it was an accidental omission.
