### PR TITLE
Add Condition abstraction

### DIFF
--- a/pkgs/checks/lib/checks.dart
+++ b/pkgs/checks/lib/checks.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'src/checks.dart' show checkThat, Check;
+export 'src/checks.dart' show checkThat, Check, Skip, it;
 export 'src/extensions/async.dart' show ChainAsync, FutureChecks, StreamChecks;
 export 'src/extensions/core.dart'
     show BoolChecks, CoreChecks, NullabilityChecks;

--- a/pkgs/checks/lib/context.dart
+++ b/pkgs/checks/lib/context.dart
@@ -6,6 +6,7 @@ export 'src/checks.dart'
     show
         Check,
         CheckFailure,
+        Condition,
         Context,
         ContextExtension,
         Extracted,

--- a/pkgs/checks/lib/src/extensions/async.dart
+++ b/pkgs/checks/lib/src/extensions/async.dart
@@ -111,7 +111,7 @@ extension StreamChecks<T> on Check<StreamQueue<T>> {
   ///
   /// Fails if the stream emits an error or closes before emitting a matching
   /// event.
-  Future<void> emitsThrough(void Function(Check<T>) condition) async {
+  Future<void> emitsThrough(Condition<T> condition) async {
     await context.expectAsync(
         () => [
               'Emits any values then a value that:',
@@ -136,7 +136,7 @@ extension StreamChecks<T> on Check<StreamQueue<T>> {
   /// Returns a `Future` that completes after the stream has closed.
   ///
   /// Fails if the stream emits any even that satisfies [condition].
-  Future<void> neverEmits(void Function(Check<T>) condition) async {
+  Future<void> neverEmits(Condition<T> condition) async {
     await context.expectAsync(
         () => ['Never emits a value that:', ...indent(describe(condition))],
         (actual) async {
@@ -167,7 +167,7 @@ extension ChainAsync<T> on Future<Check<T>> {
   /// // or, with the intermediate `await`:
   /// (await checkThat(someFuture).completes()).equals('expected');
   /// ```
-  Future<void> that(FutureOr<void> Function(Check<T>) condition) async {
-    await condition(await this);
+  Future<void> that(Condition<T> condition) async {
+    await condition.applyAsync(await this);
   }
 }

--- a/pkgs/checks/lib/src/extensions/core.dart
+++ b/pkgs/checks/lib/src/extensions/core.dart
@@ -34,13 +34,13 @@ extension CoreChecks<T> on Check<T> {
   ///     ..isLessThan(10)
   ///     ..isGreaterThan(0));
   /// ```
-  R that<R>(R Function(Check<T>) condition) => condition(this);
+  void that(Condition<T> condition) => condition.apply(this);
 
   /// Check that the expectations invoked in [condition] are not satisfied by
   /// this value.
   ///
   /// Asynchronous expectations are not allowed in [condition].
-  void not(void Function(Check<T>) condition) {
+  void not(Condition<T> condition) {
     context.expect(
       () => ['is not a value that:', ...indent(describe(condition))],
       (actual) {

--- a/pkgs/checks/lib/src/extensions/iterable.dart
+++ b/pkgs/checks/lib/src/extensions/iterable.dart
@@ -44,7 +44,7 @@ extension IterableChecks<T> on Check<Iterable<T>> {
 
   /// Expects that the iterable contains at least on element such that
   /// [elementCondition] is satisfied.
-  void any(void Function(Check<T>) elementCondition) {
+  void any(Condition<T> elementCondition) {
     context.expect(() {
       final conditionDescription = describe(elementCondition);
       assert(conditionDescription.isNotEmpty);
@@ -67,7 +67,7 @@ extension IterableChecks<T> on Check<Iterable<T>> {
   /// [elementCondition].
   ///
   /// Empty iterables will pass always pass this check.
-  void every(void Function(Check<T>) elementCondition) {
+  void every(Condition<T> elementCondition) {
     context.expect(() {
       final conditionDescription = describe(elementCondition);
       assert(conditionDescription.isNotEmpty);
@@ -108,7 +108,7 @@ extension IterableChecks<T> on Check<Iterable<T>> {
   /// without the object, for example with the description 'is less than' the
   /// full expectation will be: "pairwise is less than $expected"
   void pairwiseComparesTo<S>(List<S> expected,
-      void Function(Check<T>, S) elementCondition, String description) {
+      Condition<T> Function(S) elementCondition, String description) {
     context.expect(() {
       return ['pairwise $description ${literal(expected)}'];
     }, (actual) {
@@ -121,11 +121,9 @@ extension IterableChecks<T> on Check<Iterable<T>> {
           ]);
         }
         final actualValue = iterator.current;
-        final failure = softCheck(
-            actualValue, (check) => elementCondition(check, expectedValue));
+        final failure = softCheck(actualValue, elementCondition(expectedValue));
         if (failure == null) continue;
-        final innerDescription =
-            describe<T>((check) => elementCondition(check, expectedValue));
+        final innerDescription = describe<T>(elementCondition(expectedValue));
         final which = failure.rejection.which;
         return Rejection(actual: literal(actual), which: [
           'does not have an element at index $i that:',

--- a/pkgs/checks/lib/src/extensions/map.dart
+++ b/pkgs/checks/lib/src/extensions/map.dart
@@ -48,7 +48,7 @@ extension MapChecks<K, V> on Check<Map<K, V>> {
 
   /// Expects that the map contains some key such that [keyCondition] is
   /// satisfied.
-  void containsKeyThat(void Function(Check<K>) keyCondition) {
+  void containsKeyThat(Condition<K> keyCondition) {
     context.expect(() {
       final conditionDescription = describe(keyCondition);
       assert(conditionDescription.isNotEmpty);
@@ -78,7 +78,7 @@ extension MapChecks<K, V> on Check<Map<K, V>> {
 
   /// Expects that the map contains some value such that [valueCondition] is
   /// satisfied.
-  void containsValueThat(void Function(Check<V>) valueCondition) {
+  void containsValueThat(Condition<V> valueCondition) {
     context.expect(() {
       final conditionDescription = describe(valueCondition);
       assert(conditionDescription.isNotEmpty);

--- a/pkgs/checks/test/extensions/core_test.dart
+++ b/pkgs/checks/test/extensions/core_test.dart
@@ -14,7 +14,7 @@ void main() {
       checkThat(1).isA<int>();
 
       checkThat(
-        softCheck(1, (p0) => p0.isA<String>()),
+        softCheck(1, it()..isA<String>()),
       ).isARejection(actual: '<1>', which: ['Is a int']);
     });
   });
@@ -26,7 +26,7 @@ void main() {
       checkThat(
         softCheck<int>(
           2,
-          (p0) => p0.has((v) => throw UnimplementedError(), 'isOdd'),
+          it()..has((v) => throw UnimplementedError(), 'isOdd'),
         ),
       ).isARejection(
         actual: '<2>',
@@ -35,16 +35,16 @@ void main() {
     });
 
     test('that', () {
-      checkThat(true).that((p0) => p0.isTrue());
+      checkThat(true).that(it()..isTrue());
     });
 
     test('not', () {
-      checkThat(false).not((p0) => p0.isTrue());
+      checkThat(false).not(it()..isTrue());
 
       checkThat(
         softCheck<bool>(
           true,
-          (p0) => p0.not((p0) => p0.isTrue()),
+          it()..not(it()..isTrue()),
         ),
       ).isARejection(
         actual: '<true>',
@@ -60,7 +60,7 @@ void main() {
       checkThat(
         softCheck<bool>(
           false,
-          (p0) => p0.isTrue(),
+          it()..isTrue(),
         ),
       ).isARejection(actual: '<false>');
     });
@@ -70,7 +70,7 @@ void main() {
 
       checkThat(softCheck<bool>(
         true,
-        (p0) => p0.isFalse(),
+        it()..isFalse(),
       )).isARejection(actual: '<true>');
     });
   });
@@ -80,14 +80,14 @@ void main() {
       checkThat(1).equals(1);
 
       checkThat(
-        softCheck(1, (p0) => p0.equals(2)),
+        softCheck(1, it()..equals(2)),
       ).isARejection(actual: '<1>', which: ['are not equal']);
     });
 
     test('identical', () {
       checkThat(1).identicalTo(1);
 
-      checkThat(softCheck(1, (p0) => p0.identicalTo(2)))
+      checkThat(softCheck(1, it()..identicalTo(2)))
           .isARejection(actual: '<1>', which: ['is not identical']);
     });
   });
@@ -96,14 +96,14 @@ void main() {
     test('isNotNull', () {
       checkThat(1).isNotNull();
 
-      checkThat(softCheck(null, (p0) => p0.isNotNull()))
+      checkThat(softCheck(null, it()..isNotNull()))
           .isARejection(actual: '<null>');
     });
 
     test('isNull', () {
       checkThat(null).isNull();
 
-      checkThat(softCheck(1, (p0) => p0.isNull())).isARejection(actual: '<1>');
+      checkThat(softCheck(1, it()..isNull())).isARejection(actual: '<1>');
     });
   });
 }

--- a/pkgs/checks/test/extensions/function_test.dart
+++ b/pkgs/checks/test/extensions/function_test.dart
@@ -16,7 +16,7 @@ void main() {
       });
       test('fails for functions that return normally', () {
         checkThat(
-          softCheck<void Function()>(() {}, (p0) => p0.throws<StateError>()),
+          softCheck<void Function()>(() {}, it()..throws<StateError>()),
         ).isARejection(
             actual: 'a function that returned <null>',
             which: ['did not throw']);
@@ -25,7 +25,7 @@ void main() {
         checkThat(
           softCheck<void Function()>(
             () => throw StateError('oops!'),
-            (p0) => p0.throws<ArgumentError>(),
+            it()..throws<ArgumentError>(),
           ),
         ).isARejection(
           actual: 'a function that threw error Bad state: oops!',
@@ -42,9 +42,10 @@ void main() {
         checkThat(softCheck<int Function()>(() {
           Error.throwWithStackTrace(
               StateError('oops!'), StackTrace.fromString('fake trace'));
-        }, (c) => c.returnsNormally())).isARejection(
-            actual: 'a function that throws',
-            which: ['threw Bad state: oops!', 'fake trace']);
+        }, it()..returnsNormally()))
+            .isARejection(
+                actual: 'a function that throws',
+                which: ['threw Bad state: oops!', 'fake trace']);
       });
     });
   });

--- a/pkgs/checks/test/extensions/iterable_test.dart
+++ b/pkgs/checks/test/extensions/iterable_test.dart
@@ -27,40 +27,41 @@ void main() {
   test('isEmpty', () {
     checkThat([]).isEmpty();
     checkThat(
-      softCheck<Iterable<int>>(_testIterable, (p0) => p0.isEmpty()),
+      softCheck<Iterable<int>>(_testIterable, it()..isEmpty()),
     ).isARejection(actual: '(0, 1)', which: ['is not empty']);
   });
 
   test('isNotEmpty', () {
     checkThat(_testIterable).isNotEmpty();
     checkThat(
-      softCheck<Iterable<int>>(Iterable<int>.empty(), (p0) => p0.isNotEmpty()),
+      softCheck<Iterable<int>>(Iterable<int>.empty(), it()..isNotEmpty()),
     ).isARejection(actual: '()', which: ['is not empty']);
   });
 
   test('contains', () {
     checkThat(_testIterable).contains(0);
     checkThat(
-      softCheck<Iterable<int>>(_testIterable, (p0) => p0.contains(2)),
+      softCheck<Iterable<int>>(_testIterable, it()..contains(2)),
     ).isARejection(actual: '(0, 1)', which: ['does not contain <2>']);
   });
   test('contains', () {
-    checkThat(_testIterable).any((p0) => p0.equals(1));
+    checkThat(_testIterable).any(it()..equals(1));
     checkThat(
       softCheck<Iterable<int>>(
         _testIterable,
-        (p0) => p0.any((p1) => p1.equals(2)),
+        it()..any(it()..equals(2)),
       ),
     ).isARejection(actual: '(0, 1)', which: ['Contains no matching element']);
   });
 
   group('every', () {
     test('succeeds for the happy path', () {
-      checkThat(_testIterable).every((e) => e > -1);
+      checkThat(_testIterable).every(Condition((e) => e > -1));
     });
 
     test('includes details of first failing element', () async {
-      checkThat(softCheck(_testIterable, (i) => i.every((e) => e < 0)))
+      checkThat(softCheck<Iterable<int>>(
+              _testIterable, it()..every(Condition((e) => e < 0))))
           .isARejection(actual: '(0, 1)', which: [
         'has an element at index 0 that:',
         '  Actual: <0>',
@@ -71,17 +72,18 @@ void main() {
 
   group('pairwiseComparesTo', () {
     test('succeeds for the happy path', () {
-      checkThat(_testIterable).pairwiseComparesTo([1, 2], (check, expected) {
-        check < expected;
-      }, 'is less than');
+      checkThat(_testIterable).pairwiseComparesTo(
+          [1, 2], (expected) => Condition((c) => c < expected), 'is less than');
     });
     test('fails for mismatched element', () async {
-      checkThat(softCheck(
-          _testIterable,
-          (i) => i.pairwiseComparesTo(
-              [1, 1],
-              (check, expected) => check < expected,
-              'is less than'))).isARejection(actual: '(0, 1)', which: [
+      checkThat(softCheck<Iterable<int>>(
+              _testIterable,
+              it()
+                ..pairwiseComparesTo(
+                    [1, 1],
+                    (expected) => Condition((c) => c < expected),
+                    'is less than')))
+          .isARejection(actual: '(0, 1)', which: [
         'does not have an element at index 1 that:',
         '  is less than <1>',
         'Actual element at index 1: <1>',
@@ -89,20 +91,25 @@ void main() {
       ]);
     });
     test('fails for too few elements', () {
-      checkThat(softCheck(
-          _testIterable,
-          (i) => i.pairwiseComparesTo(
-              [1, 2, 3],
-              (check, expected) => check < expected,
-              'is less than'))).isARejection(actual: '(0, 1)', which: [
+      checkThat(softCheck<Iterable<int>>(
+              _testIterable,
+              it()
+                ..pairwiseComparesTo(
+                    [1, 2, 3],
+                    (expected) => Condition((c) => c < expected),
+                    'is less than')))
+          .isARejection(actual: '(0, 1)', which: [
         'has too few elements, there is no element to match at index 2'
       ]);
     });
     test('fails for too many elements', () {
-      checkThat(softCheck(
+      checkThat(softCheck<Iterable<int>>(
               _testIterable,
-              (i) => i.pairwiseComparesTo(
-                  [1], (check, expected) => check < expected, 'is less than')))
+              it()
+                ..pairwiseComparesTo(
+                    [1],
+                    (expected) => Condition((c) => c < expected),
+                    'is less than')))
           .isARejection(
               actual: '(0, 1)',
               which: ['has too many elements, expected exactly 1']);

--- a/pkgs/checks/test/extensions/map_test.dart
+++ b/pkgs/checks/test/extensions/map_test.dart
@@ -21,7 +21,7 @@ void main() {
   });
   test('entries', () {
     checkThat(_testMap).entries.any(
-          (p0) => p0
+          it()
             ..has((p0) => p0.key, 'key').equals('a')
             ..has((p0) => p0.value, 'value').equals(1),
         );
@@ -35,21 +35,21 @@ void main() {
 
   test('operator []', () async {
     checkThat(_testMap)['a'].equals(1);
-    checkThat(softCheck<Map<String, int>>(_testMap, (c) => c['z']))
+    checkThat(softCheck<Map<String, int>>(_testMap, it()..['z']))
         .isARejection(which: ['does not contain the key \'z\'']);
   });
 
   test('isEmpty', () {
     checkThat(<String, int>{}).isEmpty();
     checkThat(
-      softCheck<Map<String, int>>(_testMap, (p0) => p0.isEmpty()),
+      softCheck<Map<String, int>>(_testMap, it()..isEmpty()),
     ).isARejection(actual: _testMapString, which: ['is not empty']);
   });
 
   test('isNotEmpty', () {
     checkThat(_testMap).isNotEmpty();
     checkThat(
-      softCheck<Map<String, int>>({}, (p0) => p0.isNotEmpty()),
+      softCheck<Map<String, int>>({}, it()..isNotEmpty()),
     ).isARejection(actual: '{}', which: ['is not empty']);
   });
 
@@ -57,18 +57,18 @@ void main() {
     checkThat(_testMap).containsKey('a');
 
     checkThat(
-      softCheck<Map<String, int>>(_testMap, (p0) => p0.containsKey('c')),
+      softCheck<Map<String, int>>(_testMap, it()..containsKey('c')),
     ).isARejection(
       actual: _testMapString,
       which: ["does not contain key 'c'"],
     );
   });
   test('containsKeyThat', () {
-    checkThat(_testMap).containsKeyThat((p0) => p0.equals('a'));
+    checkThat(_testMap).containsKeyThat(it()..equals('a'));
     checkThat(
       softCheck<Map<String, int>>(
         _testMap,
-        (p0) => p0.containsKeyThat((p1) => p1.equals('c')),
+        it()..containsKeyThat(it()..equals('c')),
       ),
     ).isARejection(
       actual: _testMapString,
@@ -78,17 +78,17 @@ void main() {
   test('containsValue', () {
     checkThat(_testMap).containsValue(1);
     checkThat(
-      softCheck<Map<String, int>>(_testMap, (p0) => p0.containsValue(3)),
+      softCheck<Map<String, int>>(_testMap, it()..containsValue(3)),
     ).isARejection(
       actual: _testMapString,
       which: ['does not contain value <3>'],
     );
   });
   test('containsValueThat', () {
-    checkThat(_testMap).containsValueThat((p0) => p0.equals(1));
+    checkThat(_testMap).containsValueThat(it()..equals(1));
     checkThat(
       softCheck<Map<String, int>>(
-          _testMap, (p0) => p0.containsValueThat((p1) => p1.equals(3))),
+          _testMap, it()..containsValueThat(it()..equals(3))),
     ).isARejection(
       actual: _testMapString,
       which: ['Contains no matching value'],

--- a/pkgs/checks/test/extensions/math_test.dart
+++ b/pkgs/checks/test/extensions/math_test.dart
@@ -15,11 +15,11 @@ void main() {
         checkThat(42) > 7;
       });
       test('fails for less than', () {
-        checkThat(softCheck<int>(42, (p0) => p0 > 50))
+        checkThat(softCheck<int>(42, Condition((p0) => p0 > 50)))
             .isARejection(actual: '<42>', which: ['is not greater than <50>']);
       });
       test('fails for equal', () {
-        checkThat(softCheck<int>(42, (p0) => p0 > 42))
+        checkThat(softCheck<int>(42, Condition((p0) => p0 > 42)))
             .isARejection(actual: '<42>', which: ['is not greater than <42>']);
       });
     });
@@ -29,7 +29,7 @@ void main() {
         checkThat(42) >= 7;
       });
       test('fails for less than', () {
-        checkThat(softCheck<int>(42, (p0) => p0 >= 50)).isARejection(
+        checkThat(softCheck<int>(42, Condition((p0) => p0 >= 50))).isARejection(
             actual: '<42>', which: ['is not greater than or equal to <50>']);
       });
       test('succeeds for equal', () {
@@ -42,11 +42,11 @@ void main() {
         checkThat(42) < 50;
       });
       test('fails for greater than', () {
-        checkThat(softCheck<int>(42, (p0) => p0 < 7))
+        checkThat(softCheck<int>(42, Condition((p0) => p0 < 7)))
             .isARejection(actual: '<42>', which: ['is not less than <7>']);
       });
       test('fails for equal', () {
-        checkThat(softCheck<int>(42, (p0) => p0 < 42))
+        checkThat(softCheck<int>(42, Condition((p0) => p0 < 42)))
             .isARejection(actual: '<42>', which: ['is not less than <42>']);
       });
     });
@@ -56,7 +56,7 @@ void main() {
         checkThat(42) <= 50;
       });
       test('fails for greater than', () {
-        checkThat(softCheck<int>(42, (p0) => p0 <= 7)).isARejection(
+        checkThat(softCheck<int>(42, Condition((p0) => p0 <= 7))).isARejection(
             actual: '<42>', which: ['is not less than or equal to <7>']);
       });
       test('succeeds for equal', () {
@@ -69,11 +69,11 @@ void main() {
         checkThat(double.nan).isNaN();
       });
       test('fails for ints', () {
-        checkThat(softCheck<num>(42, (c) => c.isNaN()))
+        checkThat(softCheck<num>(42, it()..isNaN()))
             .isARejection(actual: '<42>', which: ['is a number']);
       });
       test('fails for numeric doubles', () {
-        checkThat(softCheck<num>(42.1, (c) => c.isNaN()))
+        checkThat(softCheck<num>(42.1, it()..isNaN()))
             .isARejection(actual: '<42.1>', which: ['is a number']);
       });
     });
@@ -86,7 +86,7 @@ void main() {
         checkThat(42.1).isNotNaN();
       });
       test('fails for NaN', () {
-        checkThat(softCheck<num>(double.nan, (c) => c.isNotNaN()))
+        checkThat(softCheck<num>(double.nan, it()..isNotNaN()))
             .isARejection(actual: '<NaN>', which: ['is not a number (NaN)']);
       });
     });
@@ -99,7 +99,7 @@ void main() {
         checkThat(-0.0).isNegative();
       });
       test('fails for zero', () {
-        checkThat(softCheck<num>(0, (c) => c.isNegative()))
+        checkThat(softCheck<num>(0, it()..isNegative()))
             .isARejection(actual: '<0>', which: ['is not negative']);
       });
     });
@@ -112,11 +112,11 @@ void main() {
         checkThat(0).isNotNegative();
       });
       test('fails for -0.0', () {
-        checkThat(softCheck<num>(-0.0, (c) => c.isNotNegative()))
+        checkThat(softCheck<num>(-0.0, it()..isNotNegative()))
             .isARejection(actual: '<-0.0>', which: ['is negative']);
       });
       test('fails for negative numbers', () {
-        checkThat(softCheck<num>(-1, (c) => c.isNotNegative()))
+        checkThat(softCheck<num>(-1, it()..isNotNegative()))
             .isARejection(actual: '<-1>', which: ['is negative']);
       });
     });
@@ -126,15 +126,15 @@ void main() {
         checkThat(1).isFinite();
       });
       test('fails for NaN', () {
-        checkThat(softCheck<num>(double.nan, (c) => c.isFinite()))
+        checkThat(softCheck<num>(double.nan, it()..isFinite()))
             .isARejection(actual: '<NaN>', which: ['is not finite']);
       });
       test('fails for infinity', () {
-        checkThat(softCheck<num>(double.infinity, (c) => c.isFinite()))
+        checkThat(softCheck<num>(double.infinity, it()..isFinite()))
             .isARejection(actual: '<Infinity>', which: ['is not finite']);
       });
       test('fails for negative infinity', () {
-        checkThat(softCheck<num>(double.negativeInfinity, (c) => c.isFinite()))
+        checkThat(softCheck<num>(double.negativeInfinity, it()..isFinite()))
             .isARejection(actual: '<-Infinity>', which: ['is not finite']);
       });
     });
@@ -150,7 +150,7 @@ void main() {
         checkThat(double.nan).isNotFinite();
       });
       test('fails for finite numbers', () {
-        checkThat(softCheck<num>(1, (c) => c.isNotFinite()))
+        checkThat(softCheck<num>(1, it()..isNotFinite()))
             .isARejection(actual: '<1>', which: ['is finite']);
       });
     });
@@ -163,11 +163,11 @@ void main() {
         checkThat(double.negativeInfinity).isInfinite();
       });
       test('fails for NaN', () {
-        checkThat(softCheck<num>(double.nan, (c) => c.isInfinite()))
+        checkThat(softCheck<num>(double.nan, it()..isInfinite()))
             .isARejection(actual: '<NaN>', which: ['is not infinite']);
       });
       test('fails for finite numbers', () {
-        checkThat(softCheck<num>(1, (c) => c.isInfinite()))
+        checkThat(softCheck<num>(1, it()..isInfinite()))
             .isARejection(actual: '<1>', which: ['is not infinite']);
       });
     });
@@ -180,12 +180,12 @@ void main() {
         checkThat(double.nan).isNotInfinite();
       });
       test('fails for infinity', () {
-        checkThat(softCheck<num>(double.infinity, (c) => c.isNotInfinite()))
+        checkThat(softCheck<num>(double.infinity, it()..isNotInfinite()))
             .isARejection(actual: '<Infinity>', which: ['is infinite']);
       });
       test('fails for negative infinity', () {
-        checkThat(softCheck<num>(
-                double.negativeInfinity, (c) => c.isNotInfinite()))
+        checkThat(
+                softCheck<num>(double.negativeInfinity, it()..isNotInfinite()))
             .isARejection(actual: '<-Infinity>', which: ['is infinite']);
       });
     });
@@ -201,11 +201,11 @@ void main() {
         checkThat(1).isCloseTo(2, 1);
       });
       test('fails for low values', () {
-        checkThat(softCheck<num>(1, (c) => c.isCloseTo(3, 1)))
+        checkThat(softCheck<num>(1, it()..isCloseTo(3, 1)))
             .isARejection(actual: '<1>', which: ['differs by <2>']);
       });
       test('fails for high values', () {
-        checkThat(softCheck<num>(5, (c) => c.isCloseTo(3, 1)))
+        checkThat(softCheck<num>(5, it()..isCloseTo(3, 1)))
             .isARejection(actual: '<5>', which: ['differs by <2>']);
       });
     });

--- a/pkgs/checks/test/extensions/string_test.dart
+++ b/pkgs/checks/test/extensions/string_test.dart
@@ -13,7 +13,7 @@ void main() {
     test('contains', () {
       checkThat('bob').contains('bo');
       checkThat(
-        softCheck<String>('bob', (p0) => p0.contains('kayleb')),
+        softCheck<String>('bob', it()..contains('kayleb')),
       ).isARejection(actual: "'bob'", which: ["Does not contain 'kayleb'"]);
     });
     test('length', () {
@@ -22,24 +22,24 @@ void main() {
     test('isEmpty', () {
       checkThat('').isEmpty();
       checkThat(
-        softCheck<String>('bob', (p0) => p0.isEmpty()),
+        softCheck<String>('bob', it()..isEmpty()),
       ).isARejection(actual: "'bob'", which: ['is not empty']);
     });
     test('isNotEmpty', () {
       checkThat('bob').isNotEmpty();
       checkThat(
-        softCheck<String>('', (p0) => p0.isNotEmpty()),
+        softCheck<String>('', it()..isNotEmpty()),
       ).isARejection(actual: "''", which: ['is empty']);
     });
     test('startsWith', () {
       checkThat('bob').startsWith('bo');
       checkThat(
-        softCheck<String>('bob', (p0) => p0.startsWith('kayleb')),
+        softCheck<String>('bob', it()..startsWith('kayleb')),
       ).isARejection(actual: "'bob'", which: ["does not start with 'kayleb'"]);
     });
     test('endsWith', () {
       checkThat('bob').endsWith('ob');
-      checkThat(softCheck<String>('bob', (p0) => p0.endsWith('kayleb')))
+      checkThat(softCheck<String>('bob', it()..endsWith('kayleb')))
           .isARejection(actual: "'bob'", which: ["does not end with 'kayleb'"]);
     });
 
@@ -48,14 +48,14 @@ void main() {
         checkThat('foo bar baz').containsInOrder(['foo', 'baz']);
       });
       test('reports when first substring is missing', () {
-        checkThat(softCheck<String>(
-                'baz', (c) => c.containsInOrder(['foo', 'baz'])))
+        checkThat(
+                softCheck<String>('baz', it()..containsInOrder(['foo', 'baz'])))
             .isARejection(
                 which: ['does not have a match for the substring \'foo\'']);
       });
       test('reports when substring is missing following a match', () {
         checkThat(softCheck<String>(
-                'foo bar', (c) => c.containsInOrder(['foo', 'baz'])))
+                'foo bar', it()..containsInOrder(['foo', 'baz'])))
             .isARejection(which: [
           'does not have a match for the substring \'baz\'',
           'following the other matches up to character 3'
@@ -71,48 +71,48 @@ void main() {
         checkThat('').equals('');
       });
       test('reports extra characters for long string', () {
-        checkThat(softCheck<String>('foobar', (c) => c.equals('foo')))
+        checkThat(softCheck<String>('foobar', it()..equals('foo')))
             .isARejection(which: [
           'is too long with unexpected trailing characters:',
           'bar'
         ]);
       });
       test('reports extra characters for long string against empty', () {
-        checkThat(softCheck<String>('foo', (c) => c.equals('')))
+        checkThat(softCheck<String>('foo', it()..equals('')))
             .isARejection(which: ['is not the empty string']);
       });
       test('reports truncated extra characters for very long string', () {
-        checkThat(softCheck<String>(
-                'foobar baz more stuff', (c) => c.equals('foo')))
+        checkThat(
+                softCheck<String>('foobar baz more stuff', it()..equals('foo')))
             .isARejection(which: [
           'is too long with unexpected trailing characters:',
           'bar baz mo ...'
         ]);
       });
       test('reports missing characters for short string', () {
-        checkThat(softCheck<String>('foo', (c) => c.equals('foobar')))
+        checkThat(softCheck<String>('foo', it()..equals('foobar')))
             .isARejection(which: [
           'is too short with missing trailing characters:',
           'bar'
         ]);
       });
       test('reports missing characters for empty string', () {
-        checkThat(softCheck<String>('', (c) => c.equals('foo bar baz')))
+        checkThat(softCheck<String>('', it()..equals('foo bar baz')))
             .isARejection(actual: 'an empty string', which: [
           'is missing all expected characters:',
           'foo bar ba ...'
         ]);
       });
       test('reports truncated missing characters for very short string', () {
-        checkThat(softCheck<String>(
-                'foo', (c) => c.equals('foobar baz more stuff')))
+        checkThat(
+                softCheck<String>('foo', it()..equals('foobar baz more stuff')))
             .isARejection(which: [
           'is too short with missing trailing characters:',
           'bar baz mo ...'
         ]);
       });
       test('reports index of different character', () {
-        checkThat(softCheck<String>('hit', (c) => c.equals('hat')))
+        checkThat(softCheck<String>('hit', it()..equals('hat')))
             .isARejection(which: [
           'differs at offset 1:',
           'hat',
@@ -123,7 +123,7 @@ void main() {
       test('reports truncated index of different character in large string',
           () {
         checkThat(softCheck<String>('blah blah blah hit blah blah blah',
-                (c) => c.equals('blah blah blah hat blah blah blah')))
+                it()..equals('blah blah blah hat blah blah blah')))
             .isARejection(which: [
           'differs at offset 16:',
           '... lah blah hat blah bl ...',
@@ -139,23 +139,21 @@ void main() {
         checkThat('foo').equalsIgnoringCase('FOO');
       });
       test('reports original extra characters for long string', () {
-        checkThat(
-                softCheck<String>('FOOBAR', (c) => c.equalsIgnoringCase('foo')))
+        checkThat(softCheck<String>('FOOBAR', it()..equalsIgnoringCase('foo')))
             .isARejection(which: [
           'is too long with unexpected trailing characters:',
           'BAR'
         ]);
       });
       test('reports original missing characters for short string', () {
-        checkThat(
-                softCheck<String>('FOO', (c) => c.equalsIgnoringCase('fooBAR')))
+        checkThat(softCheck<String>('FOO', it()..equalsIgnoringCase('fooBAR')))
             .isARejection(which: [
           'is too short with missing trailing characters:',
           'BAR'
         ]);
       });
       test('reports index of different character with original characters', () {
-        checkThat(softCheck<String>('HiT', (c) => c.equalsIgnoringCase('hAt')))
+        checkThat(softCheck<String>('HiT', it()..equalsIgnoringCase('hAt')))
             .isARejection(which: [
           'differs at offset 1:',
           'hAt',
@@ -176,15 +174,16 @@ void main() {
         checkThat('foo').equalsIgnoringWhitespace(' foo ');
       });
       test('reports original extra characters for long string', () {
-        checkThat(softCheck<String>('foo \t bar \n baz',
-            (c) => c.equalsIgnoringWhitespace('foo bar'))).isARejection(which: [
+        checkThat(softCheck<String>(
+                'foo \t bar \n baz', it()..equalsIgnoringWhitespace('foo bar')))
+            .isARejection(which: [
           'is too long with unexpected trailing characters:',
           ' baz'
         ]);
       });
       test('reports original missing characters for short string', () {
         checkThat(softCheck<String>(
-                'foo  bar', (c) => c.equalsIgnoringWhitespace('foo bar baz')))
+                'foo  bar', it()..equalsIgnoringWhitespace('foo bar baz')))
             .isARejection(which: [
           'is too short with missing trailing characters:',
           ' baz'
@@ -192,7 +191,7 @@ void main() {
       });
       test('reports index of different character with original characters', () {
         checkThat(softCheck<String>(
-                'x  hit  x', (c) => c.equalsIgnoringWhitespace('x hat x')))
+                'x  hit  x', it()..equalsIgnoringWhitespace('x hat x')))
             .isARejection(which: [
           'differs at offset 3:',
           'x hat x',


### PR DESCRIPTION
Previously, all "condition" arguments were callbacks that take a
`Check`. Now there is a `Condition` class which has an `apply` method
for the same purpose.

Add an `it()` Utility to get an object that is both a `Condition`, and a
`Check`. Expectations run against the check are recorded and played back
against the real check when the condition is applied. Expectations can
be chained with a cascade, so that the outermost object is the one
passed as an argument.

Add a factory constructor which takes a callback because there is
currently no way to express a numeric comparison expectation with a
cascade. This wouldn't be necessary if we had methods like
`.isGreaterThan` instead of `operator >`.

Move `skip` to an extension since there are now multiple implementations
of `Check`.
