### PR TITLE
Make load suite labels "bright black"

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.21.4-dev
 
+* Make the labels for test loading more readable in the compact and expanded
+  reporters, use gray instead of black.
+
 ## 1.21.3
 
 * Support the latest `package:test_api` and `package:test_core`.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.4.12
-  test_core: 0.4.15
+  test_core: 0.4.16
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.4.16-dev
 
+* Make the labels for test loading more readable in the compact and expanded
+  reporters, use gray instead of black.
+
 ## 0.4.15
 
 * Support the latest `package:test_api`.

--- a/pkgs/test_core/lib/src/runner/reporter/compact.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/compact.dart
@@ -131,7 +131,7 @@ class CompactReporter implements Reporter {
         _green = color ? '\u001b[32m' : '',
         _red = color ? '\u001b[31m' : '',
         _yellow = color ? '\u001b[33m' : '',
-        _gray = color ? '\u001b[1;30m' : '',
+        _gray = color ? '\u001b[90m' : '',
         _bold = color ? '\u001b[1m' : '',
         _noColor = color ? '\u001b[0m' : '' {
     _subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));

--- a/pkgs/test_core/lib/src/runner/reporter/expanded.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/expanded.dart
@@ -114,7 +114,7 @@ class ExpandedReporter implements Reporter {
         _green = color ? '\u001b[32m' : '',
         _red = color ? '\u001b[31m' : '',
         _yellow = color ? '\u001b[33m' : '',
-        _gray = color ? '\u001b[1;30m' : '',
+        _gray = color ? '\u001b[90m' : '',
         _bold = color ? '\u001b[1m' : '',
         _noColor = color ? '\u001b[0m' : '' {
     _subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));


### PR DESCRIPTION
Closes #1596

The ansi foreground color code `30` is "black", while `90` is "bright
black". This should show up as a more readable gray color for terminals
with dark backgrounds.

Drop the `1;` prefix, which is also setting bold, which has no effect
since `_gray` is only used following `_bold`.