### PR TITLE
Fix test which assumes `toString` of `NullThrownError()`.

### DIFF
--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.4.10
+version: 0.4.11
 description: A library for writing Dart tests.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_api
 

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.4.11
+version: 0.4.11-dev
 description: A library for writing Dart tests.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_api
 

--- a/pkgs/test_api/test/frontend/matcher/throws_type_test.dart
+++ b/pkgs/test_api/test/frontend/matcher/throws_type_test.dart
@@ -118,7 +118,7 @@ void main() {
       });
 
       expectTestFailed(
-          liveTest, startsWith("Expected: throws <${NullThrownError()}>"));
+          liveTest, startsWith('Expected: throws <${NullThrownError()}>'));
     });
   });
 

--- a/pkgs/test_api/test/frontend/matcher/throws_type_test.dart
+++ b/pkgs/test_api/test/frontend/matcher/throws_type_test.dart
@@ -117,8 +117,8 @@ void main() {
         expect(() => throw Exception(), throwsNullThrownError);
       });
 
-      expectTestFailed(liveTest,
-          startsWith("Expected: throws <Instance of 'NullThrownError'>"));
+      expectTestFailed(
+          liveTest, startsWith("Expected: throws <${NullThrownError()}>"));
     });
   });
 

--- a/pkgs/test_api/test/frontend/matcher/throws_type_test.dart
+++ b/pkgs/test_api/test/frontend/matcher/throws_type_test.dart
@@ -117,8 +117,8 @@ void main() {
         expect(() => throw Exception(), throwsNullThrownError);
       });
 
-      expectTestFailed(
-          liveTest, startsWith('Expected: throws <${NullThrownError()}>'));
+      expectTestFailed(liveTest,
+          startsWith("Expected: throws <Instance of '$NullThrownError'>"));
     });
   });
 


### PR DESCRIPTION
The `NullThrownError` is deprecated.
It should not be possible to have it thrown by null safe Dart, and the type is being replaced by a `TypeError` in general.

A test here assumes that the `toString` of a `NullThrownError` is `Instance of 'NullThrownError'`, where it's now `Instance of 'TypeError'`.
In general, we do not promise that `toString` of error objects are stable. (Our breaking-change rules do not promise to not break programs which depend on specific `Error`s being thrown.)