### PR TITLE
Improve output for collections and long strings

### DIFF
--- a/pkgs/checks/lib/context.dart
+++ b/pkgs/checks/lib/context.dart
@@ -14,4 +14,5 @@ export 'src/checks.dart'
         Rejection,
         describe,
         softCheck;
-export 'src/describe.dart' show escape, indent, literal, prefixFirst;
+export 'src/describe.dart'
+    show escape, indent, literal, postfixLast, prefixFirst;

--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -66,7 +66,8 @@ Check<T> checkThat<T>(T value, {String? because}) => Check._(_TestContext._root(
         throw TestFailure([
           ...prefixFirst('Expected: ', f.detail.expected),
           ...prefixFirst('Actual: ', f.detail.actual),
-          ...indent(['Actual: ${f.rejection.actual}'], f.detail.depth),
+          ...indent(
+              prefixFirst('Actual: ', f.rejection.actual), f.detail.depth),
           if (which != null && which.isNotEmpty)
             ...indent(prefixFirst('Which: ', which), f.detail.depth),
           if (because != null) 'Reason: $because',
@@ -250,7 +251,8 @@ abstract class Context<T> {
 class Extracted<T> {
   final Rejection? rejection;
   final T? value;
-  Extracted.rejection({required String actual, Iterable<String>? which})
+  Extracted.rejection(
+      {required Iterable<String> actual, Iterable<String>? which})
       : this.rejection = Rejection(actual: actual, which: which),
         this.value = null;
   Extracted.value(T this.value) : this.rejection = null;
@@ -619,7 +621,7 @@ class Rejection {
   /// message. The message will be indented to the level of the expectation in
   /// the description, and printed following the descriptions of any
   /// expectations that have already passed.
-  final String actual;
+  final Iterable<String> actual;
 
   /// A description of the way that [actual] failed to meet the expectation.
   ///

--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -617,10 +617,13 @@ class Rejection {
   /// expectation that a Future completes to a value may describe the actual as
   /// "A Future that completes to an error".
   ///
+  /// Lines should be split to separate elements, and individual strings should
+  /// not contain newlines.
+  ///
   /// This is printed following an "Actual: " label in the output of a failure
-  /// message. The message will be indented to the level of the expectation in
-  /// the description, and printed following the descriptions of any
-  /// expectations that have already passed.
+  /// message. All lines in the message will be indented to the level of the
+  /// expectation in the description, and printed following the descriptions of
+  /// any expectations that have already passed.
   final Iterable<String> actual;
 
   /// A description of the way that [actual] failed to meet the expectation.

--- a/pkgs/checks/lib/src/describe.dart
+++ b/pkgs/checks/lib/src/describe.dart
@@ -2,14 +2,91 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-String literal(Object? o) {
-  if (o == null || o is num || o is bool) return '<$o>';
-  // TODO Truncate long strings?
-  // TODO: handle strings with embedded `'`
-  // TODO: special handling of multi-line strings?
-  if (o is String) return "'$o'";
-  // TODO Truncate long collections?
-  return '$o';
+import 'dart:convert';
+
+/// Returns a pretty-printed representation of [object].
+///
+/// When possible, lines will be kept under [_maxLineLength]. This isn't
+/// guaranteed, since individual objects may have string representations that
+/// are too long, but most lines will be less than [_maxLineLength] long.
+///
+/// [Iterable]s and [Map]s will only print their first [_maxItems] elements or
+/// key/value pairs, respectively.
+Iterable<String> literal(Object? object) => _prettyPrint(object, 0, {}, true);
+
+const _maxLineLength = 80;
+const _maxItems = 25;
+
+Iterable<String> _prettyPrint(
+    Object? object, int indentSize, Set<Object?> seen, bool isTopLevel) {
+  if (seen.contains(object)) return ['(recursive)'];
+  seen = seen.union({object});
+  Iterable<String> prettyPrintNested(Object? child) =>
+      _prettyPrint(child, indentSize + 2, seen, false);
+
+  if (object is Iterable) {
+    String open, close;
+    if (object is List) {
+      open = '[';
+      close = ']';
+    } else if (object is Set) {
+      open = '{';
+      close = '}';
+    } else {
+      open = '(';
+      close = ')';
+    }
+    final elements = object.map(prettyPrintNested).toList();
+    return _prettyPrintCollection(
+        open, close, elements, _maxLineLength - indentSize);
+  } else if (object is Map) {
+    final entries = object.entries.map((entry) {
+      final key = prettyPrintNested(entry.key);
+      final value = prettyPrintNested(entry.value);
+      return [
+        ...key.take(key.length - 1),
+        '${key.last}: ${value.first}',
+        ...value.skip(1)
+      ];
+    }).toList();
+    return _prettyPrintCollection(
+        '{', '}', entries, _maxLineLength - indentSize);
+  } else if (object is String) {
+    if (object.isEmpty) return ["''"];
+    final escaped = const LineSplitter()
+        .convert(object)
+        .map(escape)
+        .map((line) => line.replaceAll("'", r"\'"))
+        .toList();
+    return prefixFirst("'", postfixLast("'", escaped));
+  } else {
+    final value = const LineSplitter().convert(object.toString());
+    return isTopLevel ? prefixFirst('<', postfixLast('>', value)) : value;
+  }
+}
+
+Iterable<String> _prettyPrintCollection(
+    String open, String close, List<Iterable<String>> elements, int maxLength) {
+  if (elements.length > _maxItems) {
+    elements.replaceRange(_maxItems - 1, elements.length, [
+      ['...']
+    ]);
+  }
+  if (elements.every((e) => e.length == 1)) {
+    final singleLine = '$open${elements.map((e) => e.single).join(', ')}$close';
+    if (singleLine.length <= maxLength) {
+      return [singleLine];
+    }
+  }
+  if (elements.length == 1) {
+    return prefixFirst(open, postfixLast(close, elements.single));
+  }
+  return [
+    ...prefixFirst(open, postfixLast(',', elements.first)),
+    for (var element in elements.skip(1).take(elements.length - 2))
+      ...postfixLast(',', element),
+    ...postfixLast(close, elements.last),
+  ];
 }
 
 Iterable<String> indent(Iterable<String> lines, [int depth = 1]) {
@@ -17,6 +94,10 @@ Iterable<String> indent(Iterable<String> lines, [int depth = 1]) {
   return lines.map((line) => '$indent$line');
 }
 
+/// Prepends [prefix] to the first line of [lines].
+///
+/// If [lines] is empty, the result will be as well. The prefix will not be
+/// returned for an empty input.
 Iterable<String> prefixFirst(String prefix, Iterable<String> lines) sync* {
   var isFirst = true;
   for (var line in lines) {
@@ -26,6 +107,20 @@ Iterable<String> prefixFirst(String prefix, Iterable<String> lines) sync* {
     } else {
       yield line;
     }
+  }
+}
+
+/// Append [postfix] to the last line of [lines].
+///
+/// If [lines] is empty, the result will be as well. The postfix will not be
+/// returned for an empty input.
+Iterable<String> postfixLast(String postfix, Iterable<String> lines) sync* {
+  var iterator = lines.iterator;
+  var hasNext = iterator.moveNext();
+  while (hasNext) {
+    final line = iterator.current;
+    hasNext = iterator.moveNext();
+    yield hasNext ? line : '$line$postfix';
   }
 }
 

--- a/pkgs/checks/lib/src/extensions/core.dart
+++ b/pkgs/checks/lib/src/extensions/core.dart
@@ -68,7 +68,7 @@ extension CoreChecks<T> on Check<T> {
 
   /// Expects that the value is equal to [other] according to [operator ==].
   void equals(T other) {
-    context.expect(() => ['equals ${literal(other)}'], (actual) {
+    context.expect(() => prefixFirst('equals ', literal(other)), (actual) {
       if (actual == other) return null;
       return Rejection(actual: literal(actual), which: ['are not equal']);
     });
@@ -76,7 +76,8 @@ extension CoreChecks<T> on Check<T> {
 
   /// Expects that the value is [identical] to [other].
   void identicalTo(T other) {
-    context.expect(() => ['is identical to ${literal(other)}'], (actual) {
+    context.expect(() => prefixFirst('is identical to ', literal(other)),
+        (actual) {
       if (identical(actual, other)) return null;
       return Rejection(actual: literal(actual), which: ['is not identical']);
     });

--- a/pkgs/checks/lib/src/extensions/function.dart
+++ b/pkgs/checks/lib/src/extensions/function.dart
@@ -21,13 +21,13 @@ extension ThrowsCheck<T> on Check<T Function()> {
       try {
         final result = actual();
         return Extracted.rejection(
-          actual: 'a function that returned ${literal(result)}',
+          actual: prefixFirst('a function that returned ', literal(result)),
           which: ['did not throw'],
         );
       } catch (e) {
         if (e is E) return Extracted.value(e as E);
         return Extracted.rejection(
-            actual: 'a function that threw error ${literal(e)}',
+            actual: prefixFirst('a function that threw error ', literal(e)),
             which: ['did not throw an $E']);
       }
     });
@@ -44,9 +44,12 @@ extension ThrowsCheck<T> on Check<T Function()> {
       try {
         return Extracted.value(actual());
       } catch (e, st) {
-        return Extracted.rejection(
-            actual: 'a function that throws',
-            which: ['threw ${literal(e)}', ...st.toString().split('\n')]);
+        return Extracted.rejection(actual: [
+          'a function that throws'
+        ], which: [
+          ...prefixFirst('threw ', literal(e)),
+          ...st.toString().split('\n')
+        ]);
       }
     });
   }

--- a/pkgs/checks/lib/src/extensions/iterable.dart
+++ b/pkgs/checks/lib/src/extensions/iterable.dart
@@ -30,15 +30,13 @@ extension IterableChecks<T> on Check<Iterable<T>> {
   /// [Iterable.contains].
   void contains(T element) {
     context.expect(() {
-      return [
-        'contains ${literal(element)}',
-      ];
+      return prefixFirst('contains ', literal(element));
     }, (actual) {
-      if (actual.isEmpty) return Rejection(actual: 'an empty iterable');
+      if (actual.isEmpty) return Rejection(actual: ['an empty iterable']);
       if (actual.contains(element)) return null;
       return Rejection(
           actual: literal(actual),
-          which: ['does not contain ${literal(element)}']);
+          which: prefixFirst('does not contain ', literal(element)));
     });
   }
 
@@ -53,13 +51,12 @@ extension IterableChecks<T> on Check<Iterable<T>> {
         ...conditionDescription,
       ];
     }, (actual) {
-      if (actual.isEmpty) return Rejection(actual: 'an empty iterable');
+      if (actual.isEmpty) return Rejection(actual: ['an empty iterable']);
       for (var e in actual) {
         if (softCheck(e, elementCondition) == null) return null;
       }
       return Rejection(
-          actual: '${literal(actual)}',
-          which: ['Contains no matching element']);
+          actual: literal(actual), which: ['Contains no matching element']);
     });
   }
 
@@ -85,7 +82,7 @@ extension IterableChecks<T> on Check<Iterable<T>> {
         return Rejection(actual: literal(actual), which: [
           'has an element at index $i that:',
           ...indent(failure.detail.actual.skip(1)),
-          ...indent(['Actual: ${failure.rejection.actual}'],
+          ...indent(prefixFirst('Actual: ', failure.rejection.actual),
               failure.detail.depth + 1),
           if (which != null && which.isNotEmpty)
             ...indent(prefixFirst('Which: ', which), failure.detail.depth + 1),
@@ -110,7 +107,7 @@ extension IterableChecks<T> on Check<Iterable<T>> {
   void pairwiseComparesTo<S>(List<S> expected,
       Condition<T> Function(S) elementCondition, String description) {
     context.expect(() {
-      return ['pairwise $description ${literal(expected)}'];
+      return prefixFirst('pairwise $description ', literal(expected));
     }, (actual) {
       final iterator = actual.iterator;
       for (var i = 0; i < expected.length; i++) {
@@ -128,7 +125,8 @@ extension IterableChecks<T> on Check<Iterable<T>> {
         return Rejection(actual: literal(actual), which: [
           'does not have an element at index $i that:',
           ...innerDescription,
-          'Actual element at index $i: ${failure.rejection.actual}',
+          ...prefixFirst(
+              'Actual element at index $i: ', failure.rejection.actual),
           if (which != null) ...prefixFirst('Which: ', which),
         ]);
       }

--- a/pkgs/checks/lib/src/extensions/map.dart
+++ b/pkgs/checks/lib/src/extensions/map.dart
@@ -12,15 +12,17 @@ extension MapChecks<K, V> on Check<Map<K, V>> {
   Check<Iterable<K>> get keys => has((m) => m.keys, 'keys');
   Check<Iterable<V>> get values => has((m) => m.values, 'values');
   Check<int> get length => has((m) => m.length, 'length');
-  Check<V> operator [](K key) =>
-      context.nest('contains a value for ${literal(key)}', (actual) {
-        if (!actual.containsKey(key)) {
-          return Extracted.rejection(
-              actual: literal(actual),
-              which: ['does not contain the key ${literal(key)}']);
-        }
-        return Extracted.value(actual[key] as V);
-      });
+  Check<V> operator [](K key) {
+    final keyString = literal(key).join(r'\n');
+    return context.nest('contains a value for $keyString', (actual) {
+      if (!actual.containsKey(key)) {
+        return Extracted.rejection(
+            actual: literal(actual),
+            which: ['does not contain the key $keyString']);
+      }
+      return Extracted.value(actual[key] as V);
+    });
+  }
 
   void isEmpty() {
     context.expect(() => const ['is empty'], (actual) {
@@ -38,11 +40,11 @@ extension MapChecks<K, V> on Check<Map<K, V>> {
 
   /// Expects that the map contains [key] according to [Map.containsKey].
   void containsKey(K key) {
-    context.expect(() => ['contains key ${literal(key)}'], (actual) {
+    final keyString = literal(key).join(r'\n');
+    context.expect(() => ['contains key $keyString'], (actual) {
       if (actual.containsKey(key)) return null;
       return Rejection(
-          actual: literal(actual),
-          which: ['does not contain key ${literal(key)}']);
+          actual: literal(actual), which: ['does not contain key $keyString']);
     });
   }
 
@@ -57,22 +59,23 @@ extension MapChecks<K, V> on Check<Map<K, V>> {
         ...conditionDescription,
       ];
     }, (actual) {
-      if (actual.isEmpty) return Rejection(actual: 'an empty map');
+      if (actual.isEmpty) return Rejection(actual: ['an empty map']);
       for (var k in actual.keys) {
         if (softCheck(k, keyCondition) == null) return null;
       }
       return Rejection(
-          actual: '${literal(actual)}', which: ['Contains no matching key']);
+          actual: literal(actual), which: ['Contains no matching key']);
     });
   }
 
   /// Expects that the map contains [value] according to [Map.containsValue].
   void containsValue(V value) {
-    context.expect(() => ['contains value ${literal(value)}'], (actual) {
+    final valueString = literal(value).join(r'\n');
+    context.expect(() => ['contains value $valueString'], (actual) {
       if (actual.containsValue(value)) return null;
       return Rejection(
           actual: literal(actual),
-          which: ['does not contain value ${literal(value)}']);
+          which: ['does not contain value $valueString']);
     });
   }
 
@@ -87,12 +90,12 @@ extension MapChecks<K, V> on Check<Map<K, V>> {
         ...conditionDescription,
       ];
     }, (actual) {
-      if (actual.isEmpty) return Rejection(actual: 'an empty map');
+      if (actual.isEmpty) return Rejection(actual: ['an empty map']);
       for (var v in actual.values) {
         if (softCheck(v, valueCondition) == null) return null;
       }
       return Rejection(
-          actual: '${literal(actual)}', which: ['Contains no matching value']);
+          actual: literal(actual), which: ['Contains no matching value']);
     });
   }
 }

--- a/pkgs/checks/lib/src/extensions/math.dart
+++ b/pkgs/checks/lib/src/extensions/math.dart
@@ -7,43 +7,39 @@ import 'package:checks/context.dart';
 extension NumChecks on Check<num> {
   /// Expects that this number is greater than [other].
   void isGreaterThan(num other) {
-    context.expect(() => ['is greater than ${literal(other)}'], (actual) {
+    context.expect(() => ['is greater than <$other>'], (actual) {
       if (actual > other) return null;
       return Rejection(
-          actual: literal(actual),
-          which: ['is not greater than ${literal(other)}']);
+          actual: literal(actual), which: ['is not greater than <$other>']);
     });
   }
 
   /// Expects that this number is greater than or equal to [other].
   void isGreaterOrEqual(num other) {
-    context.expect(() => ['is greater than or equal to ${literal(other)}'],
-        (actual) {
+    context.expect(() => ['is greater than or equal to <$other>'], (actual) {
       if (actual >= other) return null;
       return Rejection(
           actual: literal(actual),
-          which: ['is not greater than or equal to ${literal(other)}']);
+          which: ['is not greater than or equal to <$other>']);
     });
   }
 
   /// Expects that this number is less than [other].
   void isLessThan(num other) {
-    context.expect(() => ['is less than ${literal(other)}'], (actual) {
+    context.expect(() => ['is less than <$other>'], (actual) {
       if (actual < other) return null;
       return Rejection(
-          actual: literal(actual),
-          which: ['is not less than ${literal(other)}']);
+          actual: literal(actual), which: ['is not less than <$other>']);
     });
   }
 
   /// Expects that this number is less than or equal to [other].
   void isLessOrEqual(num other) {
-    context.expect(() => ['is less than or equal to ${literal(other)}'],
-        (actual) {
+    context.expect(() => ['is less than or equal to <$other>'], (actual) {
       if (actual <= other) return null;
       return Rejection(
           actual: literal(actual),
-          which: ['is not less than or equal to ${literal(other)}']);
+          which: ['is not less than or equal to <$other>']);
     });
   }
 
@@ -122,13 +118,11 @@ extension NumChecks on Check<num> {
   /// Expects that the difference between this number and [other] is less than
   /// or equal to [delta].
   void isCloseTo(num other, num delta) {
-    context.expect(() => ['is within ${literal(delta)} of ${literal(other)}'],
-        (actual) {
+    context.expect(() => ['is within <$delta> of <$other>'], (actual) {
       final difference = (other - actual).abs();
       if (difference <= delta) return null;
       return Rejection(
-          actual: literal(actual),
-          which: ['differs by ${literal(difference)}']);
+          actual: literal(actual), which: ['differs by <$difference>']);
     });
   }
 }

--- a/pkgs/checks/lib/src/extensions/string.dart
+++ b/pkgs/checks/lib/src/extensions/string.dart
@@ -11,11 +11,11 @@ import 'core.dart';
 extension StringChecks on Check<String> {
   /// Expects that the value contains [pattern] according to [String.contains];
   void contains(Pattern pattern) {
-    context.expect(() => ['contains ${literal(pattern)}'], (actual) {
+    context.expect(() => prefixFirst('contains ', literal(pattern)), (actual) {
       if (actual.contains(pattern)) return null;
       return Rejection(
         actual: literal(actual),
-        which: ['Does not contain ${literal(pattern)}'],
+        which: prefixFirst('Does not contain ', literal(pattern)),
       );
     });
   }
@@ -38,12 +38,12 @@ extension StringChecks on Check<String> {
 
   void startsWith(Pattern other) {
     context.expect(
-      () => ['starts with ${literal(other)}'],
+      () => prefixFirst('starts with ', literal(other)),
       (actual) {
         if (actual.startsWith(other)) return null;
         return Rejection(
           actual: literal(actual),
-          which: ['does not start with ${literal(other)}'],
+          which: prefixFirst('does not start with ', literal(other)),
         );
       },
     );
@@ -51,32 +51,33 @@ extension StringChecks on Check<String> {
 
   void endsWith(String other) {
     context.expect(
-      () => ['ends with ${literal(other)}'],
+      () => prefixFirst('ends with ', literal(other)),
       (actual) {
         if (actual.endsWith(other)) return null;
         return Rejection(
           actual: literal(actual),
-          which: ['does not end with ${literal(other)}'],
+          which: prefixFirst('does not end with ', literal(other)),
         );
       },
     );
   }
 
-  /// Expects that the `String` contains each of the sub strings in [expected]
+  /// Expects that the `String` contains each of the sub strings in expected
   /// in the given order, with any content between them.
   ///
   /// For example, the following will succeed:
   ///
   ///     checkThat('abcdefg').containsInOrder(['a','e']);
   void containsInOrder(Iterable<String> expected) {
-    context.expect(() => ['contains, in order: ${literal(expected)}'],
+    context.expect(() => prefixFirst('contains, in order: ', literal(expected)),
         (actual) {
       var fromIndex = 0;
       for (var s in expected) {
         var index = actual.indexOf(s, fromIndex);
         if (index < 0) {
           return Rejection(actual: literal(actual), which: [
-            'does not have a match for the substring ${literal(s)}',
+            ...prefixFirst(
+                'does not have a match for the substring ', literal(s)),
             if (fromIndex != 0)
               'following the other matches up to character $fromIndex'
           ]);
@@ -90,7 +91,7 @@ extension StringChecks on Check<String> {
   /// Expects that the `String` contains exactly the same code units as
   /// [expected].
   void equals(String expected) {
-    context.expect(() => ['equals ${literal(expected)}'],
+    context.expect(() => prefixFirst('equals ', literal(expected)),
         (actual) => _findDifference(actual, expected));
   }
 
@@ -98,7 +99,7 @@ extension StringChecks on Check<String> {
   /// both were lower case.
   void equalsIgnoringCase(String expected) {
     context.expect(
-        () => ['equals ignoring case ${literal(expected)}'],
+        () => prefixFirst('equals ignoring case ', literal(expected)),
         (actual) => _findDifference(
             actual.toLowerCase(), expected.toLowerCase(), actual, expected));
   }
@@ -118,7 +119,8 @@ extension StringChecks on Check<String> {
   ///     checkThat('helloworld').equalsIgnoringWhitespace('hello world');
   ///     checkThat('he llo world').equalsIgnoringWhitespace('hello world');
   void equalsIgnoringWhitespace(String expected) {
-    context.expect(() => ['equals ignoring whitespace ${literal(expected)}'],
+    context.expect(
+        () => prefixFirst('equals ignoring whitespace ', literal(expected)),
         (actual) {
       final collapsedActual = _collapseWhitespace(actual);
       final collapsedExpected = _collapseWhitespace(expected);
@@ -156,7 +158,9 @@ Rejection? _findDifference(String actual, String expected,
       ]);
     } else {
       if (actual.isEmpty) {
-        return Rejection(actual: 'an empty string', which: [
+        return Rejection(actual: [
+          'an empty string'
+        ], which: [
           'is missing all expected characters:',
           _trailing(escapedExpectedDisplay, 0)
         ]);

--- a/pkgs/checks/test/extensions/async_test.dart
+++ b/pkgs/checks/test/extensions/async_test.dart
@@ -19,7 +19,7 @@ void main() {
       await _rejectionWhichCheck<Future>(
         _futureFail(),
         it()..completes(),
-        it()..single.equals('Threw UnimplementedError'),
+        it()..single.equals('Threw <UnimplementedError>'),
       );
     });
 

--- a/pkgs/checks/test/extensions/core_test.dart
+++ b/pkgs/checks/test/extensions/core_test.dart
@@ -15,7 +15,7 @@ void main() {
 
       checkThat(
         softCheck(1, it()..isA<String>()),
-      ).isARejection(actual: '<1>', which: ['Is a int']);
+      ).isARejection(actual: ['<1>'], which: ['Is a int']);
     });
   });
 
@@ -29,7 +29,7 @@ void main() {
           it()..has((v) => throw UnimplementedError(), 'isOdd'),
         ),
       ).isARejection(
-        actual: '<2>',
+        actual: ['<2>'],
         which: ['threw while trying to read property'],
       );
     });
@@ -47,7 +47,7 @@ void main() {
           it()..not(it()..isTrue()),
         ),
       ).isARejection(
-        actual: '<true>',
+        actual: ['<true>'],
         which: ['is a value that: ', '    is true'],
       );
     });
@@ -62,7 +62,7 @@ void main() {
           false,
           it()..isTrue(),
         ),
-      ).isARejection(actual: '<false>');
+      ).isARejection(actual: ['<false>']);
     });
 
     test('isFalse', () {
@@ -71,7 +71,7 @@ void main() {
       checkThat(softCheck<bool>(
         true,
         it()..isFalse(),
-      )).isARejection(actual: '<true>');
+      )).isARejection(actual: ['<true>']);
     });
   });
 
@@ -81,14 +81,14 @@ void main() {
 
       checkThat(
         softCheck(1, it()..equals(2)),
-      ).isARejection(actual: '<1>', which: ['are not equal']);
+      ).isARejection(actual: ['<1>'], which: ['are not equal']);
     });
 
     test('identical', () {
       checkThat(1).identicalTo(1);
 
       checkThat(softCheck(1, it()..identicalTo(2)))
-          .isARejection(actual: '<1>', which: ['is not identical']);
+          .isARejection(actual: ['<1>'], which: ['is not identical']);
     });
   });
 
@@ -97,13 +97,13 @@ void main() {
       checkThat(1).isNotNull();
 
       checkThat(softCheck(null, it()..isNotNull()))
-          .isARejection(actual: '<null>');
+          .isARejection(actual: ['<null>']);
     });
 
     test('isNull', () {
       checkThat(null).isNull();
 
-      checkThat(softCheck(1, it()..isNull())).isARejection(actual: '<1>');
+      checkThat(softCheck(1, it()..isNull())).isARejection(actual: ['<1>']);
     });
   });
 }

--- a/pkgs/checks/test/extensions/function_test.dart
+++ b/pkgs/checks/test/extensions/function_test.dart
@@ -18,7 +18,7 @@ void main() {
         checkThat(
           softCheck<void Function()>(() {}, it()..throws<StateError>()),
         ).isARejection(
-            actual: 'a function that returned <null>',
+            actual: ['a function that returned <null>'],
             which: ['did not throw']);
       });
       test('fails for functions that throw the wrong type', () {
@@ -28,7 +28,7 @@ void main() {
             it()..throws<ArgumentError>(),
           ),
         ).isARejection(
-          actual: 'a function that threw error Bad state: oops!',
+          actual: ['a function that threw error <Bad state: oops!>'],
           which: ['did not throw an ArgumentError'],
         );
       });
@@ -44,8 +44,8 @@ void main() {
               StateError('oops!'), StackTrace.fromString('fake trace'));
         }, it()..returnsNormally()))
             .isARejection(
-                actual: 'a function that throws',
-                which: ['threw Bad state: oops!', 'fake trace']);
+                actual: ['a function that throws'],
+                which: ['threw <Bad state: oops!>', 'fake trace']);
       });
     });
   });

--- a/pkgs/checks/test/extensions/iterable_test.dart
+++ b/pkgs/checks/test/extensions/iterable_test.dart
@@ -28,21 +28,21 @@ void main() {
     checkThat([]).isEmpty();
     checkThat(
       softCheck<Iterable<int>>(_testIterable, it()..isEmpty()),
-    ).isARejection(actual: '(0, 1)', which: ['is not empty']);
+    ).isARejection(actual: ['(0, 1)'], which: ['is not empty']);
   });
 
   test('isNotEmpty', () {
     checkThat(_testIterable).isNotEmpty();
     checkThat(
       softCheck<Iterable<int>>(Iterable<int>.empty(), it()..isNotEmpty()),
-    ).isARejection(actual: '()', which: ['is not empty']);
+    ).isARejection(actual: ['()'], which: ['is not empty']);
   });
 
   test('contains', () {
     checkThat(_testIterable).contains(0);
     checkThat(
       softCheck<Iterable<int>>(_testIterable, it()..contains(2)),
-    ).isARejection(actual: '(0, 1)', which: ['does not contain <2>']);
+    ).isARejection(actual: ['(0, 1)'], which: ['does not contain <2>']);
   });
   test('contains', () {
     checkThat(_testIterable).any(it()..equals(1));
@@ -51,7 +51,7 @@ void main() {
         _testIterable,
         it()..any(it()..equals(2)),
       ),
-    ).isARejection(actual: '(0, 1)', which: ['Contains no matching element']);
+    ).isARejection(actual: ['(0, 1)'], which: ['Contains no matching element']);
   });
 
   group('every', () {
@@ -62,7 +62,9 @@ void main() {
     test('includes details of first failing element', () async {
       checkThat(softCheck<Iterable<int>>(
               _testIterable, it()..every(it()..isLessThan(0))))
-          .isARejection(actual: '(0, 1)', which: [
+          .isARejection(actual: [
+        '(0, 1)'
+      ], which: [
         'has an element at index 0 that:',
         '  Actual: <0>',
         '  Which: is not less than <0>',
@@ -81,7 +83,9 @@ void main() {
               it()
                 ..pairwiseComparesTo([1, 1],
                     (expected) => it()..isLessThan(expected), 'is less than')))
-          .isARejection(actual: '(0, 1)', which: [
+          .isARejection(actual: [
+        '(0, 1)'
+      ], which: [
         'does not have an element at index 1 that:',
         '  is less than <1>',
         'Actual element at index 1: <1>',
@@ -94,7 +98,9 @@ void main() {
               it()
                 ..pairwiseComparesTo([1, 2, 3],
                     (expected) => it()..isLessThan(expected), 'is less than')))
-          .isARejection(actual: '(0, 1)', which: [
+          .isARejection(actual: [
+        '(0, 1)'
+      ], which: [
         'has too few elements, there is no element to match at index 2'
       ]);
     });
@@ -105,7 +111,7 @@ void main() {
                 ..pairwiseComparesTo([1],
                     (expected) => it()..isLessThan(expected), 'is less than')))
           .isARejection(
-              actual: '(0, 1)',
+              actual: ['(0, 1)'],
               which: ['has too many elements, expected exactly 1']);
     });
   });

--- a/pkgs/checks/test/extensions/map_test.dart
+++ b/pkgs/checks/test/extensions/map_test.dart
@@ -13,7 +13,7 @@ const _testMap = {
   'b': 2,
 };
 
-const _testMapString = '{a: 1, b: 2}';
+const _testMapString = "{'a': 1, 'b': 2}";
 
 void main() {
   test('length', () {
@@ -43,14 +43,14 @@ void main() {
     checkThat(<String, int>{}).isEmpty();
     checkThat(
       softCheck<Map<String, int>>(_testMap, it()..isEmpty()),
-    ).isARejection(actual: _testMapString, which: ['is not empty']);
+    ).isARejection(actual: [_testMapString], which: ['is not empty']);
   });
 
   test('isNotEmpty', () {
     checkThat(_testMap).isNotEmpty();
     checkThat(
       softCheck<Map<String, int>>({}, it()..isNotEmpty()),
-    ).isARejection(actual: '{}', which: ['is not empty']);
+    ).isARejection(actual: ['{}'], which: ['is not empty']);
   });
 
   test('containsKey', () {
@@ -59,7 +59,7 @@ void main() {
     checkThat(
       softCheck<Map<String, int>>(_testMap, it()..containsKey('c')),
     ).isARejection(
-      actual: _testMapString,
+      actual: [_testMapString],
       which: ["does not contain key 'c'"],
     );
   });
@@ -71,7 +71,7 @@ void main() {
         it()..containsKeyThat(it()..equals('c')),
       ),
     ).isARejection(
-      actual: _testMapString,
+      actual: [_testMapString],
       which: ['Contains no matching key'],
     );
   });
@@ -80,7 +80,7 @@ void main() {
     checkThat(
       softCheck<Map<String, int>>(_testMap, it()..containsValue(3)),
     ).isARejection(
-      actual: _testMapString,
+      actual: [_testMapString],
       which: ['does not contain value <3>'],
     );
   });
@@ -90,7 +90,7 @@ void main() {
       softCheck<Map<String, int>>(
           _testMap, it()..containsValueThat(it()..equals(3))),
     ).isARejection(
-      actual: _testMapString,
+      actual: [_testMapString],
       which: ['Contains no matching value'],
     );
   });

--- a/pkgs/checks/test/extensions/math_test.dart
+++ b/pkgs/checks/test/extensions/math_test.dart
@@ -15,12 +15,12 @@ void main() {
         checkThat(42).isGreaterThan(7);
       });
       test('fails for less than', () {
-        checkThat(softCheck<int>(42, it()..isGreaterThan(50)))
-            .isARejection(actual: '<42>', which: ['is not greater than <50>']);
+        checkThat(softCheck<int>(42, it()..isGreaterThan(50))).isARejection(
+            actual: ['<42>'], which: ['is not greater than <50>']);
       });
       test('fails for equal', () {
-        checkThat(softCheck<int>(42, it()..isGreaterThan(42)))
-            .isARejection(actual: '<42>', which: ['is not greater than <42>']);
+        checkThat(softCheck<int>(42, it()..isGreaterThan(42))).isARejection(
+            actual: ['<42>'], which: ['is not greater than <42>']);
       });
     });
 
