### PR TITLE
Support running tests by absolute file: uri

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -4,6 +4,7 @@
   reporter.
 * Add support for CHROME_EXECUTABLE environment variable. This overrides any
   config file settings.
+* Support running tests by absolute file uri.
 
 ## 1.22.2
 

--- a/pkgs/test/test/runner/configuration/platform_test.dart
+++ b/pkgs/test/test/runner/configuration/platform_test.dart
@@ -205,10 +205,8 @@ void main() {
       var test = await runTest(['.']);
       expect(
           test.stdout,
-          containsInOrder([
-            '+0: .${Platform.pathSeparator}test_foo.dart: test_foo',
-            '+1: All tests passed!'
-          ]));
+          containsInOrder(
+              ['+0: ./test_foo.dart: test_foo', '+1: All tests passed!']));
       await test.shouldExit(0);
     });
 
@@ -243,10 +241,8 @@ void main() {
       var test = await runTest(['.']);
       expect(
           test.stdout,
-          containsInOrder([
-            '+0: .${Platform.pathSeparator}foo_test.dart: foo_test',
-            '+1: All tests passed!'
-          ]));
+          containsInOrder(
+              ['+0: ./foo_test.dart: foo_test', '+1: All tests passed!']));
       await test.shouldExit(0);
     });
 

--- a/pkgs/test/test/runner/configuration/platform_test.dart
+++ b/pkgs/test/test/runner/configuration/platform_test.dart
@@ -4,7 +4,6 @@
 
 @TestOn('vm')
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:test/test.dart';
 import 'package:test_core/src/util/exit_codes.dart' as exit_codes;

--- a/pkgs/test/test/runner/configuration/randomize_order_test.dart
+++ b/pkgs/test/test/runner/configuration/randomize_order_test.dart
@@ -4,7 +4,6 @@
 
 @TestOn('vm')
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;

--- a/pkgs/test/test/runner/configuration/randomize_order_test.dart
+++ b/pkgs/test/test/runner/configuration/randomize_order_test.dart
@@ -148,14 +148,14 @@ void main() {
         test.stdout,
         emitsInAnyOrder([
           containsInOrder([
-            '.${Platform.pathSeparator}1_test.dart: test 1.2',
-            '.${Platform.pathSeparator}1_test.dart: test 1.3',
-            '.${Platform.pathSeparator}1_test.dart: test 1.1'
+            './1_test.dart: test 1.2',
+            './1_test.dart: test 1.3',
+            './1_test.dart: test 1.1'
           ]),
           containsInOrder([
-            '.${Platform.pathSeparator}2_test.dart: test 2.2',
-            '.${Platform.pathSeparator}2_test.dart: test 2.3',
-            '.${Platform.pathSeparator}2_test.dart: test 2.1'
+            './2_test.dart: test 2.2',
+            './2_test.dart: test 2.3',
+            './2_test.dart: test 2.1'
           ]),
           contains('+6: All tests passed!')
         ]));

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -373,12 +373,20 @@ $_usage''');
       await test.shouldExit(0);
     });
 
-    test('with windows style (\\) relative paths', () async {
+    test('with platform specific relative paths', () async {
       await d.dir('foo', [d.file('test.dart', _success)]).create();
-      var test = await runTest(['foo\\test.dart']);
+      var test = await runTest([p.join('foo', 'test.dart')]);
       expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
       await test.shouldExit(0);
-    }, testOn: 'windows');
+    });
+
+    test('with platform specific relative paths containing query params',
+        () async {
+      await d.dir('foo', [d.file('test.dart', _success)]).create();
+      var test = await runTest(['${p.join('foo', 'test.dart')}?line=6']);
+      expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
+      await test.shouldExit(0);
+    });
   });
 
   group('runs successful tests with async setup', () {

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -366,7 +366,7 @@ $_usage''');
 
     test('given a file: uri on windows', () async {
       await d.file('test.dart', _success).create();
-      var path = p.absolute('test.dart');
+      var path = p.url.absolute('test.dart');
       var test = await runTest(['file://$path']);
       expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
       await test.shouldExit(0);

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -372,6 +372,13 @@ $_usage''');
       expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
       await test.shouldExit(0);
     });
+
+    test('with windows style (\\) relative paths', () async {
+      await d.file('foo/test.dart', _success).create();
+      var test = await runTest(['foo\\test.dart']);
+      expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
+      await test.shouldExit(0);
+    }, testOn: 'windows');
   });
 
   group('runs successful tests with async setup', () {

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -366,7 +366,7 @@ $_usage''');
 
     test('given a file: uri', () async {
       await d.file('test.dart', _success).create();
-      var fileUri = p.toUri(p.absolute('test.dart')).toString();
+      var fileUri = p.toUri(d.path('test.dart')).toString();
       expect(fileUri, startsWith('file:///'));
       var test = await runTest([fileUri]);
       expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -374,7 +374,7 @@ $_usage''');
     });
 
     test('with windows style (\\) relative paths', () async {
-      await d.file('foo/test.dart', _success).create();
+      await d.dir('foo', [d.file('test.dart', _success)]).create();
       var test = await runTest(['foo\\test.dart']);
       expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
       await test.shouldExit(0);

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -7,6 +7,7 @@
 import 'dart:io';
 import 'dart:math' as math;
 
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_core/src/util/exit_codes.dart' as exit_codes;
 import 'package:test_descriptor/test_descriptor.dart' as d;
@@ -362,6 +363,14 @@ $_usage''');
       expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
       await test.shouldExit(0);
     });
