### PR TITLE
Use pubspec_overrides.yaml files

### DIFF
--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -41,9 +41,3 @@ dev_dependencies:
   lints: '>=1.0.0 <3.0.0'
   test_descriptor: ^2.0.0
   test_process: ^2.0.0
-
-dependency_overrides:
-  test_core:
-    path: ../test_core
-  test_api:
-    path: ../test_api

--- a/pkgs/test/pubspec_overrides.yaml
+++ b/pkgs/test/pubspec_overrides.yaml
@@ -1,0 +1,5 @@
+dependency_overrides:
+  test_core:
+    path: ../test_core
+  test_api:
+    path: ../test_api

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -31,9 +31,3 @@ dev_dependencies:
   lints: '>=1.0.0 <3.0.0'
   test: any
   test_core: any
-
-dependency_overrides:
-  test:
-    path: ../test
-  test_core:
-    path: ../test_core

--- a/pkgs/test_api/pubspec_overrides.yaml
+++ b/pkgs/test_api/pubspec_overrides.yaml
@@ -1,0 +1,5 @@
+dependency_overrides:
+  test:
+    path: ../test
+  test_core:
+    path: ../test_core

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -34,7 +34,3 @@ dependencies:
 
 dev_dependencies:
   lints: '>=1.0.0 <3.0.0'
-
-dependency_overrides:
-  test_api:
-    path: ../test_api

--- a/pkgs/test_core/pubspec_overrides.yaml
+++ b/pkgs/test_core/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  test_api:
+    path: ../test_api


### PR DESCRIPTION
`dart pub publish` will ignore these files, so it won't be necessary to manually change the files for each publish. `dart pub get` and `dart pub upgrade` will use the overrides from the files.