### PR TITLE
Show list of failed tests in the final summary

### DIFF
--- a/pkgs/test_core/lib/src/runner/reporter/compact.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/compact.dart
@@ -298,6 +298,12 @@ class CompactReporter implements Reporter {
             suffix: ' - did not complete $_bold$_red[E]$_noColor');
         _sink.writeln('');
       }
+      for (var failedTest in _engine.failed) {
+        _progressLine(_description(failedTest),
+            truncate: false,
+            suffix: ' - $_bold${_red}failed$_noColor $_bold$_red[E]$_noColor');
+        _sink.writeln('');
+      }
       _progressLine('Some tests failed.', color: _red);
       _sink.writeln('');
     } else if (_engine.passed.isEmpty) {


### PR DESCRIPTION
This is a small change that adds the listing of the failed tests (path + name) in the final summary of the tests.

This is very helpful, since when we have a failed test we need to scroll back many tests outputs to find the one that have failed.

With this extra information in the final summary we have the exact information that we need when a test fails.
