### PR TITLE
Allow the latest vm service

### DIFF
--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -38,5 +38,3 @@ dev_dependencies:
 dependency_overrides:
   test_api:
     path: ../test_api
-  # Temporary to force testing with the latest version
-  vm_service: 9.0.0


### PR DESCRIPTION
has a temporary override in place which I will revert before landing, to ensure we actually work with the latest version (coverage is not yet migrated so it won't be selected otherwise).

Fixes https://github.com/dart-lang/test/issues/1717