@@ -30,7 +30,7 @@ void main() {
       });
       test('fails for less than', () {
         checkThat(softCheck<int>(42, it()..isGreaterOrEqual(50))).isARejection(
-            actual: '<42>', which: ['is not greater than or equal to <50>']);
+            actual: ['<42>'], which: ['is not greater than or equal to <50>']);
       });
       test('succeeds for equal', () {
         checkThat(42).isGreaterOrEqual(42);
@@ -43,11 +43,11 @@ void main() {
       });
       test('fails for greater than', () {
         checkThat(softCheck<int>(42, it()..isLessThan(7)))
-            .isARejection(actual: '<42>', which: ['is not less than <7>']);
+            .isARejection(actual: ['<42>'], which: ['is not less than <7>']);
       });
       test('fails for equal', () {
         checkThat(softCheck<int>(42, it()..isLessThan(42)))
-            .isARejection(actual: '<42>', which: ['is not less than <42>']);
+            .isARejection(actual: ['<42>'], which: ['is not less than <42>']);
       });
     });
 
@@ -57,7 +57,7 @@ void main() {
       });
       test('fails for greater than', () {
         checkThat(softCheck<int>(42, it()..isLessOrEqual(7))).isARejection(
-            actual: '<42>', which: ['is not less than or equal to <7>']);
+            actual: ['<42>'], which: ['is not less than or equal to <7>']);
       });
       test('succeeds for equal', () {
         checkThat(42).isLessOrEqual(42);
@@ -70,11 +70,11 @@ void main() {
       });
       test('fails for ints', () {
         checkThat(softCheck<num>(42, it()..isNaN()))
-            .isARejection(actual: '<42>', which: ['is a number']);
+            .isARejection(actual: ['<42>'], which: ['is a number']);
       });
       test('fails for numeric doubles', () {
         checkThat(softCheck<num>(42.1, it()..isNaN()))
-            .isARejection(actual: '<42.1>', which: ['is a number']);
+            .isARejection(actual: ['<42.1>'], which: ['is a number']);
       });
     });
 
