### PR TITLE
Add pairwiseCompare condition

### DIFF
--- a/pkgs/checks/lib/src/extensions/iterable.dart
+++ b/pkgs/checks/lib/src/extensions/iterable.dart
@@ -62,4 +62,50 @@ extension IterableChecks<T> on Check<Iterable<T>> {
           which: ['Contains no matching element']);
     });
   }
+
+  /// Expects that the iterable contains elements that correspond by the
+  /// [elementCondition] exactly to each element in [expected].
+  ///
+  /// Fails if the iterable has a different length than [expected].
+  ///
+  /// For each element in the iterable, calls [elementCondition] with the
+  /// corresponding element from [expected] to get the specific condition for
+  /// that index.
+  ///
+  /// [description] is used in the Expected clause. It should be a predicate
+  /// without the object, for example with the description 'is less than' the
+  /// full expectation will be: "pairwise is less than $expected"
+  void pairwiseComparesTo<S>(List<S> expected,
+      void Function(Check<T>, S) elementCondition, String description) {
+    context.expect(() {
+      return ['pairwise $description ${literal(expected)}'];
+    }, (actual) {
+      final iterator = actual.iterator;
+      for (var i = 0; i < expected.length; i++) {
+        final expectedValue = expected[i];
+        if (!iterator.moveNext()) {
+          return Rejection(actual: literal(actual), which: [
+            'has too few elements, there is no element to match at index $i'
+          ]);
+        }
+        final actualValue = iterator.current;
+        final failure = softCheck(
+            actualValue, (check) => elementCondition(check, expectedValue));
+        if (failure == null) continue;
+        final innerDescription =
+            describe<T>((check) => elementCondition(check, expectedValue));
+        final which = failure.rejection.which;
+        return Rejection(actual: literal(actual), which: [
+          'does not have an element at index $i that:',
+          ...innerDescription,
+          'Actual element at index $i: ${failure.rejection.actual}',
+          if (which != null) ...prefixFirst('Which: ', which),
+        ]);
+      }
+      if (!iterator.moveNext()) return null;
+      return Rejection(actual: literal(actual), which: [
+        'has too many elements, expected exactly ${expected.length}'
+      ]);
+    });
+  }
 }

--- a/pkgs/checks/test/extensions/iterable_test.dart
+++ b/pkgs/checks/test/extensions/iterable_test.dart
@@ -53,4 +53,44 @@ void main() {
       ),
     ).isARejection(actual: '(0, 1)', which: ['Contains no matching element']);
   });
+
+  group('pairwiseComparesTo', () {
+    test('succeeds for the happy path', () {
+      checkThat(_testIterable).pairwiseComparesTo([1, 2], (check, expected) {
+        check < expected;
+      }, 'is less than');
+    });
+    test('fails for mismatched element', () async {
+      checkThat(softCheck(
+          _testIterable,
+          (i) => i.pairwiseComparesTo(
+              [1, 1],
+              (check, expected) => check < expected,
+              'is less than'))).isARejection(actual: '(0, 1)', which: [
+        'does not have an element at index 1 that:',
+        '  is less than <1>',
+        'Actual element at index 1: <1>',
+        'Which: Is not less than <1>'
+      ]);
+    });
+    test('fails for too few elements', () {
+      checkThat(softCheck(
+          _testIterable,
+          (i) => i.pairwiseComparesTo(
+              [1, 2, 3],
+              (check, expected) => check < expected,
+              'is less than'))).isARejection(actual: '(0, 1)', which: [
+        'has too few elements, there is no element to match at index 2'
+      ]);
+    });
+    test('fails for too many elements', () {
+      checkThat(softCheck(
+              _testIterable,
+              (i) => i.pairwiseComparesTo(
+                  [1], (check, expected) => check < expected, 'is less than')))
+          .isARejection(
+              actual: '(0, 1)',
+              which: ['has too many elements, expected exactly 1']);
+    });
+  });
 }


### PR DESCRIPTION
Re-implements `pairwiseCompare` from `matcher` which has limited, but
non-zero usage.

The callback gets a `Check` and the expected value, instead of the
actual and expected values, and causes a condition to fail instead of
returning `false` for mismatch.

Rejects iterables that have the wrong number of elements, or that fail
an individual condition for any element.
