### PR TITLE
remove an unnecessary null safety opt out from a test

### DIFF
--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -713,7 +713,6 @@ void main() {
     test('defined in a single file', () async {
       await d.file('test.dart', _success).create();
       await d.file('runner.dart', '''
-// @dart=2.8
 import 'package:test_core/src/executable.dart' as test;
 
 void main(List<String> args) async {


### PR DESCRIPTION
Fixes https://github.com/dart-lang/test/issues/1707

The other 3 instances are intentional (related to testing opt out behavior and experimental behavior).