### PR TITLE
Include stack for failures unexpected async errors

### DIFF
--- a/pkgs/checks/CHANGELOG.md
+++ b/pkgs/checks/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 0.1.1-dev
 
-- Added an example.
+-   Added an example.
+-   Include a stack trace in the failure description for unexpected errors from
+    Futures or Streams.
 
 # 0.1.0
 

--- a/pkgs/checks/lib/src/extensions/async.dart
+++ b/pkgs/checks/lib/src/extensions/async.dart
@@ -19,10 +19,13 @@ extension FutureChecks<T> on Subject<Future<T>> {
       context.nestAsync<T>('completes to a value', (actual) async {
         try {
           return Extracted.value(await actual);
-        } catch (e) {
-          return Extracted.rejection(
-              actual: ['a future that completes as an error'],
-              which: prefixFirst('threw ', literal(e)));
+        } catch (e, st) {
+          return Extracted.rejection(actual: [
+            'a future that completes as an error'
+          ], which: [
+            ...prefixFirst('threw ', postfixLast(' at:', literal(e))),
+            ...(const LineSplitter()).convert(st.toString())
+          ]);
         }
       });
 
@@ -66,10 +69,13 @@ extension FutureChecks<T> on Subject<Future<T>> {
               which: ['did not throw']);
         } on E catch (e) {
           return Extracted.value(e);
-        } catch (e) {
+        } catch (e, st) {
           return Extracted.rejection(
               actual: prefixFirst('completed to error ', literal(e)),
-              which: ['is not an $E']);
+              which: [
+                'threw an exception that is not a $E at:',
+                ...(const LineSplitter()).convert(st.toString())
+              ]);
         }
       });
 }
@@ -113,10 +119,13 @@ extension StreamChecks<T> on Subject<StreamQueue<T>> {
         try {
           await actual.peek;
           return Extracted.value(await actual.next);
-        } catch (e) {
+        } catch (e, st) {
           return Extracted.rejection(
               actual: prefixFirst('a stream with error ', literal(e)),
-              which: ['emitted an error instead of a value']);
+              which: [
+                'emitted an error instead of a value at:',
+                ...(const LineSplitter()).convert(st.toString())
+              ]);
         }
       });
 
@@ -147,10 +156,13 @@ extension StreamChecks<T> on Subject<StreamQueue<T>> {
         } on E catch (e) {
           await actual.next.then<void>((_) {}, onError: (_) {});
           return Extracted.value(e);
-        } catch (e) {
+        } catch (e, st) {
           return Extracted.rejection(
               actual: prefixFirst('a stream with error ', literal(e)),
-              which: ['emitted an error with an incorrect type, is not $E']);
+              which: [
+                'emitted an error which is not $E at:',
+                ...(const LineSplitter()).convert(st.toString())
+              ]);
         }
       });
 

--- a/pkgs/checks/test/extensions/async_test.dart
+++ b/pkgs/checks/test/extensions/async_test.dart
@@ -22,7 +22,7 @@ void main() {
         await checkThat(_futureFail()).isRejectedByAsync(
           it()..completes().which(it()..equals(1)),
           actual: ['a future that completes as an error'],
-          which: ['threw <UnimplementedError>'],
+          which: ['threw <UnimplementedError> at:', 'fake trace'],
         );
       });
       test('can be described', () async {
@@ -59,7 +59,10 @@ void main() {
         await checkThat(_futureFail()).isRejectedByAsync(
           it()..throws<StateError>(),
           actual: ['completed to error <UnimplementedError>'],
-          which: ['is not an StateError'],
+          which: [
+            'threw an exception that is not a StateError at:',
+            'fake trace'
+          ],
         );
       });
       test('can be described', () async {
@@ -141,7 +144,7 @@ fake trace''');
         await checkThat(_countingStream(1, errorAt: 0)).isRejectedByAsync(
           it()..emits(),
           actual: ['a stream with error <UnimplementedError: Error at 1>'],
-          which: ['emitted an error instead of a value'],
+          which: ['emitted an error instead of a value at:', 'fake trace'],
         );
       });
       test('can be described', () async {
@@ -188,7 +191,7 @@ fake trace''');
         await checkThat(_countingStream(1, errorAt: 0)).isRejectedByAsync(
           it()..emitsError<StateError>(),
           actual: ['a stream with error <UnimplementedError: Error at 1>'],
-          which: ['emitted an error with an incorrect type, is not StateError'],
+          which: ['emitted an error which is not StateError at:', 'fake trace'],
         );
       });
       test('can be described', () async {
@@ -529,12 +532,16 @@ fake trace''');
 
 Future<int> _futureSuccess() => Future.microtask(() => 42);
 
-Future<int> _futureFail() => Future.error(UnimplementedError());
+Future<int> _futureFail() =>
+    Future.error(UnimplementedError(), StackTrace.fromString('fake trace'));
 
 StreamQueue<int> _countingStream(int count, {int? errorAt}) => StreamQueue(
       Stream.fromIterable(
         Iterable<int>.generate(count, (index) {
-          if (index == errorAt) throw UnimplementedError('Error at $count');
+          if (index == errorAt) {
+            Error.throwWithStackTrace(UnimplementedError('Error at $count'),
+                StackTrace.fromString('fake trace'));
+          }
           return index;
         }),
       ),


### PR DESCRIPTION
When a Future or Stream throw (or emit) an unexpected exception it is
useful to know where originated.
