### PR TITLE
Implement deep collection equality

### DIFF
--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -658,6 +658,10 @@ class ConditionCheck<T> implements Check<T>, Condition<T> {
 
   @override
   final _ReplayContext<T> _context = _ReplayContext();
+
+  String toString() {
+    return ['A value that:', ...describe(_context)].join('\n');
+  }
 }
 
 class _ReplayContext<T> implements Context<T>, Condition<T> {

--- a/pkgs/checks/lib/src/collection_equality.dart
+++ b/pkgs/checks/lib/src/collection_equality.dart
@@ -1,0 +1,291 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:collection';
+
+import 'package:checks/context.dart';
+
+/// Returns a rejection if the elements of [actual] are unequal to the elements
+/// of [expected].
+///
+/// {@template deep_collection_equals}
+/// Elements, keys, or values, which are a collections are deeply compared for
+/// equality, and do not use the native identity based equality or custom
+/// equality operator overrides.
+/// Elements, keys, or values, which are a [Condition] instances are checked
+/// against actual values.
+/// All other value or key types use `operator ==`.
+///
+/// Does not use [Set.contains] or [Map.containsKey]. Custom collection behavior
+/// is ignored. For example, it is not possible to distinguish between a `Set`
+/// and a `Set.identity`.
+/// {@endtemplate}
+Rejection? deepCollectionEquals(Object actual, Object expected) {
+  assert(actual is Iterable || actual is Map);
+  assert(expected is Iterable || expected is Map);
+
+  final queue = Queue.of([_Search(_Path.root(), actual, expected)]);
+  while (queue.isNotEmpty) {
+    final toCheck = queue.removeFirst();
+    final currentExpected = toCheck.expected;
+    final currentActual = toCheck.actual;
+    final path = toCheck.path;
+    Iterable<String>? rejectionWhich;
+    if (currentExpected is Set) {
+      rejectionWhich = _findSetDifference(currentActual, currentExpected, path);
+    } else if (currentExpected is Iterable) {
+      rejectionWhich =
+          _findIterableDifference(currentActual, currentExpected, path, queue);
+    } else {
+      currentExpected as Map;
+      rejectionWhich = _findMapDifference(currentActual, currentExpected, path);
+    }
+    if (rejectionWhich != null) {
+      return Rejection(actual: literal(actual), which: rejectionWhich);
+    }
+  }
+  return null;
+}
+
+List<String>? _findIterableDifference(
+    Object? actual, Iterable expected, _Path path, Queue<_Search> queue) {
+  if (actual is! Iterable) {
+    return ['${path}is not an Iterable'];
+  }
+  var actualIterator = actual.iterator;
+  var expectedIterator = expected.iterator;
+  for (var index = 0;; index++) {
+    var actualNext = actualIterator.moveNext();
+    var expectedNext = expectedIterator.moveNext();
+    if (!expectedNext && !actualNext) break;
+    if (!expectedNext) {
+      return [
+        '${path}has more elements than expected',
+        'expected an iterable with $index element(s)'
+      ];
+    }
+    if (!actualNext) {
+      return [
+        '${path}has too few elements',
+        'expected an iterable with at least ${index + 1} element(s)'
+      ];
+    }
+    var actualValue = actualIterator.current;
+    var expectedValue = expectedIterator.current;
+    if (expectedValue is Iterable || expectedValue is Map) {
+      queue.addLast(_Search(path.append(index), actualValue, expectedValue));
+    } else if (expectedValue is Condition) {
+      final failure = softCheck(actualValue, expectedValue);
+      if (failure != null) {
+        final which = failure.rejection.which;
+        return [
+          'has an element ${path.append(index)}that:',
+          ...indent(failure.detail.actual.skip(1)),
+          ...indent(prefixFirst('Actual: ', failure.rejection.actual),
+              failure.detail.depth + 1),
+          if (which != null)
+            ...indent(prefixFirst('which ', which), failure.detail.depth + 1)
+        ];
+      }
+    } else {
+      if (actualValue != expectedValue) {
+        return [
+          ...prefixFirst('${path.append(index)}is ', literal(actualValue)),
+          ...prefixFirst('which does not equal ', literal(expectedValue))
+        ];
+      }
+    }
+  }
+  return null;
+}
+
+bool _elementMatches(Object? actual, Object? expected) {
+  if (expected == null) return actual == null;
+  if (expected is Iterable || expected is Map) {
+    return actual != null && deepCollectionEquals(actual, expected) == null;
+  }
+  if (expected is Condition) {
+    return softCheck(actual, expected) == null;
+  }
+  return expected == actual;
+}
+
+Iterable<String>? _findSetDifference(
+    Object? actual, Set<Object?> expected, _Path path) {
+  if (actual is! Set) {
+    return ['${path}is not a Set'];
+  }
+  final indexedExpected = expected.toList();
+  final indexedActual = actual.toList();
+  final adjacency = <List<int>>[];
+
+  for (final expectedElement in indexedExpected) {
+    final pairs = [
+      for (var j = 0; j < indexedActual.length; j++)
+        if (_elementMatches(indexedActual[j], expectedElement)) j,
+    ];
+    if (pairs.isEmpty) {
+      return prefixFirst(
+          '${path}has no element to match ', literal(expectedElement));
+    }
+    adjacency.add(pairs);
+  }
+  if (indexedActual.length != indexedExpected.length) {
+    return [
+      '${path}has ${indexedActual.length} element(s),',
+      'expected a set with ${indexedExpected.length} element(s)'
+    ];
+  }
+  if (!_hasPerfectMatching(adjacency)) {
+    return prefixFirst(
+        '${path}cannot be matched with the elements of ', literal(expected));
+  }
+  return null;
+}
+
+Iterable<String>? _findMapDifference(Object? actual, Map expected, _Path path) {
+  if (actual is! Map) {
+    return ['${path}is not a Map'];
+  }
+  final expectedEntries = expected.entries.toList();
+  final actualEntries = actual.entries.toList();
+  final adjacency = <List<int>>[];
+  for (final expectedEntry in expectedEntries) {
+    final potentialPairs = [
+      for (var i = 0; i < actualEntries.length; i++)
+        if (_elementMatches(actualEntries[i].key, expectedEntry.key)) i
+    ];
+    if (potentialPairs.isEmpty) {
+      return prefixFirst(
+          '${path}has no key to match ', literal(expectedEntry.key));
+    }
+    final matchingPairs = [
+      for (var i in potentialPairs)
+        if (_elementMatches(actualEntries[i].value, expectedEntry.value)) i
+    ];
+    if (matchingPairs.isEmpty) {
+      return prefixFirst(
+          '${path.append(expectedEntry.key)}has no value to match ',
+          literal(expectedEntry.value));
+    }
+    adjacency.add(matchingPairs);
+  }
+  if (expectedEntries.length != actualEntries.length) {
+    return [
+      '${path}has ${actualEntries.length} entries,',
+      'expected a Map with ${expectedEntries.length} entries'
+    ];
+  }
+  if (!_hasPerfectMatching(adjacency)) {
+    return prefixFirst(
+        '${path}cannot be matched with the entries of ', literal(expected));
+  }
+  return null;
+}
+
+class _Path {
+  final _Path? parent;
+  final Object? index;
+  _Path._(this.parent, this.index);
+  _Path.root()
+      : parent = null,
+        index = '';
+  _Path append(Object? index) => _Path._(this, index);
+  String toString() {
+    if (parent == null && index == '') return '';
+    final stack = Queue.of([this]);
+    var current = this.parent;
+    while (current?.parent != null) {
+      stack.addLast(current!);
+      current = current.parent;
+    }
+    final result = StringBuffer('at ');
+    while (stack.isNotEmpty) {
+      result.write('[');
+      result.write(literal(stack.removeLast().index).join(r'\n'));
+      result.write(']');
+    }
+    result.write(' ');
+    return result.toString();
+  }
+}
+
+class _Search {
+  final _Path path;
+  final Object? actual;
+  final Object? expected;
+  _Search(this.path, this.actual, this.expected);
+}
+
+/// Returns true if [adjacency] represents a bipartite graph that has a perfect
+/// pairing without unpaired elements in either set.
+///
+/// Vertices are represented as integers - a vertice in `u` is an index in
+/// [adjacency], and a vertice in `v` is a value in list at that index. An edge
+/// from `U[n]` to `V[m]` is represented by the value `m` being present in the
+/// list at index `n`.
+/// Assumes that there are an equal number of values in both sets, equal to the
+/// length of [adjacency].
+///
+/// Uses the Hopcroft–Karp algorithm based on pseudocode from
+/// https://en.wikipedia.org/wiki/Hopcroft%E2%80%93Karp_algorithm
+bool _hasPerfectMatching(List<List<int>> adjacency) {
+  final length = adjacency.length;
+  // The index [length] represents a "dummy vertex"
+  final distances = List<num>.filled(length + 1, double.infinity);
+  // Initially, everything is paired with the "dummy vertex"
+  final leftPairs = List.filled(length, length);
+  final rightPairs = List.filled(length, length);
+  bool bfs() {
+    final queue = Queue<int>();
+    for (int leftIndex = 0; leftIndex < length; leftIndex++) {
+      if (leftPairs[leftIndex] == length) {
+        distances[leftIndex] = 0;
+        queue.add(leftIndex);
+      } else {
+        distances[leftIndex] = double.infinity;
+      }
+    }
+    distances.last = double.infinity;
+    while (queue.isNotEmpty) {
+      final current = queue.removeFirst();
+      if (distances[current] < distances[length]) {
+        for (final rightIndex in adjacency[current]) {
+          if (distances[rightPairs[rightIndex]].isInfinite) {
+            distances[rightPairs[rightIndex]] = distances[current] + 1;
+            queue.addLast(rightPairs[rightIndex]);
+          }
+        }
+      }
+    }
+    return !distances.last.isInfinite;
+  }
+
+  bool dfs(int leftIndex) {
+    if (leftIndex == length) return true;
+    for (final rightIndex in adjacency[leftIndex]) {
+      if (distances[rightPairs[rightIndex]] == distances[leftIndex] + 1) {
+        if (dfs(rightPairs[rightIndex])) {
+          leftPairs[leftIndex] = rightIndex;
+          rightPairs[rightIndex] = leftIndex;
+          return true;
+        }
+      }
+    }
+    distances[leftIndex] = double.infinity;
+    return false;
+  }
+
+  var matching = 0;
+  while (bfs()) {
+    for (int leftIndex = 0; leftIndex < length; leftIndex++) {
+      if (leftPairs[leftIndex] == length) {
+        if (dfs(leftIndex)) {
+          matching++;
+        }
+      }
+    }
+  }
+  return matching == length;
+}

--- a/pkgs/checks/lib/src/extensions/iterable.dart
+++ b/pkgs/checks/lib/src/extensions/iterable.dart
@@ -4,6 +4,7 @@
 
 import 'package:checks/context.dart';
 
+import '../collection_equality.dart';
 import 'core.dart';
 
 extension IterableChecks<T> on Check<Iterable<T>> {
@@ -91,6 +92,14 @@ extension IterableChecks<T> on Check<Iterable<T>> {
       return null;
     });
   }
