### PR TITLE
Add String.equals condition

### DIFF
--- a/pkgs/checks/lib/context.dart
+++ b/pkgs/checks/lib/context.dart
@@ -13,4 +13,4 @@ export 'src/checks.dart'
         Rejection,
         describe,
         softCheck;
-export 'src/describe.dart' show indent, literal, prefixFirst;
+export 'src/describe.dart' show escape, indent, literal, prefixFirst;

--- a/pkgs/checks/lib/src/describe.dart
+++ b/pkgs/checks/lib/src/describe.dart
@@ -28,3 +28,37 @@ Iterable<String> prefixFirst(String prefix, Iterable<String> lines) sync* {
     }
   }
 }
+
+/// Returns [output] with all whitespace characters represented as their escape
+/// sequences.
+///
+/// Backslash characters are escaped as `\\`
+String escape(String output) {
+  output = output.replaceAll('\\', r'\\');
+  return output.replaceAllMapped(_escapeRegExp, (match) {
+    var mapped = _escapeMap[match[0]];
+    if (mapped != null) return mapped;
+    return _hexLiteral(match[0]!);
+  });
+}
+
+/// A [RegExp] that matches whitespace characters that should be escaped.
+final _escapeRegExp = RegExp(
+    '[\\x00-\\x07\\x0E-\\x1F${_escapeMap.keys.map(_hexLiteral).join()}]');
+
+/// A [Map] between whitespace characters and their escape sequences.
+const _escapeMap = {
+  '\n': r'\n',
+  '\r': r'\r',
+  '\f': r'\f',
+  '\b': r'\b',
+  '\t': r'\t',
+  '\v': r'\v',
+  '\x7F': r'\x7F', // delete
+};
+
+/// Given single-character string, return the hex-escaped equivalent.
+String _hexLiteral(String input) {
+  var rune = input.runes.single;
+  return r'\x' + rune.toRadixString(16).toUpperCase().padLeft(2, '0');
+}

--- a/pkgs/checks/test/extensions/core_test.dart
+++ b/pkgs/checks/test/extensions/core_test.dart
@@ -140,5 +140,56 @@ void main() {
       checkThat(softCheck<String>('bob', (p0) => p0.endsWith('kayleb')))
           .isARejection(actual: "'bob'", which: ["does not end with 'kayleb'"]);
     });
+
+    group('equals', () {
+      test('succeeeds for happy case', () {
+        checkThat('foo').equals('foo');
+      });
+      test('reports extra characters for long string', () {
+        checkThat(softCheck<String>('foobar', (c) => c.equals('foo')))
+            .isARejection(which: [
+          'is too long with unexpected trailing characters:',
+          'bar'
+        ]);
+      });
+      test('reports truncated extra characters for very long string', () {
+        checkThat(softCheck<String>(
+                'foobar baz more stuff', (c) => c.equals('foo')))
+            .isARejection(which: [
+          'is too long with unexpected trailing characters:',
+          'bar baz mo ...'
+        ]);
+      });
+      test('reports missing characters for short string', () {
+        checkThat(softCheck<String>('foo', (c) => c.equals('foobar')))
+            .isARejection(which: [
+          'is too short with missing trailing characters:',
+          'bar'
+        ]);
+      });
+      test('reports truncated missing characters for very short string', () {
+        checkThat(softCheck<String>(
+                'foo', (c) => c.equals('foobar baz more stuff')))
+            .isARejection(which: [
+          'is too short with missing trailing characters:',
+          'bar baz mo ...'
+        ]);
+      });
+      test('reports index of different character', () {
+        checkThat(softCheck<String>('hit', (c) => c.equals('hat')))
+            .isARejection(which: ['differs at offset 1:', 'hat', 'hit', ' ^']);
+      });
+      test('reports truncated index of different character in large string',
+          () {
+        checkThat(softCheck<String>('blah blah blah hit blah blah blah',
+                (c) => c.equals('blah blah blah hat blah blah blah')))
+            .isARejection(which: [
+          'differs at offset 16:',
+          '... lah blah hat blah bl ...',
+          '... lah blah hit blah bl ...',
+          '              ^',
+        ]);
+      });
+    });
   });
 }

--- a/pkgs/checks/test/test_shared.dart
+++ b/pkgs/checks/test/test_shared.dart
@@ -25,9 +25,11 @@ extension TestIterableCheck on Check<Iterable<String>?> {
 }
 
 extension RejectionCheck on Check<CheckFailure?> {
-  void isARejection({List<String>? which, required String actual}) {
-    this.isNotNull().has((f) => f.rejection, 'rejection')
-      ..has((p0) => p0.actual, 'actual').equals(actual)
-      ..has((p0) => p0.which, 'which').toStringEquals(which);
+  void isARejection({List<String>? which, String? actual}) {
+    final rejection = this.isNotNull().has((f) => f.rejection, 'rejection');
+    if (actual != null) {
+      rejection.has((p0) => p0.actual, 'actual').equals(actual);
+    }
+    rejection.has((p0) => p0.which, 'which').toStringEquals(which);
   }
 }


### PR DESCRIPTION
Adds a specialization of the equals condition which emits more detailed
information about how the values differ. The implementation is mostly
copied from `package:matcher`.

Make the `actual` argument to `isARejection` optional. In most cases the
value will be `literal(actual)` which isn't interesting to test.

Copy `escape` from `package:matcher` into `describe.dart`.
