### PR TITLE
Tighten types of Extracted constructors

### DIFF
--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -216,11 +216,12 @@ class Extracted<T> {
   Extracted.rejection({required String actual, Iterable<String>? which})
       : this.rejection = Rejection(actual: actual, which: which),
         this.value = null;
-  Extracted.value(this.value) : this.rejection = null;
+  Extracted.value(T this.value) : this.rejection = null;
 
-  Extracted._(this.rejection) : this.value = null;
+  Extracted._(Rejection this.rejection) : this.value = null;
 
   Extracted<R> _map<R>(R Function(T) transform) {
+    final rejection = this.rejection;
     if (rejection != null) return Extracted._(rejection);
     return Extracted.value(transform(value as T));
   }


### PR DESCRIPTION
The intention is that one of the fields will always be non-null (or at
least if `T` isn't nullable) so each constructor takes one of the fields
as an argument and sets the other to null. Tighten the argument types
from the nullable field types to actually enforce this. Add a local
variable to allow promotion in one location.
