### PR TITLE
fix package config path when running precompiled vm tests from source

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Make the labels for test loading more readable in the compact and expanded
   reporters, use gray instead of black.
+* Fix the package config path used when running pre-compiled vm tests.
 
 ## 1.21.3
 

--- a/pkgs/test/test/runner/precompiled_test.dart
+++ b/pkgs/test/test/runner/precompiled_test.dart
@@ -12,7 +12,6 @@ import 'dart:isolate';
 import 'package:node_preamble/preamble.dart' as preamble;
 import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
-import 'package:test/src/util/package_map.dart';
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';

--- a/pkgs/test/test/runner/precompiled_test.dart
+++ b/pkgs/test/test/runner/precompiled_test.dart
@@ -236,18 +236,6 @@ void main() {
 
 Future<void> _writePackagesFile() async {
   var config = (await findPackageConfig(Directory.current))!;
-  // TODO: remove try/catch when this issue is resolved:
-  // https://github.com/dart-lang/package_config/issues/66
-  try {
-    await d.dir('.dart_tool').create();
-    await savePackageConfig(config, Directory(d.sandbox));
-  } catch (_) {
-    // If it fails, just write a `.packages` file.
-    var packageMap = config.toPackageMap();
-    var packagesFileContent = StringBuffer();
-    packageMap.forEach((package, location) {
-      packagesFileContent.writeln('$package:$location');
-    });
-    await d.file('.packages', '$packagesFileContent').create();
-  }
+  await d.dir('.dart_tool').create();
+  await savePackageConfig(config, Directory(d.sandbox));
 }

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Make the labels for test loading more readable in the compact and expanded
   reporters, use gray instead of black.
+* Fix the package config path used when running pre-compiled vm tests.
 
 ## 0.4.15
 

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -185,9 +185,16 @@ Future<Isolate> _spawnPrecompiledIsolate(
   if (await File(dillTestpath).exists()) {
     testPath = dillTestpath;
   }
+  File? packageConfig =
+      File(p.join(precompiledPath, '.dart_tool/package_config.json'));
+  if (!(await packageConfig.exists())) {
+    packageConfig = File(p.join(precompiledPath, '.packages'));
+    if (!(await packageConfig.exists())) {
+      packageConfig = null;
+    }
+  }
   return await Isolate.spawnUri(p.toUri(testPath), [], message,
-      packageConfig: p.toUri(p.join(precompiledPath, '.packages')),
-      checked: true);
+      packageConfig: packageConfig?.uri, checked: true);
 }
 
 Future<Map<String, dynamic>> _gatherCoverage(Environment environment) async {


### PR DESCRIPTION
Now that we don't support `.packages` files, if you pass one it won't fall back on the package_config.json any more, which we were apparently relying on.

I did retain support for `.packages` files for now as well, which we could drop eventually but I would want to wait until we can bump our min SDK to a stable version that also doesn't support it.