### PR TITLE
Add FailureDetail to allow expressive failures

### DIFF
--- a/pkgs/checks/lib/context.dart
+++ b/pkgs/checks/lib/context.dart
@@ -5,10 +5,12 @@
 export 'src/checks.dart'
     show
         Check,
+        CheckFailure,
         Context,
+        ContextExtension,
         Extracted,
+        FailureDetail,
         Rejection,
         describe,
-        softCheck,
-        ContextExtension;
+        softCheck;
 export 'src/describe.dart' show literal, indent;

--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -62,11 +62,11 @@ Check<T> checkThat<T>(T value, {String? because}) => Check._(_TestContext._root(
     fail: (f) {
       final which = f.rejection.which;
       throw TestFailure([
-        ..._prefixFirst('Expected: ', f.detail.expected),
-        ..._prefixFirst('Actual: ', f.detail.actual),
+        ...prefixFirst('Expected: ', f.detail.expected),
+        ...prefixFirst('Actual: ', f.detail.actual),
         ...indent(['Actual: ${f.rejection.actual}'], f.detail.depth),
         if (which != null && which.isNotEmpty)
-          ...indent(_prefixFirst('Which: ', which), f.detail.depth),
+          ...indent(prefixFirst('Which: ', which), f.detail.depth),
         if (because != null) 'Reason: $because',
       ].join('\n'));
     },

--- a/pkgs/checks/lib/src/describe.dart
+++ b/pkgs/checks/lib/src/describe.dart
@@ -12,4 +12,7 @@ String literal(Object? o) {
   return '$o';
 }
 
-Iterable<String> indent(Iterable<String> lines) => lines.map((l) => '  $l');
+Iterable<String> indent(Iterable<String> lines, [int depth = 1]) {
+  final indent = '  ' * depth;
+  return lines.map((line) => '$indent$line');
+}

--- a/pkgs/checks/test/extensions/async_test.dart
+++ b/pkgs/checks/test/extensions/async_test.dart
@@ -113,9 +113,10 @@ Future<void> _rejectionWhichCheck<T>(
   Future<void> Function(Check<T>) condition,
   void Function(Check<Iterable<String>>) whichCheck,
 ) async {
-  final rejection = await softCheckAsync(value, condition);
-  whichCheck(checkThat(rejection)
+  final failure = await softCheckAsync(value, condition);
+  whichCheck(checkThat(failure)
       .isNotNull()
+      .has((f) => f.rejection, 'rejection')
       .has((r) => r.which, 'which')
       .isNotNull());
 }

--- a/pkgs/checks/test/test_shared.dart
+++ b/pkgs/checks/test/test_shared.dart
@@ -24,9 +24,9 @@ extension TestIterableCheck on Check<Iterable<String>?> {
   }
 }
 
-extension RejectionCheck on Check<Rejection?> {
+extension RejectionCheck on Check<CheckFailure?> {
   void isARejection({List<String>? which, required String actual}) {
-    this.isNotNull()
+    this.isNotNull().has((f) => f.rejection, 'rejection')
       ..has((p0) => p0.actual, 'actual').equals(actual)
       ..has((p0) => p0.which, 'which').toStringEquals(which);
   }


### PR DESCRIPTION
Rejections do not carry any context about where in the
Check tree a failure occurred, so they are not sufficient to describe the
difference between the expected and actual values like we use in the
messages for test failure exceptions.

Some conditions which do a `softCheck` may want to print more
detailed mismatch information, for example an `Iterable.every` check may
want to print why an element didn't match, in addition to which index
failed.

Change the `fail` callback from taking a formatted String message and
the Rejection, to taking a `CheckFailure` with the rejection and a lazy
details field. The `FailureDetail` has the `expected` and `actual` that
were previously computed in separate methods, as well as information
about how far to indent lines from the `Rejection` so they line up with
the label for the specific check that failed.

Change the `softCheck` methods to return `CheckFailure?` instead of
`Rejection?`. Update conditions which were run against these values to
target `Check<CheckFailure?>` and add an extra `has` to read the
`rejection` field.

Remove the `_reason` field from `_TestContext` and handle it entirely
within `checkThat` since it now constructs the failure message.

Add an optional argument to the `indent` utility to let it indent more
than one level at a time.
