### PR TITLE
add lack of description to configuration document

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.22.1-dev
+
+* Add documentation for the `--ignore-timeouts` argument.
+
 ## 1.22.0
 
 * Fix an issue with the github reporter where tests that fail asynchronously

--- a/pkgs/test/doc/configuration.md
+++ b/pkgs/test/doc/configuration.md
@@ -26,6 +26,7 @@ tags:
 
 * [Test Configuration](#test-configuration)
   * [`timeout`](#timeout)
+  * [`ignore-timeouts`](#ignore-timeouts)
   * [`verbose_trace`](#verbose_trace)
   * [`chain_stack_traces`](#chain_stack_traces)
   * [`js_trace`](#js_trace)
@@ -95,6 +96,14 @@ formats:
 
 ```yaml
 timeout: 1m
+```
+
+###  `ignore-timeouts`
+
+This field disables all timeouts for all tests. This can be useful when debugging, so tests don't time out during debug sessions. It defaults to `false`.
+
+```yaml
+ignore-timeouts: true
 ```
 
 ### `verbose_trace`

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.22.0
+version: 1.22.1-dev
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test


### PR DESCRIPTION
I noticed a lack of description for `ignore-timeouts`. 

https://github.com/dart-lang/test/issues/1634
https://github.com/dart-lang/test/blob/master/pkgs/test_api/CHANGELOG.md#049