### PR TITLE
Associate printOnFailure messages with the failing test

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 1.21.5-dev
 
-* Fix `printOnFailure` output to forward through json output instead of being
-  printed directly.
+* Fix `printOnFailure` output to be associated with the correct test.
 * Migrate all dom interactions to static interop.
 
 ## 1.21.4

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.21.5-dev
 
+* Fix `printOnFailure` output to forward through json output instead of being
+  printed directly.
 * Migrate all dom interactions to static interop.
 
 ## 1.21.4

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 0.4.13-dev
 
-* Fix `printOnFailure` output to forward through json output instead of being
-  printed directly.
+* Fix `printOnFailure` output to be associated with the correct test.
 
 ## 0.4.12
 

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.4.13-dev
 
-* Internal cleanup.
+* Fix `printOnFailure` output to forward through json output instead of being
+  printed directly.
 
 ## 0.4.12
 

--- a/pkgs/test_api/lib/src/backend/invoker.dart
+++ b/pkgs/test_api/lib/src/backend/invoker.dart
@@ -315,7 +315,7 @@ class Invoker {
   void printOnFailure(String message) {
     message = message.trim();
     if (liveTest.state.result.isFailing) {
-      print('\n$message');
+      _print('\n$message');
     } else {
       _printsOnFailure.add(message);
     }
@@ -350,7 +350,7 @@ class Invoker {
     zone.run(() => _outstandingCallbacks.complete());
 
     if (_printsOnFailure.isNotEmpty) {
-      print(_printsOnFailure.join('\n\n'));
+      _print(_printsOnFailure.join('\n\n'));
       _printsOnFailure.clear();
     }
 

--- a/pkgs/test_api/test/backend/invoker_test.dart
+++ b/pkgs/test_api/test/backend/invoker_test.dart
@@ -541,27 +541,30 @@ void main() {
   });
 
   group('printOnFailure:', () {
-    test("doesn't print anything if the test succeeds", () {
-      expect(() async {
-        var liveTest = _localTest(() {
-          Invoker.current!.printOnFailure('only on failure');
-        }).load(suite);
-        liveTest.onError.listen(expectAsync1((_) {}, count: 0));
+    test("doesn't print anything if the test succeeds", () async {
+      var liveTest = _localTest(() {
+        Invoker.current!.printOnFailure('only on failure');
+      }).load(suite);
+      liveTest.onError.listen(expectAsync1((_) {}, count: 0));
 
-        await liveTest.run();
-      }, prints(isEmpty));
+      liveTest.onMessage.listen(expectAsync1((_) {}, count: 0));
+
+      await liveTest.run();
     });
 
-    test('prints if the test fails', () {
-      expect(() async {
-        var liveTest = _localTest(() {
-          Invoker.current!.printOnFailure('only on failure');
-          expect(true, isFalse);
-        }).load(suite);
-        liveTest.onError.listen(expectAsync1((_) {}, count: 1));
+    test('prints if the test fails', () async {
+      var liveTest = _localTest(() {
+        Invoker.current!.printOnFailure('only on failure');
+        expect(true, isFalse);
+      }).load(suite);
+      liveTest.onError.listen(expectAsync1((_) {}, count: 1));
 
-        await liveTest.run();
-      }, prints('only on failure\n'));
+      liveTest.onMessage.listen(expectAsync1((message) {
+        expect(message.type, equals(MessageType.print));
+        expect(message.text, equals('only on failure'));
+      }, count: 1));
+
+      await liveTest.run();
     });
   });
 }


### PR DESCRIPTION
# Motivation

I recently discovered `printOnFailure`, and I love it! However, I noticed that the error messages it prints don't seem to be associated with the failing test, and show up under "loading \<test filename\>..." headers instead. For example:

```dart
import 'package:test/test.dart';

void main() {
  test('1', () {
    printOnFailure('printOnFailure content 1');
    fail('failure');
  });

  test('2', () {
    printOnFailure('printOnFailure content 2');
    fail('failure');
  });
}
```

The output looks like:
```
$ dart test test/foo_test.dart
00:00 +0 -1: 1 [E]
  failure
  package:test_api        fail
  test/foo_test.dart 6:5  main.<fn>

00:00 +0 -1: loading test/foo_test.dart
printOnFailure content 1
00:00 +0 -2: 2 [E]
  failure
  package:test_api         fail
  test/foo_test.dart 11:5  main.<fn>

00:00 +0 -2: loading test/foo_test.dart
printOnFailure content 2
00:01 +0 -2: Some tests failed.
```

This isn't great, but it becomes more of an issue when using tools that consume the JSON output. For example, in the JSON output for the same test, noting that the `"testID"` doesn't match the test:
```
$ dart test test/foo_test.dart -r json
…
{"test":{"id":1,"name":"loading test/foo_test.dart","suiteID":0,"groupIDs":[],"metadata":{"skip":false,"skipReason":null},"line":null,"column":null,"url":null},"type":"testStart","time":5}
…
{"test":{"id":3,"name":"1","suiteID":0,"groupIDs":[2],"metadata":{"skip":false,"skipReason":null},"line":4,"column":3,"url":"file:///Users/greglittlefield/workspaces/over_react6/tools/analyzer_plugin/test/foo_test.dart"},"type":"testStart","time":784}
{"testID":3,"error":"failure","stackTrace":"package:test_api        fail\ntest/foo_test.dart 6:5  main.<fn>\n","isFailure":true,"type":"error","time":846}
{"testID":1,"messageType":"print","message":"printOnFailure content 1","type":"print","time":849}
{"testID":3,"result":"failure","skipped":false,"hidden":false,"type":"testDone","time":849}
…
```

When running tests from JetBrains IDEs, it causes that output to show up separate from the test that called it, and aggregated with output from other failing tests, which makes it harder to use if there's more than one failing test:

<img alt=ide-single-test height=299 src="https://user-images.githubusercontent.com/1713967/184976506-3ebb2f3c-a330-440f-b8b1-cdcf5659a80e.png">
<img alt=ide-printOnFailure-messages height=293 src="https://user-images.githubusercontent.com/1713967/184976508-73601374-bc6c-404d-927d-fec6e8b1d611.png">


# Solution
- Update code processing `printOnFailure` messages to use `_print` instead of `print`, so that those strings get processed like other `print` statements in user tests.
- Update tests to expect these to come through as messages.

These changes seem to get the messages associated correctly!

```
analyzer_plugin $ dart test test/foo_test.dart
00:01 +0 -1: 1 [E]
  failure
  package:test_api        fail
  test/foo_test.dart 6:5  main.<fn>

printOnFailure content 1
00:01 +0 -2: 2 [E]
  failure
  package:test_api         fail
  test/foo_test.dart 11:5  main.<fn>

printOnFailure content 2
00:01 +0 -2: Some tests failed.
```
<img alt=ide-single-test-with-fix height=308 src="https://user-images.githubusercontent.com/1713967/184977594-565491b1-aca0-49a1-961e-f24d994c01d9.png">