+
+  /// Expects that the iterable contains elements that are deeply equal to the
+  /// elements of [expected].
+  ///
+  /// {@macro deep_collection_equals}
+  void deepEquals(Iterable<Object?> expected) => context.expect(
+      () => prefixFirst('is deeply equal to ', literal(expected)),
+      (actual) => deepCollectionEquals(actual, expected));
 
   /// Expects that the iterable contains elements that correspond by the
   /// [elementCondition] exactly to each element in [expected].

--- a/pkgs/checks/lib/src/extensions/map.dart
+++ b/pkgs/checks/lib/src/extensions/map.dart
@@ -4,6 +4,7 @@
 
 import 'package:checks/context.dart';
 
+import '../collection_equality.dart';
 import 'core.dart';
 
 extension MapChecks<K, V> on Check<Map<K, V>> {
@@ -98,4 +99,12 @@ extension MapChecks<K, V> on Check<Map<K, V>> {
           actual: literal(actual), which: ['Contains no matching value']);
     });
   }
+
+  /// Expects that the map contains entries that are deeply equal to the entries
+  /// of [expected].
+  ///
+  /// {@macro deep_collection_equals}
+  void deepEquals(Map<Object?, Object?> expected) => context.expect(
+      () => prefixFirst('is deeply equal to ', literal(expected)),
+      (actual) => deepCollectionEquals(actual, expected));
 }

