### PR TITLE
Add unordered iterable comparisons

### DIFF
--- a/pkgs/checks/test/extensions/collection_equality_test.dart
+++ b/pkgs/checks/test/extensions/collection_equality_test.dart
@@ -119,7 +119,7 @@ void main() {
       checkThat(deepCollectionEquals(
               {'a': 'b'}, {'a': it()..isA<String>().startsWith('a')}))
           .isARejection(which: [
-        "at ['a'] has no value to match <A value that:",
+        "has no entry to match 'a': <A value that:",
         '  is a String',
         "  starts with 'a'>",
       ]);
@@ -129,9 +129,9 @@ void main() {
       checkThat(deepCollectionEquals(
               {'b': 'a'}, {it()..isA<String>().startsWith('a'): 'a'}))
           .isARejection(which: [
-        'has no key to match <A value that:',
+        'has no entry to match <A value that:',
         '  is a String',
-        "  starts with 'a'>",
+        "  starts with 'a'>: 'a'",
       ]);
     });
 

--- a/pkgs/checks/test/extensions/iterable_test.dart
+++ b/pkgs/checks/test/extensions/iterable_test.dart
@@ -72,6 +72,61 @@ void main() {
     });
   });
 
+  group('unorderedEquals', () {
+    test('success for happy case', () {
+      checkThat(_testIterable).unorderedEquals(_testIterable.toList().reversed);
+    });
+
+    test('reports unmatched elements', () {
+      checkThat(softCheck<Iterable<int>>(_testIterable,
+              it()..unorderedEquals(_testIterable.followedBy([42, 100]))))
+          .isARejection(which: [
+        'has no element equal to the expected element at index 2: <42>',
+        'or 1 other elements'
+      ]);
+    });
+
+    test('reports unexpected elements', () {
+      checkThat(softCheck<Iterable<int>>(_testIterable.followedBy([42, 100]),
+              it()..unorderedEquals(_testIterable)))
+          .isARejection(which: [
+        'has an unexpected element at index 2: <42>',
+        'and 1 other unexpected elements'
+      ]);
+    });
+  });
+
+  group('unorderedMatches', () {
+    test('success for happy case', () {
+      checkThat(_testIterable).unorderedMatches(
+          _testIterable.toList().reversed.map((i) => it()..equals(i)));
+    });
+
+    test('reports unmatched elements', () {
+      checkThat(softCheck<Iterable<int>>(
+              _testIterable,
+              it()
+                ..unorderedMatches(_testIterable
+                    .followedBy([42, 100]).map((i) => it()..equals(i)))))
+          .isARejection(which: [
+        'has no element matching the condition at index 2:',
+        '  equals <42>',
+        'or 1 other conditions'
+      ]);
+    });
+
+    test('reports unexpected elements', () {
+      checkThat(softCheck<Iterable<int>>(
+              _testIterable.followedBy([42, 100]),
+              it()
+                ..unorderedMatches(_testIterable.map((i) => it()..equals(i)))))
+          .isARejection(which: [
+        'has an unmatched element at index 2: <42>',
+        'and 1 other unmatched elements'
+      ]);
+    });
+  });
+
   group('pairwiseComparesTo', () {
     test('succeeds for the happy path', () {
       checkThat(_testIterable).pairwiseComparesTo(


### PR DESCRIPTION
Pull the common parts of `_findSetDifference` and `_findMapDifference`
into a utility called `unorderedCompared` which can be reused for
`unorderedEquals` and `unorderedMatches`. This removes some specificity
from rejections for non-matching Maps - it will now always refer to an
unmatched entry in its entirety, and will not have a special message for
when there is a key with no matches, vs when there are matching keys but
those keys have non-matching values.

Change `_hasPerfectMatching` to `_findUnpaired`. Don't require that the
actual and expected vertex sets have the same cardinality, take the
cardinality of the actual vertex set as an argument. Return list of the
unmatched vertices in both sets. Allows more specific failures than
solely reporting unequal lengths or that the elements don't have a full
pairing - we can be specific about at least one missing or unexpected
element.

Add `unorderedEquals` and `unorderedMatches` conditions for Iterable.
