### PR TITLE
Allow slower node test on windows

### DIFF
--- a/pkgs/test/test/runner/line_and_col_test.dart
+++ b/pkgs/test/test/runner/line_and_col_test.dart
@@ -359,7 +359,7 @@ void main() {
       );
 
       await test.shouldExit(0);
-    });
+    }, onPlatform: {'windows': Timeout.factor(2)});
   });
 
   test('bundles runs by suite, deduplicates tests that match multiple times',


### PR DESCRIPTION
This test case is flaky on windows and occasionally times out. It is not
clear if it is slow, or if it sometimes gets stuck entirely. Try
doubling the timeout on windows to see if it stops flaking.
