### PR TITLE
Allow omitting the actual argument for rejections

### DIFF
--- a/pkgs/checks/lib/src/collection_equality.dart
+++ b/pkgs/checks/lib/src/collection_equality.dart
@@ -30,9 +30,7 @@ Rejection? deepCollectionEquals(Object actual, Object expected) {
   try {
     return _deepCollectionEquals(actual, expected, 0);
   } on _ExceededDepthError {
-    return Rejection(
-        actual: literal(actual),
-        which: ['exceeds the depth limit of $_maxDepth']);
+    return Rejection(which: ['exceeds the depth limit of $_maxDepth']);
   }
 }
 
@@ -64,7 +62,7 @@ Rejection? _deepCollectionEquals(Object actual, Object expected, int depth) {
           currentActual, currentExpected, path, currentDepth);
     }
     if (rejectionWhich != null) {
-      return Rejection(actual: literal(actual), which: rejectionWhich);
+      return Rejection(which: rejectionWhich);
     }
   }
   return null;

--- a/pkgs/checks/lib/src/extensions/core.dart
+++ b/pkgs/checks/lib/src/extensions/core.dart
@@ -15,7 +15,6 @@ extension CoreChecks<T> on Check<T> {
         return Extracted.value(extract(value));
       } catch (_) {
         return Extracted.rejection(
-            actual: literal(value),
             which: ['threw while trying to read property']);
       }
     });
@@ -46,7 +45,6 @@ extension CoreChecks<T> on Check<T> {
       (actual) {
         if (softCheck(actual, condition) != null) return null;
         return Rejection(
-          actual: literal(actual),
           which: ['is a value that: ', ...indent(describe(condition))],
         );
       },
@@ -64,8 +62,7 @@ extension CoreChecks<T> on Check<T> {
       for (final condition in conditions) {
         if (softCheck(actual, condition) == null) return null;
       }
-      return Rejection(
-          actual: literal(actual), which: ['did not match any condition']);
+      return Rejection(which: ['did not match any condition']);
     });
   }
 
@@ -75,8 +72,7 @@ extension CoreChecks<T> on Check<T> {
   Check<R> isA<R>() {
     return context.nest<R>('is a $R', (actual) {
       if (actual is! R) {
-        return Extracted.rejection(
-            actual: literal(actual), which: ['Is a ${actual.runtimeType}']);
+        return Extracted.rejection(which: ['Is a ${actual.runtimeType}']);
       }
       return Extracted.value(actual);
     }, atSameLevel: true);
@@ -86,7 +82,7 @@ extension CoreChecks<T> on Check<T> {
   void equals(T other) {
     context.expect(() => prefixFirst('equals ', literal(other)), (actual) {
       if (actual == other) return null;
-      return Rejection(actual: literal(actual), which: ['are not equal']);
+      return Rejection(which: ['are not equal']);
     });
   }
 
@@ -95,7 +91,7 @@ extension CoreChecks<T> on Check<T> {
     context.expect(() => prefixFirst('is identical to ', literal(other)),
         (actual) {
       if (identical(actual, other)) return null;
-      return Rejection(actual: literal(actual), which: ['is not identical']);
+      return Rejection(which: ['is not identical']);
     });
   }
 }
@@ -106,7 +102,7 @@ extension BoolChecks on Check<bool> {
       () => ['is true'],
       (actual) => actual
           ? null // force coverage
-          : Rejection(actual: literal(actual)),
+          : Rejection(),
     );
   }
 
@@ -115,7 +111,7 @@ extension BoolChecks on Check<bool> {
       () => ['is false'],
       (actual) => !actual
           ? null // force coverage
-          : Rejection(actual: literal(actual)),
+          : Rejection(),
     );
   }
 }