--- a/pkgs/checks/test/extensions/collection_equality_test.dart
+++ b/pkgs/checks/test/extensions/collection_equality_test.dart
@@ -1,0 +1,138 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:checks/checks.dart';
+import 'package:checks/src/collection_equality.dart';
+import 'package:test/scaffolding.dart';
+
+import '../test_shared.dart';
+
+void main() {
+  group('deepCollectionEquals', () {
+    test('allows nested collections with equal elements', () {
+      checkThat(deepCollectionEquals([
+        'a',
+        {'b': 1},
+        {'c', 'd'},
+        [
+          ['e']
+        ],
+      ], [
+        'a',
+        {'b': 1},
+        {'c', 'd'},
+        [
+          ['e']
+        ],
+      ])).isNull();
+    });
+
+    test('allows collections inside sets', () {
+      checkThat(deepCollectionEquals({
+        {'a': 1}
+      }, {
+        {'a': 1}
+      })).isNull();
+    });
+
+    test('allows collections as Map keys', () {
+      checkThat(deepCollectionEquals([
+        {
+          {'a': 1}: {'b': 2}
+        }
+      ], [
+        {
+          {'a': 1}: {'b': 2}
+        }
+      ])).isNull();
+    });
+
+    test('allows conditions in place of elements in lists', () {
+      checkThat(deepCollectionEquals([
+        'a',
+        'b'
+      ], [
+        it()
+          ..isA<String>().that(it()
+            ..startsWith('a')
+            ..length.isLessThan(2)),
+        it()..isA<String>().startsWith('b')
+      ])).isNull();
+    });
+
+    test('allows conditions in place of values in maps', () {
+      checkThat(deepCollectionEquals([
+        {'a': 'b'}
+      ], [
+        {'a': it()..isA<String>().startsWith('b')}
+      ])).isNull();
+    });
+
+    test('allows conditions in place of elements in sets', () {
+      checkThat(deepCollectionEquals(
+          {'b', 'a'}, {'a', it()..isA<String>().startsWith('b')})).isNull();
+    });
+
+    test('allows conditions in place of keys in maps', () {
+      checkThat(deepCollectionEquals(
+          {'a': 'b'}, {it()..isA<String>().startsWith('a'): 'b'})).isNull();
+    });
+
+    test('reports non-Set elements', () {
+      checkThat(deepCollectionEquals([
+        ['a']
+      ], [
+        {'a'}
+      ])).isARejection(which: ['at [<0>] is not a Set']);
+    });
+
+    test('reports long iterables', () {
+      checkThat(deepCollectionEquals([0], [])).isARejection(which: [
+        'has more elements than expected',
+        'expected an iterable with 0 element(s)'
+      ]);
+    });
+
+    test('reports short iterables', () {
+      checkThat(deepCollectionEquals([], [0])).isARejection(which: [
+        'has too few elements',
+        'expected an iterable with at least 1 element(s)'
+      ]);
+    });
+
+    test('reports unequal elements in iterables', () {
+      checkThat(deepCollectionEquals([0], [1]))
+          .isARejection(which: ['at [<0>] is <0>', 'which does not equal <1>']);
+    });
+
+    test('reports unmet conditions in iterables', () {
+      checkThat(deepCollectionEquals([0], [it()..isA<int>().isGreaterThan(0)]))
+          .isARejection(which: [
+        'has an element at [<0>] that:',
+        '  Actual: <0>',
+        '  which is not greater than <0>'
+      ]);
+    });
+
+    test('reports unmet conditions in map values', () {
+      checkThat(deepCollectionEquals(
+              {'a': 'b'}, {'a': it()..isA<String>().startsWith('a')}))
+          .isARejection(which: [
+        "at ['a'] has no value to match <A value that:",
+        '  is a String',
+        "  starts with 'a'>",
+      ]);
+    });
+
+    test('reports unmet conditions in map keys', () {
+      checkThat(deepCollectionEquals(
+              {'b': 'a'}, {it()..isA<String>().startsWith('a'): 'a'}))
+          .isARejection(which: [
+        'has no key to match <A value that:',
+        '  is a String',
+        "  starts with 'a'>",
+      ]);
+    });
+  });
+}

