### PR TITLE
Update scorecards-analysis.yml

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -17,6 +17,8 @@ jobs:
       security-events: write
       actions: read
       contents: read
+      # Needed to access OIDC token.
+      id-token: write
 
     steps:
       - name: "Checkout code"


### PR DESCRIPTION
- give permissions to write to the OIDC token in the scorecards-analysis.yml workflow

I believe this is needed for the new version of the scorecards action.