### PR TITLE
Ignore some usage of dperecated errors

### DIFF
--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.4.17-dev
+
 ## 0.4.16
 
 * Add the `experimental-chrome-wasm` runtime. This is very unstable and will

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.4.16
+version: 0.4.17-dev
 description: >-
   The user facing API for structuring Dart tests and checking expectations.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_api

--- a/pkgs/test_api/test/frontend/matcher/throws_type_test.dart
+++ b/pkgs/test_api/test/frontend/matcher/throws_type_test.dart
@@ -42,6 +42,7 @@ void main() {
 
   group('[throwsCyclicInitializationError]', () {
     test('passes when a CyclicInitializationError is thrown', () {
+      // ignore: deprecated_member_use
       expect(() => throw CyclicInitializationError(''),
           throwsCyclicInitializationError);
     });
@@ -109,6 +110,7 @@ void main() {
     test('passes when a NullThrownError is thrown', () {
       // Throwing null is no longer allowed with NNBD, but we do want to allow
       // it from legacy code and should be able to catch those errors.
+      // ignore: deprecated_member_use
       expect(() => throw NullThrownError(), throwsNullThrownError);
     });
 
@@ -117,7 +119,9 @@ void main() {
         expect(() => throw Exception(), throwsNullThrownError);
       });
 
-      expectTestFailed(liveTest,
+      expectTestFailed(
+          liveTest,
+          // ignore: deprecated_member_use
           startsWith("Expected: throws <Instance of '$NullThrownError'>"));
     });
   });


### PR DESCRIPTION
We need to continue testing thee matchers, even though the errors are
deprecated.
