### PR TITLE
Fix description of conditions without expectations

### DIFF
--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -466,7 +466,6 @@ class _TestContext<T> implements Context<T>, _ClauseDescription {
 
   @override
   FailureDetail detail(_TestContext failingContext) {
-    assert(_clauses.isNotEmpty);
     final thisContextFailed =
         identical(failingContext, this) || _aliases.contains(failingContext);
     var foundDepth = thisContextFailed ? 0 : -1;

--- a/pkgs/checks/test/describe_test.dart
+++ b/pkgs/checks/test/describe_test.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:checks/checks.dart';
+import 'package:checks/context.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  group('describe', () {
+    test('succeeds for empty conditions', () {
+      checkThat(describe(it())).isEmpty();
+    });
+    test('includes condition clauses', () {
+      checkThat(describe(it()..equals(1))).deepEquals(['  equals <1>']);
+    });
+    test('includes nested clauses', () {
+      checkThat(describe(it<String>()..length.equals(1))).deepEquals([
+        '  has length that:',
+        '    equals <1>',
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
Add a test for the `describe` method with a few simple cases.
Remove one assert which does not hold up when describing a condition
without an expectations checked against it.
