### PR TITLE
Rename checkThat to check

### DIFF
--- a/pkgs/checks/CHANGELOG.md
+++ b/pkgs/checks/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.0
+
+-  **Breaking** `checkThat` renamed to `check`.
+
 # 0.1.0
 
 -   Initial release.

--- a/pkgs/checks/CHANGELOG.md
+++ b/pkgs/checks/CHANGELOG.md
@@ -3,7 +3,7 @@
 -   **Breaking** `checkThat` renamed to `check`.
 -   Added an example.
 -   Include a stack trace in the failure description for unexpected errors from
-    Futures or Streams. >>>>>>> master
+    Futures or Streams.
 
 # 0.1.0
 

--- a/pkgs/checks/README.md
+++ b/pkgs/checks/README.md
@@ -1,14 +1,14 @@
 # Checking expectations with `checks`
 
-Expectations start with `checkThat`. This utility returns a `Subject`, and
+Expectations start with `check`. This utility returns a `Subject`, and
 expectations can be checked against the subject. Expectations are defined as
 extension methods, and different expectations will be available for subjects
 with different value types.
 
 ```dart
-checkThat(someValue).equals(expectedValue);
-checkThat(someList).deepEquals(expectedList);
-checkThat(someString).contains('expected pattern');
+check(someValue).equals(expectedValue);
+check(someList).deepEquals(expectedList);
+check(someString).contains('expected pattern');
 ```
 
 Multiple expectations can be checked against the same value using cascade
@@ -16,7 +16,7 @@ syntax. When multiple expectations are checked against a single value, a failure
 will included descriptions of the expectations that already passed.
 
 ```dart
-checkThat(someString)
+check(someString)
   ..startsWith('a')
   ..endsWith('z')
   ..contains('lmno');
@@ -26,15 +26,15 @@ Some expectations return a `Subject` for another value derived from the original
 value - for instance reading a field or awaiting the result of a Future.
 
 ```dart
-checkThat(someString).length.equals(expectedLength);
-(await checkThat(someFuture).completes()).equals(expectedCompletion);
+check(someString).length.equals(expectedLength);
+(await check(someFuture).completes()).equals(expectedCompletion);
 ```
 
 Fields can be extracted from objects for checking further properties with the
 `has` utility.
 
 ```dart
-checkThat(someValue)
+check(someValue)
   .has((value) => value.property, 'property')
   .equals(expectedPropertyValue);
 ```
@@ -47,7 +47,7 @@ value as a subject will be recorded and replayed when it is applied as a
 condition. The `it()` utility returns a `ConditionSubject`.
 
 ```dart
-checkThat(someList).any(it()..isGreaterThan(0));
+check(someList).any(it()..isGreaterThan(0));
 ```
 
 Some complicated checks may be difficult to write with parenthesized awaited
@@ -55,14 +55,14 @@ expressions, or impossible to write with cascade syntax. There are `which`
 utilities for both use cases which take a `Condition`.
 
 ```dart
-checkThat(someString)
+check(someString)
   ..startsWith('a')
   // A cascade would not be possible on `length`
   ..length.which(it()
     ..isGreatherThan(10)
     ..isLessThan(100));
 
-await checkThat(someFuture)
+await check(someFuture)
     .completes()
     .which(it()..equals(expectedCompletion));
 ```
@@ -126,7 +126,7 @@ extension CustomChecks on Subject<CustomType> {
 
 # Migrating from Matchers
 
-Replace calls to `expect` with a call to `checkThat` passing the first argument.
+Replace calls to `expect` with a call to `check` passing the first argument.
 When a direct replacement is available, change the second argument from calling
 a function returning a Matcher, to calling the extension method on the
 `Subject`.
@@ -137,9 +137,9 @@ correct replacement in `package:checks`.
 
 ```dart
 expect(actual, expected);
-checkThat(actual).equals(expected);
+check(actual).equals(expected);
 // or maybe
-checkThat(actual).deepEquals(expected);
+check(actual).deepEquals(expected);
 ```
 
 ## Differences in behavior from matcher

--- a/pkgs/checks/example/example.dart
+++ b/pkgs/checks/example/example.dart
@@ -8,14 +8,14 @@ import 'package:test/scaffolding.dart';
 void main() {
   test('sample test', () {
     final someValue = 5;
-    checkThat(someValue).equals(5);
+    check(someValue).equals(5);
 
     final someList = [1, 2, 3, 4, 5];
-    checkThat(someList).deepEquals([1, 2, 3, 4, 5]);
+    check(someList).deepEquals([1, 2, 3, 4, 5]);
 
     final someString = 'abcdefghijklmnopqrstuvwxyz';
 
-    checkThat(someString)
+    check(someString)
       ..startsWith('a')
       ..endsWith('z')
       ..contains('lmno');

--- a/pkgs/checks/lib/checks.dart
+++ b/pkgs/checks/lib/checks.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'src/checks.dart' show checkThat, Subject, Skip, it;
+export 'src/checks.dart' show check, Subject, Skip, it;
 export 'src/extensions/async.dart'
     show ChainAsync, FutureChecks, StreamChecks, StreamQueueWrap;
 export 'src/extensions/core.dart'

--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -32,7 +32,7 @@ extension Skip<T> on Subject<T> {
   /// failure.
   ///
   /// ```dart
-  /// checkThat(actual)
+  /// check(actual)
   ///     ..stillChecked()
   ///     ..skip('reason the expectation is temporarily not met').notChecked();
   /// ```
