### PR TITLE
Remove operator extensions

### DIFF
--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -143,21 +143,8 @@ Iterable<String> describe<T>(Condition<T> condition) {
 /// A set of expectations that are checked against the value when applied to a
 /// [Check].
 abstract class Condition<T> {
-  factory Condition(FutureOr<void> Function(Check<T>) c) = _CallbackCondition;
   void apply(Check<T> check);
   Future<void> applyAsync(Check<T> check);
-}
-
-class _CallbackCondition<T> implements Condition<T> {
-  FutureOr<void> Function(Check<T>) _callback;
-  _CallbackCondition(this._callback);
-  void apply(Check<T> check) {
-    _callback(check);
-  }
-
-  Future<void> applyAsync(Check<T> check) async {
-    await _callback(check);
-  }
 }
 
 ConditionCheck<T> it<T>() => ConditionCheck._();

--- a/pkgs/checks/lib/src/extensions/math.dart
+++ b/pkgs/checks/lib/src/extensions/math.dart
@@ -6,7 +6,7 @@ import 'package:checks/context.dart';
 
 extension NumChecks on Check<num> {
   /// Expects that this number is greater than [other].
-  void operator >(num other) {
+  void isGreaterThan(num other) {
     context.expect(() => ['is greater than ${literal(other)}'], (actual) {
       if (actual > other) return null;
       return Rejection(
@@ -16,7 +16,7 @@ extension NumChecks on Check<num> {
   }
 
   /// Expects that this number is greater than or equal to [other].
-  void operator >=(num other) {
+  void isGreaterOrEqual(num other) {
     context.expect(() => ['is greater than or equal to ${literal(other)}'],
         (actual) {
       if (actual >= other) return null;
@@ -27,7 +27,7 @@ extension NumChecks on Check<num> {
   }
 
   /// Expects that this number is less than [other].
-  void operator <(num other) {
+  void isLessThan(num other) {
     context.expect(() => ['is less than ${literal(other)}'], (actual) {
       if (actual < other) return null;
       return Rejection(
@@ -37,7 +37,7 @@ extension NumChecks on Check<num> {
   }
 
   /// Expects that this number is less than or equal to [other].
-  void operator <=(num other) {
+  void isLessOrEqual(num other) {
     context.expect(() => ['is less than or equal to ${literal(other)}'],
         (actual) {
       if (actual <= other) return null;

--- a/pkgs/checks/test/extensions/iterable_test.dart
+++ b/pkgs/checks/test/extensions/iterable_test.dart
@@ -56,12 +56,12 @@ void main() {
 
   group('every', () {
     test('succeeds for the happy path', () {
-      checkThat(_testIterable).every(Condition((e) => e > -1));
+      checkThat(_testIterable).every(it()..isGreaterOrEqual(-1));
     });
 
     test('includes details of first failing element', () async {
       checkThat(softCheck<Iterable<int>>(
-              _testIterable, it()..every(Condition((e) => e < 0))))
+              _testIterable, it()..every(it()..isLessThan(0))))
           .isARejection(actual: '(0, 1)', which: [
         'has an element at index 0 that:',
         '  Actual: <0>',
@@ -73,16 +73,14 @@ void main() {
   group('pairwiseComparesTo', () {
     test('succeeds for the happy path', () {
       checkThat(_testIterable).pairwiseComparesTo(
-          [1, 2], (expected) => Condition((c) => c < expected), 'is less than');
+          [1, 2], (expected) => it()..isLessThan(expected), 'is less than');
     });
     test('fails for mismatched element', () async {
       checkThat(softCheck<Iterable<int>>(
               _testIterable,
               it()
-                ..pairwiseComparesTo(
-                    [1, 1],
-                    (expected) => Condition((c) => c < expected),
-                    'is less than')))
+                ..pairwiseComparesTo([1, 1],
+                    (expected) => it()..isLessThan(expected), 'is less than')))
           .isARejection(actual: '(0, 1)', which: [
         'does not have an element at index 1 that:',
         '  is less than <1>',
@@ -94,10 +92,8 @@ void main() {
       checkThat(softCheck<Iterable<int>>(
               _testIterable,
               it()
-                ..pairwiseComparesTo(
-                    [1, 2, 3],
-                    (expected) => Condition((c) => c < expected),
-                    'is less than')))
+                ..pairwiseComparesTo([1, 2, 3],
+                    (expected) => it()..isLessThan(expected), 'is less than')))
           .isARejection(actual: '(0, 1)', which: [
         'has too few elements, there is no element to match at index 2'
       ]);
@@ -106,10 +102,8 @@ void main() {
       checkThat(softCheck<Iterable<int>>(
               _testIterable,
               it()
-                ..pairwiseComparesTo(
-                    [1],
-                    (expected) => Condition((c) => c < expected),
-                    'is less than')))
+                ..pairwiseComparesTo([1],
+                    (expected) => it()..isLessThan(expected), 'is less than')))
           .isARejection(
               actual: '(0, 1)',
               which: ['has too many elements, expected exactly 1']);

--- a/pkgs/checks/test/extensions/math_test.dart
+++ b/pkgs/checks/test/extensions/math_test.dart
@@ -12,55 +12,55 @@ void main() {
   group('num checks', () {
     group('greater than', () {
       test('succeeds for happy case', () {
-        checkThat(42) > 7;
+        checkThat(42).isGreaterThan(7);
       });
       test('fails for less than', () {
-        checkThat(softCheck<int>(42, Condition((p0) => p0 > 50)))
+        checkThat(softCheck<int>(42, it()..isGreaterThan(50)))
             .isARejection(actual: '<42>', which: ['is not greater than <50>']);
       });
       test('fails for equal', () {
-        checkThat(softCheck<int>(42, Condition((p0) => p0 > 42)))
+        checkThat(softCheck<int>(42, it()..isGreaterThan(42)))
             .isARejection(actual: '<42>', which: ['is not greater than <42>']);
       });
     });
 
     group('greater than or equal', () {
       test('succeeds for happy case', () {
-        checkThat(42) >= 7;
+        checkThat(42).isGreaterOrEqual(7);
       });
       test('fails for less than', () {
-        checkThat(softCheck<int>(42, Condition((p0) => p0 >= 50))).isARejection(
+        checkThat(softCheck<int>(42, it()..isGreaterOrEqual(50))).isARejection(
             actual: '<42>', which: ['is not greater than or equal to <50>']);
       });
       test('succeeds for equal', () {
-        checkThat(42) >= 42;
+        checkThat(42).isGreaterOrEqual(42);
       });
     });
 
     group('less than', () {
       test('succeeds for happy case', () {
-        checkThat(42) < 50;
+        checkThat(42).isLessThan(50);
       });
       test('fails for greater than', () {
-        checkThat(softCheck<int>(42, Condition((p0) => p0 < 7)))
+        checkThat(softCheck<int>(42, it()..isLessThan(7)))
             .isARejection(actual: '<42>', which: ['is not less than <7>']);
       });
       test('fails for equal', () {
-        checkThat(softCheck<int>(42, Condition((p0) => p0 < 42)))
+        checkThat(softCheck<int>(42, it()..isLessThan(42)))
             .isARejection(actual: '<42>', which: ['is not less than <42>']);
       });
     });
 
     group('less than or equal', () {
       test('succeeds for happy case', () {
-        checkThat(42) <= 50;
+        checkThat(42).isLessOrEqual(50);
       });
       test('fails for greater than', () {
-        checkThat(softCheck<int>(42, Condition((p0) => p0 <= 7))).isARejection(
+        checkThat(softCheck<int>(42, it()..isLessOrEqual(7))).isARejection(
             actual: '<42>', which: ['is not less than or equal to <7>']);
       });
       test('succeeds for equal', () {
-        checkThat(42) <= 42;
+        checkThat(42).isLessOrEqual(42);
       });
     });
 

--- a/pkgs/checks/test/failure_message_test.dart
+++ b/pkgs/checks/test/failure_message_test.dart
@@ -6,7 +6,7 @@ void main() {
   group('failures', () {
     test('includes expected, actual, and which', () {
       checkThat(() {
-        checkThat(1) > 2;
+        checkThat(1).isGreaterThan(2);
       }).throwsFailure().equals('''
 Expected: a int that:
   is greater than <2>
@@ -29,19 +29,19 @@ Actual: a List<dynamic> that:
 
     test('include a reason when provided', () {
       checkThat(() {
-        checkThat(because: 'Some reason', 1) > 2;
+        checkThat(because: 'Some reason', 1).isGreaterThan(2);
       }).throwsFailure().endsWith('Reason: Some reason');
     });
 
     test('retain type label following isNotNull', () {
       checkThat(() {
-        checkThat<int?>(1).isNotNull() > 2;
+        checkThat<int?>(1).isNotNull().isGreaterThan(2);
       }).throwsFailure().startsWith('Expected: a int? that:\n');
     });
 
     test('retain reason following isNotNull', () {
       checkThat(() {
-        checkThat<int?>(because: 'Some reason', 1).isNotNull() > 2;
+        checkThat<int?>(because: 'Some reason', 1).isNotNull().isGreaterThan(2);
       }).throwsFailure().endsWith('Reason: Some reason');
     });
   });


### PR DESCRIPTION
Rename to `isGreaterThan`, `isGreaterOrEqual`, `isLessThan`,
`isLessOrEqual`.

Drop the `Condition` constructor which takes a callback since now more
conditions should be expressible with a cascade on `it()`.