@@ -123,14 +119,14 @@ extension BoolChecks on Check<bool> {
 extension NullabilityChecks<T> on Check<T?> {
   Check<T> isNotNull() {
     return context.nest<T>('is not null', (actual) {
-      if (actual == null) return Extracted.rejection(actual: literal(actual));
+      if (actual == null) return Extracted.rejection();
       return Extracted.value(actual);
     }, atSameLevel: true);
   }
 
   void isNull() {
     context.expect(() => const ['is null'], (actual) {
-      if (actual != null) return Rejection(actual: literal(actual));
+      if (actual != null) return Rejection();
       return null;
     });
   }

--- a/pkgs/checks/lib/src/extensions/iterable.dart
+++ b/pkgs/checks/lib/src/extensions/iterable.dart
@@ -16,14 +16,14 @@ extension IterableChecks<T> on Check<Iterable<T>> {
   void isEmpty() {
     context.expect(() => const ['is empty'], (actual) {
       if (actual.isEmpty) return null;
-      return Rejection(actual: literal(actual), which: ['is not empty']);
+      return Rejection(which: ['is not empty']);
     });
   }
 
   void isNotEmpty() {
     context.expect(() => const ['is not empty'], (actual) {
       if (actual.isNotEmpty) return null;
-      return Rejection(actual: literal(actual), which: ['is not empty']);
+      return Rejection(which: ['is not empty']);
     });
   }
 
@@ -36,7 +36,6 @@ extension IterableChecks<T> on Check<Iterable<T>> {
       if (actual.isEmpty) return Rejection(actual: ['an empty iterable']);
       if (actual.contains(element)) return null;
       return Rejection(
-          actual: literal(actual),
           which: prefixFirst('does not contain ', literal(element)));
     });
   }
@@ -56,8 +55,7 @@ extension IterableChecks<T> on Check<Iterable<T>> {
       for (var e in actual) {
         if (softCheck(e, elementCondition) == null) return null;
       }
-      return Rejection(
-          actual: literal(actual), which: ['Contains no matching element']);
+      return Rejection(which: ['Contains no matching element']);
     });
   }
 
@@ -80,7 +78,7 @@ extension IterableChecks<T> on Check<Iterable<T>> {
         final failure = softCheck(element, elementCondition);
         if (failure == null) continue;
         final which = failure.rejection.which;
-        return Rejection(actual: literal(actual), which: [
+        return Rejection(which: [
           'has an element at index $i that:',
           ...indent(failure.detail.actual.skip(1)),
           ...indent(prefixFirst('Actual: ', failure.rejection.actual),
@@ -128,7 +126,7 @@ extension IterableChecks<T> on Check<Iterable<T>> {
         ],
       );
       if (which == null) return null;
-      return Rejection(actual: literal(actual), which: which);
+      return Rejection(which: which);
     });
   }
 
@@ -157,7 +155,7 @@ extension IterableChecks<T> on Check<Iterable<T>> {
         ],
       );
       if (which == null) return null;
-      return Rejection(actual: literal(actual), which: which);
+      return Rejection(which: which);
     });
   }
 
