### PR TITLE
Make the prefixFirst utility public

### DIFF
--- a/pkgs/checks/lib/context.dart
+++ b/pkgs/checks/lib/context.dart
@@ -11,4 +11,4 @@ export 'src/checks.dart'
         describe,
         softCheck,
         ContextExtension;
-export 'src/describe.dart' show literal, indent;
+export 'src/describe.dart' show indent, literal, prefixFirst;

--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -502,15 +502,3 @@ class Rejection {
 
   Rejection({required this.actual, this.which});
 }
-
-Iterable<String> _prefixFirst(String prefix, Iterable<String> lines) sync* {
-  var isFirst = true;
-  for (var line in lines) {
-    if (isFirst) {
-      yield '$prefix$line';
-      isFirst = false;
-    } else {
-      yield line;
-    }
-  }
-}

--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -341,8 +341,8 @@ class _TestContext<T> implements Context<T>, _ClauseDescription {
     final root = _root;
     final reason = root._reason;
     return [
-      ..._prefixFirst('Expected: ', root.expected),
-      ..._prefixFirst('Actual: ', root.actual(rejection, this)),
+      ...prefixFirst('Expected: ', root.expected),
+      ...prefixFirst('Actual: ', root.actual(rejection, this)),
       if (reason != null) 'Reason: $reason',
     ].join('\n');
   }
@@ -414,7 +414,7 @@ class _TestContext<T> implements Context<T>, _ClauseDescription {
       return [
         if (_parent != null) '$_label that:',
         '${_parent != null ? 'Actual: ' : ''}${rejection.actual}',
-        if (which != null && which.isNotEmpty) ..._prefixFirst('Which: ', which)
+        if (which != null && which.isNotEmpty) ...prefixFirst('Which: ', which)
       ];
     } else {
       return [

--- a/pkgs/checks/lib/src/describe.dart
+++ b/pkgs/checks/lib/src/describe.dart
@@ -13,3 +13,15 @@ String literal(Object? o) {
 }
 
 Iterable<String> indent(Iterable<String> lines) => lines.map((l) => '  $l');
+
+Iterable<String> prefixFirst(String prefix, Iterable<String> lines) sync* {
+  var isFirst = true;
+  for (var line in lines) {
+    if (isFirst) {
+      yield '$prefix$line';
+      isFirst = false;
+    } else {
+      yield line;
+    }
+  }
+}


### PR DESCRIPTION
This will be useful for some condition extensions which want to do
formatting of mismatches from `softCheck`.
