### PR TITLE
Refactor tests to a new isRejectedBy utility

### DIFF
--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -128,6 +128,9 @@ Future<CheckFailure?> softCheckAsync<T>(T value, Condition<T> condition) async {
 /// Matches the "Expected: " lines in the output of a failure message if a value
 /// did not meet the last expectation in [condition], without the first labeled
 /// line.
+///
+/// Asynchronous expectations are not allowed in [condition], for async
+/// conditions use [describeAsync].
 Iterable<String> describe<T>(Condition<T> condition) {
   final context = _TestContext<T>._root(
     value: _Absent(),
@@ -138,6 +141,30 @@ Iterable<String> describe<T>(Condition<T> condition) {
     allowUnawaited: true,
   );
   condition.apply(Check._(context));
+  return context.detail(context).expected.skip(1);
+}
+
+/// Creates a description of the expectations checked by [condition].
+///
+/// The strings are individual lines of a description.
+/// The description of an expectation may be one or more adjacent lines.
+///
+/// Matches the "Expected: " lines in the output of a failure message if a value
+/// did not meet the last expectation in [condition], without the first labeled
+/// line.
+///
+/// In contrast to [describe], asynchronous expectations are allowed in
+/// [condition].
+Future<Iterable<String>> describeAsync<T>(Condition<T> condition) async {
+  final context = _TestContext<T>._root(
+    value: _Absent(),
+    fail: (_) {
+      throw UnimplementedError();
+    },
+    allowAsync: true,
+    allowUnawaited: true,
+  );
+  await condition.applyAsync(Check._(context));
   return context.detail(context).expected.skip(1);
 }
 

--- a/pkgs/checks/lib/src/collection_equality.dart
+++ b/pkgs/checks/lib/src/collection_equality.dart
@@ -6,8 +6,8 @@ import 'dart:collection';
 
 import 'package:checks/context.dart';
 
-/// Returns a rejection if the elements of [actual] are unequal to the elements
-/// of [expected].
+/// Returns a descriptive `which` for a rejection if the elements of [actual]
+/// are unequal to the elements of [expected].
 ///
 /// {@template deep_collection_equals}
 /// Elements, keys, or values, which are a collections are deeply compared for
@@ -26,11 +26,11 @@ import 'package:checks/context.dart';
 /// Collections may be nested to a maximum depth of 1000. Recursive collections
 /// are not allowed.
 /// {@endtemplate}
-Rejection? deepCollectionEquals(Object actual, Object expected) {
+Iterable<String>? deepCollectionEquals(Object actual, Object expected) {
   try {
     return _deepCollectionEquals(actual, expected, 0);
   } on _ExceededDepthError {
-    return Rejection(which: ['exceeds the depth limit of $_maxDepth']);
+    return ['exceeds the depth limit of $_maxDepth'];
   }
 }
 
@@ -38,7 +38,8 @@ const _maxDepth = 1000;
 
 class _ExceededDepthError extends Error {}
 
-Rejection? _deepCollectionEquals(Object actual, Object expected, int depth) {
+Iterable<String>? _deepCollectionEquals(
+    Object actual, Object expected, int depth) {
   assert(actual is Iterable || actual is Map);
   assert(expected is Iterable || expected is Map);
 
@@ -61,9 +62,7 @@ Rejection? _deepCollectionEquals(Object actual, Object expected, int depth) {
       rejectionWhich = _findMapDifference(
           currentActual, currentExpected, path, currentDepth);
     }
-    if (rejectionWhich != null) {
-      return Rejection(which: rejectionWhich);
-    }
+    if (rejectionWhich != null) return rejectionWhich;
   }
   return null;
 }

--- a/pkgs/checks/lib/src/extensions/iterable.dart
+++ b/pkgs/checks/lib/src/extensions/iterable.dart
@@ -95,9 +95,13 @@ extension IterableChecks<T> on Check<Iterable<T>> {
   /// elements of [expected].
   ///
   /// {@macro deep_collection_equals}
-  void deepEquals(Iterable<Object?> expected) => context.expect(
-      () => prefixFirst('is deeply equal to ', literal(expected)),
-      (actual) => deepCollectionEquals(actual, expected));
+  void deepEquals(Iterable<Object?> expected) => context
+          .expect(() => prefixFirst('is deeply equal to ', literal(expected)),
+              (actual) {
+        final which = deepCollectionEquals(actual, expected);
+        if (which == null) return null;
+        return Rejection(which: which);
+      });
 
   /// Expects that the iterable contains elements which equal those of
   /// [expected] in any order.

--- a/pkgs/checks/lib/src/extensions/map.dart
+++ b/pkgs/checks/lib/src/extensions/map.dart
@@ -98,7 +98,11 @@ extension MapChecks<K, V> on Check<Map<K, V>> {
   /// of [expected].
   ///
   /// {@macro deep_collection_equals}
-  void deepEquals(Map<Object?, Object?> expected) => context.expect(
-      () => prefixFirst('is deeply equal to ', literal(expected)),
-      (actual) => deepCollectionEquals(actual, expected));
+  void deepEquals(Map<Object?, Object?> expected) => context
+          .expect(() => prefixFirst('is deeply equal to ', literal(expected)),
+              (actual) {
+        final which = deepCollectionEquals(actual, expected);
+        if (which == null) return null;
+        return Rejection(which: which);
+      });
 }

--- a/pkgs/checks/test/extensions/async_test.dart
+++ b/pkgs/checks/test/extensions/async_test.dart
@@ -6,20 +6,21 @@ import 'dart:async';
 
 import 'package:async/async.dart';
 import 'package:checks/checks.dart';
-import 'package:checks/context.dart';
-import 'package:checks/src/checks.dart' show softCheckAsync;
 import 'package:test/scaffolding.dart';
 import 'package:test_api/hooks.dart';
+
+import '../test_shared.dart';
 
 void main() {
   group('FutureChecks', () {
     test('completes', () async {
       (await checkThat(_futureSuccess()).completes()).equals(42);
 
-      await _rejectionWhichCheck<Future>(
-        _futureFail(),
-        it()..completes(),
-        it()..single.equals('Threw <UnimplementedError>'),
+      await checkThat(_futureFail()).isRejectedByAsync(
+        it()..completes().that(it()..equals(1)),
+        hasActualThat: it()
+          ..deepEquals(['A future that completes as an error']),
+        hasWhichThat: it()..single.equals('Threw <UnimplementedError>'),
       );
     });
 
@@ -28,16 +29,17 @@ void main() {
           .has((p0) => p0.message, 'message')
           .isNull();
 
-      await _rejectionWhichCheck<Future>(
-        _futureSuccess(),
+      await checkThat(_futureSuccess()).isRejectedByAsync(
         it()..throws(),
-        it()..single.equals('Did not throw'),
+        hasActualThat: it()..deepEquals(['Completed to <42>']),
+        hasWhichThat: it()..single.equals('Did not throw'),
       );
 
-      await _rejectionWhichCheck<Future>(
-        _futureFail(),
+      await checkThat(_futureFail()).isRejectedByAsync(
         it()..throws<StateError>(),
-        it()..single.equals('Is not an StateError'),
+        hasActualThat: it()
+          ..deepEquals(['Completed to error <UnimplementedError>']),
+        hasWhichThat: it()..single.equals('Is not an StateError'),
       );
     });
 
@@ -92,32 +94,29 @@ fake trace''');
     test('emits', () async {
       (await checkThat(_countingStream(5)).emits()).equals(0);
 
-      await _rejectionWhichCheck<StreamQueue>(
-        _countingStream(0),
+      await checkThat(_countingStream(0)).isRejectedByAsync(
         it()..emits(),
-        it()..single.equals('did not emit any value'),
+        hasActualThat: it()..deepEquals(['an empty stream']),
+        hasWhichThat: it()..single.equals('did not emit any value'),
       );
 
-      await _rejectionWhichCheck<StreamQueue>(
-        _countingStream(0),
+      await checkThat(_countingStream(1, errorAt: 0)).isRejectedByAsync(
         it()..emits(),
-        it()..single.equals('did not emit any value'),
-      );
-
-      await _rejectionWhichCheck<StreamQueue>(
-        _countingStream(1, errorAt: 0),
-        it()..emits(),
-        it()..single.equals('emitted an error instead of a value'),
+        hasActualThat: it()
+          ..deepEquals(
+              ['A stream with error <UnimplementedError: Error at 1>']),
+        hasWhichThat: it()
+          ..single.equals('emitted an error instead of a value'),
       );
     });
 
     test('emitsThrough', () async {
       await checkThat(_countingStream(5)).emitsThrough(it()..equals(4));
 
-      await _rejectionWhichCheck<StreamQueue>(
-        _countingStream(4),
+      await checkThat(_countingStream(4)).isRejectedByAsync(
         it()..emitsThrough(it()..equals(5)),
-        it()
+        hasActualThat: it()..deepEquals(['a stream']),
+        hasWhichThat: it()
           ..single.equals('ended after emitting 4 elements with none matching'),
       );
     });
@@ -125,13 +124,11 @@ fake trace''');
     test('neverEmits', () async {
       await checkThat(_countingStream(5)).neverEmits(it()..equals(5));
 
-      await _rejectionWhichCheck<StreamQueue>(
-        _countingStream(6),
+      await checkThat(_countingStream(6)).isRejectedByAsync(
         it()..neverEmits(it()..equals(5)),
-        it()
-          ..length.equals(2)
-          ..first.equals('emitted <5>')
-          ..last.equals('following 5 other items'),
+        hasActualThat: it()..deepEquals(['a stream']),
+        hasWhichThat: it()
+          ..deepEquals(['emitted <5>', 'following 5 other items']),
       );
     });
   });
@@ -155,16 +152,3 @@ StreamQueue<int> _countingStream(int count, {int? errorAt}) => StreamQueue(
         }),
       ),
     );
-
-Future<void> _rejectionWhichCheck<T>(
-  T value,
-  Condition<T> condition,
-  Condition<Iterable<String>> whichCheck,
-) async {
-  final failure = await softCheckAsync(value, condition);
-  whichCheck.apply(checkThat(failure)
-      .isNotNull()
-      .has((f) => f.rejection, 'rejection')
-      .has((r) => r.which, 'which')
-      .isNotNull());
-}

--- a/pkgs/checks/test/extensions/async_test.dart
+++ b/pkgs/checks/test/extensions/async_test.dart
@@ -18,9 +18,8 @@ void main() {
 
       await checkThat(_futureFail()).isRejectedByAsync(
         it()..completes().that(it()..equals(1)),
-        hasActualThat: it()
-          ..deepEquals(['A future that completes as an error']),
-        hasWhichThat: it()..single.equals('Threw <UnimplementedError>'),
+        actual: ['A future that completes as an error'],
+        which: ['Threw <UnimplementedError>'],
       );
     });
 
@@ -31,15 +30,14 @@ void main() {
 
       await checkThat(_futureSuccess()).isRejectedByAsync(
         it()..throws(),
-        hasActualThat: it()..deepEquals(['Completed to <42>']),
-        hasWhichThat: it()..single.equals('Did not throw'),
+        actual: ['Completed to <42>'],
+        which: ['Did not throw'],
       );
 
       await checkThat(_futureFail()).isRejectedByAsync(
         it()..throws<StateError>(),
-        hasActualThat: it()
-          ..deepEquals(['Completed to error <UnimplementedError>']),
-        hasWhichThat: it()..single.equals('Is not an StateError'),
+        actual: ['Completed to error <UnimplementedError>'],
+        which: ['Is not an StateError'],
       );
     });
 
@@ -96,17 +94,14 @@ fake trace''');
 
       await checkThat(_countingStream(0)).isRejectedByAsync(
         it()..emits(),
-        hasActualThat: it()..deepEquals(['an empty stream']),
-        hasWhichThat: it()..single.equals('did not emit any value'),
+        actual: ['an empty stream'],
+        which: ['did not emit any value'],
       );
 
       await checkThat(_countingStream(1, errorAt: 0)).isRejectedByAsync(
         it()..emits(),
-        hasActualThat: it()
-          ..deepEquals(
-              ['A stream with error <UnimplementedError: Error at 1>']),
-        hasWhichThat: it()
-          ..single.equals('emitted an error instead of a value'),
+        actual: ['A stream with error <UnimplementedError: Error at 1>'],
+        which: ['emitted an error instead of a value'],
       );
     });
 
@@ -115,9 +110,8 @@ fake trace''');
 
       await checkThat(_countingStream(4)).isRejectedByAsync(
         it()..emitsThrough(it()..equals(5)),
-        hasActualThat: it()..deepEquals(['a stream']),
-        hasWhichThat: it()
-          ..single.equals('ended after emitting 4 elements with none matching'),
+        actual: ['a stream'],
+        which: ['ended after emitting 4 elements with none matching'],
       );
     });
 