@@ -87,7 +87,7 @@ void main() {
       });
       test('fails for NaN', () {
         checkThat(softCheck<num>(double.nan, it()..isNotNaN()))
-            .isARejection(actual: '<NaN>', which: ['is not a number (NaN)']);
+            .isARejection(actual: ['<NaN>'], which: ['is not a number (NaN)']);
       });
     });
 
@@ -100,7 +100,7 @@ void main() {
       });
       test('fails for zero', () {
         checkThat(softCheck<num>(0, it()..isNegative()))
-            .isARejection(actual: '<0>', which: ['is not negative']);
+            .isARejection(actual: ['<0>'], which: ['is not negative']);
       });
     });
 
@@ -113,11 +113,11 @@ void main() {
       });
       test('fails for -0.0', () {
         checkThat(softCheck<num>(-0.0, it()..isNotNegative()))
-            .isARejection(actual: '<-0.0>', which: ['is negative']);
+            .isARejection(actual: ['<-0.0>'], which: ['is negative']);
       });
       test('fails for negative numbers', () {
         checkThat(softCheck<num>(-1, it()..isNotNegative()))
-            .isARejection(actual: '<-1>', which: ['is negative']);
+            .isARejection(actual: ['<-1>'], which: ['is negative']);
       });
     });
 
