### PR TITLE
fix an issue with the github reporter

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.22.0-dev
 
+* Fix an issue with the github reporter where tests that fail asynchronously
+  after they've completed would show up as succeeded tests.
 * Add the `experimental-chrome-wasm` platform. This is very unstable and will
   eventually be deleted, to be replaced by a `--compiler` flag. See
   https://github.com/dart-lang/test/issues/1776 for more information on future

--- a/pkgs/test/test/runner/github_reporter_test.dart
+++ b/pkgs/test/test/runner/github_reporter_test.dart
@@ -36,7 +36,7 @@ void main() {
         🎉 3 tests passed.''');
   });
 
-  test('includes the platform name when multiple platforms are ran', () {
+  test('includes the platform name when multiple platforms are run', () {
     return _expectReportLines('''
         test('success 1', () {});''', [
       '::group::✅ [VM] success 1',
@@ -145,6 +145,34 @@ void main() {
         ::group::✅ wait
         ::endgroup::
         ::error::1 test passed, 1 failed.''');
+  });
+
+  test('displays failures occuring after a test completes', () {
+    return _expectReport(
+      '''
+      test('fail after completion', () {
+        Future(() {
+          Zone.current.handleUncaughtError('foo', StackTrace.current);
+        });
+      });
+
+      test('second test so that the first failure is reported', () {});''',
+      '''
+        ::group::✅ fail after completion
+        ::endgroup::
+        ::group::❌ fail after completion (failed after test completion)
+        foo
+        test.dart 8:62  main.<fn>.<fn>
+        ::endgroup::
+        ::group::❌ fail after completion (failed after test completion)
+        This test failed after it had already completed. Make sure to use [expectAsync]
+        or the [completes] matcher when testing async code.
+        test.dart 8:62  main.<fn>.<fn>
+        ::endgroup::
+        ::group::✅ second test so that the first failure is reported
+        ::endgroup::
+        ::error::1 test passed, 1 failed.''',
+    );
   });
 
   group('print:', () {

--- a/pkgs/test_api/lib/src/backend/live_test.dart
+++ b/pkgs/test_api/lib/src/backend/live_test.dart
@@ -79,7 +79,7 @@ abstract class LiveTest {
 
   /// A stream that emits a new [AsyncError] whenever an error is caught.
   ///
-  /// This will be emit an event after [errors] is updated. These errors are not
+  /// This will emit an event after [errors] is updated. These errors are not
   /// guaranteed to have the same types as when they were thrown; for example,
   /// they may need to be serialized across isolate boundaries. The stack traces
   /// will be [Chain]s.

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.4.20-dev
 
+* Fix an issue with the github reporter where tests that fail asynchronously
+  after they've completed would show up as succeeded tests.
 * Support the latest `package:test_api`.
 * Refactor `CompilerPool` to be abstract, add wasm compiler pool.
 


### PR DESCRIPTION
- fix an issue with the github reporter
- fix https://github.com/dart-lang/test/issues/1756

This addresses an issue with the github reporter. With tests that fail asynchronously after they've completed, the main github reporter UI would show all the tests as green, but would report 'xx' failed tests at the end. So, users would know something failed, but wouldn't know which test.

This changes to re-report tests which fail asynchronously; they'll show as a passing line, but later show as an ❌ failure line (they'll show two failures since the framework also emits a message about how to test async code).

I'm not sure where to put the changelog entry for this / which package to bump.