### PR TITLE
add a line to re-run the failed test after each failure in the compact reporter

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Make the labels for test loading more readable in the compact and expanded
   reporters, use gray instead of black.
+* Print a command to re-run the failed test after each failure in the compact
+  reporter.
 
 ## 1.21.3
 

--- a/pkgs/test/test/runner/compact_reporter_test.dart
+++ b/pkgs/test/test/runner/compact_reporter_test.dart
@@ -7,6 +7,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
@@ -429,6 +430,8 @@ void main() {
   });
 
   group('gives users a way to re-run failed tests', () {
+    final executablePath = p.absolute(Platform.resolvedExecutable);
+
     test('with simple names', () {
       return _expectReport('''
         test('failure', () {
@@ -440,7 +443,7 @@ void main() {
           Expected: <2>
             Actual: <1>
 
-        To run this test again: ${Platform.executable} test test.dart -p vm --plain-name 'failure'
+        To run this test again: $executablePath test test.dart -p vm --plain-name 'failure'
 
         +0 -1: Some tests failed.''');
     });
@@ -456,7 +459,7 @@ void main() {
           Expected: <2>
             Actual: <1>
 
-        To run this test again: ${Platform.executable} test test.dart -p vm --plain-name 'failure with a '\\'' in the name'
+        To run this test again: $executablePath test test.dart -p vm --plain-name 'failure with a '\\'' in the name'
 
         +0 -1: Some tests failed.''');
     });

--- a/pkgs/test/test/runner/compact_reporter_test.dart
+++ b/pkgs/test/test/runner/compact_reporter_test.dart
@@ -5,6 +5,7 @@
 @TestOn('vm')
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
@@ -425,6 +426,40 @@ void main() {
         Consider enabling the flag chain-stack-traces to receive more detailed exceptions.
         For example, 'dart test --chain-stack-traces'.''',
         chainStackTraces: false);
+  });
+
+  group('gives users a way to re-run failed tests', () {
+    test('with simple names', () {
+      return _expectReport('''
+        test('failure', () {
+          expect(1, equals(2));
+        });''', '''
+        +0: loading test.dart
+        +0: failure
+        +0 -1: failure [E]
+          Expected: <2>
+            Actual: <1>
+
+        To run this test again: ${Platform.executable} test test.dart -p vm --plain-name 'failure'
+
+        +0 -1: Some tests failed.''');
+    });
+
+    test('escapes names containing single quotes', () {
+      return _expectReport('''
+        test("failure with a ' in the name", () {
+          expect(1, equals(2));
+        });''', '''
+        +0: loading test.dart
+        +0: failure with a ' in the name
+        +0 -1: failure with a ' in the name [E]
+          Expected: <2>
+            Actual: <1>
+
+        To run this test again: ${Platform.executable} test test.dart -p vm --plain-name 'failure with a '\\'' in the name'
+
+        +0 -1: Some tests failed.''');
+    });
   });
 }
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Make the labels for test loading more readable in the compact and expanded
   reporters, use gray instead of black.
+* Print a command to re-run the failed test after each failure in the compact
+  reporter.
 
 ## 0.4.15
 

--- a/pkgs/test_core/lib/src/runner/reporter/compact.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/compact.dart
@@ -40,6 +40,10 @@ class CompactReporter implements Reporter {
   /// Windows or not outputting to a terminal.
   final String _gray;
 
+  /// The terminal escape code for cyan text, or the empty string if this is
+  /// Windows or not outputting to a terminal.
+  final String _cyan;
+
   /// The terminal escape for bold text, or the empty string if this is
   /// Windows or not outputting to a terminal.
   final String _bold;
@@ -132,6 +136,7 @@ class CompactReporter implements Reporter {
         _red = color ? '\u001b[31m' : '',
         _yellow = color ? '\u001b[33m' : '',
         _gray = color ? '\u001b[90m' : '',
+        _cyan = color ? '\u001b[36m' : '',
         _bold = color ? '\u001b[1m' : '',
         _noColor = color ? '\u001b[0m' : '' {
     _subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
@@ -214,6 +219,16 @@ class CompactReporter implements Reporter {
       if (message.type == MessageType.skip) text = '  $_yellow$text$_noColor';
       _sink.writeln(text);
     }));
+
+    liveTest.onComplete.then((_) {
+      var result = liveTest.state.result;
+      if (result != Result.error && result != Result.failure) return;
+      _sink.writeln('');
+      _sink.writeln('$_bold${_cyan}To run this test again:$_noColor '
+          '${Platform.executable} test ${liveTest.suite.path} '
+          '-p ${liveTest.suite.platform.runtime.identifier} '
+          "--plain-name '${liveTest.test.name.replaceAll("'", r"'\''")}'");
+    });
   }
 
   /// A callback called when [liveTest]'s state becomes [state].


### PR DESCRIPTION
Closes https://github.com/dart-lang/test/issues/1734

Example output:

<img width="906" alt="Screen Shot 2022-06-28 at 11 00 32 AM" src="https://user-images.githubusercontent.com/984921/176251403-63a99464-6de2-42ad-a85e-1c794d434c00.png">