@@ -56,10 +56,9 @@ extension Skip<T> on Subject<T> {
 /// messages.
 ///
 /// ```dart
-/// checkThat(actual).equals(expected);
+/// check(actual).equals(expected);
 /// ```
-Subject<T> checkThat<T>(T value, {String? because}) =>
-    Subject._(_TestContext._root(
+Subject<T> check<T>(T value, {String? because}) => Subject._(_TestContext._root(
       value: _Present(value),
       // TODO - switch between "a" and "an"
       label: 'a $T',
@@ -237,7 +236,7 @@ abstract class Context<T> {
   ///
   /// May not be used from the context for a [Subject] created by [softCheck] or
   /// [softCheckAsync]. The only useful effect of a late rejection is to throw a
-  /// [TestFailure] when used with a [checkThat] subject. Most conditions should
+  /// [TestFailure] when used with a [check] subject. Most conditions should
   /// prefer to use [expect] or [expectAsync].
   void expectUnawaited(Iterable<String> Function() clause,
       void Function(T, void Function(Rejection)) predicate);
@@ -595,7 +594,7 @@ class CheckFailure {
 ///
 /// A subject may have some number of succeeding expectations, and the failure may
 /// be for an expectation against a property derived from the value at the root
-/// of the subject. For example, in `checkThat([]).length.equals(1)` the
+/// of the subject. For example, in `check([]).length.equals(1)` the
 /// specific value that gets rejected is `0` from the length of the list, and
 /// the subject that sees the rejection is nested with the label "has length".
 class FailureDetail {

--- a/pkgs/checks/lib/src/extensions/async.dart
+++ b/pkgs/checks/lib/src/extensions/async.dart
@@ -193,7 +193,7 @@ extension StreamChecks<T> on Subject<StreamQueue<T>> {
   /// conditions.
   ///
   /// ```dart
-  /// await checkThat(StreamQueue(someStream)).inOrder([
+  /// await check(StreamQueue(someStream)).inOrder([
   ///   it()..emits().that(it()..equals(0)),
   ///   it()..emits().that(it()..equals(1)),
   //  ]);
@@ -433,9 +433,9 @@ extension ChainAsync<T> on Future<Subject<T>> {
   /// expression that would need parenthesis.
   ///
   /// ```dart
-  /// await checkThat(someFuture).completes().which(it()..equals('expected'));
+  /// await check(someFuture).completes().which(it()..equals('expected'));
   /// // or, with the intermediate `await`:
-  /// (await checkThat(someFuture).completes()).equals('expected');
+  /// (await check(someFuture).completes()).equals('expected');
   /// ```
   Future<void> which(Condition<T> condition) async {
     await condition.applyAsync(await this);

--- a/pkgs/checks/lib/src/extensions/core.dart
+++ b/pkgs/checks/lib/src/extensions/core.dart
@@ -27,7 +27,7 @@ extension CoreChecks<T> on Subject<T> {
   /// in a way that would conflict.
   ///
   /// ```
-  /// checkThat(something)
+  /// check(something)
   ///   ..has((s) => s.foo, 'foo').equals(expectedFoo)
   ///   ..has((s) => s.bar, 'bar').which(it()
   ///     ..isLessThan(10)

--- a/pkgs/checks/lib/src/extensions/iterable.dart
+++ b/pkgs/checks/lib/src/extensions/iterable.dart
@@ -47,7 +47,7 @@ extension IterableChecks<T> on Subject<Iterable<T>> {
   /// For example, the following will succeed:
   ///
   /// ```dart
-  /// checkThat([1, 0, 2, 0, 3]).containsInOrder([1, 2, 3]);
+  /// check([1, 0, 2, 0, 3]).containsInOrder([1, 2, 3]);
   /// ```
   ///
   /// Values in [elements] may be a `T`, a `Condition<T>`, or a
@@ -57,7 +57,7 @@ extension IterableChecks<T> on Subject<Iterable<T>> {
   /// equality operator.
   ///
   /// ```dart
-  /// checkThat([1, 0, 2, 0, 3])
+  /// check([1, 0, 2, 0, 3])
   ///   .containsInOrder([1, it<int>()..isGreaterThan(1), 3]);
   /// ```
   void containsInOrder(Iterable<Object?> elements) {

--- a/pkgs/checks/lib/src/extensions/string.dart
+++ b/pkgs/checks/lib/src/extensions/string.dart
@@ -73,7 +73,7 @@ extension StringChecks on Subject<String> {
   ///
   /// For example, the following will succeed:
   ///
-  ///     checkThat('abcdefg').containsInOrder(['a','e']);
+  ///     check('abcdefg').containsInOrder(['a','e']);
   void containsInOrder(Iterable<String> expected) {
     context.expect(() => prefixFirst('contains, in order: ', literal(expected)),
         (actual) {
@@ -118,12 +118,12 @@ extension StringChecks on Subject<String> {
   ///
   /// For example the following will succeed:
   ///
-  ///     checkThat(' hello   world ').equalsIgnoringWhitespace('hello world');
+  ///     check(' hello   world ').equalsIgnoringWhitespace('hello world');
   ///
   /// While the following will fail:
   ///
-  ///     checkThat('helloworld').equalsIgnoringWhitespace('hello world');
-  ///     checkThat('he llo world').equalsIgnoringWhitespace('hello world');
+  ///     check('helloworld').equalsIgnoringWhitespace('hello world');
+  ///     check('he llo world').equalsIgnoringWhitespace('hello world');
   void equalsIgnoringWhitespace(String expected) {
     context.expect(
         () => prefixFirst('equals ignoring whitespace ', literal(expected)),

--- a/pkgs/checks/pubspec.yaml
+++ b/pkgs/checks/pubspec.yaml
@@ -1,5 +1,5 @@
 name: checks
-version: 0.1.0
+version: 0.2.0
 description: >-
   A framework for checking values against expectations and building custom
   expectations.

--- a/pkgs/checks/test/describe_test.dart
+++ b/pkgs/checks/test/describe_test.dart
@@ -9,13 +9,13 @@ import 'package:test/scaffolding.dart';
 void main() {
   group('describe', () {
     test('succeeds for empty conditions', () {
-      checkThat(describe(it())).isEmpty();
+      check(describe(it())).isEmpty();
     });
     test('includes condition clauses', () {
-      checkThat(describe(it()..equals(1))).deepEquals(['  equals <1>']);
+      check(describe(it()..equals(1))).deepEquals(['  equals <1>']);
     });
     test('includes nested clauses', () {
-      checkThat(describe(it<String>()..length.equals(1))).deepEquals([
+      check(describe(it<String>()..length.equals(1))).deepEquals([
         '  has length that:',
         '    equals <1>',
       ]);

--- a/pkgs/checks/test/extensions/async_test.dart
+++ b/pkgs/checks/test/extensions/async_test.dart
@@ -16,20 +16,20 @@ void main() {
   group('FutureChecks', () {
     group('completes', () {
       test('succeeds for a future that completes to a value', () async {
-        await checkThat(_futureSuccess()).completes().which(it()..equals(42));
+        await check(_futureSuccess()).completes().which(it()..equals(42));
       });
       test('rejects futures which complete as errors', () async {
-        await checkThat(_futureFail()).isRejectedByAsync(
+        await check(_futureFail()).isRejectedByAsync(
           it()..completes().which(it()..equals(1)),
           actual: ['a future that completes as an error'],
           which: ['threw <UnimplementedError>'],
         );
       });
       test('can be described', () async {
-        await checkThat(it<Future<void>>()..completes())
+        await check(it<Future<void>>()..completes())
             .asyncDescription
             .which(it()..deepEquals(['  completes to a value']));
-        await checkThat(it<Future<int>>()..completes().which(it()..equals(42)))
+        await check(it<Future<int>>()..completes().which(it()..equals(42)))
             .asyncDescription
             .which(it()
               ..deepEquals([
@@ -43,12 +43,12 @@ void main() {
       test(
           'succeeds for a future that compeletes to an error of the expected type',
           () async {
-        await checkThat(_futureFail())
+        await check(_futureFail())
             .throws<UnimplementedError>()
             .which(it()..has((p0) => p0.message, 'message').isNull());
       });
       test('fails for futures that complete to a value', () async {
-        await checkThat(_futureSuccess()).isRejectedByAsync(
+        await check(_futureSuccess()).isRejectedByAsync(
           it()..throws(),
           actual: ['completed to <42>'],
           which: ['did not throw'],
@@ -56,17 +56,17 @@ void main() {
       });
       test('failes for futures that complete to an error of the wrong type',
           () async {
-        await checkThat(_futureFail()).isRejectedByAsync(
+        await check(_futureFail()).isRejectedByAsync(
           it()..throws<StateError>(),
           actual: ['completed to error <UnimplementedError>'],
           which: ['is not an StateError'],
         );
       });
       test('can be described', () async {
-        await checkThat(it<Future<void>>()..throws())
+        await check(it<Future<void>>()..throws())
             .asyncDescription
             .which(it()..deepEquals(['  completes to an error']));
-        await checkThat(it<Future<void>>()..throws<StateError>())
+        await check(it<Future<void>>()..throws<StateError>())
             .asyncDescription
             .which(it()
               ..deepEquals(['  completes to an error of type StateError']));
@@ -75,19 +75,19 @@ void main() {
 
     group('doesNotComplete', () {
       test('succeeds for a Future that never completes', () async {
-        checkThat(Completer<void>().future).doesNotComplete();
+        check(Completer<void>().future).doesNotComplete();
       });
       test('fails for a Future that completes as a value', () async {
         Object? testFailure;
         runZonedGuarded(() {
           final completer = Completer<String>();
-          checkThat(completer.future).doesNotComplete();
+          check(completer.future).doesNotComplete();
           completer.complete('value');
         }, (e, st) {
           testFailure = e;
         });
         await pumpEventQueue();
-        checkThat(testFailure)
+        check(testFailure)
             .isA<TestFailure>()
             .has((f) => f.message, 'message')
             .isNotNull()
@@ -100,13 +100,13 @@ Actual: a future that completed to 'value\'''');
         Object? testFailure;
         runZonedGuarded(() {
           final completer = Completer<String>();
-          checkThat(completer.future).doesNotComplete();
+          check(completer.future).doesNotComplete();
           completer.completeError('error', StackTrace.fromString('fake trace'));
         }, (e, st) {
           testFailure = e;
         });
         await pumpEventQueue();
-        checkThat(testFailure)
+        check(testFailure)
             .isA<TestFailure>()
             .has((f) => f.message, 'message')
             .isNotNull()
@@ -118,7 +118,7 @@ Which: threw 'error'
 fake trace''');
       });
       test('can be described', () async {
-        await checkThat(it<Future<void>>()..doesNotComplete())
+        await check(it<Future<void>>()..doesNotComplete())
             .asyncDescription
             .which(it()..deepEquals(['  does not complete']));
       });
@@ -128,27 +128,27 @@ fake trace''');
   group('StreamChecks', () {
     group('emits', () {
       test('succeeds for a stream that emits a value', () async {
-        await checkThat(_countingStream(5)).emits().which(it()..equals(0));
+        await check(_countingStream(5)).emits().which(it()..equals(0));
       });
       test('fails for a stream that closes without emitting', () async {
-        await checkThat(_countingStream(0)).isRejectedByAsync(
+        await check(_countingStream(0)).isRejectedByAsync(
           it()..emits(),
           actual: ['a stream'],
           which: ['closed without emitting enough values'],
         );
       });
       test('fails for a stream that emits an error', () async {
-        await checkThat(_countingStream(1, errorAt: 0)).isRejectedByAsync(
+        await check(_countingStream(1, errorAt: 0)).isRejectedByAsync(
           it()..emits(),
           actual: ['a stream with error <UnimplementedError: Error at 1>'],
           which: ['emitted an error instead of a value'],
         );
       });
       test('can be described', () async {
-        await checkThat(it<StreamQueue<void>>()..emits())
+        await check(it<StreamQueue<void>>()..emits())
             .asyncDescription
             .which(it()..deepEquals(['  emits a value']));
-        await checkThat(it<StreamQueue<int>>()..emits().which(it()..equals(42)))
+        await check(it<StreamQueue<int>>()..emits().which(it()..equals(42)))
             .asyncDescription
             .which(it()
               ..deepEquals([
@@ -159,25 +159,25 @@ fake trace''');
       test('uses a transaction', () async {
         final queue = _countingStream(1, errorAt: 0);
         await softCheckAsync<StreamQueue<int>>(queue, it()..emits());
-        await checkThat(queue).emitsError();
+        await check(queue).emitsError();
       });
     });
 
     group('emitsError', () {
       test('succeeds for a stream that emits an error', () async {
-        await checkThat(_countingStream(1, errorAt: 0))
+        await check(_countingStream(1, errorAt: 0))
             .emitsError<UnimplementedError>();
       });
       test('fails for a stream that closes without emitting an error',
           () async {
-        await checkThat(_countingStream(0)).isRejectedByAsync(
+        await check(_countingStream(0)).isRejectedByAsync(
           it()..emitsError(),
           actual: ['a stream'],
           which: ['closed without emitting an expected error'],
         );
       });
       test('fails for a stream that emits value', () async {
-        await checkThat(_countingStream(1)).isRejectedByAsync(
+        await check(_countingStream(1)).isRejectedByAsync(
           it()..emitsError(),
           actual: ['a stream emitting value <0>'],
           which: ['closed without emitting an error'],
@@ -185,20 +185,20 @@ fake trace''');
       });
       test('fails for a stream that emits an error of the incorrect type',
           () async {
-        await checkThat(_countingStream(1, errorAt: 0)).isRejectedByAsync(
+        await check(_countingStream(1, errorAt: 0)).isRejectedByAsync(
           it()..emitsError<StateError>(),
           actual: ['a stream with error <UnimplementedError: Error at 1>'],
           which: ['emitted an error with an incorrect type, is not StateError'],
         );
       });
       test('can be described', () async {
-        await checkThat(it<StreamQueue<void>>()..emitsError())
+        await check(it<StreamQueue<void>>()..emitsError())
             .asyncDescription
             .which(it()..deepEquals(['  emits an error']));
-        await checkThat(it<StreamQueue<void>>()..emitsError<StateError>())
+        await check(it<StreamQueue<void>>()..emitsError<StateError>())
             .asyncDescription
             .which(it()..deepEquals(['  emits an error of type StateError']));
-        await checkThat(it<StreamQueue<void>>()
+        await check(it<StreamQueue<void>>()
               ..emitsError<StateError>()
                   .which(it()..has((e) => e.message, 'message').equals('foo')))
             .asyncDescription
@@ -212,25 +212,25 @@ fake trace''');
       test('uses a transaction', () async {
         final queue = _countingStream(1);
         await softCheckAsync<StreamQueue<int>>(queue, it()..emitsError());
-        await checkThat(queue).emits().which((it()..equals(0)));
+        await check(queue).emits().which((it()..equals(0)));
       });
     });
 
     group('emitsThrough', () {
       test('succeeds for a stream that eventuall emits a matching value',
           () async {
-        await checkThat(_countingStream(5)).emitsThrough(it()..equals(4));
+        await check(_countingStream(5)).emitsThrough(it()..equals(4));
       });
       test('fails for a stream that closes without emitting a matching value',
           () async {
-        await checkThat(_countingStream(4)).isRejectedByAsync(
+        await check(_countingStream(4)).isRejectedByAsync(
           it()..emitsThrough(it()..equals(5)),
           actual: ['a stream'],
           which: ['ended after emitting 4 elements with none matching'],
         );
       });
       test('can be described', () async {
-        await checkThat(it<StreamQueue<int>>()..emitsThrough(it()..equals(42)))
+        await check(it<StreamQueue<int>>()..emitsThrough(it()..equals(42)))
             .asyncDescription
             .which(it()
               ..deepEquals([
@@ -242,25 +242,25 @@ fake trace''');
         final queue = _countingStream(1);
         await softCheckAsync(
             queue, it<StreamQueue<int>>()..emitsThrough(it()..equals(42)));
-        checkThat(queue).emits().which(it()..equals(0));
+        check(queue).emits().which(it()..equals(0));
       });
       test('consumes events', () async {
         final queue = _countingStream(3);
-        await checkThat(queue).emitsThrough(it()..equals(1));
-        await checkThat(queue).emits().which((it()..equals(2)));
+        await check(queue).emitsThrough(it()..equals(1));
+        await check(queue).emits().which((it()..equals(2)));
       });
     });
 
     group('emitsInOrder', () {
       test('succeeds for happy case', () async {
-        await checkThat(_countingStream(2)).inOrder([
+        await check(_countingStream(2)).inOrder([
           it()..emits().which(it()..equals(0)),
           it()..emits().which((it()..equals(1))),
           it()..isDone(),
         ]);
       });
       test('reports which condition failed', () async {
-        await checkThat(_countingStream(1)).isRejectedByAsync(
+        await check(_countingStream(1)).isRejectedByAsync(
           it()..inOrder([it()..emits(), it()..emits()]),
           actual: ['a stream'],
           which: [
@@ -271,7 +271,7 @@ fake trace''');
         );
       });
       test('nestes the report for deep failures', () async {
-        await checkThat(_countingStream(2)).isRejectedByAsync(
+        await check(_countingStream(2)).isRejectedByAsync(
           it()..inOrder([it()..emits(), it()..emits().which(it()..equals(2))]),
           actual: ['a stream'],
           which: [
@@ -285,7 +285,7 @@ fake trace''');
         );
       });
       test('gets described with the number of conditions', () async {
-        await checkThat(it<StreamQueue<int>>()..inOrder([it(), it()]))
+        await check(it<StreamQueue<int>>()..inOrder([it(), it()]))
             .asyncDescription
             .which(it()..deepEquals(['  satisfies 2 conditions in order']));
       });
@@ -299,7 +299,7 @@ fake trace''');
                 it()..emits().which(it()..equals(1)),
                 it()..emits().which(it()..equals(42)),
               ]));
-        await checkThat(queue).inOrder([
+        await check(queue).inOrder([
           it()..emits().which(it()..equals(0)),
           it()..emits().which(it()..equals(1)),
           it()..emits().which(it()..equals(2)),
@@ -308,8 +308,8 @@ fake trace''');
       });
       test('consumes events', () async {
         final queue = _countingStream(3);
-        await checkThat(queue).inOrder([it()..emits(), it()..emits()]);
-        await checkThat(queue).emits().which(it()..equals(2));
+        await check(queue).inOrder([it()..emits(), it()..emits()]);
+        await check(queue).emits().which(it()..equals(2));
       });
     });
 
@@ -317,17 +317,17 @@ fake trace''');
       test(
           'succeeds for a stream that closes without emitting a matching value',
           () async {
-        await checkThat(_countingStream(5)).neverEmits(it()..equals(5));
+        await check(_countingStream(5)).neverEmits(it()..equals(5));
       });
       test('fails for a stream that emits a matching value', () async {
-        await checkThat(_countingStream(6)).isRejectedByAsync(
+        await check(_countingStream(6)).isRejectedByAsync(
           it()..neverEmits(it()..equals(5)),
           actual: ['a stream'],
           which: ['emitted <5>', 'following 5 other items'],
         );
       });
       test('can be described', () async {
-        await checkThat(it<StreamQueue<int>>()..neverEmits(it()..equals(42)))
+        await check(it<StreamQueue<int>>()..neverEmits(it()..equals(42)))
             .asyncDescription
             .which(it()
               ..deepEquals([
@@ -339,7 +339,7 @@ fake trace''');
         final queue = _countingStream(2);
         await softCheckAsync<StreamQueue<int>>(
             queue, it()..neverEmits(it()..equals(1)));
-        await checkThat(queue).inOrder([
+        await check(queue).inOrder([
           it()..emits().which(it()..equals(0)),
           it()..emits().which(it()..equals(1)),
           it()..isDone(),
@@ -349,32 +349,31 @@ fake trace''');
 
     group('mayEmit', () {
       test('succeeds for a stream that emits a matching value', () async {
-        await checkThat(_countingStream(1)).mayEmit(it()..equals(0));
+        await check(_countingStream(1)).mayEmit(it()..equals(0));
       });
       test('succeeds for a stream that emits an error', () async {
-        await checkThat(_countingStream(1, errorAt: 0))
-            .mayEmit(it()..equals(0));
+        await check(_countingStream(1, errorAt: 0)).mayEmit(it()..equals(0));
       });
       test('succeeds for a stream that closes', () async {
-        await checkThat(_countingStream(0)).mayEmit(it()..equals(42));
+        await check(_countingStream(0)).mayEmit(it()..equals(42));
       });
       test('consumes a matching event', () async {
         final queue = _countingStream(2);
         await softCheckAsync<StreamQueue<int>>(
             queue, it()..mayEmit(it()..equals(0)));
-        await checkThat(queue).emits().which(it()..equals(1));
+        await check(queue).emits().which(it()..equals(1));
       });
       test('does not consume a non-matching event', () async {
         final queue = _countingStream(2);
         await softCheckAsync<StreamQueue<int>>(
             queue, it()..mayEmit(it()..equals(1)));
-        await checkThat(queue).emits().which(it()..equals(0));
+        await check(queue).emits().which(it()..equals(0));
       });
       test('does not consume an error', () async {
         final queue = _countingStream(1, errorAt: 0);
         await softCheckAsync<StreamQueue<int>>(
             queue, it()..mayEmit(it()..equals(0)));
-        await checkThat(queue)
+        await check(queue)
             .emitsError<UnimplementedError>()
             .which(it()..has((e) => e.message, 'message').equals('Error at 1'));
       });
@@ -382,32 +381,32 @@ fake trace''');
 
     group('mayEmitMultiple', () {
       test('succeeds for a stream that emits a matching value', () async {
-        await checkThat(_countingStream(1)).mayEmitMultiple(it()..equals(0));
+        await check(_countingStream(1)).mayEmitMultiple(it()..equals(0));
       });
       test('succeeds for a stream that emits an error', () async {
-        await checkThat(_countingStream(1, errorAt: 0))
+        await check(_countingStream(1, errorAt: 0))
             .mayEmitMultiple(it()..equals(0));
       });
       test('succeeds for a stream that closes', () async {
-        await checkThat(_countingStream(0)).mayEmitMultiple(it()..equals(42));
+        await check(_countingStream(0)).mayEmitMultiple(it()..equals(42));
       });
       test('consumes matching events', () async {
         final queue = _countingStream(3);
         await softCheckAsync<StreamQueue<int>>(
             queue, it()..mayEmitMultiple(it()..isLessThan(2)));
-        await checkThat(queue).emits().which(it()..equals(2));
+        await check(queue).emits().which(it()..equals(2));
       });
       test('consumes no events if no events match', () async {
         final queue = _countingStream(2);
         await softCheckAsync<StreamQueue<int>>(
             queue, it()..mayEmitMultiple(it()..isLessThan(0)));
-        await checkThat(queue).emits().which(it()..equals(0));
+        await check(queue).emits().which(it()..equals(0));
       });
       test('does not consume an error', () async {
         final queue = _countingStream(1, errorAt: 0);
         await softCheckAsync<StreamQueue<int>>(
             queue, it()..mayEmitMultiple(it()..equals(0)));
-        await checkThat(queue)
+        await check(queue)
             .emitsError<UnimplementedError>()
             .which(it()..has((e) => e.message, 'message').equals('Error at 1'));
       });
@@ -415,16 +414,16 @@ fake trace''');
 
     group('isDone', () {
       test('succeeds for an empty stream', () async {
-        await checkThat(_countingStream(0)).isDone();
+        await check(_countingStream(0)).isDone();
       });
       test('fails for a stream that emits a value', () async {
-        await checkThat(_countingStream(1)).isRejectedByAsync(it()..isDone(),
+        await check(_countingStream(1)).isRejectedByAsync(it()..isDone(),
             actual: ['a stream'], which: ['emitted an unexpected value: <0>']);
       });
       test('fails for a stream that emits an error', () async {
         final controller = StreamController<void>();
         controller.addError('sad', StackTrace.fromString('fake trace'));
-        await checkThat(StreamQueue(controller.stream)).isRejectedByAsync(
+        await check(StreamQueue(controller.stream)).isRejectedByAsync(
             it()..isDone(),
             actual: ['a stream'],
             which: ['emitted an unexpected error: \'sad\'', 'fake trace']);
@@ -432,10 +431,10 @@ fake trace''');
       test('uses a transaction', () async {
         final queue = _countingStream(1);
         await softCheckAsync<StreamQueue<int>>(queue, it()..isDone());
-        await checkThat(queue).emits().which(it()..equals(0));
+        await check(queue).emits().which(it()..equals(0));
       });
       test('can be described', () async {
-        await checkThat(it<StreamQueue<int>>()..isDone())
+        await check(it<StreamQueue<int>>()..isDone())
             .asyncDescription
             .which(it()..deepEquals(['  is done']));
       });
@@ -443,13 +442,13 @@ fake trace''');
 
     group('emitsAnyOf', () {
       test('succeeds for a stream that matches one condition', () async {
-        await checkThat(_countingStream(1)).anyOf([
+        await check(_countingStream(1)).anyOf([
           it()..emits().which(it()..equals(42)),
           it()..emits().which((it()..equals(0)))
         ]);
       });
       test('fails for a stream that matches no conditions', () async {
-        await checkThat(_countingStream(0)).isRejectedByAsync(
+        await check(_countingStream(0)).isRejectedByAsync(
             it()
               ..anyOf([
                 it()..emits(),
@@ -467,7 +466,7 @@ fake trace''');
             ]);
       });
       test('includes nested details for nested failures', () async {
-        await checkThat(_countingStream(1)).isRejectedByAsync(
+        await check(_countingStream(1)).isRejectedByAsync(
             it()
               ..anyOf([
                 it()..emits().which(it()..equals(42)),
@@ -487,7 +486,7 @@ fake trace''');
             ]);
       });
       test('gets described with the number of conditions', () async {
-        await checkThat(
+        await check(
                 it<StreamQueue<int>>()..anyOf([it()..emits(), it()..emits()]))
             .asyncDescription
             .which(it()..deepEquals(['  satisfies any of 2 conditions']));
@@ -501,28 +500,28 @@ fake trace''');
                 it()..emits().which(it()..equals(10)),
                 it()..emitsThrough(it()..equals(42)),
               ]));
-        await checkThat(queue).emits().which(it()..equals(0));
+        await check(queue).emits().which(it()..equals(0));
       });
       test('consumes events', () async {
         final queue = _countingStream(3);
-        await checkThat(queue).anyOf([
+        await check(queue).anyOf([
           it()..emits().which(it()..equals(1)),
           it()..emitsThrough(it()..equals(1))
         ]);
-        await checkThat(queue).emits().which(it()..equals(2));
+        await check(queue).emits().which(it()..equals(2));
       });
     });
   });
 
   group('ChainAsync', () {
     test('which', () async {
-      await checkThat(_futureSuccess()).completes().which(it()..equals(42));
+      await check(_futureSuccess()).completes().which(it()..equals(42));
     });
   });
 
   group('StreamQueueWrap', () {
     test('can wrap streams in a queue', () async {
-      await checkThat(Stream.value(1)).withQueue.emits();
+      await check(Stream.value(1)).withQueue.emits();
     });
   });
 }

--- a/pkgs/checks/test/extensions/collection_equality_test.dart
+++ b/pkgs/checks/test/extensions/collection_equality_test.dart
@@ -9,7 +9,7 @@ import 'package:test/scaffolding.dart';
 void main() {
   group('deepCollectionEquals', () {
     test('allows nested collections with equal elements', () {
-      checkThat(deepCollectionEquals([
+      check(deepCollectionEquals([
         'a',
         {'b': 1},
         {'c', 'd'},
@@ -27,7 +27,7 @@ void main() {
     });
 
     test('allows collections inside sets', () {
-      checkThat(deepCollectionEquals({
+      check(deepCollectionEquals({
         {'a': 1}
       }, {
         {'a': 1}
@@ -35,7 +35,7 @@ void main() {
     });
 
     test('allows collections as Map keys', () {
-      checkThat(deepCollectionEquals([
+      check(deepCollectionEquals([
         {
           {'a': 1}: {'b': 2}
         }
@@ -47,7 +47,7 @@ void main() {
     });
 
     test('allows conditions in place of elements in lists', () {
-      checkThat(deepCollectionEquals([
+      check(deepCollectionEquals([
         'a',
         'b'
       ], [
@@ -60,7 +60,7 @@ void main() {
     });
 
     test('allows conditions in place of values in maps', () {
-      checkThat(deepCollectionEquals([
+      check(deepCollectionEquals([
         {'a': 'b'}
       ], [
         {'a': it()..isA<String>().startsWith('b')}
@@ -68,17 +68,17 @@ void main() {
     });
 
     test('allows conditions in place of elements in sets', () {
-      checkThat(deepCollectionEquals(
+      check(deepCollectionEquals(
           {'b', 'a'}, {'a', it()..isA<String>().startsWith('b')})).isNull();
     });
 
     test('allows conditions in place of keys in maps', () {
-      checkThat(deepCollectionEquals(
+      check(deepCollectionEquals(
           {'a': 'b'}, {it()..isA<String>().startsWith('a'): 'b'})).isNull();
     });
 
     test('reports non-Set elements', () {
-      checkThat(deepCollectionEquals([
+      check(deepCollectionEquals([
         ['a']
       ], [
         {'a'}
@@ -86,27 +86,27 @@ void main() {
     });
 
     test('reports long iterables', () {
-      checkThat(deepCollectionEquals([0], [])).isNotNull().deepEquals([
+      check(deepCollectionEquals([0], [])).isNotNull().deepEquals([
         'has more elements than expected',
         'expected an iterable with 0 element(s)'
       ]);
     });
 
     test('reports short iterables', () {
-      checkThat(deepCollectionEquals([], [0])).isNotNull().deepEquals([
+      check(deepCollectionEquals([], [0])).isNotNull().deepEquals([
         'has too few elements',
         'expected an iterable with at least 1 element(s)'
       ]);
     });
 
     test('reports unequal elements in iterables', () {
-      checkThat(deepCollectionEquals([0], [1]))
+      check(deepCollectionEquals([0], [1]))
           .isNotNull()
           .deepEquals(['at [<0>] is <0>', 'which does not equal <1>']);
     });
 
     test('reports unmet conditions in iterables', () {
-      checkThat(deepCollectionEquals([0], [it()..isA<int>().isGreaterThan(0)]))
+      check(deepCollectionEquals([0], [it()..isA<int>().isGreaterThan(0)]))
           .isNotNull()
           .deepEquals([
         'has an element at [<0>] that:',
@@ -116,7 +116,7 @@ void main() {
     });
 
     test('reports unmet conditions in map values', () {
-      checkThat(deepCollectionEquals(
+      check(deepCollectionEquals(
               {'a': 'b'}, {'a': it()..isA<String>().startsWith('a')}))
           .isNotNull()
           .deepEquals([
@@ -127,7 +127,7 @@ void main() {
     });
 
     test('reports unmet conditions in map keys', () {
-      checkThat(deepCollectionEquals(
+      check(deepCollectionEquals(
               {'b': 'a'}, {it()..isA<String>().startsWith('a'): 'a'}))
           .isNotNull()
           .deepEquals([
@@ -140,7 +140,7 @@ void main() {
     test('reports recursive lists', () {
       var l = [];
       l.add(l);
-      checkThat(deepCollectionEquals(l, l))
+      check(deepCollectionEquals(l, l))
           .isNotNull()
           .deepEquals(['exceeds the depth limit of 1000']);
     });
@@ -148,7 +148,7 @@ void main() {
     test('reports recursive sets', () {
       var s = <Object>{};
       s.add(s);
-      checkThat(deepCollectionEquals(s, s))
+      check(deepCollectionEquals(s, s))
           .isNotNull()
           .deepEquals(['exceeds the depth limit of 1000']);
     });
@@ -156,7 +156,7 @@ void main() {
     test('reports maps with recursive keys', () {
       var m = <Object, Object>{};
       m[m] = 0;
-      checkThat(deepCollectionEquals(m, m))
+      check(deepCollectionEquals(m, m))
           .isNotNull()
           .deepEquals(['exceeds the depth limit of 1000']);
     });
@@ -164,7 +164,7 @@ void main() {
     test('reports maps with recursive values', () {
       var m = <Object, Object>{};
       m[0] = m;
-      checkThat(deepCollectionEquals(m, m))
+      check(deepCollectionEquals(m, m))
           .isNotNull()
           .deepEquals(['exceeds the depth limit of 1000']);
     });

--- a/pkgs/checks/test/extensions/core_test.dart
+++ b/pkgs/checks/test/extensions/core_test.dart
@@ -10,28 +10,28 @@ import '../test_shared.dart';
 void main() {
   group('TypeChecks', () {
     test('isA', () {
-      checkThat(1).isA<int>();
+      check(1).isA<int>();
 
-      checkThat(1).isRejectedBy(it()..isA<String>(), which: ['Is a int']);
+      check(1).isRejectedBy(it()..isA<String>(), which: ['Is a int']);
     });
   });
   group('HasField', () {
     test('has', () {
-      checkThat(1).has((v) => v.isOdd, 'isOdd').isTrue();
+      check(1).has((v) => v.isOdd, 'isOdd').isTrue();
 
-      checkThat(2).isRejectedBy(
+      check(2).isRejectedBy(
           it()..has((v) => throw UnimplementedError(), 'isOdd'),
           which: ['threw while trying to read property']);
     });
 
     test('which', () {
-      checkThat(true).which(it()..isTrue());
+      check(true).which(it()..isTrue());
     });
 
     test('not', () {
-      checkThat(false).not(it()..isTrue());
+      check(false).not(it()..isTrue());
 
-      checkThat(true).isRejectedBy(it()..not(it()..isTrue()), which: [
+      check(true).isRejectedBy(it()..not(it()..isTrue()), which: [
         'is a value that: ',
         '    is true',
       ]);
@@ -39,11 +39,11 @@ void main() {
 
     group('anyOf', () {
       test('succeeds for happy case', () {
-        checkThat(-10).anyOf([it()..isGreaterThan(1), it()..isLessThan(-1)]);
+        check(-10).anyOf([it()..isGreaterThan(1), it()..isLessThan(-1)]);
       });
 
       test('rejects values that do not satisfy any condition', () {
-        checkThat(0).isRejectedBy(
+        check(0).isRejectedBy(
             it()..anyOf([it()..isGreaterThan(1), it()..isLessThan(-1)]),
             which: ['did not match any condition']);
       });
@@ -52,41 +52,40 @@ void main() {
 
   group('BoolChecks', () {
     test('isTrue', () {
-      checkThat(true).isTrue();
+      check(true).isTrue();
 
-      checkThat(false).isRejectedBy(it()..isTrue());
+      check(false).isRejectedBy(it()..isTrue());
     });
 
     test('isFalse', () {
-      checkThat(false).isFalse();
+      check(false).isFalse();
 
-      checkThat(true).isRejectedBy(it()..isFalse());
+      check(true).isRejectedBy(it()..isFalse());
     });
   });
 
   group('EqualityChecks', () {
     test('equals', () {
-      checkThat(1).equals(1);
+      check(1).equals(1);
 
-      checkThat(1).isRejectedBy(it()..equals(2), which: ['are not equal']);
+      check(1).isRejectedBy(it()..equals(2), which: ['are not equal']);
     });
     test('identical', () {
-      checkThat(1).identicalTo(1);
+      check(1).identicalTo(1);
 
-      checkThat(1)
-          .isRejectedBy(it()..identicalTo(2), which: ['is not identical']);
+      check(1).isRejectedBy(it()..identicalTo(2), which: ['is not identical']);
     });
   });
   group('NullabilityChecks', () {
     test('isNotNull', () {
-      checkThat(1).isNotNull();
+      check(1).isNotNull();
 
-      checkThat(null).isRejectedBy(it()..isNotNull());
+      check(null).isRejectedBy(it()..isNotNull());
     });
     test('isNull', () {
-      checkThat(null).isNull();
+      check(null).isNull();
 
-      checkThat(1).isRejectedBy(it()..isNull());
+      check(1).isRejectedBy(it()..isNull());
     });
   });
 }

--- a/pkgs/checks/test/extensions/function_test.dart
+++ b/pkgs/checks/test/extensions/function_test.dart
@@ -11,15 +11,15 @@ void main() {
   group('ThrowsChecks', () {
     group('throws', () {
       test('succeeds for happy case', () {
-        checkThat(() => throw StateError('oops!')).throws<StateError>();
+        check(() => throw StateError('oops!')).throws<StateError>();
       });
       test('fails for functions that return normally', () {
-        checkThat(() {}).isRejectedBy(it()..throws<StateError>(),
+        check(() {}).isRejectedBy(it()..throws<StateError>(),
             actual: ['a function that returned <null>'],
             which: ['did not throw']);
       });
       test('fails for functions that throw the wrong type', () {
-        checkThat(() => throw StateError('oops!')).isRejectedBy(
+        check(() => throw StateError('oops!')).isRejectedBy(
           it()..throws<ArgumentError>(),
           actual: ['a function that threw error <Bad state: oops!>'],
           which: ['did not throw an ArgumentError'],
@@ -29,10 +29,10 @@ void main() {
 
     group('returnsNormally', () {
       test('succeeds for happy case', () {
-        checkThat(() => 1).returnsNormally().equals(1);
+        check(() => 1).returnsNormally().equals(1);
       });
       test('fails for functions that throw', () {
-        checkThat(() {
+        check(() {
           Error.throwWithStackTrace(
               StateError('oops!'), StackTrace.fromString('fake trace'));
         }).isRejectedBy(it()..returnsNormally(),

--- a/pkgs/checks/test/extensions/iterable_test.dart
+++ b/pkgs/checks/test/extensions/iterable_test.dart
@@ -11,58 +11,57 @@ Iterable<int> get _testIterable => Iterable.generate(2, (i) => i);
 
 void main() {
   test('length', () {
-    checkThat(_testIterable).length.equals(2);
+    check(_testIterable).length.equals(2);
   });
   test('first', () {
-    checkThat(_testIterable).first.equals(0);
+    check(_testIterable).first.equals(0);
   });
   test('last', () {
-    checkThat(_testIterable).last.equals(1);
+    check(_testIterable).last.equals(1);
   });
   test('single', () {
-    checkThat([42]).single.equals(42);
+    check([42]).single.equals(42);
   });
 
   test('isEmpty', () {
-    checkThat([]).isEmpty();
-    checkThat(_testIterable)
-        .isRejectedBy(it()..isEmpty(), which: ['is not empty']);
+    check([]).isEmpty();
+    check(_testIterable).isRejectedBy(it()..isEmpty(), which: ['is not empty']);
   });
 
   test('isNotEmpty', () {
-    checkThat(_testIterable).isNotEmpty();
-    checkThat(Iterable<int>.empty())
+    check(_testIterable).isNotEmpty();
+    check(Iterable<int>.empty())
         .isRejectedBy(it()..isNotEmpty(), which: ['is not empty']);
   });
 
   test('contains', () {
-    checkThat(_testIterable).contains(0);
-    checkThat(_testIterable)
+    check(_testIterable).contains(0);
+    check(_testIterable)
         .isRejectedBy(it()..contains(2), which: ['does not contain <2>']);
   });
   test('any', () {
-    checkThat(_testIterable).any(it()..equals(1));
-    checkThat(_testIterable).isRejectedBy(it()..any(it()..equals(2)),
+    check(_testIterable).any(it()..equals(1));
+    check(_testIterable).isRejectedBy(it()..any(it()..equals(2)),
         which: ['Contains no matching element']);
   });
 
   group('containsInOrder', () {
     test('succeeds for happy case', () {
-      checkThat([0, 1, 0, 2, 0, 3]).containsInOrder([1, 2, 3]);
+      check([0, 1, 0, 2, 0, 3]).containsInOrder([1, 2, 3]);
     });
     test('can use Condition<dynamic>', () {
-      checkThat([0, 1]).containsInOrder([it()..isA<int>().isGreaterThan(0)]);
+      check([0, 1]).containsInOrder([it()..isA<int>().isGreaterThan(0)]);
     });
     test('can use Condition<T>', () {
-      checkThat([0, 1]).containsInOrder([it<int>()..isGreaterThan(0)]);
+      check([0, 1]).containsInOrder([it<int>()..isGreaterThan(0)]);
     });
     test('fails for not found elements by equality', () async {
-      checkThat([0]).isRejectedBy(it()..containsInOrder([1]), which: [
+      check([0]).isRejectedBy(it()..containsInOrder([1]), which: [
         'did not have an element matching the expectation at index 0 <1>'
       ]);
     });
     test('fails for not found elements by condition', () async {
-      checkThat([0]).isRejectedBy(
+      check([0]).isRejectedBy(
           it()..containsInOrder([it()..isA<int>().isGreaterThan(0)]),
           which: [
             'did not have an element matching the expectation at index 0 '
@@ -72,10 +71,10 @@ void main() {
           ]);
     });
     test('can be described', () {
-      checkThat(it<Iterable>()..containsInOrder([1, 2, 3]))
+      check(it<Iterable>()..containsInOrder([1, 2, 3]))
           .description
           .deepEquals(['  contains, in order: [1, 2, 3]']);
-      checkThat(it<Iterable>()..containsInOrder([1, it()..equals(2)]))
+      check(it<Iterable>()..containsInOrder([1, it()..equals(2)]))
           .description
           .deepEquals([
         '  contains, in order: [1,',
@@ -86,11 +85,11 @@ void main() {
   });
   group('every', () {
     test('succeeds for the happy path', () {
-      checkThat(_testIterable).every(it()..isGreaterOrEqual(-1));
+      check(_testIterable).every(it()..isGreaterOrEqual(-1));
     });
 
     test('includes details of first failing element', () async {
-      checkThat(_testIterable)
+      check(_testIterable)
           .isRejectedBy(it()..every(it()..isLessThan(0)), which: [
         'has an element at index 0 that:',
         '  Actual: <0>',
@@ -101,11 +100,11 @@ void main() {
 
   group('unorderedEquals', () {
     test('success for happy case', () {
-      checkThat(_testIterable).unorderedEquals(_testIterable.toList().reversed);
+      check(_testIterable).unorderedEquals(_testIterable.toList().reversed);
     });
 
     test('reports unmatched elements', () {
-      checkThat(_testIterable).isRejectedBy(
+      check(_testIterable).isRejectedBy(
           it()..unorderedEquals(_testIterable.followedBy([42, 100])),
           which: [
             'has no element equal to the expected element at index 2: <42>',
@@ -114,7 +113,7 @@ void main() {
     });
 
     test('reports unexpected elements', () {
-      checkThat(_testIterable.followedBy([42, 100]))
+      check(_testIterable.followedBy([42, 100]))
           .isRejectedBy(it()..unorderedEquals(_testIterable), which: [
         'has an unexpected element at index 2: <42>',
         'and 1 other unexpected elements'
@@ -124,12 +123,12 @@ void main() {
 
   group('unorderedMatches', () {
     test('success for happy case', () {
-      checkThat(_testIterable).unorderedMatches(
+      check(_testIterable).unorderedMatches(
           _testIterable.toList().reversed.map((i) => it()..equals(i)));
     });
 
     test('reports unmatched elements', () {
-      checkThat(_testIterable).isRejectedBy(
+      check(_testIterable).isRejectedBy(
           it()
             ..unorderedMatches(_testIterable
                 .followedBy([42, 100]).map((i) => it()..equals(i))),
@@ -141,7 +140,7 @@ void main() {
     });
 
     test('reports unexpected elements', () {
-      checkThat(_testIterable.followedBy([42, 100])).isRejectedBy(
+      check(_testIterable.followedBy([42, 100])).isRejectedBy(
           it()..unorderedMatches(_testIterable.map((i) => it()..equals(i))),
           which: [
             'has an unmatched element at index 2: <42>',
@@ -152,11 +151,11 @@ void main() {
 
   group('pairwiseComparesTo', () {
     test('succeeds for the happy path', () {
-      checkThat(_testIterable).pairwiseComparesTo(
+      check(_testIterable).pairwiseComparesTo(
           [1, 2], (expected) => it()..isLessThan(expected), 'is less than');
     });
     test('fails for mismatched element', () async {
-      checkThat(_testIterable).isRejectedBy(
+      check(_testIterable).isRejectedBy(
           it()
             ..pairwiseComparesTo([1, 1],
                 (expected) => it()..isLessThan(expected), 'is less than'),
@@ -168,7 +167,7 @@ void main() {
           ]);
     });
     test('fails for too few elements', () {
-      checkThat(_testIterable).isRejectedBy(
+      check(_testIterable).isRejectedBy(
           it()
             ..pairwiseComparesTo([1, 2, 3],
                 (expected) => it()..isLessThan(expected), 'is less than'),
@@ -177,7 +176,7 @@ void main() {
           ]);
     });
     test('fails for too many elements', () {
-      checkThat(_testIterable).isRejectedBy(
+      check(_testIterable).isRejectedBy(
           it()
             ..pairwiseComparesTo(
                 [1], (expected) => it()..isLessThan(expected), 'is less than'),

--- a/pkgs/checks/test/extensions/map_test.dart
+++ b/pkgs/checks/test/extensions/map_test.dart
@@ -14,60 +14,60 @@ const _testMap = {
 
 void main() {
   test('length', () {
-    checkThat(_testMap).length.equals(2);
+    check(_testMap).length.equals(2);
   });
   test('entries', () {
-    checkThat(_testMap).entries.any(
+    check(_testMap).entries.any(
           it()
             ..has((p0) => p0.key, 'key').equals('a')
             ..has((p0) => p0.value, 'value').equals(1),
         );
   });
   test('keys', () {
-    checkThat(_testMap).keys.contains('a');
+    check(_testMap).keys.contains('a');
   });
   test('values', () {
-    checkThat(_testMap).values.contains(1);
+    check(_testMap).values.contains(1);
   });
 
   test('operator []', () async {
-    checkThat(_testMap)['a'].equals(1);
-    checkThat(_testMap)
+    check(_testMap)['a'].equals(1);
+    check(_testMap)
         .isRejectedBy(it()..['z'], which: ['does not contain the key \'z\'']);
   });
   test('isEmpty', () {
-    checkThat(<String, int>{}).isEmpty();
-    checkThat(_testMap).isRejectedBy(it()..isEmpty(), which: ['is not empty']);
+    check(<String, int>{}).isEmpty();
+    check(_testMap).isRejectedBy(it()..isEmpty(), which: ['is not empty']);
   });
   test('isNotEmpty', () {
-    checkThat(_testMap).isNotEmpty();
-    checkThat({}).isRejectedBy(it()..isNotEmpty(), which: ['is not empty']);
+    check(_testMap).isNotEmpty();
+    check({}).isRejectedBy(it()..isNotEmpty(), which: ['is not empty']);
   });
   test('containsKey', () {
-    checkThat(_testMap).containsKey('a');
+    check(_testMap).containsKey('a');
 
-    checkThat(_testMap).isRejectedBy(
+    check(_testMap).isRejectedBy(
       it()..containsKey('c'),
       which: ["does not contain key 'c'"],
     );
   });
   test('containsKeyThat', () {
-    checkThat(_testMap).containsKeyThat(it()..equals('a'));
-    checkThat(_testMap).isRejectedBy(
+    check(_testMap).containsKeyThat(it()..equals('a'));
+    check(_testMap).isRejectedBy(
       it()..containsKeyThat(it()..equals('c')),
       which: ['Contains no matching key'],
     );
   });
   test('containsValue', () {
-    checkThat(_testMap).containsValue(1);
-    checkThat(_testMap).isRejectedBy(
+    check(_testMap).containsValue(1);
+    check(_testMap).isRejectedBy(
       it()..containsValue(3),
       which: ['does not contain value <3>'],
     );
   });
   test('containsValueThat', () {
-    checkThat(_testMap).containsValueThat(it()..equals(1));
-    checkThat(_testMap).isRejectedBy(
+    check(_testMap).containsValueThat(it()..equals(1));
+    check(_testMap).isRejectedBy(
       it()..containsValueThat(it()..equals(3)),
       which: ['Contains no matching value'],
     );

--- a/pkgs/checks/test/extensions/math_test.dart
+++ b/pkgs/checks/test/extensions/math_test.dart
@@ -11,192 +11,186 @@ void main() {
   group('num checks', () {
     group('greater than', () {
       test('succeeds for happy case', () {
-        checkThat(42).isGreaterThan(7);
+        check(42).isGreaterThan(7);
       });
       test('fails for less than', () {
-        checkThat(42).isRejectedBy(it()..isGreaterThan(50),
+        check(42).isRejectedBy(it()..isGreaterThan(50),
             which: ['is not greater than <50>']);
       });
       test('fails for equal', () {
-        checkThat(42).isRejectedBy(it()..isGreaterThan(42),
+        check(42).isRejectedBy(it()..isGreaterThan(42),
             which: ['is not greater than <42>']);
       });
     });
 
     group('greater than or equal', () {
       test('succeeds for happy case', () {
-        checkThat(42).isGreaterOrEqual(7);
+        check(42).isGreaterOrEqual(7);
       });
       test('fails for less than', () {
-        checkThat(42).isRejectedBy(it()..isGreaterOrEqual(50),
+        check(42).isRejectedBy(it()..isGreaterOrEqual(50),
             which: ['is not greater than or equal to <50>']);
       });
       test('succeeds for equal', () {
-        checkThat(42).isGreaterOrEqual(42);
+        check(42).isGreaterOrEqual(42);
       });
     });
 
     group('less than', () {
       test('succeeds for happy case', () {
-        checkThat(42).isLessThan(50);
+        check(42).isLessThan(50);
       });
       test('fails for greater than', () {
-        checkThat(42)
+        check(42)
             .isRejectedBy(it()..isLessThan(7), which: ['is not less than <7>']);
       });
       test('fails for equal', () {
-        checkThat(42).isRejectedBy(it()..isLessThan(42),
+        check(42).isRejectedBy(it()..isLessThan(42),
             which: ['is not less than <42>']);
       });
     });
 
     group('less than or equal', () {
       test('succeeds for happy case', () {
-        checkThat(42).isLessOrEqual(50);
+        check(42).isLessOrEqual(50);
       });
       test('fails for greater than', () {
-        checkThat(42).isRejectedBy(it()..isLessOrEqual(7),
+        check(42).isRejectedBy(it()..isLessOrEqual(7),
             which: ['is not less than or equal to <7>']);
       });
       test('succeeds for equal', () {
-        checkThat(42).isLessOrEqual(42);
+        check(42).isLessOrEqual(42);
       });
     });
 
     group('isNaN', () {
       test('succeeds for happy case', () {
-        checkThat(double.nan).isNaN();
+        check(double.nan).isNaN();
       });
       test('fails for ints', () {
-        checkThat(42).isRejectedBy(it()..isNaN(), which: ['is a number']);
+        check(42).isRejectedBy(it()..isNaN(), which: ['is a number']);
       });
       test('fails for numeric doubles', () {
-        checkThat(42.1).isRejectedBy(it()..isNaN(), which: ['is a number']);
+        check(42.1).isRejectedBy(it()..isNaN(), which: ['is a number']);
       });
     });
 
     group('isNotNan', () {
       test('succeeds for ints', () {
-        checkThat(42).isNotNaN();
+        check(42).isNotNaN();
       });
       test('succeeds numeric doubles', () {
-        checkThat(42.1).isNotNaN();
+        check(42.1).isNotNaN();
       });
       test('fails for NaN', () {
-        checkThat(double.nan)
+        check(double.nan)
             .isRejectedBy(it()..isNotNaN(), which: ['is not a number (NaN)']);
       });
     });
     group('isNegative', () {
       test('succeeds for negative ints', () {
-        checkThat(-1).isNegative();
+        check(-1).isNegative();
       });
       test('succeeds for -0.0', () {
-        checkThat(-0.0).isNegative();
+        check(-0.0).isNegative();
       });
       test('fails for zero', () {
-        checkThat(0)
-            .isRejectedBy(it()..isNegative(), which: ['is not negative']);
+        check(0).isRejectedBy(it()..isNegative(), which: ['is not negative']);
       });
     });
     group('isNotNegative', () {
       test('succeeds for positive ints', () {
-        checkThat(1).isNotNegative();
+        check(1).isNotNegative();
       });
       test('succeeds for 0', () {
-        checkThat(0).isNotNegative();
+        check(0).isNotNegative();
       });
       test('fails for -0.0', () {
-        checkThat(-0.0)
-            .isRejectedBy(it()..isNotNegative(), which: ['is negative']);
+        check(-0.0).isRejectedBy(it()..isNotNegative(), which: ['is negative']);
       });
       test('fails for negative numbers', () {
-        checkThat(-1)
-            .isRejectedBy(it()..isNotNegative(), which: ['is negative']);
+        check(-1).isRejectedBy(it()..isNotNegative(), which: ['is negative']);
       });
     });
 
     group('isFinite', () {
       test('succeeds for finite numbers', () {
-        checkThat(1).isFinite();
+        check(1).isFinite();
       });
       test('fails for NaN', () {
-        checkThat(double.nan)
+        check(double.nan)
             .isRejectedBy(it()..isFinite(), which: ['is not finite']);
       });
       test('fails for infinity', () {
-        checkThat(double.infinity)
+        check(double.infinity)
             .isRejectedBy(it()..isFinite(), which: ['is not finite']);
       });
       test('fails for negative infinity', () {
-        checkThat(double.negativeInfinity)
+        check(double.negativeInfinity)
             .isRejectedBy(it()..isFinite(), which: ['is not finite']);
       });
     });
     group('isNotFinite', () {
       test('succeeds for infinity', () {
-        checkThat(double.infinity).isNotFinite();
+        check(double.infinity).isNotFinite();
       });
       test('succeeds for negative infinity', () {
-        checkThat(double.negativeInfinity).isNotFinite();
+        check(double.negativeInfinity).isNotFinite();
       });
       test('succeeds for NaN', () {
-        checkThat(double.nan).isNotFinite();
+        check(double.nan).isNotFinite();
       });
       test('fails for finite numbers', () {
-        checkThat(1).isRejectedBy(it()..isNotFinite(), which: ['is finite']);
+        check(1).isRejectedBy(it()..isNotFinite(), which: ['is finite']);
       });
     });
     group('isInfinite', () {
       test('succeeds for infinity', () {
-        checkThat(double.infinity).isInfinite();
+        check(double.infinity).isInfinite();
       });
       test('succeeds for negative infinity', () {
-        checkThat(double.negativeInfinity).isInfinite();
+        check(double.negativeInfinity).isInfinite();
       });
       test('fails for NaN', () {
-        checkThat(double.nan)
+        check(double.nan)
             .isRejectedBy(it()..isInfinite(), which: ['is not infinite']);
       });
       test('fails for finite numbers', () {
-        checkThat(1)
-            .isRejectedBy(it()..isInfinite(), which: ['is not infinite']);
+        check(1).isRejectedBy(it()..isInfinite(), which: ['is not infinite']);
       });
     });
 
     group('isNotInfinite', () {
       test('succeeds for finite numbers', () {
-        checkThat(1).isNotInfinite();
+        check(1).isNotInfinite();
       });
       test('succeeds for NaN', () {
-        checkThat(double.nan).isNotInfinite();
+        check(double.nan).isNotInfinite();
       });
       test('fails for infinity', () {
-        checkThat(double.infinity)
+        check(double.infinity)
             .isRejectedBy(it()..isNotInfinite(), which: ['is infinite']);
       });
       test('fails for negative infinity', () {
-        checkThat(double.negativeInfinity)
+        check(double.negativeInfinity)
             .isRejectedBy(it()..isNotInfinite(), which: ['is infinite']);
       });
     });
     group('closeTo', () {
       test('succeeds for equal numbers', () {
-        checkThat(1).isCloseTo(1, 1);
+        check(1).isCloseTo(1, 1);
       });
       test('succeeds at less than delta away', () {
-        checkThat(1).isCloseTo(2, 2);
+        check(1).isCloseTo(2, 2);
       });
       test('succeeds at exactly delta away', () {
-        checkThat(1).isCloseTo(2, 1);
+        check(1).isCloseTo(2, 1);
       });
       test('fails for low values', () {
-        checkThat(1)
-            .isRejectedBy(it()..isCloseTo(3, 1), which: ['differs by <2>']);
+        check(1).isRejectedBy(it()..isCloseTo(3, 1), which: ['differs by <2>']);
       });
       test('fails for high values', () {
-        checkThat(5)
-            .isRejectedBy(it()..isCloseTo(3, 1), which: ['differs by <2>']);
+        check(5).isRejectedBy(it()..isCloseTo(3, 1), which: ['differs by <2>']);
       });
     });
   });

--- a/pkgs/checks/test/extensions/string_test.dart
+++ b/pkgs/checks/test/extensions/string_test.dart
@@ -10,42 +10,42 @@ import '../test_shared.dart';
 void main() {
   group('StringChecks', () {
     test('contains', () {
-      checkThat('bob').contains('bo');
-      checkThat('bob').isRejectedBy(it()..contains('kayleb'),
+      check('bob').contains('bo');
+      check('bob').isRejectedBy(it()..contains('kayleb'),
           which: ["Does not contain 'kayleb'"]);
     });
     test('length', () {
-      checkThat('bob').length.equals(3);
+      check('bob').length.equals(3);
     });
     test('isEmpty', () {
-      checkThat('').isEmpty();
-      checkThat('bob').isRejectedBy(it()..isEmpty(), which: ['is not empty']);
+      check('').isEmpty();
+      check('bob').isRejectedBy(it()..isEmpty(), which: ['is not empty']);
     });
     test('isNotEmpty', () {
-      checkThat('bob').isNotEmpty();
-      checkThat('').isRejectedBy(it()..isNotEmpty(), which: ['is empty']);
+      check('bob').isNotEmpty();
+      check('').isRejectedBy(it()..isNotEmpty(), which: ['is empty']);
     });
     test('startsWith', () {
-      checkThat('bob').startsWith('bo');
-      checkThat('bob').isRejectedBy(it()..startsWith('kayleb'),
+      check('bob').startsWith('bo');
+      check('bob').isRejectedBy(it()..startsWith('kayleb'),
           which: ["does not start with 'kayleb'"]);
     });
     test('endsWith', () {
-      checkThat('bob').endsWith('ob');
-      checkThat('bob').isRejectedBy(it()..endsWith('kayleb'),
+      check('bob').endsWith('ob');
+      check('bob').isRejectedBy(it()..endsWith('kayleb'),
           which: ["does not end with 'kayleb'"]);
     });
 
     group('matches', () {
       test('succeeds for strings that match', () {
-        checkThat('123').matches(RegExp(r'\d\d\d'));
+        check('123').matches(RegExp(r'\d\d\d'));
       });
       test('fails for non-matching strings', () {
-        checkThat('abc').isRejectedBy(it()..matches(RegExp(r'\d\d\d')),
+        check('abc').isRejectedBy(it()..matches(RegExp(r'\d\d\d')),
             which: [r'does not match <RegExp: pattern=\d\d\d flags=>']);
       });
       test('can be described', () {
-        checkThat(it<String>()..matches(RegExp(r'\d\d\d')))
+        check(it<String>()..matches(RegExp(r'\d\d\d')))
             .description
             .deepEquals([r'  matches <RegExp: pattern=\d\d\d flags=>']);
       });
@@ -53,14 +53,14 @@ void main() {
 
     group('containsInOrder', () {
       test('happy case', () {
-        checkThat('foo bar baz').containsInOrder(['foo', 'baz']);
+        check('foo bar baz').containsInOrder(['foo', 'baz']);
       });
       test('reports when first substring is missing', () {
-        checkThat('baz').isRejectedBy(it()..containsInOrder(['foo', 'baz']),
+        check('baz').isRejectedBy(it()..containsInOrder(['foo', 'baz']),
             which: ['does not have a match for the substring \'foo\'']);
       });
       test('reports when substring is missing following a match', () {
-        checkThat('foo bar')
+        check('foo bar')
             .isRejectedBy(it()..containsInOrder(['foo', 'baz']), which: [
           'does not have a match for the substring \'baz\'',
           'following the other matches up to character 3'
@@ -70,44 +70,44 @@ void main() {
 
     group('equals', () {
       test('succeeeds for happy case', () {
-        checkThat('foo').equals('foo');
+        check('foo').equals('foo');
       });
       test('succeeeds for equal empty strings', () {
-        checkThat('').equals('');
+        check('').equals('');
       });
       test('reports extra characters for long string', () {
-        checkThat('foobar').isRejectedBy(it()..equals('foo'),
+        check('foobar').isRejectedBy(it()..equals('foo'),
             which: ['is too long with unexpected trailing characters:', 'bar']);
       });
       test('reports extra characters for long string against empty', () {
-        checkThat('foo')
+        check('foo')
             .isRejectedBy(it()..equals(''), which: ['is not the empty string']);
       });
       test('reports truncated extra characters for very long string', () {
-        checkThat('foobar baz more stuff').isRejectedBy(it()..equals('foo'),
+        check('foobar baz more stuff').isRejectedBy(it()..equals('foo'),
             which: [
               'is too long with unexpected trailing characters:',
               'bar baz mo ...'
             ]);
       });
       test('reports missing characters for short string', () {
-        checkThat('foo').isRejectedBy(it()..equals('foobar'),
+        check('foo').isRejectedBy(it()..equals('foobar'),
             which: ['is too short with missing trailing characters:', 'bar']);
       });
       test('reports missing characters for empty string', () {
-        checkThat('').isRejectedBy(it()..equals('foo bar baz'),
+        check('').isRejectedBy(it()..equals('foo bar baz'),
             actual: ['an empty string'],
             which: ['is missing all expected characters:', 'foo bar ba ...']);
       });
       test('reports truncated missing characters for very short string', () {
-        checkThat('foo').isRejectedBy(it()..equals('foobar baz more stuff'),
+        check('foo').isRejectedBy(it()..equals('foobar baz more stuff'),
             which: [
               'is too short with missing trailing characters:',
               'bar baz mo ...'
             ]);
       });
       test('reports index of different character', () {
-        checkThat('hit').isRejectedBy(it()..equals('hat'), which: [
+        check('hit').isRejectedBy(it()..equals('hat'), which: [
           'differs at offset 1:',
           'hat',
           'hit',
@@ -116,7 +116,7 @@ void main() {
       });
       test('reports truncated index of different character in large string',
           () {
-        checkThat('blah blah blah hit blah blah blah').isRejectedBy(
+        check('blah blah blah hit blah blah blah').isRejectedBy(
             it()..equals('blah blah blah hat blah blah blah'),
             which: [
               'differs at offset 16:',
@@ -129,19 +129,19 @@ void main() {
 
     group('equalsIgnoringCase', () {
       test('succeeeds for happy case', () {
-        checkThat('FOO').equalsIgnoringCase('foo');
-        checkThat('foo').equalsIgnoringCase('FOO');
+        check('FOO').equalsIgnoringCase('foo');
+        check('foo').equalsIgnoringCase('FOO');
       });
       test('reports original extra characters for long string', () {
-        checkThat('FOOBAR').isRejectedBy(it()..equalsIgnoringCase('foo'),
+        check('FOOBAR').isRejectedBy(it()..equalsIgnoringCase('foo'),
             which: ['is too long with unexpected trailing characters:', 'BAR']);
       });
       test('reports original missing characters for short string', () {
-        checkThat('FOO').isRejectedBy(it()..equalsIgnoringCase('fooBAR'),
+        check('FOO').isRejectedBy(it()..equalsIgnoringCase('fooBAR'),
             which: ['is too short with missing trailing characters:', 'BAR']);
       });
       test('reports index of different character with original characters', () {
-        checkThat('HiT').isRejectedBy(it()..equalsIgnoringCase('hAt'), which: [
+        check('HiT').isRejectedBy(it()..equalsIgnoringCase('hAt'), which: [
           'differs at offset 1:',
           'hAt',
           'HiT',
@@ -152,28 +152,28 @@ void main() {
 
     group('equalsIgnoringWhitespace', () {
       test('allows differing internal whitespace', () {
-        checkThat('foo \t\n bar').equalsIgnoringWhitespace('foo bar');
+        check('foo \t\n bar').equalsIgnoringWhitespace('foo bar');
       });
       test('allows extra leading/trailing whitespace', () {
-        checkThat(' foo ').equalsIgnoringWhitespace('foo');
+        check(' foo ').equalsIgnoringWhitespace('foo');
       });
       test('allows missing leading/trailing whitespace', () {
-        checkThat('foo').equalsIgnoringWhitespace(' foo ');
+        check('foo').equalsIgnoringWhitespace(' foo ');
       });
       test('reports original extra characters for long string', () {
-        checkThat('foo \t bar \n baz')
+        check('foo \t bar \n baz')
             .isRejectedBy(it()..equalsIgnoringWhitespace('foo bar'), which: [
           'is too long with unexpected trailing characters:',
           ' baz'
         ]);
       });
       test('reports original missing characters for short string', () {
-        checkThat('foo  bar').isRejectedBy(
+        check('foo  bar').isRejectedBy(
             it()..equalsIgnoringWhitespace('foo bar baz'),
             which: ['is too short with missing trailing characters:', ' baz']);
       });
       test('reports index of different character with original characters', () {
-        checkThat('x  hit  x')
+        check('x  hit  x')
             .isRejectedBy(it()..equalsIgnoringWhitespace('x hat x'), which: [
           'differs at offset 3:',
           'x hat x',

--- a/pkgs/checks/test/failure_message_test.dart
+++ b/pkgs/checks/test/failure_message_test.dart
@@ -5,8 +5,8 @@ import 'package:test_api/hooks.dart' show TestFailure;
 void main() {
   group('failures', () {
     test('includes expected, actual, and which', () {
-      checkThat(() {
-        checkThat(1).isGreaterThan(2);
+      check(() {
+        check(1).isGreaterThan(2);
       }).throwsFailure().equals('''
 Expected: a int that:
   is greater than <2>
@@ -15,8 +15,8 @@ Which: is not greater than <2>''');
     });
 
     test('includes matching portions of actual', () {
-      checkThat(() {
-        checkThat([]).length.equals(1);
+      check(() {
+        check([]).length.equals(1);
       }).throwsFailure().equals('''
 Expected: a List<dynamic> that:
   has length that:
@@ -28,20 +28,20 @@ Actual: a List<dynamic> that:
     });
 
     test('include a reason when provided', () {
-      checkThat(() {
-        checkThat(because: 'Some reason', 1).isGreaterThan(2);
+      check(() {
+        check(because: 'Some reason', 1).isGreaterThan(2);
       }).throwsFailure().endsWith('Reason: Some reason');
     });
 
     test('retain type label following isNotNull', () {
-      checkThat(() {
-        checkThat<int?>(1).isNotNull().isGreaterThan(2);
+      check(() {
+        check<int?>(1).isNotNull().isGreaterThan(2);
       }).throwsFailure().startsWith('Expected: a int? that:\n');
     });
 
     test('retain reason following isNotNull', () {
-      checkThat(() {
-        checkThat<int?>(because: 'Some reason', 1).isNotNull().isGreaterThan(2);
+      check(() {
+        check<int?>(because: 'Some reason', 1).isNotNull().isGreaterThan(2);
       }).throwsFailure().endsWith('Reason: Some reason');
     });
   });


### PR DESCRIPTION
Save 4 characters of typing millions of times. The line will not read as
nicely in many situations, but it doesn't make a significant difference.

The shorter name, with no capital letters, also draws the least possible
attention to this name, which carries the least information of any part
of the expression.
