### PR TITLE
Rename `Check` to `Subject`

### DIFF
--- a/pkgs/checks/README.md
+++ b/pkgs/checks/README.md
@@ -29,7 +29,8 @@
 
 Replace calls to `expect` with a call to `checkThat` passing the first argument.
 When a direct replacement is available, change the second argument from calling
-a function returning a Matcher, to calling the extension method on the `Check`.
+a function returning a Matcher, to calling the extension method on the
+`Subject`.
 
 When a non-matcher argument is used for the expected value, it would have been
 wrapped with `equals` automatically. See below, `.equals` may not always be the
@@ -44,6 +45,6 @@ checkThat(actual).deepEquals(expected);
 
 ## Differences in behavior from matcher
 
-- The `equals` Matcher performed a deep equality check on collections.
-  `.equals()` check will only correspond to [operator ==] so some tests may need
-  to replace `.equals()` with `.deepEquals()`. **TODO: implement `deepEquals`**
+-   The `equals` Matcher performed a deep equality check on collections.
+    `.equals()` expectation will only correspond to [operator ==] so some tests
+    may need to replace `.equals()` with `.deepEquals()`.

--- a/pkgs/checks/lib/checks.dart
+++ b/pkgs/checks/lib/checks.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'src/checks.dart' show checkThat, Check, Skip, it;
+export 'src/checks.dart' show checkThat, Subject, Skip, it;
 export 'src/extensions/async.dart'
     show ChainAsync, FutureChecks, StreamChecks, StreamQueueWrap;
 export 'src/extensions/core.dart'

--- a/pkgs/checks/lib/context.dart
+++ b/pkgs/checks/lib/context.dart
@@ -4,7 +4,7 @@
 
 export 'src/checks.dart'
     show
-        Check,
+        Subject,
         CheckFailure,
         Condition,
         Context,

--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -11,21 +11,21 @@ import 'describe.dart';
 
 /// A target for checking expectations against a value in a test.
 ///
-/// A Check my have a real value, in which case the expectations can be
+/// A subject my have a real value, in which case the expectations can be
 /// validated or rejected; or it may be a placeholder, in which case
 /// expectations describe what would be checked but cannot be rejected.
 ///
 /// Expectations are defined as extension methods specialized on the generic
 /// [T]. Expectations can use the [ContextExtension] to interact with the
