### PR TITLE
Drop dependency overrides from pkg:checks

### DIFF
--- a/pkgs/checks/pubspec.yaml
+++ b/pkgs/checks/pubspec.yaml
@@ -10,11 +10,3 @@ dependencies:
 
 dev_dependencies:
   test: ^1.21.3
-
-dependency_overrides:
-  test_api:
-    path: ../test_api
-  test_core:
-    path: ../test_core
-  test:
-    path: ../test


### PR DESCRIPTION
These tests do no currently rely on anything that isn't in the published
test runner. Remove the overrides and use the pub published test runner
for now to avoid recompiling on every run.