--- a/pkgs/checks/test/extensions/collection_equality_test.dart
+++ b/pkgs/checks/test/extensions/collection_equality_test.dart
@@ -134,5 +134,33 @@ void main() {
         "  starts with 'a'>",
       ]);
     });
+
+    test('reports recursive lists', () {
+      var l = [];
+      l.add(l);
+      checkThat(deepCollectionEquals(l, l))
+          .isARejection(which: ['exceeds the depth limit of 1000']);
+    });
+
+    test('reports recursive sets', () {
+      var s = <Object>{};
+      s.add(s);
+      checkThat(deepCollectionEquals(s, s))
+          .isARejection(which: ['exceeds the depth limit of 1000']);
+    });
+
+    test('reports maps with recursive keys', () {
+      var m = <Object, Object>{};
+      m[m] = 0;
+      checkThat(deepCollectionEquals(m, m))
+          .isARejection(which: ['exceeds the depth limit of 1000']);
+    });
+
+    test('reports maps with recursive values', () {
+      var m = <Object, Object>{};
+      m[0] = m;
+      checkThat(deepCollectionEquals(m, m))
+          .isARejection(which: ['exceeds the depth limit of 1000']);
+    });
   });
 }

--- a/pkgs/checks/test/test_shared.dart
+++ b/pkgs/checks/test/test_shared.dart
@@ -5,33 +5,30 @@
 import 'package:checks/checks.dart';
 import 'package:checks/context.dart';
 
