### PR TITLE
Retry instead of extend timeout for flaky Node tests

### DIFF
--- a/pkgs/test/test/runner/line_and_col_test.dart
+++ b/pkgs/test/test/runner/line_and_col_test.dart
@@ -359,7 +359,7 @@ void main() {
       );
 
       await test.shouldExit(0);
-    }, onPlatform: {'windows': Timeout.factor(2)});
+    }, onPlatform: {'windows': Retry(3)});
   });
 
   test('bundles runs by suite, deduplicates tests that match multiple times',

--- a/pkgs/test/test/runner/line_and_col_test.dart
+++ b/pkgs/test/test/runner/line_and_col_test.dart
@@ -359,7 +359,7 @@ void main() {
       );
 
       await test.shouldExit(0);
-    }, onPlatform: {'windows': Retry(3)});
+    }, retry: 3);
   });
 
   test('bundles runs by suite, deduplicates tests that match multiple times',


### PR DESCRIPTION
The timeout does not seem to have reduced the flakes. Add a retry instead.