@@ -126,9 +120,8 @@ fake trace''');
 
       await checkThat(_countingStream(6)).isRejectedByAsync(
         it()..neverEmits(it()..equals(5)),
-        hasActualThat: it()..deepEquals(['a stream']),
-        hasWhichThat: it()
-          ..deepEquals(['emitted <5>', 'following 5 other items']),
+        actual: ['a stream'],
+        which: ['emitted <5>', 'following 5 other items'],
       );
     });
   });

--- a/pkgs/checks/test/extensions/collection_equality_test.dart
+++ b/pkgs/checks/test/extensions/collection_equality_test.dart
@@ -6,8 +6,6 @@ import 'package:checks/checks.dart';
 import 'package:checks/src/collection_equality.dart';
 import 'package:test/scaffolding.dart';
 
-import '../test_shared.dart';
-
 void main() {
   group('deepCollectionEquals', () {
     test('allows nested collections with equal elements', () {
@@ -84,18 +82,18 @@ void main() {
         ['a']
       ], [
         {'a'}
-      ])).isARejection(which: ['at [<0>] is not a Set']);
+      ])).isNotNull().deepEquals(['at [<0>] is not a Set']);
     });
 
     test('reports long iterables', () {
-      checkThat(deepCollectionEquals([0], [])).isARejection(which: [
+      checkThat(deepCollectionEquals([0], [])).isNotNull().deepEquals([
         'has more elements than expected',
         'expected an iterable with 0 element(s)'
       ]);
     });
 
     test('reports short iterables', () {
-      checkThat(deepCollectionEquals([], [0])).isARejection(which: [
+      checkThat(deepCollectionEquals([], [0])).isNotNull().deepEquals([
         'has too few elements',
         'expected an iterable with at least 1 element(s)'
       ]);
@@ -103,12 +101,14 @@ void main() {
 
     test('reports unequal elements in iterables', () {
       checkThat(deepCollectionEquals([0], [1]))
-          .isARejection(which: ['at [<0>] is <0>', 'which does not equal <1>']);
+          .isNotNull()
+          .deepEquals(['at [<0>] is <0>', 'which does not equal <1>']);
     });
 
     test('reports unmet conditions in iterables', () {
       checkThat(deepCollectionEquals([0], [it()..isA<int>().isGreaterThan(0)]))
-          .isARejection(which: [
+          .isNotNull()
+          .deepEquals([
         'has an element at [<0>] that:',
         '  Actual: <0>',
         '  which is not greater than <0>'
@@ -118,7 +118,8 @@ void main() {
     test('reports unmet conditions in map values', () {
       checkThat(deepCollectionEquals(
               {'a': 'b'}, {'a': it()..isA<String>().startsWith('a')}))
-          .isARejection(which: [
+          .isNotNull()
+          .deepEquals([
         "has no entry to match 'a': <A value that:",
         '  is a String',
         "  starts with 'a'>",
@@ -128,7 +129,8 @@ void main() {
     test('reports unmet conditions in map keys', () {
       checkThat(deepCollectionEquals(
               {'b': 'a'}, {it()..isA<String>().startsWith('a'): 'a'}))
-          .isARejection(which: [
+          .isNotNull()
+          .deepEquals([
         'has no entry to match <A value that:',
         '  is a String',
         "  starts with 'a'>: 'a'",
@@ -139,28 +141,32 @@ void main() {
       var l = [];
       l.add(l);
       checkThat(deepCollectionEquals(l, l))
-          .isARejection(which: ['exceeds the depth limit of 1000']);
+          .isNotNull()
+          .deepEquals(['exceeds the depth limit of 1000']);
     });
 
     test('reports recursive sets', () {
       var s = <Object>{};
       s.add(s);
       checkThat(deepCollectionEquals(s, s))
-          .isARejection(which: ['exceeds the depth limit of 1000']);
+          .isNotNull()
+          .deepEquals(['exceeds the depth limit of 1000']);
     });
 
     test('reports maps with recursive keys', () {
       var m = <Object, Object>{};
       m[m] = 0;
       checkThat(deepCollectionEquals(m, m))
-          .isARejection(which: ['exceeds the depth limit of 1000']);
+          .isNotNull()
+          .deepEquals(['exceeds the depth limit of 1000']);
     });
 
     test('reports maps with recursive values', () {
       var m = <Object, Object>{};
       m[0] = m;
       checkThat(deepCollectionEquals(m, m))
-          .isARejection(which: ['exceeds the depth limit of 1000']);
+          .isNotNull()
+          .deepEquals(['exceeds the depth limit of 1000']);
     });
   });
 }

--- a/pkgs/checks/test/extensions/core_test.dart
+++ b/pkgs/checks/test/extensions/core_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:checks/checks.dart';
-import 'package:checks/context.dart';
 import 'package:test/scaffolding.dart';
 
 import '../test_shared.dart';
@@ -13,24 +12,17 @@ void main() {
     test('isA', () {
       checkThat(1).isA<int>();
 
-      checkThat(
-        softCheck(1, it()..isA<String>()),
-      ).isARejection(actual: ['<1>'], which: ['Is a int']);
+      checkThat(1).isRejectedBy(it()..isA<String>(),
+          hasWhichThat: it()..deepEquals(['Is a int']));
     });
   });
-
   group('HasField', () {
     test('has', () {
       checkThat(1).has((v) => v.isOdd, 'isOdd').isTrue();
 
-      checkThat(
-        softCheck<int>(
-          2,
-          it()..has((v) => throw UnimplementedError(), 'isOdd'),
-        ),
-      ).isARejection(
-        actual: ['<2>'],
-        which: ['threw while trying to read property'],
+      checkThat(2).isRejectedBy(
+        it()..has((v) => throw UnimplementedError(), 'isOdd'),
+        hasWhichThat: it()..deepEquals(['threw while trying to read property']),
       );
     });
 
@@ -41,14 +33,9 @@ void main() {
     test('not', () {
       checkThat(false).not(it()..isTrue());
 
-      checkThat(
-        softCheck<bool>(
-          true,
-          it()..not(it()..isTrue()),
-        ),
-      ).isARejection(
-        actual: ['<true>'],
-        which: ['is a value that: ', '    is true'],
+      checkThat(true).isRejectedBy(
+        it()..not(it()..isTrue()),
+        hasWhichThat: it()..deepEquals(['is a value that: ', '    is true']),
       );
     });
 
@@ -58,9 +45,9 @@ void main() {
       });
 
       test('rejects values that do not satisfy any condition', () {
-        checkThat(softCheck<int>(
-                0, it()..anyOf([it()..isGreaterThan(1), it()..isLessThan(-1)])))
-            .isARejection(which: ['did not match any condition']);
+        checkThat(0).isRejectedBy(
+            it()..anyOf([it()..isGreaterThan(1), it()..isLessThan(-1)]),
+            hasWhichThat: it()..deepEquals(['did not match any condition']));
       });
     });
   });
@@ -69,21 +56,13 @@ void main() {
     test('isTrue', () {
       checkThat(true).isTrue();
 
-      checkThat(
-        softCheck<bool>(
-          false,
-          it()..isTrue(),
-        ),
-      ).isARejection(actual: ['<false>']);
+      checkThat(false).isRejectedBy(it()..isTrue());
     });
 
     test('isFalse', () {
       checkThat(false).isFalse();
 
-      checkThat(softCheck<bool>(
-        true,
-        it()..isFalse(),
-      )).isARejection(actual: ['<true>']);
+      checkThat(true).isRejectedBy(it()..isFalse());
     });
   });
 
@@ -91,31 +70,26 @@ void main() {
     test('equals', () {
       checkThat(1).equals(1);
 
-      checkThat(
-        softCheck(1, it()..equals(2)),
-      ).isARejection(actual: ['<1>'], which: ['are not equal']);
+      checkThat(1).isRejectedBy(it()..equals(2),
+          hasWhichThat: it()..deepEquals(['are not equal']));
     });
-
     test('identical', () {
       checkThat(1).identicalTo(1);
 
-      checkThat(softCheck(1, it()..identicalTo(2)))
-          .isARejection(actual: ['<1>'], which: ['is not identical']);
+      checkThat(1).isRejectedBy(it()..identicalTo(2),
+          hasWhichThat: it()..deepEquals(['is not identical']));
     });
   });
-
   group('NullabilityChecks', () {
     test('isNotNull', () {
       checkThat(1).isNotNull();
 
-      checkThat(softCheck(null, it()..isNotNull()))
-          .isARejection(actual: ['<null>']);
+      checkThat(null).isRejectedBy(it()..isNotNull());
     });
-
     test('isNull', () {
       checkThat(null).isNull();
 
-      checkThat(softCheck(1, it()..isNull())).isARejection(actual: ['<1>']);
+      checkThat(1).isRejectedBy(it()..isNull());
     });
   });
 }

--- a/pkgs/checks/test/extensions/core_test.dart
+++ b/pkgs/checks/test/extensions/core_test.dart
@@ -12,8 +12,7 @@ void main() {
     test('isA', () {
       checkThat(1).isA<int>();
 
-      checkThat(1).isRejectedBy(it()..isA<String>(),
-          hasWhichThat: it()..deepEquals(['Is a int']));
+      checkThat(1).isRejectedBy(it()..isA<String>(), which: ['Is a int']);
     });
   });
   group('HasField', () {
@@ -21,9 +20,8 @@ void main() {
       checkThat(1).has((v) => v.isOdd, 'isOdd').isTrue();
 
       checkThat(2).isRejectedBy(
-        it()..has((v) => throw UnimplementedError(), 'isOdd'),
-        hasWhichThat: it()..deepEquals(['threw while trying to read property']),
-      );
+          it()..has((v) => throw UnimplementedError(), 'isOdd'),
+          which: ['threw while trying to read property']);
     });
 
     test('that', () {
@@ -33,10 +31,10 @@ void main() {
     test('not', () {
       checkThat(false).not(it()..isTrue());
 
-      checkThat(true).isRejectedBy(
-        it()..not(it()..isTrue()),
-        hasWhichThat: it()..deepEquals(['is a value that: ', '    is true']),
-      );
+      checkThat(true).isRejectedBy(it()..not(it()..isTrue()), which: [
+        'is a value that: ',
+        '    is true',
+      ]);
     });
 
     group('anyOf', () {
@@ -47,7 +45,7 @@ void main() {
       test('rejects values that do not satisfy any condition', () {
         checkThat(0).isRejectedBy(
             it()..anyOf([it()..isGreaterThan(1), it()..isLessThan(-1)]),
-            hasWhichThat: it()..deepEquals(['did not match any condition']));
+            which: ['did not match any condition']);
       });
     });
   });
@@ -70,14 +68,13 @@ void main() {
     test('equals', () {
       checkThat(1).equals(1);
 
-      checkThat(1).isRejectedBy(it()..equals(2),
-          hasWhichThat: it()..deepEquals(['are not equal']));
+      checkThat(1).isRejectedBy(it()..equals(2), which: ['are not equal']);
     });
     test('identical', () {
       checkThat(1).identicalTo(1);
 
-      checkThat(1).isRejectedBy(it()..identicalTo(2),
-          hasWhichThat: it()..deepEquals(['is not identical']));
+      checkThat(1)
+          .isRejectedBy(it()..identicalTo(2), which: ['is not identical']);
     });
   });
   group('NullabilityChecks', () {

--- a/pkgs/checks/test/extensions/function_test.dart
+++ b/pkgs/checks/test/extensions/function_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:checks/checks.dart';
-import 'package:checks/context.dart';
 import 'package:test/scaffolding.dart';
 
 import '../test_shared.dart';
@@ -15,21 +14,17 @@ void main() {
         checkThat(() => throw StateError('oops!')).throws<StateError>();
       });
       test('fails for functions that return normally', () {
-        checkThat(
-          softCheck<void Function()>(() {}, it()..throws<StateError>()),
-        ).isARejection(
-            actual: ['a function that returned <null>'],
-            which: ['did not throw']);
+        checkThat(() {}).isRejectedBy(it()..throws<StateError>(),
+            hasActualThat: it()
+              ..deepEquals(['a function that returned <null>']),
+            hasWhichThat: it()..deepEquals(['did not throw']));
       });
       test('fails for functions that throw the wrong type', () {
-        checkThat(
-          softCheck<void Function()>(
-            () => throw StateError('oops!'),
-            it()..throws<ArgumentError>(),
-          ),
-        ).isARejection(
-          actual: ['a function that threw error <Bad state: oops!>'],
-          which: ['did not throw an ArgumentError'],
+        checkThat(() => throw StateError('oops!')).isRejectedBy(
+          it()..throws<ArgumentError>(),
+          hasActualThat: it()
+            ..deepEquals(['a function that threw error <Bad state: oops!>']),
+          hasWhichThat: it()..deepEquals(['did not throw an ArgumentError']),
         );
       });
     });
@@ -39,13 +34,13 @@ void main() {
         checkThat(() => 1).returnsNormally().equals(1);
       });
       test('fails for functions that throw', () {
-        checkThat(softCheck<int Function()>(() {
+        checkThat(() {
           Error.throwWithStackTrace(
               StateError('oops!'), StackTrace.fromString('fake trace'));
-        }, it()..returnsNormally()))
-            .isARejection(
-                actual: ['a function that throws'],
-                which: ['threw <Bad state: oops!>', 'fake trace']);
+        }).isRejectedBy(it()..returnsNormally(),
+            hasActualThat: it()..deepEquals(['a function that throws']),
+            hasWhichThat: it()
+              ..deepEquals(['threw <Bad state: oops!>', 'fake trace']));
       });
     });
   });

--- a/pkgs/checks/test/extensions/function_test.dart
+++ b/pkgs/checks/test/extensions/function_test.dart
@@ -15,16 +15,14 @@ void main() {
       });
       test('fails for functions that return normally', () {
         checkThat(() {}).isRejectedBy(it()..throws<StateError>(),
-            hasActualThat: it()
-              ..deepEquals(['a function that returned <null>']),
-            hasWhichThat: it()..deepEquals(['did not throw']));
+            actual: ['a function that returned <null>'],
+            which: ['did not throw']);
       });
       test('fails for functions that throw the wrong type', () {
         checkThat(() => throw StateError('oops!')).isRejectedBy(
           it()..throws<ArgumentError>(),
-          hasActualThat: it()
-            ..deepEquals(['a function that threw error <Bad state: oops!>']),
-          hasWhichThat: it()..deepEquals(['did not throw an ArgumentError']),
+          actual: ['a function that threw error <Bad state: oops!>'],
+          which: ['did not throw an ArgumentError'],
         );
       });
     });
@@ -38,9 +36,8 @@ void main() {
           Error.throwWithStackTrace(
               StateError('oops!'), StackTrace.fromString('fake trace'));
         }).isRejectedBy(it()..returnsNormally(),
-            hasActualThat: it()..deepEquals(['a function that throws']),
-            hasWhichThat: it()
-              ..deepEquals(['threw <Bad state: oops!>', 'fake trace']));
+            actual: ['a function that throws'],
+            which: ['threw <Bad state: oops!>', 'fake trace']);
       });
     });
   });

--- a/pkgs/checks/test/extensions/iterable_test.dart
+++ b/pkgs/checks/test/extensions/iterable_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:checks/checks.dart';
-import 'package:checks/context.dart';
 import 'package:test/scaffolding.dart';
 
 import '../test_shared.dart';
@@ -26,49 +25,39 @@ void main() {
 
   test('isEmpty', () {
     checkThat([]).isEmpty();
-    checkThat(
-      softCheck<Iterable<int>>(_testIterable, it()..isEmpty()),
-    ).isARejection(actual: ['(0, 1)'], which: ['is not empty']);
+    checkThat(_testIterable).isRejectedBy(it()..isEmpty(),
+        hasWhichThat: it()..deepEquals(['is not empty']));
   });
 
   test('isNotEmpty', () {
     checkThat(_testIterable).isNotEmpty();
-    checkThat(
-      softCheck<Iterable<int>>(Iterable<int>.empty(), it()..isNotEmpty()),
-    ).isARejection(actual: ['()'], which: ['is not empty']);
+    checkThat(Iterable<int>.empty()).isRejectedBy(it()..isNotEmpty(),
+        hasWhichThat: it()..deepEquals(['is not empty']));
   });
 
   test('contains', () {
     checkThat(_testIterable).contains(0);
-    checkThat(
-      softCheck<Iterable<int>>(_testIterable, it()..contains(2)),
-    ).isARejection(actual: ['(0, 1)'], which: ['does not contain <2>']);
+    checkThat(_testIterable).isRejectedBy(it()..contains(2),
+        hasWhichThat: it()..deepEquals(['does not contain <2>']));
   });
   test('contains', () {
     checkThat(_testIterable).any(it()..equals(1));
-    checkThat(
-      softCheck<Iterable<int>>(
-        _testIterable,
-        it()..any(it()..equals(2)),
-      ),
-    ).isARejection(actual: ['(0, 1)'], which: ['Contains no matching element']);
+    checkThat(_testIterable).isRejectedBy(it()..any(it()..equals(2)),
+        hasWhichThat: it()..deepEquals(['Contains no matching element']));
   });
-
   group('every', () {
     test('succeeds for the happy path', () {
       checkThat(_testIterable).every(it()..isGreaterOrEqual(-1));
     });
 
     test('includes details of first failing element', () async {
-      checkThat(softCheck<Iterable<int>>(
-              _testIterable, it()..every(it()..isLessThan(0))))
-          .isARejection(actual: [
-        '(0, 1)'
-      ], which: [
-        'has an element at index 0 that:',
-        '  Actual: <0>',
-        '  Which: is not less than <0>',
-      ]);
+      checkThat(_testIterable).isRejectedBy(it()..every(it()..isLessThan(0)),
+          hasWhichThat: it()
+            ..deepEquals([
+              'has an element at index 0 that:',
+              '  Actual: <0>',
+              '  Which: is not less than <0>',
+            ]));
     });
   });
 
@@ -78,21 +67,23 @@ void main() {
     });
 
     test('reports unmatched elements', () {
-      checkThat(softCheck<Iterable<int>>(_testIterable,
-              it()..unorderedEquals(_testIterable.followedBy([42, 100]))))
-          .isARejection(which: [
-        'has no element equal to the expected element at index 2: <42>',
-        'or 1 other elements'
-      ]);
+      checkThat(_testIterable).isRejectedBy(
+          it()..unorderedEquals(_testIterable.followedBy([42, 100])),
+          hasWhichThat: it()
+            ..deepEquals([
+              'has no element equal to the expected element at index 2: <42>',
+              'or 1 other elements'
+            ]));
     });
 
     test('reports unexpected elements', () {
-      checkThat(softCheck<Iterable<int>>(_testIterable.followedBy([42, 100]),
-              it()..unorderedEquals(_testIterable)))
-          .isARejection(which: [
-        'has an unexpected element at index 2: <42>',
-        'and 1 other unexpected elements'
-      ]);
+      checkThat(_testIterable.followedBy([42, 100])).isRejectedBy(
+          it()..unorderedEquals(_testIterable),
+          hasWhichThat: it()
+            ..deepEquals([
+              'has an unexpected element at index 2: <42>',
+              'and 1 other unexpected elements'
+            ]));
     });
   });
 
@@ -103,27 +94,26 @@ void main() {
     });
 
     test('reports unmatched elements', () {
-      checkThat(softCheck<Iterable<int>>(
-              _testIterable,
-              it()
-                ..unorderedMatches(_testIterable
-                    .followedBy([42, 100]).map((i) => it()..equals(i)))))
-          .isARejection(which: [
-        'has no element matching the condition at index 2:',
-        '  equals <42>',
-        'or 1 other conditions'
-      ]);
+      checkThat(_testIterable).isRejectedBy(
+          it()
+            ..unorderedMatches(_testIterable
+                .followedBy([42, 100]).map((i) => it()..equals(i))),
+          hasWhichThat: it()
+            ..deepEquals([
+              'has no element matching the condition at index 2:',
+              '  equals <42>',
+              'or 1 other conditions'
+            ]));
     });
 
     test('reports unexpected elements', () {
-      checkThat(softCheck<Iterable<int>>(
-              _testIterable.followedBy([42, 100]),
-              it()
-                ..unorderedMatches(_testIterable.map((i) => it()..equals(i)))))
-          .isARejection(which: [
-        'has an unmatched element at index 2: <42>',
-        'and 1 other unmatched elements'
-      ]);
+      checkThat(_testIterable.followedBy([42, 100])).isRejectedBy(
+          it()..unorderedMatches(_testIterable.map((i) => it()..equals(i))),
+          hasWhichThat: it()
+            ..deepEquals([
+              'has an unmatched element at index 2: <42>',
+              'and 1 other unmatched elements'
+            ]));
     });
   });
 
@@ -133,41 +123,35 @@ void main() {
           [1, 2], (expected) => it()..isLessThan(expected), 'is less than');
     });
     test('fails for mismatched element', () async {
-      checkThat(softCheck<Iterable<int>>(
-              _testIterable,
-              it()
-                ..pairwiseComparesTo([1, 1],
-                    (expected) => it()..isLessThan(expected), 'is less than')))
-          .isARejection(actual: [
-        '(0, 1)'
-      ], which: [
-        'does not have an element at index 1 that:',
-        '  is less than <1>',
-        'Actual element at index 1: <1>',
-        'Which: is not less than <1>'
-      ]);
+      checkThat(_testIterable).isRejectedBy(
+          it()
+            ..pairwiseComparesTo([1, 1],
+                (expected) => it()..isLessThan(expected), 'is less than'),
+          hasWhichThat: it()
+            ..deepEquals([
+              'does not have an element at index 1 that:',
+              '  is less than <1>',
+              'Actual element at index 1: <1>',
+              'Which: is not less than <1>'
+            ]));
     });
     test('fails for too few elements', () {
-      checkThat(softCheck<Iterable<int>>(
-              _testIterable,
-              it()
-                ..pairwiseComparesTo([1, 2, 3],
-                    (expected) => it()..isLessThan(expected), 'is less than')))
-          .isARejection(actual: [
-        '(0, 1)'
-      ], which: [
-        'has too few elements, there is no element to match at index 2'
-      ]);
+      checkThat(_testIterable).isRejectedBy(
+          it()
+            ..pairwiseComparesTo([1, 2, 3],
+                (expected) => it()..isLessThan(expected), 'is less than'),
+          hasWhichThat: it()
+            ..deepEquals([
+              'has too few elements, there is no element to match at index 2'
+            ]));
     });
     test('fails for too many elements', () {
-      checkThat(softCheck<Iterable<int>>(
-              _testIterable,
-              it()
-                ..pairwiseComparesTo([1],
-                    (expected) => it()..isLessThan(expected), 'is less than')))
-          .isARejection(
-              actual: ['(0, 1)'],
-              which: ['has too many elements, expected exactly 1']);
+      checkThat(_testIterable).isRejectedBy(
+          it()
+            ..pairwiseComparesTo(
+                [1], (expected) => it()..isLessThan(expected), 'is less than'),
+          hasWhichThat: it()
+            ..deepEquals(['has too many elements, expected exactly 1']));
     });
   });
 }

--- a/pkgs/checks/test/extensions/iterable_test.dart
+++ b/pkgs/checks/test/extensions/iterable_test.dart
@@ -25,25 +25,25 @@ void main() {
 
   test('isEmpty', () {
     checkThat([]).isEmpty();
-    checkThat(_testIterable).isRejectedBy(it()..isEmpty(),
-        hasWhichThat: it()..deepEquals(['is not empty']));
+    checkThat(_testIterable)
+        .isRejectedBy(it()..isEmpty(), which: ['is not empty']);
   });
 
   test('isNotEmpty', () {
     checkThat(_testIterable).isNotEmpty();
-    checkThat(Iterable<int>.empty()).isRejectedBy(it()..isNotEmpty(),
-        hasWhichThat: it()..deepEquals(['is not empty']));
+    checkThat(Iterable<int>.empty())
+        .isRejectedBy(it()..isNotEmpty(), which: ['is not empty']);
   });
 
   test('contains', () {
     checkThat(_testIterable).contains(0);
-    checkThat(_testIterable).isRejectedBy(it()..contains(2),
-        hasWhichThat: it()..deepEquals(['does not contain <2>']));
+    checkThat(_testIterable)
+        .isRejectedBy(it()..contains(2), which: ['does not contain <2>']);
   });
   test('contains', () {
     checkThat(_testIterable).any(it()..equals(1));
     checkThat(_testIterable).isRejectedBy(it()..any(it()..equals(2)),
-        hasWhichThat: it()..deepEquals(['Contains no matching element']));
+        which: ['Contains no matching element']);
   });
   group('every', () {
     test('succeeds for the happy path', () {
@@ -51,13 +51,12 @@ void main() {
     });
 
     test('includes details of first failing element', () async {
-      checkThat(_testIterable).isRejectedBy(it()..every(it()..isLessThan(0)),
-          hasWhichThat: it()
-            ..deepEquals([
-              'has an element at index 0 that:',
-              '  Actual: <0>',
-              '  Which: is not less than <0>',
-            ]));
+      checkThat(_testIterable)
+          .isRejectedBy(it()..every(it()..isLessThan(0)), which: [
+        'has an element at index 0 that:',
+        '  Actual: <0>',
+        '  Which: is not less than <0>',
+      ]);
     });
   });
 
@@ -69,21 +68,18 @@ void main() {
     test('reports unmatched elements', () {
       checkThat(_testIterable).isRejectedBy(
           it()..unorderedEquals(_testIterable.followedBy([42, 100])),
-          hasWhichThat: it()
-            ..deepEquals([
-              'has no element equal to the expected element at index 2: <42>',
-              'or 1 other elements'
-            ]));
+          which: [
+            'has no element equal to the expected element at index 2: <42>',
+            'or 1 other elements'
+          ]);
     });
 
     test('reports unexpected elements', () {
-      checkThat(_testIterable.followedBy([42, 100])).isRejectedBy(
-          it()..unorderedEquals(_testIterable),
-          hasWhichThat: it()
-            ..deepEquals([
-              'has an unexpected element at index 2: <42>',
-              'and 1 other unexpected elements'
-            ]));
+      checkThat(_testIterable.followedBy([42, 100]))
+          .isRejectedBy(it()..unorderedEquals(_testIterable), which: [
+        'has an unexpected element at index 2: <42>',
+        'and 1 other unexpected elements'
+      ]);
     });
   });
 
@@ -98,22 +94,20 @@ void main() {
           it()
             ..unorderedMatches(_testIterable
                 .followedBy([42, 100]).map((i) => it()..equals(i))),
-          hasWhichThat: it()
-            ..deepEquals([
-              'has no element matching the condition at index 2:',
-              '  equals <42>',
-              'or 1 other conditions'
-            ]));
+          which: [
+            'has no element matching the condition at index 2:',
+            '  equals <42>',
+            'or 1 other conditions'
+          ]);
     });
 
     test('reports unexpected elements', () {
       checkThat(_testIterable.followedBy([42, 100])).isRejectedBy(
           it()..unorderedMatches(_testIterable.map((i) => it()..equals(i))),
-          hasWhichThat: it()
-            ..deepEquals([
-              'has an unmatched element at index 2: <42>',
-              'and 1 other unmatched elements'
-            ]));
+          which: [
+            'has an unmatched element at index 2: <42>',
+            'and 1 other unmatched elements'
+          ]);
     });
   });
 
@@ -127,31 +121,28 @@ void main() {
           it()
             ..pairwiseComparesTo([1, 1],
                 (expected) => it()..isLessThan(expected), 'is less than'),
-          hasWhichThat: it()
-            ..deepEquals([
-              'does not have an element at index 1 that:',
-              '  is less than <1>',
-              'Actual element at index 1: <1>',
-              'Which: is not less than <1>'
-            ]));
+          which: [
+            'does not have an element at index 1 that:',
+            '  is less than <1>',
+            'Actual element at index 1: <1>',
+            'Which: is not less than <1>'
+          ]);
     });
     test('fails for too few elements', () {
       checkThat(_testIterable).isRejectedBy(
           it()
             ..pairwiseComparesTo([1, 2, 3],
                 (expected) => it()..isLessThan(expected), 'is less than'),
-          hasWhichThat: it()
-            ..deepEquals([
-              'has too few elements, there is no element to match at index 2'
-            ]));
+          which: [
+            'has too few elements, there is no element to match at index 2'
+          ]);
     });
     test('fails for too many elements', () {
       checkThat(_testIterable).isRejectedBy(
           it()
             ..pairwiseComparesTo(
                 [1], (expected) => it()..isLessThan(expected), 'is less than'),
-          hasWhichThat: it()
-            ..deepEquals(['has too many elements, expected exactly 1']));
+          which: ['has too many elements, expected exactly 1']);
     });
   });
 }

--- a/pkgs/checks/test/extensions/map_test.dart
+++ b/pkgs/checks/test/extensions/map_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:checks/checks.dart';
-import 'package:checks/context.dart';
 import 'package:test/scaffolding.dart';
 
 import '../test_shared.dart';
@@ -12,8 +11,6 @@ const _testMap = {
   'a': 1,
   'b': 2,
 };
-
-const _testMapString = "{'a': 1, 'b': 2}";
 
 void main() {
   test('length', () {
@@ -35,63 +32,46 @@ void main() {
 
   test('operator []', () async {
     checkThat(_testMap)['a'].equals(1);
-    checkThat(softCheck<Map<String, int>>(_testMap, it()..['z']))
-        .isARejection(which: ['does not contain the key \'z\'']);
+    checkThat(_testMap).isRejectedBy(it()..['z'],
+        hasWhichThat: it()..deepEquals(['does not contain the key \'z\'']));
   });
-
   test('isEmpty', () {
     checkThat(<String, int>{}).isEmpty();
-    checkThat(
-      softCheck<Map<String, int>>(_testMap, it()..isEmpty()),
-    ).isARejection(actual: [_testMapString], which: ['is not empty']);
+    checkThat(_testMap).isRejectedBy(it()..isEmpty(),
+        hasWhichThat: it()..deepEquals(['is not empty']));
   });
-
   test('isNotEmpty', () {
     checkThat(_testMap).isNotEmpty();
-    checkThat(
-      softCheck<Map<String, int>>({}, it()..isNotEmpty()),
-    ).isARejection(actual: ['{}'], which: ['is not empty']);
+    checkThat({}).isRejectedBy(it()..isNotEmpty(),
+        hasWhichThat: it()..deepEquals(['is not empty']));
   });
-
   test('containsKey', () {
     checkThat(_testMap).containsKey('a');
 
-    checkThat(
-      softCheck<Map<String, int>>(_testMap, it()..containsKey('c')),
-    ).isARejection(
-      actual: [_testMapString],
-      which: ["does not contain key 'c'"],
+    checkThat(_testMap).isRejectedBy(
+      it()..containsKey('c'),
+      hasWhichThat: it()..deepEquals(["does not contain key 'c'"]),
     );
   });
   test('containsKeyThat', () {
     checkThat(_testMap).containsKeyThat(it()..equals('a'));
-    checkThat(
-      softCheck<Map<String, int>>(
-        _testMap,
-        it()..containsKeyThat(it()..equals('c')),
-      ),
-    ).isARejection(
-      actual: [_testMapString],
-      which: ['Contains no matching key'],
+    checkThat(_testMap).isRejectedBy(
+      it()..containsKeyThat(it()..equals('c')),
+      hasWhichThat: it()..deepEquals(['Contains no matching key']),
     );
   });
   test('containsValue', () {
     checkThat(_testMap).containsValue(1);
-    checkThat(
-      softCheck<Map<String, int>>(_testMap, it()..containsValue(3)),
-    ).isARejection(
-      actual: [_testMapString],
-      which: ['does not contain value <3>'],
+    checkThat(_testMap).isRejectedBy(
+      it()..containsValue(3),
+      hasWhichThat: it()..deepEquals(['does not contain value <3>']),
     );
   });
   test('containsValueThat', () {
     checkThat(_testMap).containsValueThat(it()..equals(1));
-    checkThat(
-      softCheck<Map<String, int>>(
-          _testMap, it()..containsValueThat(it()..equals(3))),
-    ).isARejection(
-      actual: [_testMapString],
-      which: ['Contains no matching value'],
+    checkThat(_testMap).isRejectedBy(
+      it()..containsValueThat(it()..equals(3)),
+      hasWhichThat: it()..deepEquals(['Contains no matching value']),
     );
   });
 }

--- a/pkgs/checks/test/extensions/map_test.dart
+++ b/pkgs/checks/test/extensions/map_test.dart
@@ -32,46 +32,44 @@ void main() {
 
   test('operator []', () async {
     checkThat(_testMap)['a'].equals(1);
-    checkThat(_testMap).isRejectedBy(it()..['z'],
-        hasWhichThat: it()..deepEquals(['does not contain the key \'z\'']));
+    checkThat(_testMap)
+        .isRejectedBy(it()..['z'], which: ['does not contain the key \'z\'']);
   });
   test('isEmpty', () {
     checkThat(<String, int>{}).isEmpty();
-    checkThat(_testMap).isRejectedBy(it()..isEmpty(),
-        hasWhichThat: it()..deepEquals(['is not empty']));
+    checkThat(_testMap).isRejectedBy(it()..isEmpty(), which: ['is not empty']);
   });
   test('isNotEmpty', () {
     checkThat(_testMap).isNotEmpty();
-    checkThat({}).isRejectedBy(it()..isNotEmpty(),
-        hasWhichThat: it()..deepEquals(['is not empty']));
+    checkThat({}).isRejectedBy(it()..isNotEmpty(), which: ['is not empty']);
   });
   test('containsKey', () {
     checkThat(_testMap).containsKey('a');
 
     checkThat(_testMap).isRejectedBy(
       it()..containsKey('c'),
-      hasWhichThat: it()..deepEquals(["does not contain key 'c'"]),
+      which: ["does not contain key 'c'"],
     );
   });
   test('containsKeyThat', () {
     checkThat(_testMap).containsKeyThat(it()..equals('a'));
     checkThat(_testMap).isRejectedBy(
       it()..containsKeyThat(it()..equals('c')),
-      hasWhichThat: it()..deepEquals(['Contains no matching key']),
+      which: ['Contains no matching key'],
     );
   });
   test('containsValue', () {
     checkThat(_testMap).containsValue(1);
     checkThat(_testMap).isRejectedBy(
       it()..containsValue(3),
-      hasWhichThat: it()..deepEquals(['does not contain value <3>']),
+      which: ['does not contain value <3>'],
     );
   });
   test('containsValueThat', () {
     checkThat(_testMap).containsValueThat(it()..equals(1));
     checkThat(_testMap).isRejectedBy(
       it()..containsValueThat(it()..equals(3)),
-      hasWhichThat: it()..deepEquals(['Contains no matching value']),
+      which: ['Contains no matching value'],
     );
   });
 }

--- a/pkgs/checks/test/extensions/math_test.dart
+++ b/pkgs/checks/test/extensions/math_test.dart
@@ -15,11 +15,11 @@ void main() {
       });
       test('fails for less than', () {
         checkThat(42).isRejectedBy(it()..isGreaterThan(50),
-            hasWhichThat: it()..deepEquals(['is not greater than <50>']));
+            which: ['is not greater than <50>']);
       });
       test('fails for equal', () {
         checkThat(42).isRejectedBy(it()..isGreaterThan(42),
-            hasWhichThat: it()..deepEquals(['is not greater than <42>']));
+            which: ['is not greater than <42>']);
       });
     });
 
@@ -29,8 +29,7 @@ void main() {
       });
       test('fails for less than', () {
         checkThat(42).isRejectedBy(it()..isGreaterOrEqual(50),
-            hasWhichThat: it()
-              ..deepEquals(['is not greater than or equal to <50>']));
+            which: ['is not greater than or equal to <50>']);
       });
       test('succeeds for equal', () {
         checkThat(42).isGreaterOrEqual(42);
@@ -42,12 +41,12 @@ void main() {
         checkThat(42).isLessThan(50);
       });
       test('fails for greater than', () {
-        checkThat(42).isRejectedBy(it()..isLessThan(7),
-            hasWhichThat: it()..deepEquals(['is not less than <7>']));
+        checkThat(42)
+            .isRejectedBy(it()..isLessThan(7), which: ['is not less than <7>']);
       });
       test('fails for equal', () {
         checkThat(42).isRejectedBy(it()..isLessThan(42),
-            hasWhichThat: it()..deepEquals(['is not less than <42>']));
+            which: ['is not less than <42>']);
       });
     });
 
@@ -57,8 +56,7 @@ void main() {
       });
       test('fails for greater than', () {
         checkThat(42).isRejectedBy(it()..isLessOrEqual(7),
-            hasWhichThat: it()
-              ..deepEquals(['is not less than or equal to <7>']));
+            which: ['is not less than or equal to <7>']);
       });
       test('succeeds for equal', () {
         checkThat(42).isLessOrEqual(42);
@@ -70,12 +68,10 @@ void main() {
         checkThat(double.nan).isNaN();
       });
       test('fails for ints', () {
-        checkThat(42).isRejectedBy(it()..isNaN(),
-            hasWhichThat: it()..deepEquals(['is a number']));
+        checkThat(42).isRejectedBy(it()..isNaN(), which: ['is a number']);
       });
       test('fails for numeric doubles', () {
-        checkThat(42.1).isRejectedBy(it()..isNaN(),
-            hasWhichThat: it()..deepEquals(['is a number']));
+        checkThat(42.1).isRejectedBy(it()..isNaN(), which: ['is a number']);
       });
     });
 
@@ -87,8 +83,8 @@ void main() {
         checkThat(42.1).isNotNaN();
       });
       test('fails for NaN', () {
-        checkThat(double.nan).isRejectedBy(it()..isNotNaN(),
-            hasWhichThat: it()..deepEquals(['is not a number (NaN)']));
+        checkThat(double.nan)
+            .isRejectedBy(it()..isNotNaN(), which: ['is not a number (NaN)']);
       });
     });
     group('isNegative', () {
@@ -99,8 +95,8 @@ void main() {
         checkThat(-0.0).isNegative();
       });
       test('fails for zero', () {
-        checkThat(0).isRejectedBy(it()..isNegative(),
-            hasWhichThat: it()..deepEquals(['is not negative']));
+        checkThat(0)
+            .isRejectedBy(it()..isNegative(), which: ['is not negative']);
       });
     });
     group('isNotNegative', () {
@@ -111,12 +107,12 @@ void main() {
         checkThat(0).isNotNegative();
       });
       test('fails for -0.0', () {
-        checkThat(-0.0).isRejectedBy(it()..isNotNegative(),
-            hasWhichThat: it()..deepEquals(['is negative']));
+        checkThat(-0.0)
+            .isRejectedBy(it()..isNotNegative(), which: ['is negative']);
       });
       test('fails for negative numbers', () {
-        checkThat(-1).isRejectedBy(it()..isNotNegative(),
-            hasWhichThat: it()..deepEquals(['is negative']));
+        checkThat(-1)
+            .isRejectedBy(it()..isNotNegative(), which: ['is negative']);
       });
     });
 
@@ -125,16 +121,16 @@ void main() {
         checkThat(1).isFinite();
       });
       test('fails for NaN', () {
-        checkThat(double.nan).isRejectedBy(it()..isFinite(),
-            hasWhichThat: it()..deepEquals(['is not finite']));
+        checkThat(double.nan)
+            .isRejectedBy(it()..isFinite(), which: ['is not finite']);
       });
       test('fails for infinity', () {
-        checkThat(double.infinity).isRejectedBy(it()..isFinite(),
-            hasWhichThat: it()..deepEquals(['is not finite']));
+        checkThat(double.infinity)
+            .isRejectedBy(it()..isFinite(), which: ['is not finite']);
       });
       test('fails for negative infinity', () {
-        checkThat(double.negativeInfinity).isRejectedBy(it()..isFinite(),
-            hasWhichThat: it()..deepEquals(['is not finite']));
+        checkThat(double.negativeInfinity)
+            .isRejectedBy(it()..isFinite(), which: ['is not finite']);
       });
     });
     group('isNotFinite', () {
@@ -148,8 +144,7 @@ void main() {
         checkThat(double.nan).isNotFinite();
       });
       test('fails for finite numbers', () {
-        checkThat(1).isRejectedBy(it()..isNotFinite(),
-            hasWhichThat: it()..deepEquals(['is finite']));
+        checkThat(1).isRejectedBy(it()..isNotFinite(), which: ['is finite']);
       });
     });
     group('isInfinite', () {
@@ -160,12 +155,12 @@ void main() {
         checkThat(double.negativeInfinity).isInfinite();
       });
       test('fails for NaN', () {
-        checkThat(double.nan).isRejectedBy(it()..isInfinite(),
-            hasWhichThat: it()..deepEquals(['is not infinite']));
+        checkThat(double.nan)
+            .isRejectedBy(it()..isInfinite(), which: ['is not infinite']);
       });
       test('fails for finite numbers', () {
-        checkThat(1).isRejectedBy(it()..isInfinite(),
-            hasWhichThat: it()..deepEquals(['is not infinite']));
+        checkThat(1)
+            .isRejectedBy(it()..isInfinite(), which: ['is not infinite']);
       });
     });
 
@@ -177,12 +172,12 @@ void main() {
         checkThat(double.nan).isNotInfinite();
       });
       test('fails for infinity', () {
-        checkThat(double.infinity).isRejectedBy(it()..isNotInfinite(),
-            hasWhichThat: it()..deepEquals(['is infinite']));
+        checkThat(double.infinity)
+            .isRejectedBy(it()..isNotInfinite(), which: ['is infinite']);
       });
       test('fails for negative infinity', () {
-        checkThat(double.negativeInfinity).isRejectedBy(it()..isNotInfinite(),
-            hasWhichThat: it()..deepEquals(['is infinite']));
+        checkThat(double.negativeInfinity)
+            .isRejectedBy(it()..isNotInfinite(), which: ['is infinite']);
       });
     });
     group('closeTo', () {
@@ -196,12 +191,12 @@ void main() {
         checkThat(1).isCloseTo(2, 1);
       });
       test('fails for low values', () {
-        checkThat(1).isRejectedBy(it()..isCloseTo(3, 1),
-            hasWhichThat: it()..deepEquals(['differs by <2>']));
+        checkThat(1)
+            .isRejectedBy(it()..isCloseTo(3, 1), which: ['differs by <2>']);
       });
       test('fails for high values', () {
-        checkThat(5).isRejectedBy(it()..isCloseTo(3, 1),
-            hasWhichThat: it()..deepEquals(['differs by <2>']));
+        checkThat(5)
+            .isRejectedBy(it()..isCloseTo(3, 1), which: ['differs by <2>']);
       });
     });
   });

--- a/pkgs/checks/test/extensions/math_test.dart
+++ b/pkgs/checks/test/extensions/math_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:checks/checks.dart';
-import 'package:checks/context.dart';
 import 'package:test/scaffolding.dart';
 
 import '../test_shared.dart';
@@ -15,12 +14,12 @@ void main() {
         checkThat(42).isGreaterThan(7);
       });
       test('fails for less than', () {
-        checkThat(softCheck<int>(42, it()..isGreaterThan(50))).isARejection(
-            actual: ['<42>'], which: ['is not greater than <50>']);
+        checkThat(42).isRejectedBy(it()..isGreaterThan(50),
+            hasWhichThat: it()..deepEquals(['is not greater than <50>']));
       });
       test('fails for equal', () {
-        checkThat(softCheck<int>(42, it()..isGreaterThan(42))).isARejection(
-            actual: ['<42>'], which: ['is not greater than <42>']);
+        checkThat(42).isRejectedBy(it()..isGreaterThan(42),
+            hasWhichThat: it()..deepEquals(['is not greater than <42>']));
       });
     });
 
@@ -29,8 +28,9 @@ void main() {
         checkThat(42).isGreaterOrEqual(7);
       });
       test('fails for less than', () {
-        checkThat(softCheck<int>(42, it()..isGreaterOrEqual(50))).isARejection(
-            actual: ['<42>'], which: ['is not greater than or equal to <50>']);
+        checkThat(42).isRejectedBy(it()..isGreaterOrEqual(50),
+            hasWhichThat: it()
+              ..deepEquals(['is not greater than or equal to <50>']));
       });
       test('succeeds for equal', () {
         checkThat(42).isGreaterOrEqual(42);
@@ -42,12 +42,12 @@ void main() {
         checkThat(42).isLessThan(50);
       });
       test('fails for greater than', () {
-        checkThat(softCheck<int>(42, it()..isLessThan(7)))
-            .isARejection(actual: ['<42>'], which: ['is not less than <7>']);
+        checkThat(42).isRejectedBy(it()..isLessThan(7),
+            hasWhichThat: it()..deepEquals(['is not less than <7>']));
       });
       test('fails for equal', () {
-        checkThat(softCheck<int>(42, it()..isLessThan(42)))
-            .isARejection(actual: ['<42>'], which: ['is not less than <42>']);
+        checkThat(42).isRejectedBy(it()..isLessThan(42),
+            hasWhichThat: it()..deepEquals(['is not less than <42>']));
       });
     });
 
@@ -56,8 +56,9 @@ void main() {
         checkThat(42).isLessOrEqual(50);
       });
       test('fails for greater than', () {
-        checkThat(softCheck<int>(42, it()..isLessOrEqual(7))).isARejection(
-            actual: ['<42>'], which: ['is not less than or equal to <7>']);
+        checkThat(42).isRejectedBy(it()..isLessOrEqual(7),
+            hasWhichThat: it()
+              ..deepEquals(['is not less than or equal to <7>']));
       });
       test('succeeds for equal', () {
         checkThat(42).isLessOrEqual(42);
@@ -69,12 +70,12 @@ void main() {
         checkThat(double.nan).isNaN();
       });
       test('fails for ints', () {
-        checkThat(softCheck<num>(42, it()..isNaN()))
-            .isARejection(actual: ['<42>'], which: ['is a number']);
+        checkThat(42).isRejectedBy(it()..isNaN(),
+            hasWhichThat: it()..deepEquals(['is a number']));
       });
       test('fails for numeric doubles', () {
-        checkThat(softCheck<num>(42.1, it()..isNaN()))
-            .isARejection(actual: ['<42.1>'], which: ['is a number']);
+        checkThat(42.1).isRejectedBy(it()..isNaN(),
+            hasWhichThat: it()..deepEquals(['is a number']));
       });
     });
 
@@ -86,11 +87,10 @@ void main() {
         checkThat(42.1).isNotNaN();
       });
       test('fails for NaN', () {
-        checkThat(softCheck<num>(double.nan, it()..isNotNaN()))
-            .isARejection(actual: ['<NaN>'], which: ['is not a number (NaN)']);
+        checkThat(double.nan).isRejectedBy(it()..isNotNaN(),
+            hasWhichThat: it()..deepEquals(['is not a number (NaN)']));
       });
     });
-
     group('isNegative', () {
       test('succeeds for negative ints', () {
         checkThat(-1).isNegative();
@@ -99,11 +99,10 @@ void main() {
         checkThat(-0.0).isNegative();
       });
       test('fails for zero', () {
-        checkThat(softCheck<num>(0, it()..isNegative()))
-            .isARejection(actual: ['<0>'], which: ['is not negative']);
+        checkThat(0).isRejectedBy(it()..isNegative(),
+            hasWhichThat: it()..deepEquals(['is not negative']));
       });
     });
-
     group('isNotNegative', () {
       test('succeeds for positive ints', () {
         checkThat(1).isNotNegative();
@@ -112,12 +111,12 @@ void main() {
         checkThat(0).isNotNegative();
       });
       test('fails for -0.0', () {
-        checkThat(softCheck<num>(-0.0, it()..isNotNegative()))
-            .isARejection(actual: ['<-0.0>'], which: ['is negative']);
+        checkThat(-0.0).isRejectedBy(it()..isNotNegative(),
+            hasWhichThat: it()..deepEquals(['is negative']));
       });
       test('fails for negative numbers', () {
-        checkThat(softCheck<num>(-1, it()..isNotNegative()))
-            .isARejection(actual: ['<-1>'], which: ['is negative']);
+        checkThat(-1).isRejectedBy(it()..isNotNegative(),
+            hasWhichThat: it()..deepEquals(['is negative']));
       });
     });
 
@@ -126,19 +125,18 @@ void main() {
         checkThat(1).isFinite();
       });
       test('fails for NaN', () {
-        checkThat(softCheck<num>(double.nan, it()..isFinite()))
-            .isARejection(actual: ['<NaN>'], which: ['is not finite']);
+        checkThat(double.nan).isRejectedBy(it()..isFinite(),
+            hasWhichThat: it()..deepEquals(['is not finite']));
       });
       test('fails for infinity', () {
-        checkThat(softCheck<num>(double.infinity, it()..isFinite()))
-            .isARejection(actual: ['<Infinity>'], which: ['is not finite']);
+        checkThat(double.infinity).isRejectedBy(it()..isFinite(),
+            hasWhichThat: it()..deepEquals(['is not finite']));
       });
       test('fails for negative infinity', () {
-        checkThat(softCheck<num>(double.negativeInfinity, it()..isFinite()))
-            .isARejection(actual: ['<-Infinity>'], which: ['is not finite']);
+        checkThat(double.negativeInfinity).isRejectedBy(it()..isFinite(),
+            hasWhichThat: it()..deepEquals(['is not finite']));
       });
     });
-
     group('isNotFinite', () {
       test('succeeds for infinity', () {
         checkThat(double.infinity).isNotFinite();
@@ -150,11 +148,10 @@ void main() {
         checkThat(double.nan).isNotFinite();
       });
       test('fails for finite numbers', () {
-        checkThat(softCheck<num>(1, it()..isNotFinite()))
-            .isARejection(actual: ['<1>'], which: ['is finite']);
+        checkThat(1).isRejectedBy(it()..isNotFinite(),
+            hasWhichThat: it()..deepEquals(['is finite']));
       });
     });
-
     group('isInfinite', () {
       test('succeeds for infinity', () {
         checkThat(double.infinity).isInfinite();
@@ -163,12 +160,12 @@ void main() {
         checkThat(double.negativeInfinity).isInfinite();
       });
       test('fails for NaN', () {
-        checkThat(softCheck<num>(double.nan, it()..isInfinite()))
-            .isARejection(actual: ['<NaN>'], which: ['is not infinite']);
+        checkThat(double.nan).isRejectedBy(it()..isInfinite(),
+            hasWhichThat: it()..deepEquals(['is not infinite']));
       });
       test('fails for finite numbers', () {
-        checkThat(softCheck<num>(1, it()..isInfinite()))
-            .isARejection(actual: ['<1>'], which: ['is not infinite']);
+        checkThat(1).isRejectedBy(it()..isInfinite(),
+            hasWhichThat: it()..deepEquals(['is not infinite']));
       });
     });
 
@@ -180,16 +177,14 @@ void main() {
         checkThat(double.nan).isNotInfinite();
       });
       test('fails for infinity', () {
-        checkThat(softCheck<num>(double.infinity, it()..isNotInfinite()))
-            .isARejection(actual: ['<Infinity>'], which: ['is infinite']);
+        checkThat(double.infinity).isRejectedBy(it()..isNotInfinite(),
+            hasWhichThat: it()..deepEquals(['is infinite']));
       });
       test('fails for negative infinity', () {
-        checkThat(
-                softCheck<num>(double.negativeInfinity, it()..isNotInfinite()))
-            .isARejection(actual: ['<-Infinity>'], which: ['is infinite']);
+        checkThat(double.negativeInfinity).isRejectedBy(it()..isNotInfinite(),
+            hasWhichThat: it()..deepEquals(['is infinite']));
       });
     });
-
     group('closeTo', () {
       test('succeeds for equal numbers', () {
         checkThat(1).isCloseTo(1, 1);
@@ -201,12 +196,12 @@ void main() {
         checkThat(1).isCloseTo(2, 1);
       });
       test('fails for low values', () {
-        checkThat(softCheck<num>(1, it()..isCloseTo(3, 1)))
-            .isARejection(actual: ['<1>'], which: ['differs by <2>']);
+        checkThat(1).isRejectedBy(it()..isCloseTo(3, 1),
+            hasWhichThat: it()..deepEquals(['differs by <2>']));
       });
       test('fails for high values', () {
-        checkThat(softCheck<num>(5, it()..isCloseTo(3, 1)))
-            .isARejection(actual: ['<5>'], which: ['differs by <2>']);
+        checkThat(5).isRejectedBy(it()..isCloseTo(3, 1),
+            hasWhichThat: it()..deepEquals(['differs by <2>']));
       });
     });
   });

--- a/pkgs/checks/test/extensions/string_test.dart
+++ b/pkgs/checks/test/extensions/string_test.dart
@@ -12,30 +12,28 @@ void main() {
     test('contains', () {
       checkThat('bob').contains('bo');
       checkThat('bob').isRejectedBy(it()..contains('kayleb'),
-          hasWhichThat: it()..deepEquals(["Does not contain 'kayleb'"]));
+          which: ["Does not contain 'kayleb'"]);
     });
     test('length', () {
       checkThat('bob').length.equals(3);
     });
     test('isEmpty', () {
       checkThat('').isEmpty();
-      checkThat('bob').isRejectedBy(it()..isEmpty(),
-          hasWhichThat: it()..deepEquals(['is not empty']));
+      checkThat('bob').isRejectedBy(it()..isEmpty(), which: ['is not empty']);
     });
     test('isNotEmpty', () {
       checkThat('bob').isNotEmpty();
-      checkThat('').isRejectedBy(it()..isNotEmpty(),
-          hasWhichThat: it()..deepEquals(['is empty']));
+      checkThat('').isRejectedBy(it()..isNotEmpty(), which: ['is empty']);
     });
     test('startsWith', () {
       checkThat('bob').startsWith('bo');
       checkThat('bob').isRejectedBy(it()..startsWith('kayleb'),
-          hasWhichThat: it()..deepEquals(["does not start with 'kayleb'"]));
+          which: ["does not start with 'kayleb'"]);
     });
     test('endsWith', () {
       checkThat('bob').endsWith('ob');
       checkThat('bob').isRejectedBy(it()..endsWith('kayleb'),
-          hasWhichThat: it()..deepEquals(["does not end with 'kayleb'"]));
+          which: ["does not end with 'kayleb'"]);
     });
     group('containsInOrder', () {
       test('happy case', () {
@@ -43,17 +41,14 @@ void main() {
       });
       test('reports when first substring is missing', () {
         checkThat('baz').isRejectedBy(it()..containsInOrder(['foo', 'baz']),
-            hasWhichThat: it()
-              ..deepEquals(
-                  ['does not have a match for the substring \'foo\'']));
+            which: ['does not have a match for the substring \'foo\'']);
       });
       test('reports when substring is missing following a match', () {
-        checkThat('foo bar').isRejectedBy(it()..containsInOrder(['foo', 'baz']),
-            hasWhichThat: it()
-              ..deepEquals([
-                'does not have a match for the substring \'baz\'',
-                'following the other matches up to character 3'
-              ]));
+        checkThat('foo bar')
+            .isRejectedBy(it()..containsInOrder(['foo', 'baz']), which: [
+          'does not have a match for the substring \'baz\'',
+          'following the other matches up to character 3'
+        ]);
       });
     });
 
@@ -66,64 +61,53 @@ void main() {
       });
       test('reports extra characters for long string', () {
         checkThat('foobar').isRejectedBy(it()..equals('foo'),
-            hasWhichThat: it()
-              ..deepEquals(
-                  ['is too long with unexpected trailing characters:', 'bar']));
+            which: ['is too long with unexpected trailing characters:', 'bar']);
       });
       test('reports extra characters for long string against empty', () {
-        checkThat('foo').isRejectedBy(it()..equals(''),
-            hasWhichThat: it()..deepEquals(['is not the empty string']));
+        checkThat('foo')
+            .isRejectedBy(it()..equals(''), which: ['is not the empty string']);
       });
       test('reports truncated extra characters for very long string', () {
         checkThat('foobar baz more stuff').isRejectedBy(it()..equals('foo'),
-            hasWhichThat: it()
-              ..deepEquals([
-                'is too long with unexpected trailing characters:',
-                'bar baz mo ...'
-              ]));
+            which: [
+              'is too long with unexpected trailing characters:',
+              'bar baz mo ...'
+            ]);
       });
       test('reports missing characters for short string', () {
         checkThat('foo').isRejectedBy(it()..equals('foobar'),
-            hasWhichThat: it()
-              ..deepEquals(
-                  ['is too short with missing trailing characters:', 'bar']));
+            which: ['is too short with missing trailing characters:', 'bar']);
       });
       test('reports missing characters for empty string', () {
         checkThat('').isRejectedBy(it()..equals('foo bar baz'),
-            hasActualThat: it()..deepEquals(['an empty string']),
-            hasWhichThat: it()
-              ..deepEquals(
-                  ['is missing all expected characters:', 'foo bar ba ...']));
+            actual: ['an empty string'],
+            which: ['is missing all expected characters:', 'foo bar ba ...']);
       });
       test('reports truncated missing characters for very short string', () {
         checkThat('foo').isRejectedBy(it()..equals('foobar baz more stuff'),
-            hasWhichThat: it()
-              ..deepEquals([
-                'is too short with missing trailing characters:',
-                'bar baz mo ...'
-              ]));
+            which: [
+              'is too short with missing trailing characters:',
+              'bar baz mo ...'
+            ]);
       });
       test('reports index of different character', () {
-        checkThat('hit').isRejectedBy(it()..equals('hat'),
-            hasWhichThat: it()
-              ..deepEquals([
-                'differs at offset 1:',
-                'hat',
-                'hit',
-                ' ^',
-              ]));
+        checkThat('hit').isRejectedBy(it()..equals('hat'), which: [
+          'differs at offset 1:',
+          'hat',
+          'hit',
+          ' ^',
+        ]);
       });
       test('reports truncated index of different character in large string',
           () {
-        checkThat('blah blah blah hit blah blah blah')
-            .isRejectedBy(it()..equals('blah blah blah hat blah blah blah'),
-                hasWhichThat: it()
-                  ..deepEquals([
-                    'differs at offset 16:',
-                    '... lah blah hat blah bl ...',
-                    '... lah blah hit blah bl ...',
-                    '              ^',
-                  ]));
+        checkThat('blah blah blah hit blah blah blah').isRejectedBy(
+            it()..equals('blah blah blah hat blah blah blah'),
+            which: [
+              'differs at offset 16:',
+              '... lah blah hat blah bl ...',
+              '... lah blah hit blah bl ...',
+              '              ^',
+            ]);
       });
     });
 
@@ -134,25 +118,19 @@ void main() {
       });
       test('reports original extra characters for long string', () {
         checkThat('FOOBAR').isRejectedBy(it()..equalsIgnoringCase('foo'),
-            hasWhichThat: it()
-              ..deepEquals(
-                  ['is too long with unexpected trailing characters:', 'BAR']));
+            which: ['is too long with unexpected trailing characters:', 'BAR']);
       });
       test('reports original missing characters for short string', () {
         checkThat('FOO').isRejectedBy(it()..equalsIgnoringCase('fooBAR'),
-            hasWhichThat: it()
-              ..deepEquals(
-                  ['is too short with missing trailing characters:', 'BAR']));
+            which: ['is too short with missing trailing characters:', 'BAR']);
       });
       test('reports index of different character with original characters', () {
-        checkThat('HiT').isRejectedBy(it()..equalsIgnoringCase('hAt'),
-            hasWhichThat: it()
-              ..deepEquals([
-                'differs at offset 1:',
-                'hAt',
-                'HiT',
-                ' ^',
-              ]));
+        checkThat('HiT').isRejectedBy(it()..equalsIgnoringCase('hAt'), which: [
+          'differs at offset 1:',
+          'hAt',
+          'HiT',
+          ' ^',
+        ]);
       });
     });
 
@@ -167,31 +145,25 @@ void main() {
         checkThat('foo').equalsIgnoringWhitespace(' foo ');
       });
       test('reports original extra characters for long string', () {
-        checkThat('foo \t bar \n baz').isRejectedBy(
-            it()..equalsIgnoringWhitespace('foo bar'),
-            hasWhichThat: it()
-              ..deepEquals([
-                'is too long with unexpected trailing characters:',
-                ' baz'
-              ]));
+        checkThat('foo \t bar \n baz')
+            .isRejectedBy(it()..equalsIgnoringWhitespace('foo bar'), which: [
+          'is too long with unexpected trailing characters:',
+          ' baz'
+        ]);
       });
       test('reports original missing characters for short string', () {
         checkThat('foo  bar').isRejectedBy(
             it()..equalsIgnoringWhitespace('foo bar baz'),
-            hasWhichThat: it()
-              ..deepEquals(
-                  ['is too short with missing trailing characters:', ' baz']));
+            which: ['is too short with missing trailing characters:', ' baz']);
       });
       test('reports index of different character with original characters', () {
         checkThat('x  hit  x')
-            .isRejectedBy(it()..equalsIgnoringWhitespace('x hat x'),
-                hasWhichThat: it()
-                  ..deepEquals([
-                    'differs at offset 3:',
-                    'x hat x',
-                    'x hit x',
-                    '   ^',
-                  ]));
+            .isRejectedBy(it()..equalsIgnoringWhitespace('x hat x'), which: [
+          'differs at offset 3:',
+          'x hat x',
+          'x hit x',
+          '   ^',
+        ]);
       });
     });
   });

--- a/pkgs/checks/test/extensions/string_test.dart
+++ b/pkgs/checks/test/extensions/string_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:checks/checks.dart';
-import 'package:checks/context.dart';
 import 'package:test/scaffolding.dart';
 
 import '../test_shared.dart';
@@ -12,56 +11,49 @@ void main() {
   group('StringChecks', () {
     test('contains', () {
       checkThat('bob').contains('bo');
-      checkThat(
-        softCheck<String>('bob', it()..contains('kayleb')),
-      ).isARejection(actual: ["'bob'"], which: ["Does not contain 'kayleb'"]);
+      checkThat('bob').isRejectedBy(it()..contains('kayleb'),
+          hasWhichThat: it()..deepEquals(["Does not contain 'kayleb'"]));
     });
     test('length', () {
       checkThat('bob').length.equals(3);
     });
     test('isEmpty', () {
       checkThat('').isEmpty();
-      checkThat(
-        softCheck<String>('bob', it()..isEmpty()),
-      ).isARejection(actual: ["'bob'"], which: ['is not empty']);
+      checkThat('bob').isRejectedBy(it()..isEmpty(),
+          hasWhichThat: it()..deepEquals(['is not empty']));
     });
     test('isNotEmpty', () {
       checkThat('bob').isNotEmpty();
-      checkThat(
-        softCheck<String>('', it()..isNotEmpty()),
-      ).isARejection(actual: ["''"], which: ['is empty']);
+      checkThat('').isRejectedBy(it()..isNotEmpty(),
+          hasWhichThat: it()..deepEquals(['is empty']));
     });
     test('startsWith', () {
       checkThat('bob').startsWith('bo');
-      checkThat(
-        softCheck<String>('bob', it()..startsWith('kayleb')),
-      ).isARejection(
-          actual: ["'bob'"], which: ["does not start with 'kayleb'"]);
+      checkThat('bob').isRejectedBy(it()..startsWith('kayleb'),
+          hasWhichThat: it()..deepEquals(["does not start with 'kayleb'"]));
     });
     test('endsWith', () {
       checkThat('bob').endsWith('ob');
-      checkThat(softCheck<String>('bob', it()..endsWith('kayleb')))
-          .isARejection(
-              actual: ["'bob'"], which: ["does not end with 'kayleb'"]);
+      checkThat('bob').isRejectedBy(it()..endsWith('kayleb'),
+          hasWhichThat: it()..deepEquals(["does not end with 'kayleb'"]));
     });
-
     group('containsInOrder', () {
       test('happy case', () {
         checkThat('foo bar baz').containsInOrder(['foo', 'baz']);
       });
       test('reports when first substring is missing', () {
-        checkThat(
-                softCheck<String>('baz', it()..containsInOrder(['foo', 'baz'])))
-            .isARejection(
-                which: ['does not have a match for the substring \'foo\'']);
+        checkThat('baz').isRejectedBy(it()..containsInOrder(['foo', 'baz']),
+            hasWhichThat: it()
+              ..deepEquals(
+                  ['does not have a match for the substring \'foo\'']));
       });
       test('reports when substring is missing following a match', () {
-        checkThat(softCheck<String>(
-                'foo bar', it()..containsInOrder(['foo', 'baz'])))
-            .isARejection(which: [
-          'does not have a match for the substring \'baz\'',
-          'following the other matches up to character 3'
-        ]);
+        checkThat('foo bar').isRejectedBy(it()..containsInOrder(['foo', 'baz']),
+            hasWhichThat: it()
+              ..deepEquals([
+                'does not have a match for the substring \'baz\'',
+                'following the other matches up to character 3'
+              ]));
       });
     });
 
@@ -73,67 +65,65 @@ void main() {
         checkThat('').equals('');
       });
       test('reports extra characters for long string', () {
-        checkThat(softCheck<String>('foobar', it()..equals('foo')))
-            .isARejection(which: [
-          'is too long with unexpected trailing characters:',
-          'bar'
-        ]);
+        checkThat('foobar').isRejectedBy(it()..equals('foo'),
+            hasWhichThat: it()
+              ..deepEquals(
+                  ['is too long with unexpected trailing characters:', 'bar']));
       });
       test('reports extra characters for long string against empty', () {
-        checkThat(softCheck<String>('foo', it()..equals('')))
-            .isARejection(which: ['is not the empty string']);
+        checkThat('foo').isRejectedBy(it()..equals(''),
+            hasWhichThat: it()..deepEquals(['is not the empty string']));
       });
       test('reports truncated extra characters for very long string', () {
-        checkThat(
-                softCheck<String>('foobar baz more stuff', it()..equals('foo')))
-            .isARejection(which: [
-          'is too long with unexpected trailing characters:',
-          'bar baz mo ...'
-        ]);
+        checkThat('foobar baz more stuff').isRejectedBy(it()..equals('foo'),
+            hasWhichThat: it()
+              ..deepEquals([
+                'is too long with unexpected trailing characters:',
+                'bar baz mo ...'
+              ]));
       });
       test('reports missing characters for short string', () {
-        checkThat(softCheck<String>('foo', it()..equals('foobar')))
-            .isARejection(which: [
-          'is too short with missing trailing characters:',
-          'bar'
-        ]);
+        checkThat('foo').isRejectedBy(it()..equals('foobar'),
+            hasWhichThat: it()
+              ..deepEquals(
+                  ['is too short with missing trailing characters:', 'bar']));
       });
       test('reports missing characters for empty string', () {
-        checkThat(softCheck<String>('', it()..equals('foo bar baz')))
-            .isARejection(actual: [
-          'an empty string'
-        ], which: [
-          'is missing all expected characters:',
-          'foo bar ba ...'
-        ]);
+        checkThat('').isRejectedBy(it()..equals('foo bar baz'),
+            hasActualThat: it()..deepEquals(['an empty string']),
+            hasWhichThat: it()
+              ..deepEquals(
+                  ['is missing all expected characters:', 'foo bar ba ...']));
       });
       test('reports truncated missing characters for very short string', () {
-        checkThat(
-                softCheck<String>('foo', it()..equals('foobar baz more stuff')))
-            .isARejection(which: [
-          'is too short with missing trailing characters:',
-          'bar baz mo ...'
-        ]);
+        checkThat('foo').isRejectedBy(it()..equals('foobar baz more stuff'),
+            hasWhichThat: it()
+              ..deepEquals([
+                'is too short with missing trailing characters:',
+                'bar baz mo ...'
+              ]));
       });
       test('reports index of different character', () {
-        checkThat(softCheck<String>('hit', it()..equals('hat')))
-            .isARejection(which: [
-          'differs at offset 1:',
-          'hat',
-          'hit',
-          ' ^',
-        ]);
+        checkThat('hit').isRejectedBy(it()..equals('hat'),
+            hasWhichThat: it()
+              ..deepEquals([
+                'differs at offset 1:',
+                'hat',
+                'hit',
+                ' ^',
+              ]));
       });
       test('reports truncated index of different character in large string',
           () {
-        checkThat(softCheck<String>('blah blah blah hit blah blah blah',
-                it()..equals('blah blah blah hat blah blah blah')))
-            .isARejection(which: [
-          'differs at offset 16:',
-          '... lah blah hat blah bl ...',
-          '... lah blah hit blah bl ...',
-          '              ^',
-        ]);
+        checkThat('blah blah blah hit blah blah blah')
+            .isRejectedBy(it()..equals('blah blah blah hat blah blah blah'),
+                hasWhichThat: it()
+                  ..deepEquals([
+                    'differs at offset 16:',
+                    '... lah blah hat blah bl ...',
+                    '... lah blah hit blah bl ...',
+                    '              ^',
+                  ]));
       });
     });
 
@@ -143,27 +133,26 @@ void main() {
         checkThat('foo').equalsIgnoringCase('FOO');
       });
       test('reports original extra characters for long string', () {
-        checkThat(softCheck<String>('FOOBAR', it()..equalsIgnoringCase('foo')))
-            .isARejection(which: [
-          'is too long with unexpected trailing characters:',
-          'BAR'
-        ]);
+        checkThat('FOOBAR').isRejectedBy(it()..equalsIgnoringCase('foo'),
+            hasWhichThat: it()
+              ..deepEquals(
+                  ['is too long with unexpected trailing characters:', 'BAR']));
       });
       test('reports original missing characters for short string', () {
-        checkThat(softCheck<String>('FOO', it()..equalsIgnoringCase('fooBAR')))
-            .isARejection(which: [
-          'is too short with missing trailing characters:',
-          'BAR'
-        ]);
+        checkThat('FOO').isRejectedBy(it()..equalsIgnoringCase('fooBAR'),
+            hasWhichThat: it()
+              ..deepEquals(
+                  ['is too short with missing trailing characters:', 'BAR']));
       });
       test('reports index of different character with original characters', () {
-        checkThat(softCheck<String>('HiT', it()..equalsIgnoringCase('hAt')))
-            .isARejection(which: [
-          'differs at offset 1:',
-          'hAt',
-          'HiT',
-          ' ^',
-        ]);
+        checkThat('HiT').isRejectedBy(it()..equalsIgnoringCase('hAt'),
+            hasWhichThat: it()
+              ..deepEquals([
+                'differs at offset 1:',
+                'hAt',
+                'HiT',
+                ' ^',
+              ]));
       });
     });
 
@@ -178,30 +167,31 @@ void main() {
         checkThat('foo').equalsIgnoringWhitespace(' foo ');
       });
       test('reports original extra characters for long string', () {
-        checkThat(softCheck<String>(
-                'foo \t bar \n baz', it()..equalsIgnoringWhitespace('foo bar')))
-            .isARejection(which: [
-          'is too long with unexpected trailing characters:',
-          ' baz'
-        ]);
+        checkThat('foo \t bar \n baz').isRejectedBy(
+            it()..equalsIgnoringWhitespace('foo bar'),
+            hasWhichThat: it()
+              ..deepEquals([
+                'is too long with unexpected trailing characters:',
+                ' baz'
+              ]));
       });
       test('reports original missing characters for short string', () {
-        checkThat(softCheck<String>(
-                'foo  bar', it()..equalsIgnoringWhitespace('foo bar baz')))
-            .isARejection(which: [
-          'is too short with missing trailing characters:',
-          ' baz'
-        ]);
+        checkThat('foo  bar').isRejectedBy(
+            it()..equalsIgnoringWhitespace('foo bar baz'),
+            hasWhichThat: it()
+              ..deepEquals(
+                  ['is too short with missing trailing characters:', ' baz']));
       });
       test('reports index of different character with original characters', () {
-        checkThat(softCheck<String>(
-                'x  hit  x', it()..equalsIgnoringWhitespace('x hat x')))
-            .isARejection(which: [
-          'differs at offset 3:',
-          'x hat x',
-          'x hit x',
-          '   ^',
-        ]);
+        checkThat('x  hit  x')
+            .isRejectedBy(it()..equalsIgnoringWhitespace('x hat x'),
+                hasWhichThat: it()
+                  ..deepEquals([
+                    'differs at offset 3:',
+                    'x hat x',
+                    'x hit x',
+                    '   ^',
+                  ]));
       });
     });
   });

--- a/pkgs/checks/test/test_shared.dart
+++ b/pkgs/checks/test/test_shared.dart
@@ -8,12 +8,11 @@ import 'package:checks/src/checks.dart' show softCheckAsync, describeAsync;
 
 extension RejectionChecks<T> on Check<T> {
   void isRejectedBy(Condition<T> condition,
-      {Condition<Iterable<String>>? hasWhichThat,
-      Condition<Iterable<String>>? hasActualThat}) {
+      {Iterable<String>? actual, Iterable<String>? which}) {
     late T actualValue;
     var didRunCallback = false;
-    context.nest<Rejection>('does not meet a condition with a Rejection',
-        (value) {
+    final rejection = context
+        .nest<Rejection>('does not meet a condition with a Rejection', (value) {
       actualValue = value;
       didRunCallback = true;
       final failure = softCheck(value, condition);
@@ -24,26 +23,30 @@ extension RejectionChecks<T> on Check<T> {
         ]);
       }
       return Extracted.value(failure.rejection);
-    })
-      ..has((r) => r.actual, 'actual').that(hasActualThat ??
-          (didRunCallback
-              ? (it()..deepEquals(literal(actualValue)))
-              : (it()
-                ..context
-                    .expect(() => ['uses the default actual'], (_) => null))))
-      ..has((r) => r.which, 'which').that(hasWhichThat == null
-          ? (it()..isNull())
-          : (it()..isNotNull().that(hasWhichThat)));
+    });
+    if (didRunCallback) {
+      rejection
+          .has((r) => r.actual, 'actual')
+          .deepEquals(actual ?? literal(actualValue));
+    } else {
+      rejection
+          .has((r) => r.actual, 'actual')
+          .context
+          .expect(() => ['is left default'], (_) => null);
+    }
+    if (which == null) {
+      rejection.has((r) => r.which, 'which').isNull();
+    } else {
+      rejection.has((r) => r.which, 'which').isNotNull().deepEquals(which);
+    }
   }
 
   Future<void> isRejectedByAsync(Condition<T> condition,
-      {Condition<Iterable<String>>? hasWhichThat,
-      Condition<Iterable<String>>? hasActualThat}) async {
+      {Iterable<String>? actual, Iterable<String>? which}) async {
     late T actualValue;
     var didRunCallback = false;
-    (await context.nestAsync<Rejection>(() {
-      return 'does not meet an async condition with a Rejection';
-    }(), (value) async {
+    final rejection = (await context.nestAsync<Rejection>(
+        'does not meet an async condition with a Rejection', (value) async {
       actualValue = value;
       didRunCallback = true;
       final failure = await softCheckAsync(value, condition);
@@ -53,15 +56,21 @@ extension RejectionChecks<T> on Check<T> {
           ...await describeAsync(condition)
         ]);
       return Extracted.value(failure.rejection);
-    }))
-      ..has((r) => r.actual, 'actual').that(hasActualThat ??
-          (didRunCallback
-              ? (it()..deepEquals(literal(actualValue)))
-              : (it()
-                ..context
-                    .expect(() => ['uses the default actual'], (_) => null))))
-      ..has((r) => r.which, 'which').that(hasWhichThat == null
-          ? (it()..isNull())
-          : (it()..isNotNull().that(hasWhichThat)));
+    }));
+    if (didRunCallback) {
+      rejection
+          .has((r) => r.actual, 'actual')
+          .deepEquals(actual ?? literal(actualValue));
+    } else {
+      rejection
+          .has((r) => r.actual, 'actual')
+          .context
+          .expect(() => ['is left default'], (_) => null);
+    }
+    if (which == null) {
+      rejection.has((r) => r.which, 'which').isNull();
+    } else {
+      rejection.has((r) => r.which, 'which').isNotNull().deepEquals(which);
+    }
   }
 }

--- a/pkgs/checks/test/test_shared.dart
+++ b/pkgs/checks/test/test_shared.dart
@@ -4,31 +4,64 @@
 
 import 'package:checks/checks.dart';
 import 'package:checks/context.dart';
+import 'package:checks/src/checks.dart' show softCheckAsync, describeAsync;
 
-extension FailureCheck on Check<CheckFailure?> {
-  void isARejection({List<String>? which, List<String>? actual}) {
-    isNotNull()
-        .has((f) => f.rejection, 'rejection')
-        ._hasActualWhich(actual: actual, which: which);
+extension RejectionChecks<T> on Check<T> {
+  void isRejectedBy(Condition<T> condition,
+      {Condition<Iterable<String>>? hasWhichThat,
+      Condition<Iterable<String>>? hasActualThat}) {
+    late T actualValue;
+    var didRunCallback = false;
+    context.nest<Rejection>('does not meet a condition with a Rejection',
+        (value) {
+      actualValue = value;
+      didRunCallback = true;
+      final failure = softCheck(value, condition);
+      if (failure == null) {
+        return Extracted.rejection(which: [
+          'was accepted by the condition checking:',
+          ...describe(condition)
+        ]);
+      }
+      return Extracted.value(failure.rejection);
+    })
+      ..has((r) => r.actual, 'actual').that(hasActualThat ??
+          (didRunCallback
+              ? (it()..deepEquals(literal(actualValue)))
+              : (it()
+                ..context
+                    .expect(() => ['uses the default actual'], (_) => null))))
+      ..has((r) => r.which, 'which').that(hasWhichThat == null
+          ? (it()..isNull())
+          : (it()..isNotNull().that(hasWhichThat)));
   }
-}
 
-extension RejectionCheck on Check<Rejection?> {
-  void isARejection({List<String>? which, List<String>? actual}) {
-    isNotNull()._hasActualWhich(actual: actual, which: which);
-  }
-}
-
-extension _RejectionCheck on Check<Rejection> {
-  void _hasActualWhich({List<String>? which, List<String>? actual}) {
-    if (actual != null) {
-      has((r) => r.actual.toList(), 'actual').deepEquals(actual);
-    }
-    final whichCheck = has((r) => r.which?.toList(), 'which');
-    if (which == null) {
-      whichCheck.isNull();
-    } else {
-      whichCheck.isNotNull().deepEquals(which);
-    }
+  Future<void> isRejectedByAsync(Condition<T> condition,
+      {Condition<Iterable<String>>? hasWhichThat,
+      Condition<Iterable<String>>? hasActualThat}) async {
+    late T actualValue;
+    var didRunCallback = false;
+    (await context.nestAsync<Rejection>(() {
+      return 'does not meet an async condition with a Rejection';
+    }(), (value) async {
+      actualValue = value;
+      didRunCallback = true;
+      final failure = await softCheckAsync(value, condition);
+      if (failure == null)
+        return Extracted.rejection(which: [
+          'was accepted by the condition checking:',
+          ...await describeAsync(condition)
+        ]);
+      return Extracted.value(failure.rejection);
+    }))
+      ..has((r) => r.actual, 'actual').that(hasActualThat ??
+          (didRunCallback
+              ? (it()..deepEquals(literal(actualValue)))
+              : (it()
+                ..context
+                    .expect(() => ['uses the default actual'], (_) => null))))
+      ..has((r) => r.which, 'which').that(hasWhichThat == null
+          ? (it()..isNull())
+          : (it()..isNotNull().that(hasWhichThat)));
   }
 }


### PR DESCRIPTION
The new structure has a few advantages over the previous pattern of
calling `softCheck` and passing the result to `checkThat`, we can omit
some generic type arguments, and the failure can carry more context when
the failure is caused by accepted a value that should be rejected.

With `softCheck` the generic must be explicit on the `it()` call, or
explicit on `softCheck` and then filled through downward inference.
Without an explicit generic the correct extension methods are not
available for the condition. With a value passed to `checkThat` instead,
the generic can be inferred, and then carried forward to `it()` through
downwards inference.

With `softCheck` the value and the `Condition` are both opaque to the
failure, because the check only sees the `Rejection?`. With
`isRejectedBy` we can include a description of the condition for
failures where the value was incorrectly accepted. If the failure is
instead with the `actual` or `which` conditions, this context is still
missing from the failure message.

Change `deepCollectionEquals` to return an `Iterable<String>` instead of
a `Rejection?`. The `which` is the only interesting information, and
this lets us test the method with standard expectations instead of
still needing a `isARejection`.

Strengthen the tests for the "actual" rejection arguments. Test that the
default was actually used instead of skipping the expectation entirely
for the cases where we don't pass an expectation for actual. Fill in
some non-default actual values in tests that were previously not
checking them.
