### PR TITLE
Add a withQueue utility

### DIFF
--- a/pkgs/checks/lib/checks.dart
+++ b/pkgs/checks/lib/checks.dart
@@ -3,7 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 export 'src/checks.dart' show checkThat, Check, Skip, it;
-export 'src/extensions/async.dart' show ChainAsync, FutureChecks, StreamChecks;
+export 'src/extensions/async.dart'
+    show ChainAsync, FutureChecks, StreamChecks, StreamQueueWrap;
 export 'src/extensions/core.dart'
     show BoolChecks, CoreChecks, NullabilityChecks;
 export 'src/extensions/function.dart' show ThrowsCheck;

--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -222,11 +222,13 @@ abstract class Context<T> {
   /// more spaces.
   ///
   /// If [atSameLevel] is true then [R] should be a subtype of [T], and a
-  /// returned [Extracted.value] should be the same instance as passed value.
-  /// This may be useful to refine the type for further checks. In this case the
-  /// label is used like a single line "clause" passed to [expect], and
-  /// expectations applied to the return [Check] will behave as if they were
-  /// applied to the Check for this context.
+  /// returned [Extracted.value] should be the same instance as the passed
+  /// value, or an object which is is equivalent but has a type which is more
+  /// convenient to test. In this case expectations applied to the return
+  /// [Check] will behave as if they were applied to the Check for this
+  /// context. The [label] will be used as if it were a single line "clause"
+  /// passed to [expect]. If the label is empty, the clause will be omitted. The
+  /// label should only be left empty if the value extraction cannot fail.
   Check<R> nest<R>(String label, Extracted<R> Function(T) extract,
       {bool atSameLevel = false});
 
@@ -423,7 +425,7 @@ class _TestContext<T> implements Context<T>, _ClauseDescription {
     if (atSameLevel) {
       context = _TestContext._alias(this, value);
       _aliases.add(context);
-      _clauses.add(_StringClause(() => [label]));
+      if (label.isNotEmpty) _clauses.add(_StringClause(() => [label]));
     } else {
       context = _TestContext._child(value, label, this);
       _clauses.add(context);

--- a/pkgs/checks/lib/src/extensions/async.dart
+++ b/pkgs/checks/lib/src/extensions/async.dart
@@ -174,3 +174,15 @@ extension ChainAsync<T> on Future<Check<T>> {
     await condition.applyAsync(await this);
   }
 }
+
+extension StreamQueueWrap<T> on Check<Stream<T>> {
+  /// Wrap the stream in a [StreamQueue] to allow using checks from
+  /// [StreamChecks].
+  ///
+  /// Stream expectations operate on a queue, instead of directly on the stream,
+  /// so that they can support conditional expectations and check multiple
+  /// possibilities from the same point in the stream.
+  Check<StreamQueue<T>> get withQueue =>
+      context.nest('', (actual) => Extracted.value(StreamQueue(actual)),
+          atSameLevel: true);
+}

--- a/pkgs/checks/test/extensions/async_test.dart
+++ b/pkgs/checks/test/extensions/async_test.dart
@@ -141,6 +141,12 @@ fake trace''');
       await checkThat(_futureSuccess()).completes().that(it()..equals(42));
     });
   });
+
+  group('StreamQueueWrap', () {
+    test('can wrap streams in a queue', () async {
+      await checkThat(Stream.value(1)).withQueue.emits();
+    });
+  });
 }
 
 Future<int> _futureSuccess() => Future.microtask(() => 42);


### PR DESCRIPTION
Allow an empty `label` argument to `context.nest` to indicate that no
expectation is checked and no detail is relevant to the user seeing a
failure.

Add an extension on `Check<Stream>` to wrap the stream in a queue which
allows for the interesting expectations to be checked.
