### PR TITLE
Add some tests with full failure messages

### DIFF
--- a/pkgs/checks/test/failure_message_test.dart
+++ b/pkgs/checks/test/failure_message_test.dart
@@ -4,10 +4,27 @@ import 'package:test_api/hooks.dart' show TestFailure;
 
 void main() {
   group('failures', () {
-    test('start with a label based on the type', () {
+    test('includes expected, actual, and which', () {
       checkThat(() {
         checkThat(1) > 2;
-      }).throwsFailure().startsWith('Expected: a int that:\n');
+      }).throwsFailure().equals('''
+Expected: a int that:
+  is greater than <2>
+Actual: <1>
+Which: Is not greater than <2>''');
+    });
+
+    test('includes matching portions of actual', () {
+      checkThat(() {
+        checkThat([]).length.equals(1);
+      }).throwsFailure().equals('''
+Expected: a List<dynamic> that:
+  has length that:
+    equals <1>
+Actual: a List<dynamic> that:
+  has length that:
+  Actual: <0>
+  Which: are not equal''');
     });
 
     test('include a reason when provided', () {


### PR DESCRIPTION
Replace one test that only checked the first line of a failure with one
that checks the entire message.

Add a test with a failure on a nested check and compare the entire
message to check the indentation and partial "actual" printing.