@@ -127,15 +127,15 @@ void main() {
       });
       test('fails for NaN', () {
         checkThat(softCheck<num>(double.nan, it()..isFinite()))
-            .isARejection(actual: '<NaN>', which: ['is not finite']);
+            .isARejection(actual: ['<NaN>'], which: ['is not finite']);
       });
       test('fails for infinity', () {
         checkThat(softCheck<num>(double.infinity, it()..isFinite()))
-            .isARejection(actual: '<Infinity>', which: ['is not finite']);
+            .isARejection(actual: ['<Infinity>'], which: ['is not finite']);
       });
       test('fails for negative infinity', () {
         checkThat(softCheck<num>(double.negativeInfinity, it()..isFinite()))
-            .isARejection(actual: '<-Infinity>', which: ['is not finite']);
+            .isARejection(actual: ['<-Infinity>'], which: ['is not finite']);
       });
     });
 
@@ -151,7 +151,7 @@ void main() {
       });
       test('fails for finite numbers', () {
         checkThat(softCheck<num>(1, it()..isNotFinite()))
-            .isARejection(actual: '<1>', which: ['is finite']);
+            .isARejection(actual: ['<1>'], which: ['is finite']);
       });
     });
 
@@ -164,11 +164,11 @@ void main() {
       });
       test('fails for NaN', () {
         checkThat(softCheck<num>(double.nan, it()..isInfinite()))
-            .isARejection(actual: '<NaN>', which: ['is not infinite']);
+            .isARejection(actual: ['<NaN>'], which: ['is not infinite']);
       });
       test('fails for finite numbers', () {
         checkThat(softCheck<num>(1, it()..isInfinite()))
-            .isARejection(actual: '<1>', which: ['is not infinite']);
+            .isARejection(actual: ['<1>'], which: ['is not infinite']);
       });
     });
 
