### PR TITLE
Update coverage usage example

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.21.6
+
+* Fix the coverage usage example in the README.md
+
 ## 1.21.5
 
 * Fix `printOnFailure` output to be associated with the correct test.

--- a/pkgs/test/README.md
+++ b/pkgs/test/README.md
@@ -278,7 +278,7 @@ dart run test --coverage=./coverage
 dart pub global activate coverage
 
 ## Format collected coverage to LCOV (only for directory "lib")
-pub global run coverage:format_coverage --packages=.packages --report-on=lib --lcov -o ./coverage/lcov.info -i ./coverage
+dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o ./coverage/lcov.info -i ./coverage
 
 ## Generate LCOV report:
 genhtml -o ./coverage/report ./coverage/lcov.info

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.21.5
+version: 1.21.6-dev
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test


### PR DESCRIPTION
- Use `dart pub` instead of `pub`
- Point `--packages` to `.dart_tool/package_config.json` as suggested by the `coverage` package.