### PR TITLE
Don't ignore outstanding work on failure

### DIFF
--- a/pkgs/test_core/lib/src/runner/load_suite.dart
+++ b/pkgs/test_core/lib/src/runner/load_suite.dart
@@ -94,7 +94,13 @@ class LoadSuite extends Suite implements RunnerSuite {
       invoker!.addOutstandingCallback();
 
       unawaited(() async {
-        var suite = await body();
+        RunnerSuite? suite;
+        try {
+          suite = await body();
+        } catch (_) {
+          invoker.removeOutstandingCallback();
+          rethrow;
+        }
         if (completer.isCompleted) {
           // If the load test has already been closed, close the suite it
           // generated.


### PR DESCRIPTION
Fixes #1512

The test invoker tracks the work down by the test, both the callback
bodies and the other work registered with the framework, and in the
typical case waits for it to be complete before the test is considered
done and the next work, like running teardowns, can resume.

Previously, any error would immediately ignore all outstanding work. In
the case of an unhandled async error, the test may still be using
resources that will be cleaned up by the tear down.

- Stop ignoring all outstanding work on any error.
- Explicitly ignore outstanding work for a timeout.
- More reliably decrement the outstanding work counter in a few
  situations where an exception from a test callback could cause it to
  be missed.

Previously these errors would have also caused the outstanding work to
be ignored, so it didn't matter if the decrement happened. Use a
try/finally around callbacks which introduce their own outstanding work
tracking zones. Use a try/catch/rethrow around the body for load suites
(the platform work including the user `main` method). Using a
try/finally for the LoadSuite case can cause the runner to be held open
waiting for `main` to complete after a signal should have stopped tests.