-extension TestIterableCheck on Check<Iterable<String>?> {
-  // TODO: remove this once we have a deepEquals or equivalent
-  void toStringEquals(List<String>? other) {
-    final otherToString = other.toString();
-    context.expect(
-      () => prefixFirst('toString equals ', literal(otherToString)),
-      (actual) {
-        final actualToString = actual.toString();
-        return actualToString == otherToString
-            ? null
-            : Rejection(
-                actual: literal(actualToString),
-                which: ['does not have a matching toString'],
-              );
-      },
-    );
+extension FailureCheck on Check<CheckFailure?> {
+  void isARejection({List<String>? which, List<String>? actual}) {
+    isNotNull()
+        .has((f) => f.rejection, 'rejection')
+        ._hasActualWhich(actual: actual, which: which);
   }
 }
 
-extension RejectionCheck on Check<CheckFailure?> {
+extension RejectionCheck on Check<Rejection?> {
   void isARejection({List<String>? which, List<String>? actual}) {
-    final rejection = this.isNotNull().has((f) => f.rejection, 'rejection');
+    isNotNull()._hasActualWhich(actual: actual, which: which);
+  }
+}
+
+extension _RejectionCheck on Check<Rejection> {
+  void _hasActualWhich({List<String>? which, List<String>? actual}) {
     if (actual != null) {
-      rejection
-          .has((p0) => p0.actual.toList(), 'actual')
-          .toStringEquals(actual);
+      has((r) => r.actual.toList(), 'actual').deepEquals(actual);
     }
-    rejection.has((p0) => p0.which?.toList(), 'which').toStringEquals(which);
+    final whichCheck = has((r) => r.which?.toList(), 'which');
+    if (which == null) {
+      whichCheck.isNull();
+    } else {
+      whichCheck.isNotNull().deepEquals(which);
+    }
   }
 }


### PR DESCRIPTION
Add a `deepCollectionEquals` utility to find the Rejection for any
collection type. Add extensions for `Iterable` and `Map` to use the new
utility.

Iterable checking is implemented with a Queue that tracks the path
within a deeply nested iterable and the elements that need to be
compared.

Set and Map checking are implemented by comparing the all combinations
of values or entries and checking that all elements or entries can be
paired between the expected and actual collections. This allows for
cases where a Condition matches more than one key or element, and the
specific pairing needs to be aligned correctly to allow matching all
elements. This flexibility for matching Map keys does cause less
specific failure for mismatches within the Map value.

Add `deepEqual` conditions for Iterable and map. The Iterable condition
covers List and Set.

Add a `isARejection` extension for `Check<Rejection?>` and test against
`deepCollectionEquals` directly, instead of testing through the
`deepEquals` signature.
Drop the `toStringEquals` extension in favor of using `deepEquals`.
