### PR TITLE
Support the latest pkg:matcher

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.21.3
+
+* Support the latest `package:test_api` and `package:test_core`.
+
 ## 1.21.2
 
 * Add `Target` to restrict `TestOn` annotation to library level.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.21.2
+version: 1.21.3
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test
@@ -32,8 +32,8 @@ dependencies:
   webkit_inspection_protocol: ^1.0.0
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.4.10
-  test_core: 0.4.14
+  test_api: 0.4.11
+  test_core: 0.4.15
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.11
+
+* Support the latest version of `package:matcher`.
+
 ## 0.4.10
 
 * Add `Target` to restrict `TestOn` annotation to library level.

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.4.11-dev
+version: 0.4.11
 description: A library for writing Dart tests.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_api
 
@@ -19,7 +19,7 @@ dependencies:
 
   # Use a tight version constraint to ensure that a constraint on matcher
   # properly constrains all features it provides.
-  matcher: '>=0.12.11 <0.12.12'
+  matcher: '>=0.12.11 <0.12.13'
 
 dev_dependencies:
   analyzer: '>=2.1.0 <5.0.0'

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.15
+
+* Support the latest `package:test_api`.
+
 ## 0.4.14
 
 * Update the github reporter to output the platform in the test names when

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.14
+version: 0.4.15
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 
@@ -30,7 +30,7 @@ dependencies:
   # matcher is tightly constrained by test_api
   matcher: any
   # Use an exact version until the test_api package is stable.
-  test_api: 0.4.10
+  test_api: 0.4.11
 
 dev_dependencies:
   lints: '>=1.0.0 <3.0.0'


### PR DESCRIPTION
Just increased the upper bound because the last matcher release changed
no functionality