@@ -181,12 +181,12 @@ void main() {
       });
       test('fails for infinity', () {
         checkThat(softCheck<num>(double.infinity, it()..isNotInfinite()))
-            .isARejection(actual: '<Infinity>', which: ['is infinite']);
+            .isARejection(actual: ['<Infinity>'], which: ['is infinite']);
       });
       test('fails for negative infinity', () {
         checkThat(
                 softCheck<num>(double.negativeInfinity, it()..isNotInfinite()))
-            .isARejection(actual: '<-Infinity>', which: ['is infinite']);
+            .isARejection(actual: ['<-Infinity>'], which: ['is infinite']);
       });
     });
 
@@ -202,11 +202,11 @@ void main() {
       });
       test('fails for low values', () {
         checkThat(softCheck<num>(1, it()..isCloseTo(3, 1)))
-            .isARejection(actual: '<1>', which: ['differs by <2>']);
+            .isARejection(actual: ['<1>'], which: ['differs by <2>']);
       });
       test('fails for high values', () {
         checkThat(softCheck<num>(5, it()..isCloseTo(3, 1)))
-            .isARejection(actual: '<5>', which: ['differs by <2>']);
+            .isARejection(actual: ['<5>'], which: ['differs by <2>']);
       });
     });
   });

--- a/pkgs/checks/test/extensions/string_test.dart
+++ b/pkgs/checks/test/extensions/string_test.dart
@@ -14,7 +14,7 @@ void main() {
       checkThat('bob').contains('bo');
       checkThat(
         softCheck<String>('bob', it()..contains('kayleb')),
-      ).isARejection(actual: "'bob'", which: ["Does not contain 'kayleb'"]);
+      ).isARejection(actual: ["'bob'"], which: ["Does not contain 'kayleb'"]);
     });
     test('length', () {
       checkThat('bob').length.equals(3);
@@ -23,24 +23,26 @@ void main() {
       checkThat('').isEmpty();
       checkThat(
         softCheck<String>('bob', it()..isEmpty()),
-      ).isARejection(actual: "'bob'", which: ['is not empty']);
+      ).isARejection(actual: ["'bob'"], which: ['is not empty']);
     });
     test('isNotEmpty', () {
       checkThat('bob').isNotEmpty();
       checkThat(
         softCheck<String>('', it()..isNotEmpty()),
-      ).isARejection(actual: "''", which: ['is empty']);
+      ).isARejection(actual: ["''"], which: ['is empty']);
     });
     test('startsWith', () {
       checkThat('bob').startsWith('bo');
       checkThat(
         softCheck<String>('bob', it()..startsWith('kayleb')),
-      ).isARejection(actual: "'bob'", which: ["does not start with 'kayleb'"]);
+      ).isARejection(
+          actual: ["'bob'"], which: ["does not start with 'kayleb'"]);
     });
     test('endsWith', () {
       checkThat('bob').endsWith('ob');
       checkThat(softCheck<String>('bob', it()..endsWith('kayleb')))
-          .isARejection(actual: "'bob'", which: ["does not end with 'kayleb'"]);
+          .isARejection(
+              actual: ["'bob'"], which: ["does not end with 'kayleb'"]);
     });
 
     group('containsInOrder', () {
@@ -98,7 +100,9 @@ void main() {
       });
       test('reports missing characters for empty string', () {
         checkThat(softCheck<String>('', it()..equals('foo bar baz')))
-            .isARejection(actual: 'an empty string', which: [
+            .isARejection(actual: [
+          'an empty string'
+        ], which: [
           'is missing all expected characters:',
           'foo bar ba ...'
         ]);

--- a/pkgs/checks/test/test_shared.dart
+++ b/pkgs/checks/test/test_shared.dart
@@ -10,13 +10,13 @@ extension TestIterableCheck on Check<Iterable<String>?> {
   void toStringEquals(List<String>? other) {
     final otherToString = other.toString();
     context.expect(
-      () => ['toString equals ${literal(otherToString)}'],
+      () => prefixFirst('toString equals ', literal(otherToString)),
       (actual) {
         final actualToString = actual.toString();
         return actualToString == otherToString
             ? null
             : Rejection(
-                actual: actualToString,
+                actual: literal(actualToString),
                 which: ['does not have a matching toString'],
               );
       },
@@ -25,11 +25,13 @@ extension TestIterableCheck on Check<Iterable<String>?> {
 }
 
 extension RejectionCheck on Check<CheckFailure?> {
-  void isARejection({List<String>? which, String? actual}) {
+  void isARejection({List<String>? which, List<String>? actual}) {
     final rejection = this.isNotNull().has((f) => f.rejection, 'rejection');
     if (actual != null) {
-      rejection.has((p0) => p0.actual, 'actual').equals(actual);
+      rejection
+          .has((p0) => p0.actual.toList(), 'actual')
+          .toStringEquals(actual);
     }
-    rejection.has((p0) => p0.which, 'which').toStringEquals(which);
+    rejection.has((p0) => p0.which?.toList(), 'which').toStringEquals(which);
   }
 }


### PR DESCRIPTION
Change the `actual` argument for rejections from a single String to an
`Iterable<String>`. This allows for maintaining alignment when a multi
line value is displayed with indentation. Change the `literal` utility
to return an Iterable, and update conditions passing something other
than the return from `literal` to pass a List to `Rejection.actual`.

Add a `postfixLast` utility to mirror `prefixFirst` and append content
to the last line of a value. Combining `prefixFirst` and `postfixLast`
with delimiters like quotes or braces allows wrapping content than may be
be 1 or more lines.

Flesh out the `literal` utility. The implementation is based on
`prettyPrint` from `matcher` with some simplifications and adapted to
return an Iterable instead of a String with newlines. One significant
difference from `prettyPrint` is that type names are not included since
they are often redundant.

In some places where `literal` was used for a signature that must take a
single String (the label in a nested context can only be a single line)
join the result with `r'\n'`.
