### PR TITLE
Add a Map operator[] extension

### DIFF
--- a/pkgs/checks/lib/src/extensions/map.dart
+++ b/pkgs/checks/lib/src/extensions/map.dart
@@ -12,6 +12,15 @@ extension MapChecks<K, V> on Check<Map<K, V>> {
   Check<Iterable<K>> get keys => has((m) => m.keys, 'keys');
   Check<Iterable<V>> get values => has((m) => m.values, 'values');
   Check<int> get length => has((m) => m.length, 'length');
+  Check<V> operator [](K key) =>
+      context.nest('contains a value for ${literal(key)}', (actual) {
+        if (!actual.containsKey(key)) {
+          return Extracted.rejection(
+              actual: literal(actual),
+              which: ['does not contain the key ${literal(key)}']);
+        }
+        return Extracted.value(actual[key] as V);
+      });
 
   void isEmpty() {
     context.expect(() => const ['is empty'], (actual) {

--- a/pkgs/checks/test/extensions/map_test.dart
+++ b/pkgs/checks/test/extensions/map_test.dart
@@ -33,6 +33,12 @@ void main() {
     checkThat(_testMap).values.contains(1);
   });
 
+  test('index operator', () async {
+    checkThat(_testMap)['a'].equals(1);
+    checkThat(softCheck<Map<String, int>>(_testMap, (c) => c['z']))
+        .isARejection(which: ['does not contain the key \'z\'']);
+  });
+
   test('isEmpty', () {
     checkThat(<String, int>{}).isEmpty();
     checkThat(

--- a/pkgs/checks/test/extensions/map_test.dart
+++ b/pkgs/checks/test/extensions/map_test.dart
@@ -33,7 +33,7 @@ void main() {
     checkThat(_testMap).values.contains(1);
   });
 
-  test('index operator', () async {
+  test('operator []', () async {
     checkThat(_testMap)['a'].equals(1);
     checkThat(softCheck<Map<String, int>>(_testMap, (c) => c['z']))
         .isARejection(which: ['does not contain the key \'z\'']);


### PR DESCRIPTION
Allows performing validation on a specific key within a map. Expects
that a value with the given key is present, and returns a check on the
value.
