### PR TITLE
Use double quotes for test names on windows

### DIFF
--- a/pkgs/test/test/runner/compact_reporter_test.dart
+++ b/pkgs/test/test/runner/compact_reporter_test.dart
@@ -429,7 +429,7 @@ void main() {
         chainStackTraces: false);
   });
 
-  group('gives users a way to re-run failed tests', () {
+  group('gives non-windows users a way to re-run failed tests', () {
     final executablePath = p.absolute(Platform.resolvedExecutable);
 
     test('with simple names', () {
@@ -463,7 +463,43 @@ void main() {
 
         +0 -1: Some tests failed.''');
     });
-  });
+  }, testOn: '!windows');
+
+  group('gives windows users a way to re-run failed tests', () {
+    final executablePath = p.absolute(Platform.resolvedExecutable);
+
+    test('with simple names', () {
+      return _expectReport('''
+        test('failure', () {
+          expect(1, equals(2));
+        });''', '''
+        +0: loading test.dart
+        +0: failure
+        +0 -1: failure [E]
+          Expected: <2>
+            Actual: <1>
+
+        To run this test again: $executablePath test test.dart -p vm --plain-name "failure"
+
+        +0 -1: Some tests failed.''');
+    });
+
+    test('escapes names containing double quotes', () {
+      return _expectReport('''
+        test("failure with a " in the name", () {
+          expect(1, equals(2));
+        });''', '''
+        +0: loading test.dart
+        +0: failure with a " in the name
+        +0 -1: failure with a " in the name [E]
+          Expected: <2>
+            Actual: <1>
+
+        To run this test again: $executablePath test test.dart -p vm --plain-name "failure with a """ in the name"
+
+        +0 -1: Some tests failed.''');
+    });
+  }, testOn: 'windows');
 }
 
 Future<void> _expectReport(String tests, String expected,

--- a/pkgs/test/test/runner/compact_reporter_test.dart
+++ b/pkgs/test/test/runner/compact_reporter_test.dart
@@ -486,7 +486,7 @@ void main() {
 
     test('escapes names containing double quotes', () {
       return _expectReport('''
-        test("failure with a " in the name", () {
+        test('failure with a " in the name', () {
           expect(1, equals(2));
         });''', '''
         +0: loading test.dart

--- a/pkgs/test_core/lib/src/runner/reporter/compact.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/compact.dart
@@ -223,11 +223,14 @@ class CompactReporter implements Reporter {
     liveTest.onComplete.then((_) {
       var result = liveTest.state.result;
       if (result != Result.error && result != Result.failure) return;
+      var quotedName = Platform.isWindows
+          ? '"${liveTest.test.name.replaceAll('"', '"""')}"'
+          : "'${liveTest.test.name.replaceAll("'", r"'\''")}'";
       _sink.writeln('');
       _sink.writeln('$_bold${_cyan}To run this test again:$_noColor '
           '${Platform.executable} test ${liveTest.suite.path} '
           '-p ${liveTest.suite.platform.runtime.identifier} '
-          "--plain-name '${liveTest.test.name.replaceAll("'", r"'\''")}'");
+          '--plain-name $quotedName');
     });
   }
 


### PR DESCRIPTION
Closes #1798

The windows shell does not allow single quotes around arguments. Use
double quotes on windows, and escape double quotes with 3 double quotes
in a row. The escape sequence closes the quoted string, emits an
adjacent double quote, then opens a new quoted string.

If any quotes are escaped the command will not work for users of the
bash shell in VSCode, but there were already issue with the path
separators in that shell so this shouldn't introduce severe new
problems. Test names that don't have double quotes in them should work
in either place.
