### PR TITLE
Fix a test to use an still invalid URI

### DIFF
--- a/pkgs/test/test/runner/configuration/top_level_error_test.dart
+++ b/pkgs/test/test/runner/configuration/top_level_error_test.dart
@@ -390,15 +390,15 @@ void main() {
           .file(
               'dart_test.yaml',
               jsonEncode({
-                'paths': ['[invalid]']
+                'paths': [':invalid']
               }))
           .create();
 
       var test = await runTest(['test.dart']);
       expect(test.stderr,
-          containsInOrder(['Invalid path: Invalid character', '^^^^^^^^^']));
+          containsInOrder(['Invalid path: Invalid empty scheme', '^^^^^^^^']));
       await test.shouldExit(exit_codes.data);
-    }, skip: 'Broken by sdk#34988');
+    });
   });
 
   group('filename', () {


### PR DESCRIPTION
A test was skipped because a URI which used to result in a `FormatError`
started getting accepted by the SDK. The linked issue is closed as
working as intended. Update the test to use a URI which is invalid
according to the current SDK.
