### PR TITLE
Add more numeric matchers

### DIFF
--- a/pkgs/checks/lib/src/extensions/math.dart
+++ b/pkgs/checks/lib/src/extensions/math.dart
@@ -15,7 +15,7 @@ extension NumChecks on Check<num> {
     });
   }
 
-  /// Expects that this number is greater than  or equal to [other].
+  /// Expects that this number is greater than or equal to [other].
   void operator >=(num other) {
     context.expect(() => ['is greater than ${literal(other)}'], (actual) {
       if (actual >= other) return null;
@@ -35,7 +35,7 @@ extension NumChecks on Check<num> {
     });
   }
 
-  /// Expects that this number is less than  or equal to [other].
+  /// Expects that this number is less than or equal to [other].
   void operator <=(num other) {
     context.expect(() => ['is less than ${literal(other)}'], (actual) {
       if (actual <= other) return null;

--- a/pkgs/checks/lib/src/extensions/math.dart
+++ b/pkgs/checks/lib/src/extensions/math.dart
@@ -91,7 +91,7 @@ extension NumChecks on Check<num> {
   /// Satisfied by [double.nan], [double.infinity] and
   /// [double.negativeInfinity].
   void isNotFinite() {
-    context.expect(() => ['is finite'], (actual) {
+    context.expect(() => ['is not finite'], (actual) {
       if (!actual.isFinite) return null;
       return Rejection(actual: literal(actual), which: ['is finite']);
     });
@@ -111,7 +111,7 @@ extension NumChecks on Check<num> {
   ///
   /// Satisfied by [double.nan] and finite numbers.
   void isNotInfinite() {
-    context.expect(() => ['is infinite'], (actual) {
+    context.expect(() => ['is not infinite'], (actual) {
       if (!actual.isInfinite) return null;
       return Rejection(actual: literal(actual), which: ['is infinite']);
     });

--- a/pkgs/checks/lib/src/extensions/math.dart
+++ b/pkgs/checks/lib/src/extensions/math.dart
@@ -17,7 +17,8 @@ extension NumChecks on Check<num> {
 
   /// Expects that this number is greater than or equal to [other].
   void operator >=(num other) {
-    context.expect(() => ['is greater than ${literal(other)}'], (actual) {
+    context.expect(() => ['is greater than or equal to ${literal(other)}'],
+        (actual) {
       if (actual >= other) return null;
       return Rejection(
           actual: literal(actual),
@@ -37,7 +38,8 @@ extension NumChecks on Check<num> {
 
   /// Expects that this number is less than or equal to [other].
   void operator <=(num other) {
-    context.expect(() => ['is less than ${literal(other)}'], (actual) {
+    context.expect(() => ['is less than or equal to ${literal(other)}'],
+        (actual) {
       if (actual <= other) return null;
       return Rejection(
           actual: literal(actual),

--- a/pkgs/checks/lib/src/extensions/math.dart
+++ b/pkgs/checks/lib/src/extensions/math.dart
@@ -5,21 +5,73 @@
 import 'package:checks/context.dart';
 
 extension NumChecks on Check<num> {
+  /// Expects that this number is greater than [other].
   void operator >(num other) {
     context.expect(() => ['is greater than ${literal(other)}'], (actual) {
       if (actual > other) return null;
       return Rejection(
           actual: literal(actual),
-          which: ['Is not greater than ${literal(other)}']);
+          which: ['is not greater than ${literal(other)}']);
     });
   }
 
+  /// Expects that this number is greater than  or equal to [other].
+  void operator >=(num other) {
+    context.expect(() => ['is greater than ${literal(other)}'], (actual) {
+      if (actual >= other) return null;
+      return Rejection(
+          actual: literal(actual),
+          which: ['is not greater than or equal to ${literal(other)}']);
+    });
+  }
+
+  /// Expects that this number is less than [other].
   void operator <(num other) {
     context.expect(() => ['is less than ${literal(other)}'], (actual) {
       if (actual < other) return null;
       return Rejection(
           actual: literal(actual),
-          which: ['Is not less than ${literal(other)}']);
+          which: ['is not less than ${literal(other)}']);
+    });
+  }
+
+  /// Expects that this number is less than  or equal to [other].
+  void operator <=(num other) {
+    context.expect(() => ['is less than ${literal(other)}'], (actual) {
+      if (actual <= other) return null;
+      return Rejection(
+          actual: literal(actual),
+          which: ['is not less than or equal to ${literal(other)}']);
+    });
+  }
+
+  /// Expects that `isNaN` is true.
+  void isNaN() {
+    context.expect(() => ['is not a number (NaN)'], (actual) {
+      if (actual.isNaN) return null;
+      return Rejection(actual: literal(actual), which: ['is a number']);
+    });
+  }
+
+  /// Expects that `isNaN` is false.
+  void isNotNaN() {
+    context.expect(() => ['is a number (not NaN)'], (actual) {
+      if (!actual.isNaN) return null;
+      return Rejection(
+          actual: literal(actual), which: ['is not a number (NaN)']);
+    });
+  }
+
+  /// Expects that the difference between this number and [other] is less than
+  /// or equal to [delta].
+  void isCloseTo(num other, num delta) {
+    context.expect(() => ['is within ${literal(delta)} of ${literal(other)}'],
+        (actual) {
+      final difference = (other - actual).abs();
+      if (difference <= delta) return null;
+      return Rejection(
+          actual: literal(actual),
+          which: ['differs by ${literal(difference)}']);
     });
   }
 }

--- a/pkgs/checks/lib/src/extensions/math.dart
+++ b/pkgs/checks/lib/src/extensions/math.dart
@@ -45,7 +45,7 @@ extension NumChecks on Check<num> {
     });
   }
 
-  /// Expects that `isNaN` is true.
+  /// Expects that [num.isNaN] is true.
   void isNaN() {
     context.expect(() => ['is not a number (NaN)'], (actual) {
       if (actual.isNaN) return null;
@@ -53,12 +53,67 @@ extension NumChecks on Check<num> {
     });
   }
 
-  /// Expects that `isNaN` is false.
+  /// Expects that [num.isNaN] is false.
   void isNotNaN() {
     context.expect(() => ['is a number (not NaN)'], (actual) {
       if (!actual.isNaN) return null;
       return Rejection(
           actual: literal(actual), which: ['is not a number (NaN)']);
+    });
+  }
+
+  /// Expects that [num.isNegative] is true.
+  void isNegative() {
+    context.expect(() => ['is negative'], (actual) {
+      if (actual.isNegative) return null;
+      return Rejection(actual: literal(actual), which: ['is not negative']);
+    });
+  }
+
+  /// Expects that [num.isNegative] is false.
+  void isNotNegative() {
+    context.expect(() => ['is not negative'], (actual) {
+      if (!actual.isNegative) return null;
+      return Rejection(actual: literal(actual), which: ['is negative']);
+    });
+  }
+
+  /// Expects that [num.isFinite] is true.
+  void isFinite() {
+    context.expect(() => ['is finite'], (actual) {
+      if (actual.isFinite) return null;
+      return Rejection(actual: literal(actual), which: ['is not finite']);
+    });
+  }
+
+  /// Expects that [num.isFinite] is false.
+  ///
+  /// Satisfied by [double.nan], [double.infinity] and
+  /// [double.negativeInfinity].
+  void isNotFinite() {
+    context.expect(() => ['is finite'], (actual) {
+      if (!actual.isFinite) return null;
+      return Rejection(actual: literal(actual), which: ['is finite']);
+    });
+  }
+
+  /// Expects that [num.isInfinite] is true.
+  ///
+  /// Satisfied by [double.infinity] and [double.negativeInfinity].
+  void isInfinite() {
+    context.expect(() => ['is infinite'], (actual) {
+      if (actual.isInfinite) return null;
+      return Rejection(actual: literal(actual), which: ['is not infinite']);
+    });
+  }
+
+  /// Expects that [num.isInfinite] is false.
+  ///
+  /// Satisfied by [double.nan] and finite numbers.
+  void isNotInfinite() {
+    context.expect(() => ['is infinite'], (actual) {
+      if (!actual.isInfinite) return null;
+      return Rejection(actual: literal(actual), which: ['is infinite']);
     });
   }
 

--- a/pkgs/checks/test/extensions/iterable_test.dart
+++ b/pkgs/checks/test/extensions/iterable_test.dart
@@ -85,7 +85,7 @@ void main() {
         'does not have an element at index 1 that:',
         '  is less than <1>',
         'Actual element at index 1: <1>',
-        'Which: Is not less than <1>'
+        'Which: is not less than <1>'
       ]);
     });
     test('fails for too few elements', () {

--- a/pkgs/checks/test/extensions/iterable_test.dart
+++ b/pkgs/checks/test/extensions/iterable_test.dart
@@ -64,7 +64,7 @@ void main() {
           .isARejection(actual: '(0, 1)', which: [
         'has an element at index 0 that:',
         '  Actual: <0>',
-        '  Which: Is not less than <0>',
+        '  Which: is not less than <0>',
       ]);
     });
   });

--- a/pkgs/checks/test/extensions/math_test.dart
+++ b/pkgs/checks/test/extensions/math_test.dart
@@ -23,6 +23,7 @@ void main() {
             .isARejection(actual: '<42>', which: ['is not greater than <42>']);
       });
     });
+
     group('greater than or equal', () {
       test('succeeds for happy case', () {
         checkThat(42) >= 7;
@@ -35,6 +36,7 @@ void main() {
         checkThat(42) >= 42;
       });
     });
+
     group('less than', () {
       test('succeeds for happy case', () {
         checkThat(42) < 50;
@@ -48,6 +50,7 @@ void main() {
             .isARejection(actual: '<42>', which: ['is not less than <42>']);
       });
     });
+
     group('less than or equal', () {
       test('succeeds for happy case', () {
         checkThat(42) <= 50;
@@ -60,6 +63,7 @@ void main() {
         checkThat(42) <= 42;
       });
     });
+
     group('isNan', () {
       test('succeeds for happy case', () {
         checkThat(double.nan).isNaN();
@@ -73,6 +77,7 @@ void main() {
             .isARejection(actual: '<42.1>', which: ['is a number']);
       });
     });
+
     group('isNan', () {
       test('succeeds for ints', () {
         checkThat(42).isNotNaN();
@@ -85,6 +90,7 @@ void main() {
             .isARejection(actual: '<NaN>', which: ['is not a number (NaN)']);
       });
     });
+
     group('isNegative', () {
       test('succeeds for negative ints', () {
         checkThat(-1).isNegative();
@@ -97,6 +103,7 @@ void main() {
             .isARejection(actual: '<0>', which: ['is not negative']);
       });
     });
+
     group('isNotNegative', () {
       test('succeeds for positive ints', () {
         checkThat(1).isNotNegative();
@@ -113,6 +120,7 @@ void main() {
             .isARejection(actual: '<-1>', which: ['is negative']);
       });
     });
+
     group('isFinite', () {
       test('succeeds for finite numbers', () {
         checkThat(1).isFinite();
@@ -130,6 +138,7 @@ void main() {
             .isARejection(actual: '<-Infinity>', which: ['is not finite']);
       });
     });
+
     group('isNotFinite', () {
       test('succeeds for infinity', () {
         checkThat(double.infinity).isNotFinite();
@@ -145,6 +154,7 @@ void main() {
             .isARejection(actual: '<1>', which: ['is finite']);
       });
     });
+
     group('isInfinite', () {
       test('succeeds for infinity', () {
         checkThat(double.infinity).isInfinite();
@@ -161,6 +171,7 @@ void main() {
             .isARejection(actual: '<1>', which: ['is not infinite']);
       });
     });
+
     group('isNotInfinite', () {
       test('succeeds for finite numbers', () {
         checkThat(1).isNotInfinite();
@@ -178,6 +189,7 @@ void main() {
             .isARejection(actual: '<-Infinity>', which: ['is infinite']);
       });
     });
+
     group('closeTo', () {
       test('succeeds for equal numbers', () {
         checkThat(1).isCloseTo(1, 1);

--- a/pkgs/checks/test/extensions/math_test.dart
+++ b/pkgs/checks/test/extensions/math_test.dart
@@ -85,6 +85,99 @@ void main() {
             .isARejection(actual: '<NaN>', which: ['is not a number (NaN)']);
       });
     });
+    group('isNegative', () {
+      test('succeeds for negative ints', () {
+        checkThat(-1).isNegative();
+      });
+      test('succeeds for -0.0', () {
+        checkThat(-0.0).isNegative();
+      });
+      test('fails for zero', () {
+        checkThat(softCheck<num>(0, (c) => c.isNegative()))
+            .isARejection(actual: '<0>', which: ['is not negative']);
+      });
+    });
+    group('isNotNegative', () {
+      test('succeeds for positive ints', () {
+        checkThat(1).isNotNegative();
+      });
+      test('succeeds for 0', () {
+        checkThat(0).isNotNegative();
+      });
+      test('fails for -0.0', () {
+        checkThat(softCheck<num>(-0.0, (c) => c.isNotNegative()))
+            .isARejection(actual: '<-0.0>', which: ['is negative']);
+      });
+      test('fails for negative numbers', () {
+        checkThat(softCheck<num>(-1, (c) => c.isNotNegative()))
+            .isARejection(actual: '<-1>', which: ['is negative']);
+      });
+    });
+    group('isFinite', () {
+      test('succeeds for finite numbers', () {
+        checkThat(1).isFinite();
+      });
+      test('fails for NaN', () {
+        checkThat(softCheck<num>(double.nan, (c) => c.isFinite()))
+            .isARejection(actual: '<NaN>', which: ['is not finite']);
+      });
+      test('fails for infinity', () {
+        checkThat(softCheck<num>(double.infinity, (c) => c.isFinite()))
+            .isARejection(actual: '<Infinity>', which: ['is not finite']);
+      });
+      test('fails for negative infinity', () {
+        checkThat(softCheck<num>(double.negativeInfinity, (c) => c.isFinite()))
+            .isARejection(actual: '<-Infinity>', which: ['is not finite']);
+      });
+    });
+    group('isNotFinite', () {
+      test('succeeds for infinity', () {
+        checkThat(double.infinity).isNotFinite();
+      });
+      test('succeeds for negative infinity', () {
+        checkThat(double.negativeInfinity).isNotFinite();
+      });
+      test('succeeds for NaN', () {
+        checkThat(double.nan).isNotFinite();
+      });
+      test('fails for finite numbers', () {
+        checkThat(softCheck<num>(1, (c) => c.isNotFinite()))
+            .isARejection(actual: '<1>', which: ['is finite']);
+      });
+    });
+    group('isInfinite', () {
+      test('succeeds for infinity', () {
+        checkThat(double.infinity).isInfinite();
+      });
+      test('succeeds for negative infinity', () {
+        checkThat(double.negativeInfinity).isInfinite();
+      });
+      test('fails for NaN', () {
+        checkThat(softCheck<num>(double.nan, (c) => c.isInfinite()))
+            .isARejection(actual: '<NaN>', which: ['is not infinite']);
+      });
+      test('fails for finite numbers', () {
+        checkThat(softCheck<num>(1, (c) => c.isInfinite()))
+            .isARejection(actual: '<1>', which: ['is not infinite']);
+      });
+    });
+    group('isNotInfinite', () {
+      test('succeeds for finite numbers', () {
+        checkThat(1).isNotInfinite();
+      });
+      test('succeeds for NaN', () {
+        checkThat(double.nan).isNotInfinite();
+      });
+      test('fails for infinity', () {
+        checkThat(softCheck<num>(double.infinity, (c) => c.isNotInfinite()))
+            .isARejection(actual: '<Infinity>', which: ['is infinite']);
+      });
+      test('fails for negative infinity', () {
+        checkThat(softCheck<num>(
+                double.negativeInfinity, (c) => c.isNotInfinite()))
+            .isARejection(actual: '<-Infinity>', which: ['is infinite']);
+      });
+    });
     group('closeTo', () {
       test('succeeds for equal numbers', () {
         checkThat(1).isCloseTo(1, 1);

--- a/pkgs/checks/test/extensions/math_test.dart
+++ b/pkgs/checks/test/extensions/math_test.dart
@@ -55,7 +55,7 @@ void main() {
       test('succeeds for happy case', () {
         checkThat(42) <= 50;
       });
-      test('fails for less than', () {
+      test('fails for greater than', () {
         checkThat(softCheck<int>(42, (p0) => p0 <= 7)).isARejection(
             actual: '<42>', which: ['is not less than or equal to <7>']);
       });
@@ -64,7 +64,7 @@ void main() {
       });
     });
 
-    group('isNan', () {
+    group('isNaN', () {
       test('succeeds for happy case', () {
         checkThat(double.nan).isNaN();
       });
@@ -78,7 +78,7 @@ void main() {
       });
     });
 
-    group('isNan', () {
+    group('isNotNan', () {
       test('succeeds for ints', () {
         checkThat(42).isNotNaN();
       });

--- a/pkgs/checks/test/extensions/math_test.dart
+++ b/pkgs/checks/test/extensions/math_test.dart
@@ -9,16 +9,100 @@ import 'package:test/scaffolding.dart';
 import '../test_shared.dart';
 
 void main() {
-  group('NumChecks', () {
-    test('greater-than', () {
-      checkThat(42) > 7;
-      checkThat(softCheck<int>(42, (p0) => p0 > 50))
-          .isARejection(actual: '<42>', which: ['Is not greater than <50>']);
+  group('num checks', () {
+    group('greater than', () {
+      test('succeeds for happy case', () {
+        checkThat(42) > 7;
+      });
+      test('fails for less than', () {
+        checkThat(softCheck<int>(42, (p0) => p0 > 50))
+            .isARejection(actual: '<42>', which: ['is not greater than <50>']);
+      });
+      test('fails for equal', () {
+        checkThat(softCheck<int>(42, (p0) => p0 > 42))
+            .isARejection(actual: '<42>', which: ['is not greater than <42>']);
+      });
     });
-    test('less-than', () {
-      checkThat(42) < 50;
-      checkThat(softCheck<int>(42, (p0) => p0 < 7))
-          .isARejection(actual: '<42>', which: ['Is not less than <7>']);
+    group('greater than or equal', () {
+      test('succeeds for happy case', () {
+        checkThat(42) >= 7;
+      });
+      test('fails for less than', () {
+        checkThat(softCheck<int>(42, (p0) => p0 >= 50)).isARejection(
+            actual: '<42>', which: ['is not greater than or equal to <50>']);
+      });
+      test('succeeds for equal', () {
+        checkThat(42) >= 42;
+      });
+    });
+    group('less than', () {
+      test('succeeds for happy case', () {
+        checkThat(42) < 50;
+      });
+      test('fails for greater than', () {
+        checkThat(softCheck<int>(42, (p0) => p0 < 7))
+            .isARejection(actual: '<42>', which: ['is not less than <7>']);
+      });
+      test('fails for equal', () {
+        checkThat(softCheck<int>(42, (p0) => p0 < 42))
+            .isARejection(actual: '<42>', which: ['is not less than <42>']);
+      });
+    });
+    group('less than or equal', () {
+      test('succeeds for happy case', () {
+        checkThat(42) <= 50;
+      });
+      test('fails for less than', () {
+        checkThat(softCheck<int>(42, (p0) => p0 <= 7)).isARejection(
+            actual: '<42>', which: ['is not less than or equal to <7>']);
+      });
+      test('succeeds for equal', () {
+        checkThat(42) <= 42;
+      });
+    });
+    group('isNan', () {
+      test('succeeds for happy case', () {
+        checkThat(double.nan).isNaN();
+      });
+      test('fails for ints', () {
+        checkThat(softCheck<num>(42, (c) => c.isNaN()))
+            .isARejection(actual: '<42>', which: ['is a number']);
+      });
+      test('fails for numeric doubles', () {
+        checkThat(softCheck<num>(42.1, (c) => c.isNaN()))
+            .isARejection(actual: '<42.1>', which: ['is a number']);
+      });
+    });
+    group('isNan', () {
+      test('succeeds for ints', () {
+        checkThat(42).isNotNaN();
+      });
+      test('succeeds numeric doubles', () {
+        checkThat(42.1).isNotNaN();
+      });
+      test('fails for NaN', () {
+        checkThat(softCheck<num>(double.nan, (c) => c.isNotNaN()))
+            .isARejection(actual: '<NaN>', which: ['is not a number (NaN)']);
+      });
+    });
+    group('closeTo', () {
+      test('succeeds for equal numbers', () {
+        checkThat(1).isCloseTo(1, 1);
+      });
+      test('succeeds at less than delta away', () {
+        checkThat(1).isCloseTo(2, 2);
+      });
+      test('succeeds at exactly delta away', () {
+        checkThat(1).isCloseTo(2, 1);
+      });
+      test('fails for low values', () {
+        checkThat(softCheck<num>(1, (c) => c.isCloseTo(3, 1)))
+            .isARejection(actual: '<1>', which: ['differs by <2>']);
+      });
+      test('fails for high values', () {
+        checkThat(softCheck<num>(5, (c) => c.isCloseTo(3, 1)))
+            .isARejection(actual: '<5>', which: ['differs by <2>']);
+      });
     });
   });
 }

--- a/pkgs/checks/test/failure_message_test.dart
+++ b/pkgs/checks/test/failure_message_test.dart
@@ -11,7 +11,7 @@ void main() {
 Expected: a int that:
   is greater than <2>
 Actual: <1>
-Which: Is not greater than <2>''');
+Which: is not greater than <2>''');
     });
 
     test('includes matching portions of actual', () {


### PR DESCRIPTION
- Add `<=` and `>=` to complement `<` and `>`.
- Add `isNaN` and `isNotNaN`.
- Add `closeTo`.
- Add tests for the new conditions.
- Use lowercase for the `which` on `<` and `>`.
- Add positive and negative conditions for `isNegative`, `isFinite`, and `isInfinite`.
- Split the test for less than and greater than into separate cases and
  add an equal case.