-/// [Context] for this check.
-class Check<T> {
+/// [Context] for this subject.
+class Subject<T> {
   final Context<T> _context;
-  Check._(this._context);
+  Subject._(this._context);
 }
 
-extension Skip<T> on Check<T> {
-  /// Mark the currently running test as skipped and return a [Check] that will
-  /// ignore all expectations.
+extension Skip<T> on Subject<T> {
+  /// Mark the currently running test as skipped and return a [Subject] that
+  /// will ignore all expectations.
   ///
   /// Any expectations against the return value will not be checked and will not
   /// be included in the "Expected" or "Actual" string representations of a
@@ -40,13 +40,14 @@ extension Skip<T> on Check<T> {
   /// If `skip` is used in a callback passed to `softCheck` or `describe` it
   /// will still mark the test as skipped, even though failing the expectation
   /// would not have otherwise caused the test to fail.
-  Check<T> skip(String message) {
+  Subject<T> skip(String message) {
     TestHandle.current.markSkipped(message);
-    return Check._(_SkippedContext());
+    return Subject._(_SkippedContext());
   }
 }
 
-/// Creates a [Check] that can be used to validate expectations against [value].
+/// Creates a [Subject] that can be used to validate expectations against
+/// [value], with an exception upon a failed expectation.
 ///
 /// Expectations that are not satisfied throw a [TestFailure] to interrupt the
 /// currently running test and mark it as failed.
@@ -57,7 +58,8 @@ extension Skip<T> on Check<T> {
 /// ```dart
 /// checkThat(actual).equals(expected);
 /// ```
-Check<T> checkThat<T>(T value, {String? because}) => Check._(_TestContext._root(
+Subject<T> checkThat<T>(T value, {String? because}) =>
+    Subject._(_TestContext._root(
       value: _Present(value),
       // TODO - switch between "a" and "an"
       label: 'a $T',
@@ -77,7 +79,8 @@ Check<T> checkThat<T>(T value, {String? because}) => Check._(_TestContext._root(
       allowUnawaited: true,
     ));
 
-/// Checks whether [value] satisfies all expectations invoked in [condition].
+/// Checks whether [value] satisfies all expectations invoked in [condition],
+/// without throwing an exception.
 ///
 /// Returns `null` if all expectations are satisfied, otherwise returns the
 /// [CheckFailure] for the first expectation that fails.
@@ -86,7 +89,7 @@ Check<T> checkThat<T>(T value, {String? because}) => Check._(_TestContext._root(
 /// runtime error if they are used.
 CheckFailure? softCheck<T>(T value, Condition<T> condition) {
   CheckFailure? failure;
-  final check = Check<T>._(_TestContext._root(
+  final subject = Subject<T>._(_TestContext._root(
     value: _Present(value),
     fail: (f) {
       failure = f;
@@ -94,11 +97,12 @@ CheckFailure? softCheck<T>(T value, Condition<T> condition) {
     allowAsync: false,
     allowUnawaited: false,
   ));
-  condition.apply(check);
+  condition.apply(subject);
   return failure;
 }
 
-/// Checks whether [value] satisfies all expectations invoked in [condition].
+/// Checks whether [value] satisfies all expectations invoked in [condition],
+/// without throwing an exception.
 ///
 /// The future will complete to `null` if all expectations are satisfied,
 /// otherwise it will complete to the [CheckFailure] for the first expectation
@@ -108,7 +112,7 @@ CheckFailure? softCheck<T>(T value, Condition<T> condition) {
 /// [condition].
 Future<CheckFailure?> softCheckAsync<T>(T value, Condition<T> condition) async {
   CheckFailure? failure;
-  final check = Check<T>._(_TestContext._root(
+  final subject = Subject<T>._(_TestContext._root(
     value: _Present(value),
     fail: (f) {
       failure = f;
@@ -116,7 +120,7 @@ Future<CheckFailure?> softCheckAsync<T>(T value, Condition<T> condition) async {
     allowAsync: true,
     allowUnawaited: false,
   ));
-  await condition.applyAsync(check);
+  await condition.applyAsync(subject);
   return failure;
 }
 
@@ -140,7 +144,7 @@ Iterable<String> describe<T>(Condition<T> condition) {
     allowAsync: false,
     allowUnawaited: true,
   );
-  condition.apply(Check._(context));
+  condition.apply(Subject._(context));
   return context.detail(context).expected.skip(1);
 }
 
@@ -164,25 +168,25 @@ Future<Iterable<String>> describeAsync<T>(Condition<T> condition) async {
     allowAsync: true,
     allowUnawaited: true,
   );
-  await condition.applyAsync(Check._(context));
+  await condition.applyAsync(Subject._(context));
   return context.detail(context).expected.skip(1);
 }
 
 /// A set of expectations that are checked against the value when applied to a
-/// [Check].
+/// [Subject].
 abstract class Condition<T> {
-  void apply(Check<T> check);
-  Future<void> applyAsync(Check<T> check);
+  void apply(Subject<T> subject);
+  Future<void> applyAsync(Subject<T> subject);
 }
 
-ConditionCheck<T> it<T>() => ConditionCheck._();
+ConditionSubject<T> it<T>() => ConditionSubject._();
 
-extension ContextExtension<T> on Check<T> {
-  /// The expectations and nesting context for this check.
+extension ContextExtension<T> on Subject<T> {
+  /// The expectations and nesting context for this subject.
   Context<T> get context => _context;
 }
 
-/// The expectation and nesting context already applied to a [Check].
+/// The expectation and nesting context already applied to a [Subject].
 ///
 /// This is the surface of interaction for expectation extension method
 /// implementations.
@@ -231,9 +235,9 @@ abstract class Context<T> {
   /// listening for the event, there is no way to complete a returned future and
   /// consider the check "complete".
   ///
-  /// May not be used from the context for a [Check] created by [softCheck] or
+  /// May not be used from the context for a [Subject] created by [softCheck] or
   /// [softCheckAsync]. The only useful effect of a late rejection is to throw a
-  /// [TestFailure] when used with a [checkThat] check. Most conditions should
+  /// [TestFailure] when used with a [checkThat] subject. Most conditions should
   /// prefer to use [expect] or [expectAsync].
   void expectUnawaited(Iterable<String> Function() clause,
       void Function(T, void Function(Rejection)) predicate);
@@ -245,18 +249,18 @@ abstract class Context<T> {
   /// an [Extracted.value].
   ///
   /// The [label] will be used preceding "that:" in a description. Expectations
-  /// applied to the returned [Check] will follow the label, indented by two
+  /// applied to the returned [Subject] will follow the label, indented by two
   /// more spaces.
   ///
   /// If [atSameLevel] is true then [R] should be a subtype of [T], and a
   /// returned [Extracted.value] should be the same instance as the passed
   /// value, or an object which is is equivalent but has a type which is more
   /// convenient to test. In this case expectations applied to the return
-  /// [Check] will behave as if they were applied to the Check for this
+  /// [Subject] will behave as if they were applied to the subject for this
   /// context. The [label] will be used as if it were a single line "clause"
   /// passed to [expect]. If the label is empty, the clause will be omitted. The
   /// label should only be left empty if the value extraction cannot fail.
-  Check<R> nest<R>(String label, Extracted<R> Function(T) extract,
+  Subject<R> nest<R>(String label, Extracted<R> Function(T) extract,
       {bool atSameLevel = false});
 
   /// Extract an asynchronous property from the value for further checking.
@@ -266,13 +270,13 @@ abstract class Context<T> {
   /// an [Extracted.value].
   ///
   /// The [label] will be used preceding "that:" in a description. Expectations
-  /// applied to the returned [Check] will follow the label, indented by two
+  /// applied to the returned [Subject] will follow the label, indented by two
   /// more spaces.
   ///
   /// Some context may disallow asynchronous expectations, for instance in
   /// [softCheck] which must synchronously check the value. In those contexts
   /// this method will throw.
-  Future<Check<R>> nestAsync<R>(
+  Future<Subject<R>> nestAsync<R>(
       String label, FutureOr<Extracted<R>> Function(T) extract);
 }
 
@@ -415,7 +419,7 @@ class _TestContext<T> implements Context<T>, _ClauseDescription {
       FutureOr<Rejection?> Function(T) predicate) async {
     if (!_allowAsync) {
       throw StateError(
-          'Async expectations cannot be used in a synchronous check');
+          'Async expectations cannot be used on a synchronous subject');
     }
     _clauses.add(_StringClause(clause));
     final outstandingWork = TestHandle.current.markPending();
@@ -439,7 +443,7 @@ class _TestContext<T> implements Context<T>, _ClauseDescription {
   }
 
   @override
-  Check<R> nest<R>(String label, Extracted<R> Function(T) extract,
+  Subject<R> nest<R>(String label, Extracted<R> Function(T) extract,
       {bool atSameLevel = false}) {
     final result = _value.map((actual) => extract(actual)._fillActual(actual));
     final rejection = result.rejection;
@@ -457,15 +461,15 @@ class _TestContext<T> implements Context<T>, _ClauseDescription {
       context = _TestContext._child(value, label, this);
       _clauses.add(context);
     }
-    return Check._(context);
+    return Subject._(context);
   }
 
   @override
-  Future<Check<R>> nestAsync<R>(
+  Future<Subject<R>> nestAsync<R>(
       String label, FutureOr<Extracted<R>> Function(T) extract) async {
     if (!_allowAsync) {
       throw StateError(
-          'Async expectations cannot be used in a synchronous check');
+          'Async expectations cannot be used on a synchronous subject');
     }
     final outstandingWork = TestHandle.current.markPending();
     final result = await _value.mapAsync(
@@ -479,7 +483,7 @@ class _TestContext<T> implements Context<T>, _ClauseDescription {
     final value = result.value ?? _Absent<R>();
     final context = _TestContext<R>._child(value, label, this);
     _clauses.add(context);
-    return Check._(context);
+    return Subject._(context);
   }
 
   CheckFailure _failure(Rejection rejection) =>
@@ -545,15 +549,15 @@ class _SkippedContext<T> implements Context<T> {
   }
 
   @override
-  Check<R> nest<R>(String label, Extracted<R> Function(T p1) extract,
+  Subject<R> nest<R>(String label, Extracted<R> Function(T p1) extract,
       {bool atSameLevel = false}) {
-    return Check._(_SkippedContext());
+    return Subject._(_SkippedContext());
   }
 
   @override
-  Future<Check<R>> nestAsync<R>(
+  Future<Subject<R>> nestAsync<R>(
       String label, FutureOr<Extracted<R>> Function(T p1) extract) async {
-    return Check._(_SkippedContext());
+    return Subject._(_SkippedContext());
   }
 }
 
@@ -569,17 +573,17 @@ class _StringClause implements _ClauseDescription {
       FailureDetail(_expected(), -1, -1);
 }
 
-/// The result of a Check which is rejected by some expectation.
+/// The result an expectation that failed for a subject..
 class CheckFailure {
-  /// The specific rejected value within the overall check that caused the
+  /// The specific rejected value within the overall subject that caused the
   /// failure.
   ///
   /// The [Rejection.actual] may be a property derived from the value at the
-  /// root of the check, for instance a field or an element in a collection.
+  /// root of the subject, for instance a field or an element in a collection.
   final Rejection rejection;
 
-  /// The context within the overall check where an expectation resulted in the
-  /// [rejection].
+  /// The context within the overall subject where an expectation resulted in
+  /// the [rejection].
   late final FailureDetail detail = _readDetail();
 
   final FailureDetail Function() _readDetail;
@@ -587,19 +591,18 @@ class CheckFailure {
   CheckFailure(this.rejection, this._readDetail);
 }
 
-/// The context of a Check that failed.
+/// The context for a failed expectation.
 ///
-/// A check may have some number of succeeding expectations, and the failure may
+/// A subject may have some number of succeeding expectations, and the failure may
 /// be for an expectation against a property derived from the value at the root
-/// of the check. For example, in `checkThat([]).length.equals(1)` the specific
-/// value that gets rejected is `0` from the length of the list, and the `Check`
-/// that sees the rejection is nested with the label "has length".
+/// of the subject. For example, in `checkThat([]).length.equals(1)` the
+/// specific value that gets rejected is `0` from the length of the list, and
+/// the subject that sees the rejection is nested with the label "has length".
 class FailureDetail {
-  /// A description of all the conditions the checked value was expected to
-  /// satisfy.
+  /// A description of all the conditions the subject was expected to satisfy.
   ///
-  /// Each Check has a label. At the root the label is typically "a <Type>" and
-  /// nested conditions get a label based on the condition which extracted a
+  /// Each subject has a label. At the root the label is typically "a <Type>"
+  /// and nested subjects get a label based on the condition which extracted a
   /// property for further checks. Each level of nesting is described as
   /// "<label> that:" followed by an indented list of the expectations for that
   /// property.
@@ -614,13 +617,13 @@ class FailureDetail {
   /// A description of the conditions the checked value satisfied.
   ///
   /// Matches the format of [expected], except it will be cut off after the
-  /// label for the check that had a failing expectation. For example, if the
+  /// label for the subject that had a failing expectation. For example, if the
   /// equality check for the length of a list fails:
   ///
   ///   a List that:
   ///     has length that:
   ///
-  /// If the check with a failing expectation is the root, returns an empty
+  /// If the subject with a failing expectation is the root, returns an empty
   /// list. Instead the "Actual: " value from the rejection can be used without
   /// indentation.
   Iterable<String> get actual =>
@@ -629,16 +632,17 @@ class FailureDetail {
   /// The number of lines from [expected] which describe conditions that were
   /// successful.
   ///
-  /// A check which fails due to a derived property may have some number of
-  /// expectations that were checked and satisfied. This field indicates how
-  /// many lines of expectations were successful.
+  /// A failed expectation on a derived property may have some number of
+  /// expectations that were checked and satisfied starting from the root
+  /// subject. This field indicates how many lines of expectations were
+  /// successful.
   final int _actualOverlap;
 
-  /// The number of times the failing check was nested from the root check.
+  /// The number of times the failing subject was nested from the root subject.
   ///
   /// Indicates how far the "Actual: " and "Which: " lines from the [Rejection]
   /// should be indented so that they are at the same level of indentation as
-  /// the label for the check where the expectation failed.
+  /// the label for the subject where the expectation failed.
   ///
   /// For example, if a `List` is expected to and have a certain length
   /// [expected] may be:
@@ -697,17 +701,17 @@ class Rejection {
   Rejection({this.actual = const [], this.which});
 }
 
-class ConditionCheck<T> implements Check<T>, Condition<T> {
-  ConditionCheck._();
+class ConditionSubject<T> implements Subject<T>, Condition<T> {
+  ConditionSubject._();
 
   @override
-  void apply(Check<T> check) {
-    _context.apply(check);
+  void apply(Subject<T> subject) {
+    _context.apply(subject);
   }
 
   @override
-  Future<void> applyAsync(Check<T> check) async {
-    await _context.applyAsync(check);
+  Future<void> applyAsync(Subject<T> subject) async {
+    await _context.applyAsync(subject);
   }
 
   @override
@@ -722,16 +726,16 @@ class _ReplayContext<T> implements Context<T>, Condition<T> {
   final _interactions = <FutureOr<void> Function(Context<T>)>[];
 
   @override
-  void apply(Check<T> check) {
+  void apply(Subject<T> subject) {
     for (var interaction in _interactions) {
-      interaction(check.context);
+      interaction(subject.context);
     }
   }
 
   @override
-  Future<void> applyAsync(Check<T> check) async {
+  Future<void> applyAsync(Subject<T> subject) async {
     for (var interaction in _interactions) {
-      await interaction(check.context);
+      await interaction(subject.context);
     }
   }
 
@@ -760,24 +764,24 @@ class _ReplayContext<T> implements Context<T>, Condition<T> {
   }
 
   @override
-  Check<R> nest<R>(String label, Extracted<R> Function(T p1) extract,
+  Subject<R> nest<R>(String label, Extracted<R> Function(T p1) extract,
       {bool atSameLevel = false}) {
     final nestedContext = _ReplayContext<R>();
     _interactions.add((c) {
       var result = c.nest(label, extract, atSameLevel: atSameLevel);
       nestedContext.apply(result);
     });
-    return Check._(nestedContext);
+    return Subject._(nestedContext);
   }
 
   @override
-  Future<Check<R>> nestAsync<R>(
+  Future<Subject<R>> nestAsync<R>(
       String label, FutureOr<Extracted<R>> Function(T) extract) async {
     final nestedContext = _ReplayContext<R>();
     _interactions.add((c) async {
       var result = await c.nestAsync(label, extract);
       await nestedContext.applyAsync(result);
     });
-    return Check._(nestedContext);
+    return Subject._(nestedContext);
   }
 }

--- a/pkgs/checks/lib/src/extensions/async.dart
+++ b/pkgs/checks/lib/src/extensions/async.dart
@@ -8,14 +8,14 @@ import 'dart:convert';
 import 'package:async/async.dart';
 import 'package:checks/context.dart';
 
-extension FutureChecks<T> on Check<Future<T>> {
+extension FutureChecks<T> on Subject<Future<T>> {
   /// Expects that the `Future` completes to a value without throwing.
   ///
-  /// Returns a future that completes to a [Check<T>] on the result once the
+  /// Returns a future that completes to a [Subject] on the result once the
   /// future completes.
   ///
   /// Fails if the future completes as an error.
-  Future<Check<T>> completes() =>
+  Future<Subject<T>> completes() =>
       context.nestAsync<T>('completes to a value', (actual) async {
         try {
           return Extracted.value(await actual);
@@ -53,11 +53,11 @@ extension FutureChecks<T> on Check<Future<T>> {
 
   /// Expects that the `Future` completes as an error.
   ///
-  /// Returns a future that completes to a [Check<E>] on the error once the
+  /// Returns a future that completes to a [Subject] on the error once the
   /// future completes as an error.
   ///
   /// Fails if the future completes to a value.
-  Future<Check<E>> throws<E extends Object>() => context.nestAsync<E>(
+  Future<Subject<E>> throws<E extends Object>() => context.nestAsync<E>(
           'completes to an error${E == Object ? '' : ' of type $E'}',
           (actual) async {
         try {
@@ -78,7 +78,7 @@ extension FutureChecks<T> on Check<Future<T>> {
 ///
 /// Streams should be wrapped in user test code so that any reuse of the same
 /// Stream, and the full stream lifecycle, is explicit.
-extension StreamChecks<T> on Check<StreamQueue<T>> {
+extension StreamChecks<T> on Subject<StreamQueue<T>> {
   /// Calls [Context.expectAsync] and wraps [predicate] with a transaction.
   ///
   /// The transaction is committed if the check passes, or rejected if it fails.
@@ -98,12 +98,12 @@ extension StreamChecks<T> on Check<StreamQueue<T>> {
 
   /// Expect that the `Stream` emits a value without first emitting an error.
   ///
-  /// Returns a `Future` that completes to a [Check<T>] on the next event
-  /// emitted by the stream.
+  /// Returns a `Future` that completes to a [Subject] on the next event emitted
+  /// by the stream.
   ///
   /// Fails if the stream emits an error instead of a value, or closes without
   /// emitting a value.
-  Future<Check<T>> emits() =>
+  Future<Subject<T>> emits() =>
       context.nestAsync<T>('emits a value', (actual) async {
         if (!await actual.hasNext) {
           return Extracted.rejection(
@@ -122,7 +122,7 @@ extension StreamChecks<T> on Check<StreamQueue<T>> {
 
   /// Expects that the stream emits an error of type [E].
   ///
-  /// Returns a [Check] on the error's value.
+  /// Returns a [Subject] on the error's value.
   ///
   /// Fails if the stream emits any value.
   /// Fails if the stream emits an error with an incorrect type.
@@ -131,7 +131,7 @@ extension StreamChecks<T> on Check<StreamQueue<T>> {
   /// If this expectation fails, the source queue will be left in it's original
   /// state.
   /// If this expectation succeeds, consumes the error event.
-  Future<Check<E>> emitsError<E extends Object>() =>
+  Future<Subject<E>> emitsError<E extends Object>() =>
       context.nestAsync('emits an error${E == Object ? '' : ' of type $E'}',
           (actual) async {
         if (!await actual.hasNext) {
@@ -424,11 +424,11 @@ extension StreamChecks<T> on Check<StreamQueue<T>> {
   }
 }
 
-extension ChainAsync<T> on Future<Check<T>> {
+extension ChainAsync<T> on Future<Subject<T>> {
   /// Checks the expectations in [condition] against the result of this
   /// `Future`.
   ///
-  /// Extensions written on [Check] cannot be invoked on [Future<Check>]. This
+  /// Extensions written on [Subject] cannot be invoked on [Future<Check>]. This
   /// method allows adding expectations for the value without awaiting it.
   ///
   /// ```dart
@@ -441,14 +441,14 @@ extension ChainAsync<T> on Future<Check<T>> {
   }
 }
 
-extension StreamQueueWrap<T> on Check<Stream<T>> {
+extension StreamQueueWrap<T> on Subject<Stream<T>> {
   /// Wrap the stream in a [StreamQueue] to allow using checks from
   /// [StreamChecks].
   ///
   /// Stream expectations operate on a queue, instead of directly on the stream,
   /// so that they can support conditional expectations and check multiple
   /// possibilities from the same point in the stream.
-  Check<StreamQueue<T>> get withQueue =>
+  Subject<StreamQueue<T>> get withQueue =>
       context.nest('', (actual) => Extracted.value(StreamQueue(actual)),
           atSameLevel: true);
 }

--- a/pkgs/checks/lib/src/extensions/core.dart
+++ b/pkgs/checks/lib/src/extensions/core.dart
@@ -4,12 +4,12 @@
 
 import 'package:checks/context.dart';
 
-extension CoreChecks<T> on Check<T> {
+extension CoreChecks<T> on Subject<T> {
   /// Extracts a property of the value for further expectations.
   ///
   /// Sets up a clause that the value "has [name] that:" followed by any
-  /// expectations applied to the returned [Check].
-  Check<R> has<R>(R Function(T) extract, String name) {
+  /// expectations applied to the returned [Subject].
+  Subject<R> has<R>(R Function(T) extract, String name) {
     return context.nest('has $name', (T value) {
       try {
         return Extracted.value(extract(value));
@@ -20,11 +20,11 @@ extension CoreChecks<T> on Check<T> {
     });
   }
 
-  /// Checks the expectations invoked in [condition] against this value.
+  /// Applies the expectations invoked in [condition] to this subject.
   ///
   /// Use this method when it would otherwise not be possible to check multiple
-  /// properties of this value due to cascade notation already being used in a
-  /// way that would conflict.
+  /// expectations for this subject due to cascade notation already being used
+  /// in a way that would conflict.
   ///
   /// ```
   /// checkThat(something)
@@ -68,8 +68,8 @@ extension CoreChecks<T> on Check<T> {
 
   /// Expects that the value is assignable to type [T].
   ///
-  /// If the value is a [T], returns a [Check<T>] for further expectations.
-  Check<R> isA<R>() {
+  /// If the value is a [T], returns a [Subject] for further expectations.
+  Subject<R> isA<R>() {
     return context.nest<R>('is a $R', (actual) {
       if (actual is! R) {
         return Extracted.rejection(which: ['Is a ${actual.runtimeType}']);
@@ -96,7 +96,7 @@ extension CoreChecks<T> on Check<T> {
   }
 }
 
-extension BoolChecks on Check<bool> {
+extension BoolChecks on Subject<bool> {
   void isTrue() {
     context.expect(
       () => ['is true'],
@@ -116,8 +116,8 @@ extension BoolChecks on Check<bool> {
   }
 }
 
-extension NullabilityChecks<T> on Check<T?> {
-  Check<T> isNotNull() {
+extension NullabilityChecks<T> on Subject<T?> {
+  Subject<T> isNotNull() {
     return context.nest<T>('is not null', (actual) {
       if (actual == null) return Extracted.rejection();
       return Extracted.value(actual);

--- a/pkgs/checks/lib/src/extensions/function.dart
+++ b/pkgs/checks/lib/src/extensions/function.dart
@@ -4,11 +4,11 @@
 
 import 'package:checks/context.dart';
 
-extension ThrowsCheck<T> on Check<T Function()> {
+extension ThrowsCheck<T> on Subject<T Function()> {
   /// Expects that a function throws synchronously when it is called.
   ///
   /// If the function synchronously throws a value of type [E], return a
-  /// [Check<E>] to check further expectations on the error.
+  /// [Subject] to check further expectations on the error.
   ///
   /// If the function does not throw synchronously, or if it throws an error
   /// that is not of type [E], this expectation will fail.
@@ -16,7 +16,7 @@ extension ThrowsCheck<T> on Check<T Function()> {
   /// If this function is async and returns a [Future], this expectation will
   /// fail. Instead invoke the function and check the expectation on the
   /// returned [Future].
-  Check<E> throws<E>() {
+  Subject<E> throws<E>() {
     return context.nest<E>('throws an error of type $E', (actual) {
       try {
         final result = actual();
@@ -35,11 +35,11 @@ extension ThrowsCheck<T> on Check<T Function()> {
 
   /// Expects that the function returns without throwing.
   ///
-  /// If the function runs without exception, return a [Check<T>] to check
+  /// If the function runs without exception, return a [Subject] to check
   /// further expecations on the returned value.
   ///
   /// If the function throws synchronously, this expectation will fail.
-  Check<T> returnsNormally() {
+  Subject<T> returnsNormally() {
     return context.nest<T>('returns a value', (actual) {
       try {
         return Extracted.value(actual());

--- a/pkgs/checks/lib/src/extensions/iterable.dart
+++ b/pkgs/checks/lib/src/extensions/iterable.dart
@@ -7,11 +7,11 @@ import 'package:checks/context.dart';
 import '../collection_equality.dart';
 import 'core.dart';
 
-extension IterableChecks<T> on Check<Iterable<T>> {
-  Check<int> get length => has((l) => l.length, 'length');
-  Check<T> get first => has((l) => l.first, 'first element');
-  Check<T> get last => has((l) => l.last, 'last element');
-  Check<T> get single => has((l) => l.single, 'single element');
+extension IterableChecks<T> on Subject<Iterable<T>> {
+  Subject<int> get length => has((l) => l.length, 'length');
+  Subject<T> get first => has((l) => l.first, 'first element');
+  Subject<T> get last => has((l) => l.last, 'last element');
+  Subject<T> get single => has((l) => l.single, 'single element');
 
   void isEmpty() {
     context.expect(() => const ['is empty'], (actual) {
@@ -62,7 +62,7 @@ extension IterableChecks<T> on Check<Iterable<T>> {
   /// Expects there are no elements in the iterable which fail to satisfy
   /// [elementCondition].
   ///
-  /// Empty iterables will pass always pass this check.
+  /// Empty iterables will pass always pass this expectation.
   void every(Condition<T> elementCondition) {
     context.expect(() {
       final conditionDescription = describe(elementCondition);

--- a/pkgs/checks/lib/src/extensions/map.dart
+++ b/pkgs/checks/lib/src/extensions/map.dart
@@ -7,13 +7,13 @@ import 'package:checks/context.dart';
 import '../collection_equality.dart';
 import 'core.dart';
 
-extension MapChecks<K, V> on Check<Map<K, V>> {
-  Check<Iterable<MapEntry<K, V>>> get entries =>
+extension MapChecks<K, V> on Subject<Map<K, V>> {
+  Subject<Iterable<MapEntry<K, V>>> get entries =>
       has((m) => m.entries, 'entries');
-  Check<Iterable<K>> get keys => has((m) => m.keys, 'keys');
-  Check<Iterable<V>> get values => has((m) => m.values, 'values');
-  Check<int> get length => has((m) => m.length, 'length');
-  Check<V> operator [](K key) {
+  Subject<Iterable<K>> get keys => has((m) => m.keys, 'keys');
+  Subject<Iterable<V>> get values => has((m) => m.values, 'values');
+  Subject<int> get length => has((m) => m.length, 'length');
+  Subject<V> operator [](K key) {
     final keyString = literal(key).join(r'\n');
     return context.nest('contains a value for $keyString', (actual) {
       if (!actual.containsKey(key)) {

--- a/pkgs/checks/lib/src/extensions/math.dart
+++ b/pkgs/checks/lib/src/extensions/math.dart
@@ -4,7 +4,7 @@
 
 import 'package:checks/context.dart';
 
-extension NumChecks on Check<num> {
+extension NumChecks on Subject<num> {
   /// Expects that this number is greater than [other].
   void isGreaterThan(num other) {
     context.expect(() => ['is greater than <$other>'], (actual) {

--- a/pkgs/checks/lib/src/extensions/string.dart
+++ b/pkgs/checks/lib/src/extensions/string.dart
@@ -8,7 +8,7 @@ import 'package:checks/context.dart';
 
 import 'core.dart';
 
-extension StringChecks on Check<String> {
+extension StringChecks on Subject<String> {
   /// Expects that the value contains [pattern] according to [String.contains];
   void contains(Pattern pattern) {
     context.expect(() => prefixFirst('contains ', literal(pattern)), (actual) {
@@ -19,7 +19,7 @@ extension StringChecks on Check<String> {
     });
   }
 
-  Check<int> get length => has((m) => m.length, 'length');
+  Subject<int> get length => has((m) => m.length, 'length');
 
   void isEmpty() {
     context.expect(() => const ['is empty'], (actual) {

--- a/pkgs/checks/pubspec.yaml
+++ b/pkgs/checks/pubspec.yaml
@@ -10,3 +10,4 @@ dependencies:
 
 dev_dependencies:
   test: ^1.21.3
+  lints: ^2.0.0

--- a/pkgs/checks/pubspec.yaml
+++ b/pkgs/checks/pubspec.yaml
@@ -10,4 +10,3 @@ dependencies:
 
 dev_dependencies:
   test: ^1.21.3
-  lints: ^2.0.0

--- a/pkgs/checks/test/failure_message_test.dart
+++ b/pkgs/checks/test/failure_message_test.dart
@@ -47,7 +47,7 @@ Actual: a List<dynamic> that:
   });
 }
 
-extension on Check<void Function()> {
-  Check<String> throwsFailure() =>
+extension on Subject<void Function()> {
+  Subject<String> throwsFailure() =>
       throws<TestFailure>().has((f) => f.message, 'message').isNotNull();
 }

--- a/pkgs/checks/test/test_shared.dart
+++ b/pkgs/checks/test/test_shared.dart
@@ -5,7 +5,7 @@
 import 'package:checks/checks.dart';
 import 'package:checks/context.dart';
 
-extension RejectionChecks<T> on Check<T> {
+extension RejectionChecks<T> on Subject<T> {
   void isRejectedBy(Condition<T> condition,
       {Iterable<String>? actual, Iterable<String>? which}) {
     late T actualValue;
@@ -74,10 +74,10 @@ extension RejectionChecks<T> on Check<T> {
   }
 }
 
-extension ConditionChecks<T> on Check<Condition<T>> {
-  Check<Iterable<String>> get description =>
+extension ConditionChecks<T> on Subject<Condition<T>> {
+  Subject<Iterable<String>> get description =>
       has((c) => describe<T>(c), 'description');
-  Future<Check<Iterable<String>>> get asyncDescription async =>
+  Future<Subject<Iterable<String>>> get asyncDescription async =>
       context.nestAsync(
           'has description',
           (condition) async =>


### PR DESCRIPTION
The word "check" is a bit overused in the documentation, and it's a
little confusing to use it as a noun. "Subject" is unambiguously a noun,
and it makes the docs read nicer in some places.