@@ -182,7 +180,7 @@ extension IterableChecks<T> on Check<Iterable<T>> {
       for (var i = 0; i < expected.length; i++) {
         final expectedValue = expected[i];
         if (!iterator.moveNext()) {
-          return Rejection(actual: literal(actual), which: [
+          return Rejection(which: [
             'has too few elements, there is no element to match at index $i'
           ]);
         }
@@ -191,7 +189,7 @@ extension IterableChecks<T> on Check<Iterable<T>> {
         if (failure == null) continue;
         final innerDescription = describe<T>(elementCondition(expectedValue));
         final which = failure.rejection.which;
-        return Rejection(actual: literal(actual), which: [
+        return Rejection(which: [
           'does not have an element at index $i that:',
           ...innerDescription,
           ...prefixFirst(
@@ -200,7 +198,7 @@ extension IterableChecks<T> on Check<Iterable<T>> {
         ]);
       }
       if (!iterator.moveNext()) return null;
-      return Rejection(actual: literal(actual), which: [
+      return Rejection(which: [
         'has too many elements, expected exactly ${expected.length}'
       ]);
     });

--- a/pkgs/checks/lib/src/extensions/map.dart
+++ b/pkgs/checks/lib/src/extensions/map.dart
@@ -18,7 +18,6 @@ extension MapChecks<K, V> on Check<Map<K, V>> {
     return context.nest('contains a value for $keyString', (actual) {
       if (!actual.containsKey(key)) {
         return Extracted.rejection(
-            actual: literal(actual),
             which: ['does not contain the key $keyString']);
       }
       return Extracted.value(actual[key] as V);
@@ -28,14 +27,14 @@ extension MapChecks<K, V> on Check<Map<K, V>> {
   void isEmpty() {
     context.expect(() => const ['is empty'], (actual) {
       if (actual.isEmpty) return null;
-      return Rejection(actual: literal(actual), which: ['is not empty']);
+      return Rejection(which: ['is not empty']);
     });
   }
 
   void isNotEmpty() {
     context.expect(() => const ['is not empty'], (actual) {
       if (actual.isNotEmpty) return null;
-      return Rejection(actual: literal(actual), which: ['is not empty']);
+      return Rejection(which: ['is not empty']);
     });
   }
 
@@ -44,8 +43,7 @@ extension MapChecks<K, V> on Check<Map<K, V>> {
     final keyString = literal(key).join(r'\n');
     context.expect(() => ['contains key $keyString'], (actual) {
       if (actual.containsKey(key)) return null;
-      return Rejection(
-          actual: literal(actual), which: ['does not contain key $keyString']);
+      return Rejection(which: ['does not contain key $keyString']);
     });
   }
 
@@ -64,8 +62,7 @@ extension MapChecks<K, V> on Check<Map<K, V>> {
       for (var k in actual.keys) {
         if (softCheck(k, keyCondition) == null) return null;
       }
-      return Rejection(
-          actual: literal(actual), which: ['Contains no matching key']);
+      return Rejection(which: ['Contains no matching key']);
     });
   }
 
@@ -74,9 +71,7 @@ extension MapChecks<K, V> on Check<Map<K, V>> {
     final valueString = literal(value).join(r'\n');
     context.expect(() => ['contains value $valueString'], (actual) {
       if (actual.containsValue(value)) return null;
-      return Rejection(
-          actual: literal(actual),
-          which: ['does not contain value $valueString']);
+      return Rejection(which: ['does not contain value $valueString']);
     });
   }
 
@@ -95,8 +90,7 @@ extension MapChecks<K, V> on Check<Map<K, V>> {
       for (var v in actual.values) {
         if (softCheck(v, valueCondition) == null) return null;
       }
-      return Rejection(
-          actual: literal(actual), which: ['Contains no matching value']);
+      return Rejection(which: ['Contains no matching value']);
     });
   }
 

--- a/pkgs/checks/lib/src/extensions/math.dart
+++ b/pkgs/checks/lib/src/extensions/math.dart
@@ -9,8 +9,7 @@ extension NumChecks on Check<num> {
   void isGreaterThan(num other) {
     context.expect(() => ['is greater than <$other>'], (actual) {
       if (actual > other) return null;
-      return Rejection(
-          actual: literal(actual), which: ['is not greater than <$other>']);
+      return Rejection(which: ['is not greater than <$other>']);
     });
   }
 
@@ -18,9 +17,7 @@ extension NumChecks on Check<num> {
   void isGreaterOrEqual(num other) {
     context.expect(() => ['is greater than or equal to <$other>'], (actual) {
       if (actual >= other) return null;
-      return Rejection(
-          actual: literal(actual),
-          which: ['is not greater than or equal to <$other>']);
+      return Rejection(which: ['is not greater than or equal to <$other>']);
     });
   }
 
@@ -28,8 +25,7 @@ extension NumChecks on Check<num> {
   void isLessThan(num other) {
     context.expect(() => ['is less than <$other>'], (actual) {
       if (actual < other) return null;
-      return Rejection(
-          actual: literal(actual), which: ['is not less than <$other>']);
+      return Rejection(which: ['is not less than <$other>']);
     });
   }
 
@@ -37,9 +33,7 @@ extension NumChecks on Check<num> {
   void isLessOrEqual(num other) {
     context.expect(() => ['is less than or equal to <$other>'], (actual) {
       if (actual <= other) return null;
-      return Rejection(
-          actual: literal(actual),
-          which: ['is not less than or equal to <$other>']);
+      return Rejection(which: ['is not less than or equal to <$other>']);
     });
   }
 
@@ -47,7 +41,7 @@ extension NumChecks on Check<num> {
   void isNaN() {
     context.expect(() => ['is not a number (NaN)'], (actual) {
       if (actual.isNaN) return null;
-      return Rejection(actual: literal(actual), which: ['is a number']);
+      return Rejection(which: ['is a number']);
     });
   }
 
@@ -55,8 +49,7 @@ extension NumChecks on Check<num> {
   void isNotNaN() {
     context.expect(() => ['is a number (not NaN)'], (actual) {
       if (!actual.isNaN) return null;
-      return Rejection(
-          actual: literal(actual), which: ['is not a number (NaN)']);
+      return Rejection(which: ['is not a number (NaN)']);
     });
   }
 
@@ -64,7 +57,7 @@ extension NumChecks on Check<num> {
   void isNegative() {
     context.expect(() => ['is negative'], (actual) {
       if (actual.isNegative) return null;
-      return Rejection(actual: literal(actual), which: ['is not negative']);
+      return Rejection(which: ['is not negative']);
     });
   }
 
@@ -72,7 +65,7 @@ extension NumChecks on Check<num> {
   void isNotNegative() {
     context.expect(() => ['is not negative'], (actual) {
       if (!actual.isNegative) return null;
-      return Rejection(actual: literal(actual), which: ['is negative']);
+      return Rejection(which: ['is negative']);
     });
   }
 
@@ -80,7 +73,7 @@ extension NumChecks on Check<num> {
   void isFinite() {
     context.expect(() => ['is finite'], (actual) {
       if (actual.isFinite) return null;
-      return Rejection(actual: literal(actual), which: ['is not finite']);
+      return Rejection(which: ['is not finite']);
     });
   }
 
@@ -91,7 +84,7 @@ extension NumChecks on Check<num> {
   void isNotFinite() {
     context.expect(() => ['is not finite'], (actual) {
       if (!actual.isFinite) return null;
-      return Rejection(actual: literal(actual), which: ['is finite']);
+      return Rejection(which: ['is finite']);
     });
   }
 
@@ -101,7 +94,7 @@ extension NumChecks on Check<num> {
   void isInfinite() {
     context.expect(() => ['is infinite'], (actual) {
       if (actual.isInfinite) return null;
-      return Rejection(actual: literal(actual), which: ['is not infinite']);
+      return Rejection(which: ['is not infinite']);
     });
   }
 
@@ -111,7 +104,7 @@ extension NumChecks on Check<num> {
   void isNotInfinite() {
     context.expect(() => ['is not infinite'], (actual) {
       if (!actual.isInfinite) return null;
-      return Rejection(actual: literal(actual), which: ['is infinite']);
+      return Rejection(which: ['is infinite']);
     });
   }
 
@@ -121,8 +114,7 @@ extension NumChecks on Check<num> {
     context.expect(() => ['is within <$delta> of <$other>'], (actual) {
       final difference = (other - actual).abs();
       if (difference <= delta) return null;
-      return Rejection(
-          actual: literal(actual), which: ['differs by <$difference>']);
+      return Rejection(which: ['differs by <$difference>']);
     });
   }
 }

--- a/pkgs/checks/lib/src/extensions/string.dart
+++ b/pkgs/checks/lib/src/extensions/string.dart
@@ -14,7 +14,6 @@ extension StringChecks on Check<String> {
     context.expect(() => prefixFirst('contains ', literal(pattern)), (actual) {
       if (actual.contains(pattern)) return null;
       return Rejection(
-        actual: literal(actual),
         which: prefixFirst('Does not contain ', literal(pattern)),
       );
     });
@@ -25,14 +24,14 @@ extension StringChecks on Check<String> {
   void isEmpty() {
     context.expect(() => const ['is empty'], (actual) {
       if (actual.isEmpty) return null;
-      return Rejection(actual: literal(actual), which: ['is not empty']);
+      return Rejection(which: ['is not empty']);
     });
   }
 
   void isNotEmpty() {
     context.expect(() => const ['is not empty'], (actual) {
       if (actual.isNotEmpty) return null;
-      return Rejection(actual: literal(actual), which: ['is empty']);
+      return Rejection(which: ['is empty']);
     });
   }
 
@@ -42,7 +41,6 @@ extension StringChecks on Check<String> {
       (actual) {
         if (actual.startsWith(other)) return null;
         return Rejection(
-          actual: literal(actual),
           which: prefixFirst('does not start with ', literal(other)),
         );
       },
@@ -55,7 +53,6 @@ extension StringChecks on Check<String> {
       (actual) {
         if (actual.endsWith(other)) return null;
         return Rejection(
-          actual: literal(actual),
           which: prefixFirst('does not end with ', literal(other)),
         );
       },
@@ -75,7 +72,7 @@ extension StringChecks on Check<String> {
       for (var s in expected) {
         var index = actual.indexOf(s, fromIndex);
         if (index < 0) {
-          return Rejection(actual: literal(actual), which: [
+          return Rejection(which: [
             ...prefixFirst(
                 'does not have a match for the substring ', literal(s)),
             if (fromIndex != 0)
@@ -149,10 +146,9 @@ Rejection? _findDifference(String actual, String expected,
   if (i == minLength) {
     if (escapedExpected.length < escapedActual.length) {
       if (expected.isEmpty) {
-        return Rejection(
-            actual: literal(actual), which: ['is not the empty string']);
+        return Rejection(which: ['is not the empty string']);
       }
-      return Rejection(actual: literal(actual), which: [
+      return Rejection(which: [
         'is too long with unexpected trailing characters:',
         _trailing(escapedActualDisplay, i)
       ]);
@@ -165,14 +161,14 @@ Rejection? _findDifference(String actual, String expected,
           _trailing(escapedExpectedDisplay, 0)
         ]);
       }
-      return Rejection(actual: literal(actual), which: [
+      return Rejection(which: [
         'is too short with missing trailing characters:',
         _trailing(escapedExpectedDisplay, i)
       ]);
     }
   } else {
     final indentation = ' ' * (i > 10 ? 14 : i);
-    return Rejection(actual: literal(actual), which: [
+    return Rejection(which: [
       'differs at offset $i:',
       '${_leading(escapedExpectedDisplay, i)}'
           '${_trailing(escapedExpectedDisplay, i)}',


### PR DESCRIPTION
Wrap callbacks to look for rejections without an `actual` value, and
fill it in with a default. Remove all `actual` arguments that were
passing exactly `literal(actual)`.
