### PR TITLE
Annotate `checkThat` with `usResult`

### DIFF
--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -5,6 +5,7 @@
 // TODO Add doc about how failure strings work.
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:test_api/hooks.dart';
 
 import 'describe.dart';
@@ -58,6 +59,7 @@ extension Skip<T> on Subject<T> {
 /// ```dart
 /// checkThat(actual).equals(expected);
 /// ```
+@useResult
 Subject<T> checkThat<T>(T value, {String? because}) =>
     Subject._(_TestContext._root(
       value: _Present(value),

--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -5,7 +5,7 @@
 // TODO Add doc about how failure strings work.
 import 'dart:async';
 
-import 'package:meta/meta.dart';
+import 'package:meta/meta.dart' as meta;
 import 'package:test_api/hooks.dart';
 
 import 'describe.dart';
@@ -59,7 +59,7 @@ extension Skip<T> on Subject<T> {
 /// ```dart
 /// checkThat(actual).equals(expected);
 /// ```
-@useResult
+@meta.useResult
 Subject<T> checkThat<T>(T value, {String? because}) =>
     Subject._(_TestContext._root(
       value: _Present(value),

--- a/pkgs/checks/pubspec.yaml
+++ b/pkgs/checks/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   async: ^2.8.0
+  meta: ^1.9.0
   test_api: ^0.4.0
 
 dev_dependencies:


### PR DESCRIPTION
It would never be useful to set up a `Subject` and not check any
expectations on it.
