### PR TITLE
Add String.equalsIgnoringWhitespace condition

### DIFF
--- a/pkgs/checks/lib/src/extensions/string.dart
+++ b/pkgs/checks/lib/src/extensions/string.dart
@@ -77,6 +77,30 @@ extension StringChecks on Check<String> {
         (actual) => _findDifference(
             actual.toLowerCase(), expected.toLowerCase(), actual, expected));
   }
+
+  /// Expects that the `String` contains the same content as [expected],
+  /// ignoring differences in whitsepace.
+  ///
+  /// All runs of whitespace characters are collapsed to a single space, and
+  /// leading and traiilng whitespace are removed before comparison.
+  ///
+  /// For example the following will succeed:
+  ///
+  ///     checkThat(' hello   world ').equalsIgnoringWhitespace('hello world');
+  ///
+  /// While the following will fail:
+  ///
+  ///     checkThat('helloworld').equalsIgnoringWhitespace('hello world');
+  ///     checkThat('he llo world').equalsIgnoringWhitespace('hello world');
+  void equalsIgnoringWhitespace(String expected) {
+    context.expect(() => ['equals ignoring whitespace ${literal(expected)}'],
+        (actual) {
+      final collapsedActual = _collapseWhitespace(actual);
+      final collapsedExpected = _collapseWhitespace(expected);
+      return _findDifference(collapsedActual, collapsedExpected,
+          collapsedActual, collapsedExpected);
+    });
+  }
 }
 
 Rejection? _findDifference(String actual, String expected,
@@ -138,3 +162,26 @@ String _leading(String s, int end) =>
 String _trailing(String s, int start) => (start + 10 > s.length)
     ? s.substring(start)
     : '${s.substring(start, start + 10)} ...';
+
+/// Utility function to collapse whitespace runs to single spaces
+/// and strip leading/trailing whitespace.
+String _collapseWhitespace(String string) {
+  var result = StringBuffer();
+  var skipSpace = true;
+  for (var i = 0; i < string.length; i++) {
+    var character = string[i];
+    if (_isWhitespace(character)) {
+      if (!skipSpace) {
+        result.write(' ');
+        skipSpace = true;
+      }
+    } else {
+      result.write(character);
+      skipSpace = false;
+    }
+  }
+  return result.toString().trim();
+}
+
+bool _isWhitespace(String ch) =>
+    ch == ' ' || ch == '\n' || ch == '\r' || ch == '\t';

--- a/pkgs/checks/test/extensions/string_test.dart
+++ b/pkgs/checks/test/extensions/string_test.dart
@@ -144,5 +144,42 @@ void main() {
         ]);
       });
     });
+
+    group('equalsIgnoringWhitespace', () {
+      test('allows differing internal whitespace', () {
+        checkThat('foo \t\n bar').equalsIgnoringWhitespace('foo bar');
+      });
+      test('allows extra leading/trailing whitespace', () {
+        checkThat(' foo ').equalsIgnoringWhitespace('foo');
+      });
+      test('allows missing leading/trailing whitespace', () {
+        checkThat('foo').equalsIgnoringWhitespace(' foo ');
+      });
+      test('reports original extra characters for long string', () {
+        checkThat(softCheck<String>('foo \t bar \n baz',
+            (c) => c.equalsIgnoringWhitespace('foo bar'))).isARejection(which: [
+          'is too long with unexpected trailing characters:',
+          ' baz'
+        ]);
+      });
+      test('reports original missing characters for short string', () {
+        checkThat(softCheck<String>(
+                'foo  bar', (c) => c.equalsIgnoringWhitespace('foo bar baz')))
+            .isARejection(which: [
+          'is too short with missing trailing characters:',
+          ' baz'
+        ]);
+      });
+      test('reports index of different character with original characters', () {
+        checkThat(softCheck<String>(
+                'x  hit  x', (c) => c.equalsIgnoringWhitespace('x hat x')))
+            .isARejection(which: [
+          'differs at offset 3:',
+          'x hat x',
+          'x hit x',
+          '   ^',
+        ]);
+      });
+    });
   });
 }


### PR DESCRIPTION
Copy the `collapseWhitespace` utility from `package:matcher`. Add
`equalsIgnoringWhitespace` and tests. The collapsed version of the
strings needs to also be used for the "display" strings, since they may
have differing indexes.