+
+    test('given a file: uri on windows', () async {
+      await d.file('test.dart', _success).create();
+      var path = p.absolute('test.dart');
+      var test = await runTest(['file://$path']);
+      expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
+      await test.shouldExit(0);
+    }, testOn: 'windows');
   });
 
   group('runs successful tests with async setup', () {

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -364,9 +364,11 @@ $_usage''');
       await test.shouldExit(0);
     });
 
-    test('given a file: uri on windows', () async {
+    test('given a file: uri', () async {
       await d.file('test.dart', _success).create();
-      var test = await runTest([p.toUri(p.absolute('test.dart')).toString()]);
+      var fileUri = p.toUri(p.absolute('test.dart')).toString();
+      expect(fileUri, startsWith('file:///'));
+      var test = await runTest([fileUri]);
       expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
       await test.shouldExit(0);
     });

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -366,11 +366,10 @@ $_usage''');
 
     test('given a file: uri on windows', () async {
       await d.file('test.dart', _success).create();
-      var path = p.url.absolute('test.dart');
-      var test = await runTest(['file://$path']);
+      var test = await runTest([p.toUri(p.absolute('test.dart')).toString()]);
       expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
       await test.shouldExit(0);
-    }, testOn: 'windows');
+    });
   });
 
   group('runs successful tests with async setup', () {

--- a/pkgs/test/test/runner/shard_test.dart
+++ b/pkgs/test/test/runner/shard_test.dart
@@ -3,9 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
-
-import 'dart:io';
-
 import 'package:test/test.dart';
 import 'package:test_core/src/util/exit_codes.dart' as exit_codes;
 import 'package:test_descriptor/test_descriptor.dart' as d;

--- a/pkgs/test/test/runner/shard_test.dart
+++ b/pkgs/test/test/runner/shard_test.dart
@@ -95,14 +95,10 @@ void main() {
         test.stdout,
         emitsInOrder([
           emitsAnyOf([
-            containsInOrder([
-              '+0: .${Platform.pathSeparator}1_test.dart: test 1.1',
-              '+1: .${Platform.pathSeparator}2_test.dart: test 2.1'
-            ]),
-            containsInOrder([
-              '+0: .${Platform.pathSeparator}2_test.dart: test 2.1',
-              '+1: .${Platform.pathSeparator}1_test.dart: test 1.1'
-            ])
+            containsInOrder(
+                ['+0: ./1_test.dart: test 1.1', '+1: ./2_test.dart: test 2.1']),
+            containsInOrder(
+                ['+0: ./2_test.dart: test 2.1', '+1: ./1_test.dart: test 1.1'])
           ]),
           contains('+2: All tests passed!')
         ]));
@@ -113,14 +109,10 @@ void main() {
         test.stdout,
         emitsInOrder([
           emitsAnyOf([
-            containsInOrder([
-              '+0: .${Platform.pathSeparator}1_test.dart: test 1.2',
-              '+1: .${Platform.pathSeparator}2_test.dart: test 2.2'
-            ]),
-            containsInOrder([
-              '+0: .${Platform.pathSeparator}2_test.dart: test 2.2',
-              '+1: .${Platform.pathSeparator}1_test.dart: test 1.2'
-            ])
+            containsInOrder(
+                ['+0: ./1_test.dart: test 1.2', '+1: ./2_test.dart: test 2.2']),
+            containsInOrder(
+                ['+0: ./2_test.dart: test 2.2', '+1: ./1_test.dart: test 1.2'])
           ]),
           contains('+2: All tests passed!')
         ]));
@@ -131,14 +123,10 @@ void main() {
         test.stdout,
         emitsInOrder([
           emitsAnyOf([
-            containsInOrder([
-              '+0: .${Platform.pathSeparator}1_test.dart: test 1.3',
-              '+1: .${Platform.pathSeparator}2_test.dart: test 2.3'
-            ]),
-            containsInOrder([
-              '+0: .${Platform.pathSeparator}2_test.dart: test 2.3',
-              '+1: .${Platform.pathSeparator}1_test.dart: test 1.3'
-            ])
+            containsInOrder(
+                ['+0: ./1_test.dart: test 1.3', '+1: ./2_test.dart: test 2.3']),
+            containsInOrder(
+                ['+0: ./2_test.dart: test 2.3', '+1: ./1_test.dart: test 1.3'])
           ]),
           contains('+2: All tests passed!')
         ]));

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Avoid empty expandable groups for tests without extra output in Github
   reporter.
+* Always parse test paths as uris and grab the path from that.
 
 # 0.4.22
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Avoid empty expandable groups for tests without extra output in Github
   reporter.
-* Always parse test paths as uris and grab the path from that.
+* Support running tests by absolute file uri.
 
 # 0.4.22
 

--- a/pkgs/test_core/lib/src/runner.dart
+++ b/pkgs/test_core/lib/src/runner.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 
 import 'package:async/async.dart';
 import 'package:boolean_selector/boolean_selector.dart';
-import 'package:path/path.dart' as p;
 import 'package:stack_trace/stack_trace.dart';
 // ignore: deprecated_member_use
 import 'package:test_api/backend.dart'

--- a/pkgs/test_core/lib/src/runner.dart
+++ b/pkgs/test_core/lib/src/runner.dart
@@ -317,7 +317,8 @@ class Runner {
                   'Cannot filter by line/column for this test suite, no suite'
                   'path available.');
             }
-            var absoluteSuitePath = p.absolute(path);
+            // The absolute path as it will appear in stack traces.
+            var absoluteSuitePath = File(path).absolute.uri.toFilePath();
 
             bool matchLineAndCol(Frame frame) {
               if (frame.uri.scheme != 'file' ||

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -181,7 +181,7 @@ void _parseTestSelection(
   TestSelection selection;
   String path;
   if (firstQuestion == -1) {
-    path = option;
+    path = Uri.parse(option).path;
     selection = TestSelection();
   } else if (option.substring(0, firstQuestion).contains('\\')) {
     throw FormatException(

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -178,9 +178,7 @@ Configuration parse(List<String> args) => _Parser(args).parse();
 void _parseTestSelection(
     String option, Map<String, Set<TestSelection>> selections) {
   final uri = Uri.parse(option);
-  // Restore the path to how it was given (namely, we want to report paths
-  // with their original separators).
-  var path = Uri.decodeComponent(uri.path);
+  var path = uri.path;
   // Strip out the leading slash before the drive letter on windows.
   if (Platform.isWindows && path.startsWith('/')) {
     path = path.substring(1);

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -181,7 +181,15 @@ void _parseTestSelection(
   TestSelection selection;
   String path;
   if (firstQuestion == -1) {
-    path = Uri.parse(option).path;
+    if (option.contains('://')) {
+      path = Uri.parse(option).path;
+      // Strip out the leading slash before the drive letter.
+      if (Platform.isWindows && path.startsWith('/')) {
+        path = path.substring(1);
+      }
+    } else {
+      path = option;
+    }
     selection = TestSelection();
   } else if (option.substring(0, firstQuestion).contains('\\')) {
     throw FormatException(

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -178,7 +178,9 @@ Configuration parse(List<String> args) => _Parser(args).parse();
 void _parseTestSelection(
     String option, Map<String, Set<TestSelection>> selections) {
   final uri = Uri.parse(option);
-  var path = uri.path;
+  // Restore the path to how it was given (namely, we want to report paths
+  // with their original separators).
+  var path = Uri.decodeComponent(uri.path);
   // Strip out the leading slash before the drive letter on windows.
   if (Platform.isWindows && path.startsWith('/')) {
     path = path.substring(1);

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -180,20 +180,13 @@ void _parseTestSelection(
   var firstQuestion = option.indexOf('?');
   TestSelection selection;
   String path;
-  if (firstQuestion == -1) {
-    if (option.contains('://')) {
-      path = Uri.parse(option).path;
-      // Strip out the leading slash before the drive letter.
-      if (Platform.isWindows && path.startsWith('/')) {
-        path = path.substring(1);
-      }
-    } else {
-      path = option;
-    }
+  if (firstQuestion == -1 && !option.contains('://')) {
+    path = option;
     selection = TestSelection();
-  } else if (option.substring(0, firstQuestion).contains('\\')) {
+  } else if (firstQuestion != -1 &&
+      option.substring(0, firstQuestion).contains('\\')) {
     throw FormatException(
-        'When passing test path queries, you must pass the path in URI '
+        'When passing test path uris, you must pass the path in URI '
         'format (use `/` for directory separators instead of `\\`).');
   } else {
     final uri = Uri.parse(option);
@@ -209,6 +202,10 @@ void _parseTestSelection(
       );
     }
     path = uri.path;
+    // Strip out the leading slash before the drive letter on windows.
+    if (Platform.isWindows && path.startsWith('/')) {
+      path = path.substring(1);
+    }
     selection = TestSelection(
       testPatterns: fullName != null
           ? {RegExp('^${RegExp.escape(fullName)}\$')}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/test/issues/1891
Fixes https://github.com/dart-lang/test/issues/1899

For any path which looks like it has a scheme (contains "://"), parse it as a uri and grab the path from that. On windows, we also remove any leading `/` from the path because it will be followed by a drive letter, which we want to be the first part of the path (and not preceded by a `/`).

Open to better ideas here too, if you have them :)