### PR TITLE
Try a postfix phrasing

### DIFF
--- a/pkgs/checks/example/example.dart
+++ b/pkgs/checks/example/example.dart
@@ -8,16 +8,16 @@ import 'package:test/scaffolding.dart';
 void main() {
   test('sample test', () {
     final someValue = 5;
-    checkThat(someValue).equals(5);
+    someValue.must.equal(5);
 
     final someList = [1, 2, 3, 4, 5];
-    checkThat(someList).deepEquals([1, 2, 3, 4, 5]);
+    someList.must.deeplyEqual([1, 2, 3, 4, 5]);
 
     final someString = 'abcdefghijklmnopqrstuvwxyz';
 
-    checkThat(someString)
-      ..startsWith('a')
-      ..endsWith('z')
-      ..contains('lmno');
+    someString.must
+      ..startWith('a')
+      ..endWith('z')
+      ..contain('lmno');
   });
 }

--- a/pkgs/checks/lib/checks.dart
+++ b/pkgs/checks/lib/checks.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'src/checks.dart' show checkThat, Subject, Skip, it;
+export 'src/checks.dart' show Check, Subject, Skip, would;
 export 'src/extensions/async.dart'
     show ChainAsync, FutureChecks, StreamChecks, StreamQueueWrap;
 export 'src/extensions/core.dart'

--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -47,20 +47,22 @@ extension Skip<T> on Subject<T> {
   }
 }
 
-/// Creates a [Subject] that can be used to validate expectations against
-/// [value], with an exception upon a failed expectation.
-///
-/// Expectations that are not satisfied throw a [TestFailure] to interrupt the
-/// currently running test and mark it as failed.
-///
-/// If [because] is passed it will be included as a "Reason:" line in failure
-/// messages.
-///
-/// ```dart
-/// checkThat(actual).equals(expected);
-/// ```
-@meta.useResult
-Subject<T> checkThat<T>(T value, {String? because}) =>
+extension Check<T> on T {
+  /// Creates a [Subject] that can be used to validate expectations against
+  /// this value, with an exception upon a failed expectation.
+  ///
+  /// Expectations that are not satisfied throw a [TestFailure] to interrupt the
+  /// currently running test and mark it as failed.
+  ///
+  /// ```dart
+  /// actual.check.equals(expected);
+  /// ```
+  @meta.useResult
+  // TODO: Cannot support `because` with a getter
+  Subject<T> get must => _check(this);
+}
+
+Subject<T> _check<T>(T value, {String? because}) =>
     Subject._(_TestContext._root(
       value: _Present(value),
       // TODO - switch between "a" and "an"
@@ -181,7 +183,7 @@ abstract class Condition<T> {
   Future<void> applyAsync(Subject<T> subject);
 }
 
-ConditionSubject<T> it<T>() => ConditionSubject._();
+ConditionSubject<T> would<T>() => ConditionSubject._();
 
 extension ContextExtension<T> on Subject<T> {
   /// The expectations and nesting context for this subject.

--- a/pkgs/checks/lib/src/extensions/async.dart
+++ b/pkgs/checks/lib/src/extensions/async.dart
@@ -15,7 +15,7 @@ extension FutureChecks<T> on Subject<Future<T>> {
   /// future completes.
   ///
   /// Fails if the future completes as an error.
-  Future<Subject<T>> completes() =>
+  Future<Subject<T>> complete() =>
       context.nestAsync<T>('completes to a value', (actual) async {
         try {
           return Extracted.value(await actual);
@@ -24,7 +24,7 @@ extension FutureChecks<T> on Subject<Future<T>> {
             'a future that completes as an error'
           ], which: [
             ...prefixFirst('threw ', postfixLast(' at:', literal(e))),
-            ...(const LineSplitter()).convert(st.toString())
+            ...const LineSplitter().convert(st.toString())
           ]);
         }
       });
@@ -38,7 +38,7 @@ extension FutureChecks<T> on Subject<Future<T>> {
   ///
   /// Not compatible with [softCheck] or [softCheckAsync] since there is no
   /// concrete end point where this condition has definitely succeeded.
-  void doesNotComplete() {
+  void neverComplete() {
     context.expectUnawaited(() => ['does not complete'], (actual, reject) {
       unawaited(actual.then((r) {
         reject(Rejection(
@@ -48,7 +48,7 @@ extension FutureChecks<T> on Subject<Future<T>> {
           'a future that completed as an error:'
         ], which: [
           ...prefixFirst('threw ', literal(e)),
-          ...(const LineSplitter()).convert(st.toString())
+          ...const LineSplitter().convert(st.toString())
         ]));
       }));
     });
@@ -60,7 +60,7 @@ extension FutureChecks<T> on Subject<Future<T>> {
   /// future completes as an error.
   ///
   /// Fails if the future completes to a value.
-  Future<Subject<E>> throws<E extends Object>() => context.nestAsync<E>(
+  Future<Subject<E>> throwException<E extends Object>() => context.nestAsync<E>(
           'completes to an error${E == Object ? '' : ' of type $E'}',
           (actual) async {
         try {
@@ -74,7 +74,7 @@ extension FutureChecks<T> on Subject<Future<T>> {
               actual: prefixFirst('completed to error ', literal(e)),
               which: [
                 'threw an exception that is not a $E at:',
-                ...(const LineSplitter()).convert(st.toString())
+                ...const LineSplitter().convert(st.toString())
               ]);
         }
       });
@@ -109,7 +109,7 @@ extension StreamChecks<T> on Subject<StreamQueue<T>> {
   ///
   /// Fails if the stream emits an error instead of a value, or closes without
   /// emitting a value.
-  Future<Subject<T>> emits() =>
+  Future<Subject<T>> emit() =>
       context.nestAsync<T>('emits a value', (actual) async {
         if (!await actual.hasNext) {
           return Extracted.rejection(
@@ -124,7 +124,7 @@ extension StreamChecks<T> on Subject<StreamQueue<T>> {
               actual: prefixFirst('a stream with error ', literal(e)),
               which: [
                 'emitted an error instead of a value at:',
-                ...(const LineSplitter()).convert(st.toString())
+                ...const LineSplitter().convert(st.toString())
               ]);
         }
       });
@@ -140,7 +140,7 @@ extension StreamChecks<T> on Subject<StreamQueue<T>> {
   /// If this expectation fails, the source queue will be left in it's original
   /// state.
   /// If this expectation succeeds, consumes the error event.
-  Future<Subject<E>> emitsError<E extends Object>() =>
+  Future<Subject<E>> emitError<E extends Object>() =>
       context.nestAsync('emits an error${E == Object ? '' : ' of type $E'}',
           (actual) async {
         if (!await actual.hasNext) {
@@ -161,7 +161,7 @@ extension StreamChecks<T> on Subject<StreamQueue<T>> {
               actual: prefixFirst('a stream with error ', literal(e)),
               which: [
                 'emitted an error which is not $E at:',
-                ...(const LineSplitter()).convert(st.toString())
+                ...const LineSplitter().convert(st.toString())
               ]);
         }
       });
@@ -179,7 +179,7 @@ extension StreamChecks<T> on Subject<StreamQueue<T>> {
   /// state.
   /// If this expectation succeeds, consumes the matching event and all prior
   /// events.
-  Future<void> emitsThrough(Condition<T> condition) async {
+  Future<void> emitThrough(Condition<T> condition) async {
     await _expectAsync(
         () => [
               'emits any values then emits a value that:',
@@ -341,7 +341,7 @@ extension StreamChecks<T> on Subject<StreamQueue<T>> {
   /// state.
   /// If this expectation succeeds, consumes all the events that did not satisfy
   /// [condition] until the end of the stream.
-  Future<void> neverEmits(Condition<T> condition) async {
+  Future<void> neverEmit(Condition<T> condition) async {
     await _expectAsync(
         () => ['never emits a value that:', ...describe(condition)],
         (actual) async {
@@ -367,7 +367,7 @@ extension StreamChecks<T> on Subject<StreamQueue<T>> {
   ///
   /// If a non-matching event is emitted, no events are consumed.
   /// If a matching event is emitted, that event is consumed.
-  Future<void> mayEmit(Condition<T> condition) async {
+  Future<void> maybeEmit(Condition<T> condition) async {
     await context
         .expectAsync(() => ['may emit a value that:', ...describe(condition)],
             (actual) async {
@@ -392,7 +392,7 @@ extension StreamChecks<T> on Subject<StreamQueue<T>> {
   /// - A non-matching event is emitted.
   /// - An error is emitted.
   /// - The stream closes.
-  Future<void> mayEmitMultiple(Condition<T> condition) async {
+  Future<void> maybeEmitMultiple(Condition<T> condition) async {
     await context
         .expectAsync(() => ['may emit a value that:', ...describe(condition)],
             (actual) async {
@@ -416,7 +416,7 @@ extension StreamChecks<T> on Subject<StreamQueue<T>> {
   ///
   /// If this expectation fails, the source queue will be left in its original
   /// state, the event or error that caused it to fail will not be consumed.
-  Future<void> isDone() async {
+  Future<void> beDone() async {
     await _expectAsync(() => ['is done'], (actual) async {
       if (!await actual.hasNext) return null;
       try {
@@ -429,7 +429,7 @@ extension StreamChecks<T> on Subject<StreamQueue<T>> {
           'a stream'
         ], which: [
           ...prefixFirst('emitted an unexpected error: ', literal(e)),
-          ...(const LineSplitter()).convert(st.toString())
+          ...const LineSplitter().convert(st.toString())
         ]);
       }
     });
@@ -454,14 +454,12 @@ extension ChainAsync<T> on Future<Subject<T>> {
   }
 }
 
-extension StreamQueueWrap<T> on Subject<Stream<T>> {
+extension StreamQueueWrap<T> on Stream<T> {
   /// Wrap the stream in a [StreamQueue] to allow using checks from
   /// [StreamChecks].
   ///
   /// Stream expectations operate on a queue, instead of directly on the stream,
   /// so that they can support conditional expectations and check multiple
   /// possibilities from the same point in the stream.
-  Subject<StreamQueue<T>> get withQueue =>
-      context.nest('', (actual) => Extracted.value(StreamQueue(actual)),
-          atSameLevel: true);
+  StreamQueue<T> get withQueue => StreamQueue(this);
 }

--- a/pkgs/checks/lib/src/extensions/core.dart
+++ b/pkgs/checks/lib/src/extensions/core.dart
@@ -9,7 +9,7 @@ extension CoreChecks<T> on Subject<T> {
   ///
   /// Sets up a clause that the value "has [name] that:" followed by any
   /// expectations applied to the returned [Subject].
-  Subject<R> has<R>(R Function(T) extract, String name) {
+  Subject<R> have<R>(R Function(T) extract, String name) {
     return context.nest('has $name', (T value) {
       try {
         return Extracted.value(extract(value));
@@ -69,7 +69,7 @@ extension CoreChecks<T> on Subject<T> {
   /// Expects that the value is assignable to type [T].
   ///
   /// If the value is a [T], returns a [Subject] for further expectations.
-  Subject<R> isA<R>() {
+  Subject<R> beA<R>() {
     return context.nest<R>('is a $R', (actual) {
       if (actual is! R) {
         return Extracted.rejection(which: ['Is a ${actual.runtimeType}']);
@@ -79,7 +79,7 @@ extension CoreChecks<T> on Subject<T> {
   }
 
   /// Expects that the value is equal to [other] according to [operator ==].
-  void equals(T other) {
+  void equal(T other) {
     context.expect(() => prefixFirst('equals ', literal(other)), (actual) {
       if (actual == other) return null;
       return Rejection(which: ['are not equal']);
@@ -87,7 +87,7 @@ extension CoreChecks<T> on Subject<T> {
   }
 
   /// Expects that the value is [identical] to [other].
-  void identicalTo(T other) {
+  void beIdenticalTo(T other) {
     context.expect(() => prefixFirst('is identical to ', literal(other)),
         (actual) {
       if (identical(actual, other)) return null;
@@ -97,7 +97,7 @@ extension CoreChecks<T> on Subject<T> {
 }
 
 extension BoolChecks on Subject<bool> {
-  void isTrue() {
+  void beTrue() {
     context.expect(
       () => ['is true'],
       (actual) => actual
@@ -106,7 +106,7 @@ extension BoolChecks on Subject<bool> {
     );
   }
 
-  void isFalse() {
+  void beFalse() {
     context.expect(
       () => ['is false'],
       (actual) => !actual
@@ -117,14 +117,14 @@ extension BoolChecks on Subject<bool> {
 }
 
 extension NullabilityChecks<T> on Subject<T?> {
-  Subject<T> isNotNull() {
+  Subject<T> beNonNull() {
     return context.nest<T>('is not null', (actual) {
       if (actual == null) return Extracted.rejection();
       return Extracted.value(actual);
     }, atSameLevel: true);
   }
 
-  void isNull() {
+  void beNull() {
     context.expect(() => const ['is null'], (actual) {
       if (actual != null) return Rejection();
       return null;

--- a/pkgs/checks/lib/src/extensions/function.dart
+++ b/pkgs/checks/lib/src/extensions/function.dart
@@ -16,7 +16,7 @@ extension ThrowsCheck<T> on Subject<T Function()> {
   /// If this function is async and returns a [Future], this expectation will
   /// fail. Instead invoke the function and check the expectation on the
   /// returned [Future].
-  Subject<E> throws<E>() {
+  Subject<E> throwException<E>() {
     return context.nest<E>('throws an error of type $E', (actual) {
       try {
         final result = actual();
@@ -39,7 +39,7 @@ extension ThrowsCheck<T> on Subject<T Function()> {
   /// further expecations on the returned value.
   ///
   /// If the function throws synchronously, this expectation will fail.
-  Subject<T> returnsNormally() {
+  Subject<T> returnNormally() {
     return context.nest<T>('returns a value', (actual) {
       try {
         return Extracted.value(actual());

--- a/pkgs/checks/lib/src/extensions/iterable.dart
+++ b/pkgs/checks/lib/src/extensions/iterable.dart
@@ -8,19 +8,19 @@ import '../collection_equality.dart';
 import 'core.dart';
 
 extension IterableChecks<T> on Subject<Iterable<T>> {
-  Subject<int> get length => has((l) => l.length, 'length');
-  Subject<T> get first => has((l) => l.first, 'first element');
-  Subject<T> get last => has((l) => l.last, 'last element');
-  Subject<T> get single => has((l) => l.single, 'single element');
+  Subject<int> get haveLength => have((l) => l.length, 'length');
+  Subject<T> get haveFirst => have((l) => l.first, 'first element');
+  Subject<T> get haveLast => have((l) => l.last, 'last element');
+  Subject<T> get haveSingleElement => have((l) => l.single, 'single element');
 
-  void isEmpty() {
+  void beEmpty() {
     context.expect(() => const ['is empty'], (actual) {
       if (actual.isEmpty) return null;
       return Rejection(which: ['is not empty']);
     });
   }
 
-  void isNotEmpty() {
+  void beNotEmpty() {
     context.expect(() => const ['is not empty'], (actual) {
       if (actual.isNotEmpty) return null;
       return Rejection(which: ['is not empty']);
@@ -29,7 +29,7 @@ extension IterableChecks<T> on Subject<Iterable<T>> {
 
   /// Expects that the iterable contains [element] according to
   /// [Iterable.contains].
-  void contains(T element) {
+  void contain(T element) {
     context.expect(() {
       return prefixFirst('contains ', literal(element));
     }, (actual) {
@@ -60,7 +60,7 @@ extension IterableChecks<T> on Subject<Iterable<T>> {
   /// checkThat([1, 0, 2, 0, 3])
   ///   .containsInOrder([1, it<int>()..isGreaterThan(1), 3]);
   /// ```
-  void containsInOrder(Iterable<Object?> elements) {
+  void containInOrder(Iterable<Object?> elements) {
     context.expect(() => prefixFirst('contains, in order: ', literal(elements)),
         (actual) {
       final expected = elements.toList();
@@ -88,7 +88,7 @@ extension IterableChecks<T> on Subject<Iterable<T>> {
 
   /// Expects that the iterable contains at least on element such that
   /// [elementCondition] is satisfied.
-  void any(Condition<T> elementCondition) {
+  void containElementWhich(Condition<T> elementCondition) {
     context.expect(() {
       final conditionDescription = describe(elementCondition);
       assert(conditionDescription.isNotEmpty);
@@ -109,7 +109,7 @@ extension IterableChecks<T> on Subject<Iterable<T>> {
   /// [elementCondition].
   ///
   /// Empty iterables will pass always pass this expectation.
-  void every(Condition<T> elementCondition) {
+  void containOnlyElementsWhich(Condition<T> elementCondition) {
     context.expect(() {
       final conditionDescription = describe(elementCondition);
       assert(conditionDescription.isNotEmpty);
@@ -141,7 +141,7 @@ extension IterableChecks<T> on Subject<Iterable<T>> {
   /// elements of [expected].
   ///
   /// {@macro deep_collection_equals}
-  void deepEquals(Iterable<Object?> expected) => context
+  void deeplyEqual(Iterable<Object?> expected) => context
           .expect(() => prefixFirst('is deeply equal to ', literal(expected)),
               (actual) {
         final which = deepCollectionEquals(actual, expected);
@@ -155,7 +155,7 @@ extension IterableChecks<T> on Subject<Iterable<T>> {
   /// Should not be used for very large collections, runtime is O(n^2.5) in the
   /// worst case where the iterables contain many equal elements, and O(n^2) in
   /// more typical cases.
-  void unorderedEquals(Iterable<T> expected) {
+  void unorderedEqual(Iterable<T> expected) {
     context.expect(() => prefixFirst('unordered equals ', literal(expected)),
         (actual) {
       final which = unorderedCompare(
@@ -221,7 +221,7 @@ extension IterableChecks<T> on Subject<Iterable<T>> {
   /// [description] is used in the Expected clause. It should be a predicate
   /// without the object, for example with the description 'is less than' the
   /// full expectation will be: "pairwise is less than $expected"
-  void pairwiseComparesTo<S>(List<S> expected,
+  void pairwiseCompareTo<S>(List<S> expected,
       Condition<T> Function(S) elementCondition, String description) {
     context.expect(() {
       return prefixFirst('pairwise $description ', literal(expected));

--- a/pkgs/checks/lib/src/extensions/map.dart
+++ b/pkgs/checks/lib/src/extensions/map.dart
@@ -8,11 +8,11 @@ import '../collection_equality.dart';
 import 'core.dart';
 
 extension MapChecks<K, V> on Subject<Map<K, V>> {
-  Subject<Iterable<MapEntry<K, V>>> get entries =>
-      has((m) => m.entries, 'entries');
-  Subject<Iterable<K>> get keys => has((m) => m.keys, 'keys');
-  Subject<Iterable<V>> get values => has((m) => m.values, 'values');
-  Subject<int> get length => has((m) => m.length, 'length');
+  Subject<Iterable<MapEntry<K, V>>> get haveEntries =>
+      have((m) => m.entries, 'entries');
+  Subject<Iterable<K>> get haveKeys => have((m) => m.keys, 'keys');
+  Subject<Iterable<V>> get haveValues => have((m) => m.values, 'values');
+  Subject<int> get haveLength => have((m) => m.length, 'length');
   Subject<V> operator [](K key) {
     final keyString = literal(key).join(r'\n');
     return context.nest('contains a value for $keyString', (actual) {
@@ -24,14 +24,14 @@ extension MapChecks<K, V> on Subject<Map<K, V>> {
     });
   }
 
-  void isEmpty() {
+  void beEmpty() {
     context.expect(() => const ['is empty'], (actual) {
       if (actual.isEmpty) return null;
       return Rejection(which: ['is not empty']);
     });
   }
 
-  void isNotEmpty() {
+  void beNotEmpty() {
     context.expect(() => const ['is not empty'], (actual) {
       if (actual.isNotEmpty) return null;
       return Rejection(which: ['is not empty']);
@@ -39,7 +39,7 @@ extension MapChecks<K, V> on Subject<Map<K, V>> {
   }
 
   /// Expects that the map contains [key] according to [Map.containsKey].
-  void containsKey(K key) {
+  void containKey(K key) {
     final keyString = literal(key).join(r'\n');
     context.expect(() => ['contains key $keyString'], (actual) {
       if (actual.containsKey(key)) return null;
@@ -49,7 +49,7 @@ extension MapChecks<K, V> on Subject<Map<K, V>> {
 
   /// Expects that the map contains some key such that [keyCondition] is
   /// satisfied.
-  void containsKeyThat(Condition<K> keyCondition) {
+  void containKeyWhich(Condition<K> keyCondition) {
     context.expect(() {
       final conditionDescription = describe(keyCondition);
       assert(conditionDescription.isNotEmpty);
@@ -67,7 +67,7 @@ extension MapChecks<K, V> on Subject<Map<K, V>> {
   }
 
   /// Expects that the map contains [value] according to [Map.containsValue].
-  void containsValue(V value) {
+  void containValue(V value) {
     final valueString = literal(value).join(r'\n');
     context.expect(() => ['contains value $valueString'], (actual) {
       if (actual.containsValue(value)) return null;
@@ -77,7 +77,7 @@ extension MapChecks<K, V> on Subject<Map<K, V>> {
 
   /// Expects that the map contains some value such that [valueCondition] is
   /// satisfied.
-  void containsValueThat(Condition<V> valueCondition) {
+  void containValueWhich(Condition<V> valueCondition) {
     context.expect(() {
       final conditionDescription = describe(valueCondition);
       assert(conditionDescription.isNotEmpty);
@@ -98,7 +98,7 @@ extension MapChecks<K, V> on Subject<Map<K, V>> {
   /// of [expected].
   ///
   /// {@macro deep_collection_equals}
-  void deepEquals(Map<Object?, Object?> expected) => context
+  void deeplyEqual(Map<Object?, Object?> expected) => context
           .expect(() => prefixFirst('is deeply equal to ', literal(expected)),
               (actual) {
         final which = deepCollectionEquals(actual, expected);

--- a/pkgs/checks/lib/src/extensions/math.dart
+++ b/pkgs/checks/lib/src/extensions/math.dart
@@ -6,7 +6,7 @@ import 'package:checks/context.dart';
 
 extension NumChecks on Subject<num> {
   /// Expects that this number is greater than [other].
-  void isGreaterThan(num other) {
+  void beGreaterThan(num other) {
     context.expect(() => ['is greater than <$other>'], (actual) {
       if (actual > other) return null;
       return Rejection(which: ['is not greater than <$other>']);
@@ -14,7 +14,7 @@ extension NumChecks on Subject<num> {
   }
 
   /// Expects that this number is greater than or equal to [other].
-  void isGreaterOrEqual(num other) {
+  void beGreaterOrEqual(num other) {
     context.expect(() => ['is greater than or equal to <$other>'], (actual) {
       if (actual >= other) return null;
       return Rejection(which: ['is not greater than or equal to <$other>']);
@@ -22,7 +22,7 @@ extension NumChecks on Subject<num> {
   }
 
   /// Expects that this number is less than [other].
-  void isLessThan(num other) {
+  void beLessThat(num other) {
     context.expect(() => ['is less than <$other>'], (actual) {
       if (actual < other) return null;
       return Rejection(which: ['is not less than <$other>']);
@@ -30,7 +30,7 @@ extension NumChecks on Subject<num> {
   }
 
   /// Expects that this number is less than or equal to [other].
-  void isLessOrEqual(num other) {
+  void beLessOrEqual(num other) {
     context.expect(() => ['is less than or equal to <$other>'], (actual) {
       if (actual <= other) return null;
       return Rejection(which: ['is not less than or equal to <$other>']);
@@ -38,7 +38,7 @@ extension NumChecks on Subject<num> {
   }
 
   /// Expects that [num.isNaN] is true.
-  void isNaN() {
+  void beNaN() {
     context.expect(() => ['is not a number (NaN)'], (actual) {
       if (actual.isNaN) return null;
       return Rejection(which: ['is a number']);
@@ -46,7 +46,7 @@ extension NumChecks on Subject<num> {
   }
 
   /// Expects that [num.isNaN] is false.
-  void isNotNaN() {
+  void beANumber() {
     context.expect(() => ['is a number (not NaN)'], (actual) {
       if (!actual.isNaN) return null;
       return Rejection(which: ['is not a number (NaN)']);
@@ -54,7 +54,7 @@ extension NumChecks on Subject<num> {
   }
 
   /// Expects that [num.isNegative] is true.
-  void isNegative() {
+  void beNegative() {
     context.expect(() => ['is negative'], (actual) {
       if (actual.isNegative) return null;
       return Rejection(which: ['is not negative']);
@@ -62,7 +62,7 @@ extension NumChecks on Subject<num> {
   }
 
   /// Expects that [num.isNegative] is false.
-  void isNotNegative() {
+  void beNonNegative() {
     context.expect(() => ['is not negative'], (actual) {
       if (!actual.isNegative) return null;
       return Rejection(which: ['is negative']);
@@ -70,7 +70,7 @@ extension NumChecks on Subject<num> {
   }
 
   /// Expects that [num.isFinite] is true.
-  void isFinite() {
+  void beFinite() {
     context.expect(() => ['is finite'], (actual) {
       if (actual.isFinite) return null;
       return Rejection(which: ['is not finite']);
@@ -81,7 +81,7 @@ extension NumChecks on Subject<num> {
   ///
   /// Satisfied by [double.nan], [double.infinity] and
   /// [double.negativeInfinity].
-  void isNotFinite() {
+  void notBeFinite() {
     context.expect(() => ['is not finite'], (actual) {
       if (!actual.isFinite) return null;
       return Rejection(which: ['is finite']);
@@ -91,7 +91,7 @@ extension NumChecks on Subject<num> {
   /// Expects that [num.isInfinite] is true.
   ///
   /// Satisfied by [double.infinity] and [double.negativeInfinity].
-  void isInfinite() {
+  void beInfinite() {
     context.expect(() => ['is infinite'], (actual) {
       if (actual.isInfinite) return null;
       return Rejection(which: ['is not infinite']);
@@ -101,7 +101,7 @@ extension NumChecks on Subject<num> {
   /// Expects that [num.isInfinite] is false.
   ///
   /// Satisfied by [double.nan] and finite numbers.
-  void isNotInfinite() {
+  void notBeInfinite() {
     context.expect(() => ['is not infinite'], (actual) {
       if (!actual.isInfinite) return null;
       return Rejection(which: ['is infinite']);
@@ -110,7 +110,7 @@ extension NumChecks on Subject<num> {
 
   /// Expects that the difference between this number and [other] is less than
   /// or equal to [delta].
-  void isCloseTo(num other, num delta) {
+  void beCloseTo(num other, num delta) {
     context.expect(() => ['is within <$delta> of <$other>'], (actual) {
       final difference = (other - actual).abs();
       if (difference <= delta) return null;

--- a/pkgs/checks/lib/src/extensions/string.dart
+++ b/pkgs/checks/lib/src/extensions/string.dart
@@ -10,7 +10,7 @@ import 'core.dart';
 
 extension StringChecks on Subject<String> {
   /// Expects that the value contains [pattern] according to [String.contains];
-  void contains(Pattern pattern) {
+  void contain(Pattern pattern) {
     context.expect(() => prefixFirst('contains ', literal(pattern)), (actual) {
       if (actual.contains(pattern)) return null;
       return Rejection(
@@ -19,23 +19,23 @@ extension StringChecks on Subject<String> {
     });
   }
 
-  Subject<int> get length => has((m) => m.length, 'length');
+  Subject<int> get haveLength => have((m) => m.length, 'length');
 
-  void isEmpty() {
+  void beEmpty() {
     context.expect(() => const ['is empty'], (actual) {
       if (actual.isEmpty) return null;
       return Rejection(which: ['is not empty']);
     });
   }
 
-  void isNotEmpty() {
+  void beNotEmpty() {
     context.expect(() => const ['is not empty'], (actual) {
       if (actual.isNotEmpty) return null;
       return Rejection(which: ['is empty']);
     });
   }
 
-  void startsWith(Pattern other) {
+  void startWith(Pattern other) {
     context.expect(
       () => prefixFirst('starts with ', literal(other)),
       (actual) {
@@ -47,7 +47,7 @@ extension StringChecks on Subject<String> {
     );
   }
 
-  void endsWith(String other) {
+  void endWith(String other) {
     context.expect(
       () => prefixFirst('ends with ', literal(other)),
       (actual) {
@@ -60,7 +60,7 @@ extension StringChecks on Subject<String> {
   }
 
   /// Expects that the string matches the regular expression [expected].
-  void matches(RegExp expected) {
+  void matchRegex(RegExp expected) {
     context.expect(() => prefixFirst('matches ', literal(expected)), (actual) {
       if (expected.hasMatch(actual)) return null;
       return Rejection(
@@ -74,7 +74,7 @@ extension StringChecks on Subject<String> {
   /// For example, the following will succeed:
   ///
   ///     checkThat('abcdefg').containsInOrder(['a','e']);
-  void containsInOrder(Iterable<String> expected) {
+  void containInOrder(Iterable<String> expected) {
     context.expect(() => prefixFirst('contains, in order: ', literal(expected)),
         (actual) {
       var fromIndex = 0;
@@ -96,14 +96,14 @@ extension StringChecks on Subject<String> {
 
   /// Expects that the `String` contains exactly the same code units as
   /// [expected].
-  void equals(String expected) {
+  void equal(String expected) {
     context.expect(() => prefixFirst('equals ', literal(expected)),
         (actual) => _findDifference(actual, expected));
   }
 
   /// Expects that the `String` contains the same characters as [expected] if
   /// both were lower case.
-  void equalsIgnoringCase(String expected) {
+  void equalIgnoringCase(String expected) {
     context.expect(
         () => prefixFirst('equals ignoring case ', literal(expected)),
         (actual) => _findDifference(
@@ -124,7 +124,7 @@ extension StringChecks on Subject<String> {
   ///
   ///     checkThat('helloworld').equalsIgnoringWhitespace('hello world');
   ///     checkThat('he llo world').equalsIgnoringWhitespace('hello world');
-  void equalsIgnoringWhitespace(String expected) {
+  void equalIgnoringQhitespace(String expected) {
     context.expect(
         () => prefixFirst('equals ignoring whitespace ', literal(expected)),
         (actual) {

--- a/pkgs/checks/test/describe_test.dart
+++ b/pkgs/checks/test/describe_test.dart
@@ -9,13 +9,13 @@ import 'package:test/scaffolding.dart';
 void main() {
   group('describe', () {
     test('succeeds for empty conditions', () {
-      checkThat(describe(it())).isEmpty();
+      (describe(would())).must.beEmpty();
     });
     test('includes condition clauses', () {
-      checkThat(describe(it()..equals(1))).deepEquals(['  equals <1>']);
+      (describe(would()..equal(1))).must.deeplyEqual(['  equals <1>']);
     });
     test('includes nested clauses', () {
-      checkThat(describe(it<String>()..length.equals(1))).deepEquals([
+      (describe(would<String>()..haveLength.equal(1))).must.deeplyEqual([
         '  has length that:',
         '    equals <1>',
       ]);

--- a/pkgs/checks/test/extensions/async_test.dart
+++ b/pkgs/checks/test/extensions/async_test.dart
@@ -16,23 +16,25 @@ void main() {
   group('FutureChecks', () {
     group('completes', () {
       test('succeeds for a future that completes to a value', () async {
-        await checkThat(_futureSuccess()).completes().which(it()..equals(42));
+        await (_futureSuccess()).must.complete().which(would()..equal(42));
       });
       test('rejects futures which complete as errors', () async {
-        await checkThat(_futureFail()).isRejectedByAsync(
-          it()..completes().which(it()..equals(1)),
+        await (_futureFail()).must.beRejectedByAsync(
+          would()..complete().which(would()..equal(1)),
           actual: ['a future that completes as an error'],
           which: ['threw <UnimplementedError> at:', 'fake trace'],
         );
       });
       test('can be described', () async {
-        await checkThat(it<Future<void>>()..completes())
-            .asyncDescription
-            .which(it()..deepEquals(['  completes to a value']));
-        await checkThat(it<Future<int>>()..completes().which(it()..equals(42)))
-            .asyncDescription
-            .which(it()
-              ..deepEquals([
+        await (would<Future<void>>()..complete())
+            .must
+            .haveAsyncDescription
+            .which(would()..deeplyEqual(['  completes to a value']));
+        await (would<Future<int>>()..complete().which(would()..equal(42)))
+            .must
+            .haveAsyncDescription
+            .which(would()
+              ..deeplyEqual([
                 '  completes to a value that:',
                 '    equals <42>',
               ]));
@@ -43,21 +45,22 @@ void main() {
       test(
           'succeeds for a future that compeletes to an error of the expected type',
           () async {
-        await checkThat(_futureFail())
-            .throws<UnimplementedError>()
-            .which(it()..has((p0) => p0.message, 'message').isNull());
+        await (_futureFail())
+            .must
+            .throwException<UnimplementedError>()
+            .which(would()..have((p0) => p0.message, 'message').beNull());
       });
       test('fails for futures that complete to a value', () async {
-        await checkThat(_futureSuccess()).isRejectedByAsync(
-          it()..throws(),
+        await (_futureSuccess()).must.beRejectedByAsync(
+          would()..throwException(),
           actual: ['completed to <42>'],
           which: ['did not throw'],
         );
       });
       test('failes for futures that complete to an error of the wrong type',
           () async {
-        await checkThat(_futureFail()).isRejectedByAsync(
-          it()..throws<StateError>(),
+        await (_futureFail()).must.beRejectedByAsync(
+          would()..throwException<StateError>(),
           actual: ['completed to error <UnimplementedError>'],
           which: [
             'threw an exception that is not a StateError at:',
@@ -66,35 +69,37 @@ void main() {
         );
       });
       test('can be described', () async {
-        await checkThat(it<Future<void>>()..throws())
-            .asyncDescription
-            .which(it()..deepEquals(['  completes to an error']));
-        await checkThat(it<Future<void>>()..throws<StateError>())
-            .asyncDescription
-            .which(it()
-              ..deepEquals(['  completes to an error of type StateError']));
+        await (would<Future<void>>()..throwException())
+            .must
+            .haveAsyncDescription
+            .which(would()..deeplyEqual(['  completes to an error']));
+        await (would<Future<void>>()..throwException<StateError>())
+            .must
+            .haveAsyncDescription
+            .which(would()
+              ..deeplyEqual(['  completes to an error of type StateError']));
       });
     });
 
     group('doesNotComplete', () {
       test('succeeds for a Future that never completes', () async {
-        checkThat(Completer<void>().future).doesNotComplete();
+        (Completer<void>().future).must.neverComplete();
       });
       test('fails for a Future that completes as a value', () async {
         Object? testFailure;
         runZonedGuarded(() {
           final completer = Completer<String>();
-          checkThat(completer.future).doesNotComplete();
+          (completer.future).must.neverComplete();
           completer.complete('value');
         }, (e, st) {
           testFailure = e;
         });
         await pumpEventQueue();
-        checkThat(testFailure)
-            .isA<TestFailure>()
-            .has((f) => f.message, 'message')
-            .isNotNull()
-            .equals('''
+        testFailure.must
+            .beA<TestFailure>()
+            .have((f) => f.message, 'message')
+            .beNonNull()
+            .equal('''
 Expected: a Future<String> that:
   does not complete
 Actual: a future that completed to 'value\'''');
@@ -103,17 +108,17 @@ Actual: a future that completed to 'value\'''');
         Object? testFailure;
         runZonedGuarded(() {
           final completer = Completer<String>();
-          checkThat(completer.future).doesNotComplete();
+          (completer.future).must.neverComplete();
           completer.completeError('error', StackTrace.fromString('fake trace'));
         }, (e, st) {
           testFailure = e;
         });
         await pumpEventQueue();
-        checkThat(testFailure)
-            .isA<TestFailure>()
-            .has((f) => f.message, 'message')
-            .isNotNull()
-            .equals('''
+        testFailure.must
+            .beA<TestFailure>()
+            .have((f) => f.message, 'message')
+            .beNonNull()
+            .equal('''
 Expected: a Future<String> that:
   does not complete
 Actual: a future that completed as an error:
@@ -121,9 +126,10 @@ Which: threw 'error'
 fake trace''');
       });
       test('can be described', () async {
-        await checkThat(it<Future<void>>()..doesNotComplete())
-            .asyncDescription
-            .which(it()..deepEquals(['  does not complete']));
+        await (would<Future<void>>()..neverComplete())
+            .must
+            .haveAsyncDescription
+            .which(would()..deeplyEqual(['  does not complete']));
       });
     });
   });
@@ -131,82 +137,89 @@ fake trace''');
   group('StreamChecks', () {
     group('emits', () {
       test('succeeds for a stream that emits a value', () async {
-        await checkThat(_countingStream(5)).emits().which(it()..equals(0));
+        await (_countingStream(5)).must.emit().which(would()..equal(0));
       });
       test('fails for a stream that closes without emitting', () async {
-        await checkThat(_countingStream(0)).isRejectedByAsync(
-          it()..emits(),
+        await (_countingStream(0)).must.beRejectedByAsync(
+          would()..emit(),
           actual: ['a stream'],
           which: ['closed without emitting enough values'],
         );
       });
       test('fails for a stream that emits an error', () async {
-        await checkThat(_countingStream(1, errorAt: 0)).isRejectedByAsync(
-          it()..emits(),
+        await (_countingStream(1, errorAt: 0)).must.beRejectedByAsync(
+          would()..emit(),
           actual: ['a stream with error <UnimplementedError: Error at 1>'],
           which: ['emitted an error instead of a value at:', 'fake trace'],
         );
       });
       test('can be described', () async {
-        await checkThat(it<StreamQueue<void>>()..emits())
-            .asyncDescription
-            .which(it()..deepEquals(['  emits a value']));
-        await checkThat(it<StreamQueue<int>>()..emits().which(it()..equals(42)))
-            .asyncDescription
-            .which(it()
-              ..deepEquals([
+        await (would<StreamQueue<void>>()..emit())
+            .must
+            .haveAsyncDescription
+            .which(would()..deeplyEqual(['  emits a value']));
+        await (would<StreamQueue<int>>()..emit().which(would()..equal(42)))
+            .must
+            .haveAsyncDescription
+            .which(would()
+              ..deeplyEqual([
                 '  emits a value that:',
                 '    equals <42>',
               ]));
       });
       test('uses a transaction', () async {
         final queue = _countingStream(1, errorAt: 0);
-        await softCheckAsync<StreamQueue<int>>(queue, it()..emits());
-        await checkThat(queue).emitsError();
+        await softCheckAsync<StreamQueue<int>>(queue, would()..emit());
+        await queue.must.emitError();
       });
     });
 
     group('emitsError', () {
       test('succeeds for a stream that emits an error', () async {
-        await checkThat(_countingStream(1, errorAt: 0))
-            .emitsError<UnimplementedError>();
+        await (_countingStream(1, errorAt: 0))
+            .must
+            .emitError<UnimplementedError>();
       });
       test('fails for a stream that closes without emitting an error',
           () async {
-        await checkThat(_countingStream(0)).isRejectedByAsync(
-          it()..emitsError(),
+        await (_countingStream(0)).must.beRejectedByAsync(
+          would()..emitError(),
           actual: ['a stream'],
           which: ['closed without emitting an expected error'],
         );
       });
       test('fails for a stream that emits value', () async {
-        await checkThat(_countingStream(1)).isRejectedByAsync(
-          it()..emitsError(),
+        await (_countingStream(1)).must.beRejectedByAsync(
+          would()..emitError(),
           actual: ['a stream emitting value <0>'],
           which: ['closed without emitting an error'],
         );
       });
       test('fails for a stream that emits an error of the incorrect type',
           () async {
-        await checkThat(_countingStream(1, errorAt: 0)).isRejectedByAsync(
-          it()..emitsError<StateError>(),
+        await (_countingStream(1, errorAt: 0)).must.beRejectedByAsync(
+          would()..emitError<StateError>(),
           actual: ['a stream with error <UnimplementedError: Error at 1>'],
           which: ['emitted an error which is not StateError at:', 'fake trace'],
         );
       });
       test('can be described', () async {
-        await checkThat(it<StreamQueue<void>>()..emitsError())
-            .asyncDescription
-            .which(it()..deepEquals(['  emits an error']));
-        await checkThat(it<StreamQueue<void>>()..emitsError<StateError>())
-            .asyncDescription
-            .which(it()..deepEquals(['  emits an error of type StateError']));
-        await checkThat(it<StreamQueue<void>>()
-              ..emitsError<StateError>()
-                  .which(it()..has((e) => e.message, 'message').equals('foo')))
-            .asyncDescription
-            .which(it()
-              ..deepEquals([
+        await (would<StreamQueue<void>>()..emitError())
+            .must
+            .haveAsyncDescription
+            .which(would()..deeplyEqual(['  emits an error']));
+        await (would<StreamQueue<void>>()..emitError<StateError>())
+            .must
+            .haveAsyncDescription
+            .which(
+                would()..deeplyEqual(['  emits an error of type StateError']));
+        await (would<StreamQueue<void>>()
+              ..emitError<StateError>().which(
+                  would()..have((e) => e.message, 'message').equal('foo')))
+            .must
+            .haveAsyncDescription
+            .which(would()
+              ..deeplyEqual([
                 '  emits an error of type StateError that:',
                 '    has message that:',
                 '      equals \'foo\''
@@ -214,29 +227,30 @@ fake trace''');
       });
       test('uses a transaction', () async {
         final queue = _countingStream(1);
-        await softCheckAsync<StreamQueue<int>>(queue, it()..emitsError());
-        await checkThat(queue).emits().which((it()..equals(0)));
+        await softCheckAsync<StreamQueue<int>>(queue, would()..emitError());
+        await queue.must.emit().which((would()..equal(0)));
       });
     });
 
     group('emitsThrough', () {
       test('succeeds for a stream that eventuall emits a matching value',
           () async {
-        await checkThat(_countingStream(5)).emitsThrough(it()..equals(4));
+        await (_countingStream(5)).must.emitThrough(would()..equal(4));
       });
       test('fails for a stream that closes without emitting a matching value',
           () async {
-        await checkThat(_countingStream(4)).isRejectedByAsync(
-          it()..emitsThrough(it()..equals(5)),
+        await (_countingStream(4)).must.beRejectedByAsync(
+          would()..emitThrough(would()..equal(5)),
           actual: ['a stream'],
           which: ['ended after emitting 4 elements with none matching'],
         );
       });
       test('can be described', () async {
-        await checkThat(it<StreamQueue<int>>()..emitsThrough(it()..equals(42)))
-            .asyncDescription
-            .which(it()
-              ..deepEquals([
+        await (would<StreamQueue<int>>()..emitThrough(would()..equal(42)))
+            .must
+            .haveAsyncDescription
+            .which(would()
+              ..deeplyEqual([
                 '  emits any values then emits a value that:',
                 '    equals <42>'
               ]));
@@ -244,27 +258,27 @@ fake trace''');
       test('uses a transaction', () async {
         final queue = _countingStream(1);
         await softCheckAsync(
-            queue, it<StreamQueue<int>>()..emitsThrough(it()..equals(42)));
-        checkThat(queue).emits().which(it()..equals(0));
+            queue, would<StreamQueue<int>>()..emitThrough(would()..equal(42)));
+        queue.must.emit().which(would()..equal(0));
       });
       test('consumes events', () async {
         final queue = _countingStream(3);
-        await checkThat(queue).emitsThrough(it()..equals(1));
-        await checkThat(queue).emits().which((it()..equals(2)));
+        await queue.must.emitThrough(would()..equal(1));
+        await queue.must.emit().which((would()..equal(2)));
       });
     });
 
     group('emitsInOrder', () {
       test('succeeds for happy case', () async {
-        await checkThat(_countingStream(2)).inOrder([
-          it()..emits().which(it()..equals(0)),
-          it()..emits().which((it()..equals(1))),
-          it()..isDone(),
+        await (_countingStream(2)).must.inOrder([
+          would()..emit().which(would()..equal(0)),
+          would()..emit().which((would()..equal(1))),
+          would()..beDone(),
         ]);
       });
       test('reports which condition failed', () async {
-        await checkThat(_countingStream(1)).isRejectedByAsync(
-          it()..inOrder([it()..emits(), it()..emits()]),
+        await (_countingStream(1)).must.beRejectedByAsync(
+          would()..inOrder([would()..emit(), would()..emit()]),
           actual: ['a stream'],
           which: [
             'satisfied 1 conditions then',
@@ -274,8 +288,10 @@ fake trace''');
         );
       });
       test('nestes the report for deep failures', () async {
-        await checkThat(_countingStream(2)).isRejectedByAsync(
-          it()..inOrder([it()..emits(), it()..emits().which(it()..equals(2))]),
+        await (_countingStream(2)).must.beRejectedByAsync(
+          would()
+            ..inOrder(
+                [would()..emit(), would()..emit().which(would()..equal(2))]),
           actual: ['a stream'],
           which: [
             'satisfied 1 conditions then',
@@ -288,31 +304,32 @@ fake trace''');
         );
       });
       test('gets described with the number of conditions', () async {
-        await checkThat(it<StreamQueue<int>>()..inOrder([it(), it()]))
-            .asyncDescription
-            .which(it()..deepEquals(['  satisfies 2 conditions in order']));
+        await (would<StreamQueue<int>>()..inOrder([would(), would()]))
+            .must
+            .haveAsyncDescription
+            .which(would()..deeplyEqual(['  satisfies 2 conditions in order']));
       });
       test('uses a transaction', () async {
         final queue = _countingStream(3);
         await softCheckAsync<StreamQueue<int>>(
             queue,
-            it()
+            would()
               ..inOrder([
-                it()..emits().which(it()..equals(0)),
-                it()..emits().which(it()..equals(1)),
-                it()..emits().which(it()..equals(42)),
+                would()..emit().which(would()..equal(0)),
+                would()..emit().which(would()..equal(1)),
+                would()..emit().which(would()..equal(42)),
               ]));
-        await checkThat(queue).inOrder([
-          it()..emits().which(it()..equals(0)),
-          it()..emits().which(it()..equals(1)),
-          it()..emits().which(it()..equals(2)),
-          it()..isDone(),
+        await queue.must.inOrder([
+          would()..emit().which(would()..equal(0)),
+          would()..emit().which(would()..equal(1)),
+          would()..emit().which(would()..equal(2)),
+          would()..beDone(),
         ]);
       });
       test('consumes events', () async {
         final queue = _countingStream(3);
-        await checkThat(queue).inOrder([it()..emits(), it()..emits()]);
-        await checkThat(queue).emits().which(it()..equals(2));
+        await queue.must.inOrder([would()..emit(), would()..emit()]);
+        await queue.must.emit().which(would()..equal(2));
       });
     });
 
@@ -320,20 +337,21 @@ fake trace''');
       test(
           'succeeds for a stream that closes without emitting a matching value',
           () async {
-        await checkThat(_countingStream(5)).neverEmits(it()..equals(5));
+        await (_countingStream(5)).must.neverEmit(would()..equal(5));
       });
       test('fails for a stream that emits a matching value', () async {
-        await checkThat(_countingStream(6)).isRejectedByAsync(
-          it()..neverEmits(it()..equals(5)),
+        await (_countingStream(6)).must.beRejectedByAsync(
+          would()..neverEmit(would()..equal(5)),
           actual: ['a stream'],
           which: ['emitted <5>', 'following 5 other items'],
         );
       });
       test('can be described', () async {
-        await checkThat(it<StreamQueue<int>>()..neverEmits(it()..equals(42)))
-            .asyncDescription
-            .which(it()
-              ..deepEquals([
+        await (would<StreamQueue<int>>()..neverEmit(would()..equal(42)))
+            .must
+            .haveAsyncDescription
+            .which(would()
+              ..deeplyEqual([
                 '  never emits a value that:',
                 '    equals <42>',
               ]));
@@ -341,122 +359,123 @@ fake trace''');
       test('uses a transaction', () async {
         final queue = _countingStream(2);
         await softCheckAsync<StreamQueue<int>>(
-            queue, it()..neverEmits(it()..equals(1)));
-        await checkThat(queue).inOrder([
-          it()..emits().which(it()..equals(0)),
-          it()..emits().which(it()..equals(1)),
-          it()..isDone(),
+            queue, would()..neverEmit(would()..equal(1)));
+        await queue.must.inOrder([
+          would()..emit().which(would()..equal(0)),
+          would()..emit().which(would()..equal(1)),
+          would()..beDone(),
         ]);
       });
     });
 
     group('mayEmit', () {
       test('succeeds for a stream that emits a matching value', () async {
-        await checkThat(_countingStream(1)).mayEmit(it()..equals(0));
+        await (_countingStream(1)).must.maybeEmit(would()..equal(0));
       });
       test('succeeds for a stream that emits an error', () async {
-        await checkThat(_countingStream(1, errorAt: 0))
-            .mayEmit(it()..equals(0));
+        await (_countingStream(1, errorAt: 0))
+            .must
+            .maybeEmit(would()..equal(0));
       });
       test('succeeds for a stream that closes', () async {
-        await checkThat(_countingStream(0)).mayEmit(it()..equals(42));
+        await (_countingStream(0)).must.maybeEmit(would()..equal(42));
       });
       test('consumes a matching event', () async {
         final queue = _countingStream(2);
         await softCheckAsync<StreamQueue<int>>(
-            queue, it()..mayEmit(it()..equals(0)));
-        await checkThat(queue).emits().which(it()..equals(1));
+            queue, would()..maybeEmit(would()..equal(0)));
+        await queue.must.emit().which(would()..equal(1));
       });
       test('does not consume a non-matching event', () async {
         final queue = _countingStream(2);
         await softCheckAsync<StreamQueue<int>>(
-            queue, it()..mayEmit(it()..equals(1)));
-        await checkThat(queue).emits().which(it()..equals(0));
+            queue, would()..maybeEmit(would()..equal(1)));
+        await queue.must.emit().which(would()..equal(0));
       });
       test('does not consume an error', () async {
         final queue = _countingStream(1, errorAt: 0);
         await softCheckAsync<StreamQueue<int>>(
-            queue, it()..mayEmit(it()..equals(0)));
-        await checkThat(queue)
-            .emitsError<UnimplementedError>()
-            .which(it()..has((e) => e.message, 'message').equals('Error at 1'));
+            queue, would()..maybeEmit(would()..equal(0)));
+        await queue.must.emitError<UnimplementedError>().which(
+            would()..have((e) => e.message, 'message').equal('Error at 1'));
       });
     });
 
     group('mayEmitMultiple', () {
       test('succeeds for a stream that emits a matching value', () async {
-        await checkThat(_countingStream(1)).mayEmitMultiple(it()..equals(0));
+        await (_countingStream(1)).must.maybeEmitMultiple(would()..equal(0));
       });
       test('succeeds for a stream that emits an error', () async {
-        await checkThat(_countingStream(1, errorAt: 0))
-            .mayEmitMultiple(it()..equals(0));
+        await (_countingStream(1, errorAt: 0))
+            .must
+            .maybeEmitMultiple(would()..equal(0));
       });
       test('succeeds for a stream that closes', () async {
-        await checkThat(_countingStream(0)).mayEmitMultiple(it()..equals(42));
+        await (_countingStream(0)).must.maybeEmitMultiple(would()..equal(42));
       });
       test('consumes matching events', () async {
         final queue = _countingStream(3);
         await softCheckAsync<StreamQueue<int>>(
-            queue, it()..mayEmitMultiple(it()..isLessThan(2)));
-        await checkThat(queue).emits().which(it()..equals(2));
+            queue, would()..maybeEmitMultiple(would()..beLessThat(2)));
+        await queue.must.emit().which(would()..equal(2));
       });
       test('consumes no events if no events match', () async {
         final queue = _countingStream(2);
         await softCheckAsync<StreamQueue<int>>(
-            queue, it()..mayEmitMultiple(it()..isLessThan(0)));
-        await checkThat(queue).emits().which(it()..equals(0));
+            queue, would()..maybeEmitMultiple(would()..beLessThat(0)));
+        await queue.must.emit().which(would()..equal(0));
       });
       test('does not consume an error', () async {
         final queue = _countingStream(1, errorAt: 0);
         await softCheckAsync<StreamQueue<int>>(
-            queue, it()..mayEmitMultiple(it()..equals(0)));
-        await checkThat(queue)
-            .emitsError<UnimplementedError>()
-            .which(it()..has((e) => e.message, 'message').equals('Error at 1'));
+            queue, would()..maybeEmitMultiple(would()..equal(0)));
+        await queue.must.emitError<UnimplementedError>().which(
+            would()..have((e) => e.message, 'message').equal('Error at 1'));
       });
     });
 
     group('isDone', () {
       test('succeeds for an empty stream', () async {
-        await checkThat(_countingStream(0)).isDone();
+        await (_countingStream(0)).must.beDone();
       });
       test('fails for a stream that emits a value', () async {
-        await checkThat(_countingStream(1)).isRejectedByAsync(it()..isDone(),
+        await (_countingStream(1)).must.beRejectedByAsync(would()..beDone(),
             actual: ['a stream'], which: ['emitted an unexpected value: <0>']);
       });
       test('fails for a stream that emits an error', () async {
         final controller = StreamController<void>();
         controller.addError('sad', StackTrace.fromString('fake trace'));
-        await checkThat(StreamQueue(controller.stream)).isRejectedByAsync(
-            it()..isDone(),
+        await StreamQueue(controller.stream).must.beRejectedByAsync(
+            would()..beDone(),
             actual: ['a stream'],
             which: ['emitted an unexpected error: \'sad\'', 'fake trace']);
       });
       test('uses a transaction', () async {
         final queue = _countingStream(1);
-        await softCheckAsync<StreamQueue<int>>(queue, it()..isDone());
-        await checkThat(queue).emits().which(it()..equals(0));
+        await softCheckAsync<StreamQueue<int>>(queue, would()..beDone());
+        await queue.must.emit().which(would()..equal(0));
       });
       test('can be described', () async {
-        await checkThat(it<StreamQueue<int>>()..isDone())
-            .asyncDescription
-            .which(it()..deepEquals(['  is done']));
+        await (would<StreamQueue<int>>()..beDone())
+            .must
+            .haveAsyncDescription
+            .which(would()..deeplyEqual(['  is done']));
       });
     });
 
     group('emitsAnyOf', () {
       test('succeeds for a stream that matches one condition', () async {
-        await checkThat(_countingStream(1)).anyOf([
-          it()..emits().which(it()..equals(42)),
-          it()..emits().which((it()..equals(0)))
+        await (_countingStream(1)).must.anyOf([
+          would()..emit().which(would()..equal(42)),
+          would()..emit().which((would()..equal(0)))
         ]);
       });
       test('fails for a stream that matches no conditions', () async {
-        await checkThat(_countingStream(0)).isRejectedByAsync(
-            it()
+        await (_countingStream(0)).must.beRejectedByAsync(
+            would()
               ..anyOf([
-                it()..emits(),
-                it()..emitsThrough(it()..equals(1)),
+                would()..emit(),
+                would()..emitThrough(would()..equal(1)),
               ]),
             actual: [
               'a stream'
@@ -470,11 +489,11 @@ fake trace''');
             ]);
       });
       test('includes nested details for nested failures', () async {
-        await checkThat(_countingStream(1)).isRejectedByAsync(
-            it()
+        await (_countingStream(1)).must.beRejectedByAsync(
+            would()
               ..anyOf([
-                it()..emits().which(it()..equals(42)),
-                it()..emitsThrough(it()..equals(10)),
+                would()..emit().which(would()..equal(42)),
+                would()..emitThrough(would()..equal(10)),
               ]),
             actual: [
               'a stream'
@@ -490,42 +509,43 @@ fake trace''');
             ]);
       });
       test('gets described with the number of conditions', () async {
-        await checkThat(
-                it<StreamQueue<int>>()..anyOf([it()..emits(), it()..emits()]))
-            .asyncDescription
-            .which(it()..deepEquals(['  satisfies any of 2 conditions']));
+        await (would<StreamQueue<int>>()
+              ..anyOf([would()..emit(), would()..emit()]))
+            .must
+            .haveAsyncDescription
+            .which(would()..deeplyEqual(['  satisfies any of 2 conditions']));
       });
       test('uses a transaction', () async {
         final queue = _countingStream(1);
         await softCheckAsync<StreamQueue<int>>(
             queue,
-            it()
+            would()
               ..anyOf([
-                it()..emits().which(it()..equals(10)),
-                it()..emitsThrough(it()..equals(42)),
+                would()..emit().which(would()..equal(10)),
+                would()..emitThrough(would()..equal(42)),
               ]));
-        await checkThat(queue).emits().which(it()..equals(0));
+        await queue.must.emit().which(would()..equal(0));
       });
       test('consumes events', () async {
         final queue = _countingStream(3);
-        await checkThat(queue).anyOf([
-          it()..emits().which(it()..equals(1)),
-          it()..emitsThrough(it()..equals(1))
+        await queue.must.anyOf([
+          would()..emit().which(would()..equal(1)),
+          would()..emitThrough(would()..equal(1))
         ]);
-        await checkThat(queue).emits().which(it()..equals(2));
+        await queue.must.emit().which(would()..equal(2));
       });
     });
   });
 
   group('ChainAsync', () {
     test('which', () async {
-      await checkThat(_futureSuccess()).completes().which(it()..equals(42));
+      await (_futureSuccess()).must.complete().which(would()..equal(42));
     });
   });
 
   group('StreamQueueWrap', () {
     test('can wrap streams in a queue', () async {
-      await checkThat(Stream.value(1)).withQueue.emits();
+      await Stream.value(1).withQueue.must.emit();
     });
   });
 }

--- a/pkgs/checks/test/extensions/collection_equality_test.dart
+++ b/pkgs/checks/test/extensions/collection_equality_test.dart
@@ -9,7 +9,7 @@ import 'package:test/scaffolding.dart';
 void main() {
   group('deepCollectionEquals', () {
     test('allows nested collections with equal elements', () {
-      checkThat(deepCollectionEquals([
+      (deepCollectionEquals([
         'a',
         {'b': 1},
         {'c', 'd'},
@@ -23,19 +23,19 @@ void main() {
         [
           ['e']
         ],
-      ])).isNull();
+      ])).must.beNull();
     });
 
     test('allows collections inside sets', () {
-      checkThat(deepCollectionEquals({
+      (deepCollectionEquals({
         {'a': 1}
       }, {
         {'a': 1}
-      })).isNull();
+      })).must.beNull();
     });
 
     test('allows collections as Map keys', () {
-      checkThat(deepCollectionEquals([
+      (deepCollectionEquals([
         {
           {'a': 1}: {'b': 2}
         }
@@ -43,72 +43,78 @@ void main() {
         {
           {'a': 1}: {'b': 2}
         }
-      ])).isNull();
+      ])).must.beNull();
     });
 
     test('allows conditions in place of elements in lists', () {
-      checkThat(deepCollectionEquals([
+      (deepCollectionEquals([
         'a',
         'b'
       ], [
-        it()
-          ..isA<String>().which(it()
-            ..startsWith('a')
-            ..length.isLessThan(2)),
-        it()..isA<String>().startsWith('b')
-      ])).isNull();
+        would()
+          ..beA<String>().which(would()
+            ..startWith('a')
+            ..haveLength.beLessThat(2)),
+        would()..beA<String>().startWith('b')
+      ])).must.beNull();
     });
 
     test('allows conditions in place of values in maps', () {
-      checkThat(deepCollectionEquals([
+      (deepCollectionEquals([
         {'a': 'b'}
       ], [
-        {'a': it()..isA<String>().startsWith('b')}
-      ])).isNull();
+        {'a': would()..beA<String>().startWith('b')}
+      ])).must.beNull();
     });
 
     test('allows conditions in place of elements in sets', () {
-      checkThat(deepCollectionEquals(
-          {'b', 'a'}, {'a', it()..isA<String>().startsWith('b')})).isNull();
+      (deepCollectionEquals(
+              {'b', 'a'}, {'a', would()..beA<String>().startWith('b')}))
+          .must
+          .beNull();
     });
 
     test('allows conditions in place of keys in maps', () {
-      checkThat(deepCollectionEquals(
-          {'a': 'b'}, {it()..isA<String>().startsWith('a'): 'b'})).isNull();
+      (deepCollectionEquals(
+              {'a': 'b'}, {would()..beA<String>().startWith('a'): 'b'}))
+          .must
+          .beNull();
     });
 
     test('reports non-Set elements', () {
-      checkThat(deepCollectionEquals([
+      (deepCollectionEquals([
         ['a']
       ], [
         {'a'}
-      ])).isNotNull().deepEquals(['at [<0>] is not a Set']);
+      ])).must.beNonNull().deeplyEqual(['at [<0>] is not a Set']);
     });
 
     test('reports long iterables', () {
-      checkThat(deepCollectionEquals([0], [])).isNotNull().deepEquals([
+      (deepCollectionEquals([0], [])).must.beNonNull().deeplyEqual([
         'has more elements than expected',
         'expected an iterable with 0 element(s)'
       ]);
     });
 
     test('reports short iterables', () {
-      checkThat(deepCollectionEquals([], [0])).isNotNull().deepEquals([
+      (deepCollectionEquals([], [0])).must.beNonNull().deeplyEqual([
         'has too few elements',
         'expected an iterable with at least 1 element(s)'
       ]);
     });
 
     test('reports unequal elements in iterables', () {
-      checkThat(deepCollectionEquals([0], [1]))
-          .isNotNull()
-          .deepEquals(['at [<0>] is <0>', 'which does not equal <1>']);
+      (deepCollectionEquals([0], [1]))
+          .must
+          .beNonNull()
+          .deeplyEqual(['at [<0>] is <0>', 'which does not equal <1>']);
     });
 
     test('reports unmet conditions in iterables', () {
-      checkThat(deepCollectionEquals([0], [it()..isA<int>().isGreaterThan(0)]))
-          .isNotNull()
-          .deepEquals([
+      (deepCollectionEquals([0], [would()..beA<int>().beGreaterThan(0)]))
+          .must
+          .beNonNull()
+          .deeplyEqual([
         'has an element at [<0>] that:',
         '  Actual: <0>',
         '  which is not greater than <0>'
@@ -116,10 +122,11 @@ void main() {
     });
 
     test('reports unmet conditions in map values', () {
-      checkThat(deepCollectionEquals(
-              {'a': 'b'}, {'a': it()..isA<String>().startsWith('a')}))
-          .isNotNull()
-          .deepEquals([
+      (deepCollectionEquals(
+              {'a': 'b'}, {'a': would()..beA<String>().startWith('a')}))
+          .must
+          .beNonNull()
+          .deeplyEqual([
         "has no entry to match 'a': <A value that:",
         '  is a String',
         "  starts with 'a'>",
@@ -127,10 +134,11 @@ void main() {
     });
 
     test('reports unmet conditions in map keys', () {
-      checkThat(deepCollectionEquals(
-              {'b': 'a'}, {it()..isA<String>().startsWith('a'): 'a'}))
-          .isNotNull()
-          .deepEquals([
+      (deepCollectionEquals(
+              {'b': 'a'}, {would()..beA<String>().startWith('a'): 'a'}))
+          .must
+          .beNonNull()
+          .deeplyEqual([
         'has no entry to match <A value that:',
         '  is a String',
         "  starts with 'a'>: 'a'",
@@ -140,33 +148,37 @@ void main() {
     test('reports recursive lists', () {
       var l = [];
       l.add(l);
-      checkThat(deepCollectionEquals(l, l))
-          .isNotNull()
-          .deepEquals(['exceeds the depth limit of 1000']);
+      (deepCollectionEquals(l, l))
+          .must
+          .beNonNull()
+          .deeplyEqual(['exceeds the depth limit of 1000']);
     });
 
     test('reports recursive sets', () {
       var s = <Object>{};
       s.add(s);
-      checkThat(deepCollectionEquals(s, s))
-          .isNotNull()
-          .deepEquals(['exceeds the depth limit of 1000']);
+      (deepCollectionEquals(s, s))
+          .must
+          .beNonNull()
+          .deeplyEqual(['exceeds the depth limit of 1000']);
     });
 
     test('reports maps with recursive keys', () {
       var m = <Object, Object>{};
       m[m] = 0;
-      checkThat(deepCollectionEquals(m, m))
-          .isNotNull()
-          .deepEquals(['exceeds the depth limit of 1000']);
+      (deepCollectionEquals(m, m))
+          .must
+          .beNonNull()
+          .deeplyEqual(['exceeds the depth limit of 1000']);
     });
 
     test('reports maps with recursive values', () {
       var m = <Object, Object>{};
       m[0] = m;
-      checkThat(deepCollectionEquals(m, m))
-          .isNotNull()
-          .deepEquals(['exceeds the depth limit of 1000']);
+      (deepCollectionEquals(m, m))
+          .must
+          .beNonNull()
+          .deeplyEqual(['exceeds the depth limit of 1000']);
     });
   });
 }

--- a/pkgs/checks/test/extensions/core_test.dart
+++ b/pkgs/checks/test/extensions/core_test.dart
@@ -10,28 +10,28 @@ import '../test_shared.dart';
 void main() {
   group('TypeChecks', () {
     test('isA', () {
-      checkThat(1).isA<int>();
+      1.must.beA<int>();
 
-      checkThat(1).isRejectedBy(it()..isA<String>(), which: ['Is a int']);
+      1.must.beRejectedBy(would()..beA<String>(), which: ['Is a int']);
     });
   });
   group('HasField', () {
     test('has', () {
-      checkThat(1).has((v) => v.isOdd, 'isOdd').isTrue();
+      1.must.have((v) => v.isOdd, 'isOdd').beTrue();
 
-      checkThat(2).isRejectedBy(
-          it()..has((v) => throw UnimplementedError(), 'isOdd'),
+      2.must.beRejectedBy(
+          would()..have((v) => throw UnimplementedError(), 'isOdd'),
           which: ['threw while trying to read property']);
     });
 
     test('which', () {
-      checkThat(true).which(it()..isTrue());
+      true.must.which(would()..beTrue());
     });
 
     test('not', () {
-      checkThat(false).not(it()..isTrue());
+      false.must.not(would()..beTrue());
 
-      checkThat(true).isRejectedBy(it()..not(it()..isTrue()), which: [
+      true.must.beRejectedBy(would()..not(would()..beTrue()), which: [
         'is a value that: ',
         '    is true',
       ]);
@@ -39,12 +39,13 @@ void main() {
 
     group('anyOf', () {
       test('succeeds for happy case', () {
-        checkThat(-10).anyOf([it()..isGreaterThan(1), it()..isLessThan(-1)]);
+        (-10).must.anyOf([would()..beGreaterThan(1), would()..beLessThat(-1)]);
       });
 
       test('rejects values that do not satisfy any condition', () {
-        checkThat(0).isRejectedBy(
-            it()..anyOf([it()..isGreaterThan(1), it()..isLessThan(-1)]),
+        0.must.beRejectedBy(
+            would()
+              ..anyOf([would()..beGreaterThan(1), would()..beLessThat(-1)]),
             which: ['did not match any condition']);
       });
     });
@@ -52,41 +53,42 @@ void main() {
 
   group('BoolChecks', () {
     test('isTrue', () {
-      checkThat(true).isTrue();
+      true.must.beTrue();
 
-      checkThat(false).isRejectedBy(it()..isTrue());
+      false.must.beRejectedBy(would()..beTrue());
     });
 
     test('isFalse', () {
-      checkThat(false).isFalse();
+      false.must.beFalse();
 
-      checkThat(true).isRejectedBy(it()..isFalse());
+      true.must.beRejectedBy(would()..beFalse());
     });
   });
 
   group('EqualityChecks', () {
     test('equals', () {
-      checkThat(1).equals(1);
+      1.must.equal(1);
 
-      checkThat(1).isRejectedBy(it()..equals(2), which: ['are not equal']);
+      1.must.beRejectedBy(would()..equal(2), which: ['are not equal']);
     });
     test('identical', () {
-      checkThat(1).identicalTo(1);
+      1.must.beIdenticalTo(1);
 
-      checkThat(1)
-          .isRejectedBy(it()..identicalTo(2), which: ['is not identical']);
+      1
+          .must
+          .beRejectedBy(would()..beIdenticalTo(2), which: ['is not identical']);
     });
   });
   group('NullabilityChecks', () {
     test('isNotNull', () {
-      checkThat(1).isNotNull();
+      1.must.beNonNull();
 
-      checkThat(null).isRejectedBy(it()..isNotNull());
+      null.must.beRejectedBy(would()..beNonNull());
     });
     test('isNull', () {
-      checkThat(null).isNull();
+      null.must.beNull();
 
-      checkThat(1).isRejectedBy(it()..isNull());
+      1.must.beRejectedBy(would()..beNull());
     });
   });
 }

--- a/pkgs/checks/test/extensions/function_test.dart
+++ b/pkgs/checks/test/extensions/function_test.dart
@@ -11,16 +11,16 @@ void main() {
   group('ThrowsChecks', () {
     group('throws', () {
       test('succeeds for happy case', () {
-        checkThat(() => throw StateError('oops!')).throws<StateError>();
+        (() => throw StateError('oops!')).must.throwException<StateError>();
       });
       test('fails for functions that return normally', () {
-        checkThat(() {}).isRejectedBy(it()..throws<StateError>(),
+        (() {}).must.beRejectedBy(would()..throwException<StateError>(),
             actual: ['a function that returned <null>'],
             which: ['did not throw']);
       });
       test('fails for functions that throw the wrong type', () {
-        checkThat(() => throw StateError('oops!')).isRejectedBy(
-          it()..throws<ArgumentError>(),
+        (() => throw StateError('oops!')).must.beRejectedBy(
+          would()..throwException<ArgumentError>(),
           actual: ['a function that threw error <Bad state: oops!>'],
           which: ['did not throw an ArgumentError'],
         );
@@ -29,13 +29,13 @@ void main() {
 
     group('returnsNormally', () {
       test('succeeds for happy case', () {
-        checkThat(() => 1).returnsNormally().equals(1);
+        (() => 1).must.returnNormally().equal(1);
       });
       test('fails for functions that throw', () {
-        checkThat(() {
+        (() {
           Error.throwWithStackTrace(
               StateError('oops!'), StackTrace.fromString('fake trace'));
-        }).isRejectedBy(it()..returnsNormally(),
+        }).must.beRejectedBy(would()..returnNormally(),
             actual: ['a function that throws'],
             which: ['threw <Bad state: oops!>', 'fake trace']);
       });

--- a/pkgs/checks/test/extensions/iterable_test.dart
+++ b/pkgs/checks/test/extensions/iterable_test.dart
@@ -11,59 +11,61 @@ Iterable<int> get _testIterable => Iterable.generate(2, (i) => i);
 
 void main() {
   test('length', () {
-    checkThat(_testIterable).length.equals(2);
+    _testIterable.must.haveLength.equal(2);
   });
   test('first', () {
-    checkThat(_testIterable).first.equals(0);
+    _testIterable.must.haveFirst.equal(0);
   });
   test('last', () {
-    checkThat(_testIterable).last.equals(1);
+    _testIterable.must.haveLast.equal(1);
   });
   test('single', () {
-    checkThat([42]).single.equals(42);
+    [42].must.haveSingleElement.equal(42);
   });
 
   test('isEmpty', () {
-    checkThat([]).isEmpty();
-    checkThat(_testIterable)
-        .isRejectedBy(it()..isEmpty(), which: ['is not empty']);
+    [].must.beEmpty();
+    _testIterable.must
+        .beRejectedBy(would()..beEmpty(), which: ['is not empty']);
   });
 
   test('isNotEmpty', () {
-    checkThat(_testIterable).isNotEmpty();
-    checkThat(Iterable<int>.empty())
-        .isRejectedBy(it()..isNotEmpty(), which: ['is not empty']);
+    _testIterable.must.beNotEmpty();
+    Iterable<int>.empty()
+        .must
+        .beRejectedBy(would()..beNotEmpty(), which: ['is not empty']);
   });
 
   test('contains', () {
-    checkThat(_testIterable).contains(0);
-    checkThat(_testIterable)
-        .isRejectedBy(it()..contains(2), which: ['does not contain <2>']);
+    _testIterable.must.contain(0);
+    _testIterable.must
+        .beRejectedBy(would()..contain(2), which: ['does not contain <2>']);
   });
   test('any', () {
-    checkThat(_testIterable).any(it()..equals(1));
-    checkThat(_testIterable).isRejectedBy(it()..any(it()..equals(2)),
+    _testIterable.must.containElementWhich(would()..equal(1));
+    _testIterable.must.beRejectedBy(
+        would()..containElementWhich(would()..equal(2)),
         which: ['Contains no matching element']);
   });
 
   group('containsInOrder', () {
     test('succeeds for happy case', () {
-      checkThat([0, 1, 0, 2, 0, 3]).containsInOrder([1, 2, 3]);
+      [0, 1, 0, 2, 0, 3].must.containInOrder([1, 2, 3]);
     });
     test('can use Condition<dynamic>', () {
-      checkThat([0, 1]).containsInOrder([it()..isA<int>().isGreaterThan(0)]);
+      [0, 1].must.containInOrder([would()..beA<int>().beGreaterThan(0)]);
     });
     test('can use Condition<T>', () {
-      checkThat([0, 1]).containsInOrder([it<int>()..isGreaterThan(0)]);
+      [0, 1].must.containInOrder([would<int>()..beGreaterThan(0)]);
     });
     test('fails for not found elements by equality', () async {
-      checkThat([0]).isRejectedBy(it()..containsInOrder([1]), which: [
+      [0].must.beRejectedBy(would()..containInOrder([1]), which: [
         'did not have an element matching the expectation at index 0 <1>'
       ]);
     });
     test('fails for not found elements by condition', () async {
-      checkThat([0]).isRejectedBy(
-          it()..containsInOrder([it()..isA<int>().isGreaterThan(0)]),
+      [0].must.beRejectedBy(
+          would()..containInOrder([would()..beA<int>().beGreaterThan(0)]),
           which: [
             'did not have an element matching the expectation at index 0 '
                 '<A value that:',
@@ -72,12 +74,14 @@ void main() {
           ]);
     });
     test('can be described', () {
-      checkThat(it<Iterable>()..containsInOrder([1, 2, 3]))
-          .description
-          .deepEquals(['  contains, in order: [1, 2, 3]']);
-      checkThat(it<Iterable>()..containsInOrder([1, it()..equals(2)]))
-          .description
-          .deepEquals([
+      (would<Iterable>()..containInOrder([1, 2, 3]))
+          .must
+          .haveDescription
+          .deeplyEqual(['  contains, in order: [1, 2, 3]']);
+      (would<Iterable>()..containInOrder([1, would()..equal(2)]))
+          .must
+          .haveDescription
+          .deeplyEqual([
         '  contains, in order: [1,',
         '  A value that:',
         '    equals <2>]'
@@ -86,27 +90,29 @@ void main() {
   });
   group('every', () {
     test('succeeds for the happy path', () {
-      checkThat(_testIterable).every(it()..isGreaterOrEqual(-1));
+      _testIterable.must
+          .containOnlyElementsWhich(would()..beGreaterOrEqual(-1));
     });
 
     test('includes details of first failing element', () async {
-      checkThat(_testIterable)
-          .isRejectedBy(it()..every(it()..isLessThan(0)), which: [
-        'has an element at index 0 that:',
-        '  Actual: <0>',
-        '  Which: is not less than <0>',
-      ]);
+      _testIterable.must.beRejectedBy(
+          would()..containOnlyElementsWhich(would()..beLessThat(0)),
+          which: [
+            'has an element at index 0 that:',
+            '  Actual: <0>',
+            '  Which: is not less than <0>',
+          ]);
     });
   });
 
   group('unorderedEquals', () {
     test('success for happy case', () {
-      checkThat(_testIterable).unorderedEquals(_testIterable.toList().reversed);
+      _testIterable.must.unorderedEqual(_testIterable.toList().reversed);
     });
 
     test('reports unmatched elements', () {
-      checkThat(_testIterable).isRejectedBy(
-          it()..unorderedEquals(_testIterable.followedBy([42, 100])),
+      _testIterable.must.beRejectedBy(
+          would()..unorderedEqual(_testIterable.followedBy([42, 100])),
           which: [
             'has no element equal to the expected element at index 2: <42>',
             'or 1 other elements'
@@ -114,8 +120,9 @@ void main() {
     });
 
     test('reports unexpected elements', () {
-      checkThat(_testIterable.followedBy([42, 100]))
-          .isRejectedBy(it()..unorderedEquals(_testIterable), which: [
+      (_testIterable.followedBy([42, 100]))
+          .must
+          .beRejectedBy(would()..unorderedEqual(_testIterable), which: [
         'has an unexpected element at index 2: <42>',
         'and 1 other unexpected elements'
       ]);
@@ -124,15 +131,15 @@ void main() {
 
   group('unorderedMatches', () {
     test('success for happy case', () {
-      checkThat(_testIterable).unorderedMatches(
-          _testIterable.toList().reversed.map((i) => it()..equals(i)));
+      _testIterable.must.unorderedMatches(
+          _testIterable.toList().reversed.map((i) => would()..equal(i)));
     });
 
     test('reports unmatched elements', () {
-      checkThat(_testIterable).isRejectedBy(
-          it()
+      _testIterable.must.beRejectedBy(
+          would()
             ..unorderedMatches(_testIterable
-                .followedBy([42, 100]).map((i) => it()..equals(i))),
+                .followedBy([42, 100]).map((i) => would()..equal(i))),
           which: [
             'has no element matching the condition at index 2:',
             '  equals <42>',
@@ -141,8 +148,9 @@ void main() {
     });
 
     test('reports unexpected elements', () {
-      checkThat(_testIterable.followedBy([42, 100])).isRejectedBy(
-          it()..unorderedMatches(_testIterable.map((i) => it()..equals(i))),
+      (_testIterable.followedBy([42, 100])).must.beRejectedBy(
+          would()
+            ..unorderedMatches(_testIterable.map((i) => would()..equal(i))),
           which: [
             'has an unmatched element at index 2: <42>',
             'and 1 other unmatched elements'
@@ -152,14 +160,14 @@ void main() {
 
   group('pairwiseComparesTo', () {
     test('succeeds for the happy path', () {
-      checkThat(_testIterable).pairwiseComparesTo(
-          [1, 2], (expected) => it()..isLessThan(expected), 'is less than');
+      _testIterable.must.pairwiseCompareTo(
+          [1, 2], (expected) => would()..beLessThat(expected), 'is less than');
     });
     test('fails for mismatched element', () async {
-      checkThat(_testIterable).isRejectedBy(
-          it()
-            ..pairwiseComparesTo([1, 1],
-                (expected) => it()..isLessThan(expected), 'is less than'),
+      _testIterable.must.beRejectedBy(
+          would()
+            ..pairwiseCompareTo([1, 1],
+                (expected) => would()..beLessThat(expected), 'is less than'),
           which: [
             'does not have an element at index 1 that:',
             '  is less than <1>',
@@ -168,19 +176,19 @@ void main() {
           ]);
     });
     test('fails for too few elements', () {
-      checkThat(_testIterable).isRejectedBy(
-          it()
-            ..pairwiseComparesTo([1, 2, 3],
-                (expected) => it()..isLessThan(expected), 'is less than'),
+      _testIterable.must.beRejectedBy(
+          would()
+            ..pairwiseCompareTo([1, 2, 3],
+                (expected) => would()..beLessThat(expected), 'is less than'),
           which: [
             'has too few elements, there is no element to match at index 2'
           ]);
     });
     test('fails for too many elements', () {
-      checkThat(_testIterable).isRejectedBy(
-          it()
-            ..pairwiseComparesTo(
-                [1], (expected) => it()..isLessThan(expected), 'is less than'),
+      _testIterable.must.beRejectedBy(
+          would()
+            ..pairwiseCompareTo([1],
+                (expected) => would()..beLessThat(expected), 'is less than'),
           which: ['has too many elements, expected exactly 1']);
     });
   });

--- a/pkgs/checks/test/extensions/map_test.dart
+++ b/pkgs/checks/test/extensions/map_test.dart
@@ -14,61 +14,61 @@ const _testMap = {
 
 void main() {
   test('length', () {
-    checkThat(_testMap).length.equals(2);
+    _testMap.must.haveLength.equal(2);
   });
   test('entries', () {
-    checkThat(_testMap).entries.any(
-          it()
-            ..has((p0) => p0.key, 'key').equals('a')
-            ..has((p0) => p0.value, 'value').equals(1),
-        );
+    _testMap.must.haveEntries.containElementWhich(
+      would()
+        ..have((p0) => p0.key, 'key').equal('a')
+        ..have((p0) => p0.value, 'value').equal(1),
+    );
   });
   test('keys', () {
-    checkThat(_testMap).keys.contains('a');
+    _testMap.must.haveKeys.contain('a');
   });
   test('values', () {
-    checkThat(_testMap).values.contains(1);
+    _testMap.must.haveValues.contain(1);
   });
 
   test('operator []', () async {
-    checkThat(_testMap)['a'].equals(1);
-    checkThat(_testMap)
-        .isRejectedBy(it()..['z'], which: ['does not contain the key \'z\'']);
+    _testMap.must['a'].equal(1);
+    _testMap.must.beRejectedBy(would()..['z'],
+        which: ['does not contain the key \'z\'']);
   });
   test('isEmpty', () {
-    checkThat(<String, int>{}).isEmpty();
-    checkThat(_testMap).isRejectedBy(it()..isEmpty(), which: ['is not empty']);
+    (<String, int>{}).must.beEmpty();
+    _testMap.must.beRejectedBy(would()..beEmpty(), which: ['is not empty']);
   });
   test('isNotEmpty', () {
-    checkThat(_testMap).isNotEmpty();
-    checkThat({}).isRejectedBy(it()..isNotEmpty(), which: ['is not empty']);
+    _testMap.must.beNotEmpty();
+    ({}).must.beRejectedBy(would()..beNotEmpty(), which: ['is not empty']);
   });
   test('containsKey', () {
-    checkThat(_testMap).containsKey('a');
+    _testMap.must.containKey('a');
 
-    checkThat(_testMap).isRejectedBy(
-      it()..containsKey('c'),
+    _testMap.must.beRejectedBy(
+      would()..containKey('c'),
       which: ["does not contain key 'c'"],
     );
   });
   test('containsKeyThat', () {
-    checkThat(_testMap).containsKeyThat(it()..equals('a'));
-    checkThat(_testMap).isRejectedBy(
-      it()..containsKeyThat(it()..equals('c')),
+    _testMap.must.containKeyWhich(would()..equal('a'));
+    _testMap.must.beRejectedBy(
+      would()..containKeyWhich(would()..equal('c')),
       which: ['Contains no matching key'],
     );
   });
   test('containsValue', () {
-    checkThat(_testMap).containsValue(1);
-    checkThat(_testMap).isRejectedBy(
-      it()..containsValue(3),
+    _testMap.must.containValue(1);
+    _testMap.must.beRejectedBy(
+      would()..containValue(3),
       which: ['does not contain value <3>'],
     );
   });
   test('containsValueThat', () {
-    checkThat(_testMap).containsValueThat(it()..equals(1));
-    checkThat(_testMap).isRejectedBy(
-      it()..containsValueThat(it()..equals(3)),
+    _testMap.must.containValueWhich(would()..equal(1));
+    _testMap.must.beRejectedBy(
+      would()..containValueWhich(would()..equal(3)),
       which: ['Contains no matching value'],
     );
   });

--- a/pkgs/checks/test/extensions/math_test.dart
+++ b/pkgs/checks/test/extensions/math_test.dart
@@ -11,192 +11,200 @@ void main() {
   group('num checks', () {
     group('greater than', () {
       test('succeeds for happy case', () {
-        checkThat(42).isGreaterThan(7);
+        42.must.beGreaterThan(7);
       });
       test('fails for less than', () {
-        checkThat(42).isRejectedBy(it()..isGreaterThan(50),
+        42.must.beRejectedBy(would()..beGreaterThan(50),
             which: ['is not greater than <50>']);
       });
       test('fails for equal', () {
-        checkThat(42).isRejectedBy(it()..isGreaterThan(42),
+        42.must.beRejectedBy(would()..beGreaterThan(42),
             which: ['is not greater than <42>']);
       });
     });
 
     group('greater than or equal', () {
       test('succeeds for happy case', () {
-        checkThat(42).isGreaterOrEqual(7);
+        42.must.beGreaterOrEqual(7);
       });
       test('fails for less than', () {
-        checkThat(42).isRejectedBy(it()..isGreaterOrEqual(50),
+        42.must.beRejectedBy(would()..beGreaterOrEqual(50),
             which: ['is not greater than or equal to <50>']);
       });
       test('succeeds for equal', () {
-        checkThat(42).isGreaterOrEqual(42);
+        42.must.beGreaterOrEqual(42);
       });
     });
 
     group('less than', () {
       test('succeeds for happy case', () {
-        checkThat(42).isLessThan(50);
+        42.must.beLessThat(50);
       });
       test('fails for greater than', () {
-        checkThat(42)
-            .isRejectedBy(it()..isLessThan(7), which: ['is not less than <7>']);
+        42.must.beRejectedBy(would()..beLessThat(7),
+            which: ['is not less than <7>']);
       });
       test('fails for equal', () {
-        checkThat(42).isRejectedBy(it()..isLessThan(42),
+        42.must.beRejectedBy(would()..beLessThat(42),
             which: ['is not less than <42>']);
       });
     });
 
     group('less than or equal', () {
       test('succeeds for happy case', () {
-        checkThat(42).isLessOrEqual(50);
+        42.must.beLessOrEqual(50);
       });
       test('fails for greater than', () {
-        checkThat(42).isRejectedBy(it()..isLessOrEqual(7),
+        42.must.beRejectedBy(would()..beLessOrEqual(7),
             which: ['is not less than or equal to <7>']);
       });
       test('succeeds for equal', () {
-        checkThat(42).isLessOrEqual(42);
+        42.must.beLessOrEqual(42);
       });
     });
 
     group('isNaN', () {
       test('succeeds for happy case', () {
-        checkThat(double.nan).isNaN();
+        (double.nan).must.beNaN();
       });
       test('fails for ints', () {
-        checkThat(42).isRejectedBy(it()..isNaN(), which: ['is a number']);
+        42.must.beRejectedBy(would()..beNaN(), which: ['is a number']);
       });
       test('fails for numeric doubles', () {
-        checkThat(42.1).isRejectedBy(it()..isNaN(), which: ['is a number']);
+        42.1.must.beRejectedBy(would()..beNaN(), which: ['is a number']);
       });
     });
 
     group('isNotNan', () {
       test('succeeds for ints', () {
-        checkThat(42).isNotNaN();
+        42.must.beANumber();
       });
       test('succeeds numeric doubles', () {
-        checkThat(42.1).isNotNaN();
+        42.1.must.beANumber();
       });
       test('fails for NaN', () {
-        checkThat(double.nan)
-            .isRejectedBy(it()..isNotNaN(), which: ['is not a number (NaN)']);
+        (double.nan).must.beRejectedBy(would()..beANumber(),
+            which: ['is not a number (NaN)']);
       });
     });
     group('isNegative', () {
       test('succeeds for negative ints', () {
-        checkThat(-1).isNegative();
+        (-1).must.beNegative();
       });
       test('succeeds for -0.0', () {
-        checkThat(-0.0).isNegative();
+        (-0.0).must.beNegative();
       });
       test('fails for zero', () {
-        checkThat(0)
-            .isRejectedBy(it()..isNegative(), which: ['is not negative']);
+        0.must.beRejectedBy(would()..beNegative(), which: ['is not negative']);
       });
     });
     group('isNotNegative', () {
       test('succeeds for positive ints', () {
-        checkThat(1).isNotNegative();
+        1.must.beNonNegative();
       });
       test('succeeds for 0', () {
-        checkThat(0).isNotNegative();
+        0.must.beNonNegative();
       });
       test('fails for -0.0', () {
-        checkThat(-0.0)
-            .isRejectedBy(it()..isNotNegative(), which: ['is negative']);
+        (-0.0)
+            .must
+            .beRejectedBy(would()..beNonNegative(), which: ['is negative']);
       });
       test('fails for negative numbers', () {
-        checkThat(-1)
-            .isRejectedBy(it()..isNotNegative(), which: ['is negative']);
+        (-1)
+            .must
+            .beRejectedBy(would()..beNonNegative(), which: ['is negative']);
       });
     });
 
     group('isFinite', () {
       test('succeeds for finite numbers', () {
-        checkThat(1).isFinite();
+        1.must.beFinite();
       });
       test('fails for NaN', () {
-        checkThat(double.nan)
-            .isRejectedBy(it()..isFinite(), which: ['is not finite']);
+        (double.nan)
+            .must
+            .beRejectedBy(would()..beFinite(), which: ['is not finite']);
       });
       test('fails for infinity', () {
-        checkThat(double.infinity)
-            .isRejectedBy(it()..isFinite(), which: ['is not finite']);
+        (double.infinity)
+            .must
+            .beRejectedBy(would()..beFinite(), which: ['is not finite']);
       });
       test('fails for negative infinity', () {
-        checkThat(double.negativeInfinity)
-            .isRejectedBy(it()..isFinite(), which: ['is not finite']);
+        (double.negativeInfinity)
+            .must
+            .beRejectedBy(would()..beFinite(), which: ['is not finite']);
       });
     });
     group('isNotFinite', () {
       test('succeeds for infinity', () {
-        checkThat(double.infinity).isNotFinite();
+        (double.infinity).must.notBeFinite();
       });
       test('succeeds for negative infinity', () {
-        checkThat(double.negativeInfinity).isNotFinite();
+        (double.negativeInfinity).must.notBeFinite();
       });
       test('succeeds for NaN', () {
-        checkThat(double.nan).isNotFinite();
+        (double.nan).must.notBeFinite();
       });
       test('fails for finite numbers', () {
-        checkThat(1).isRejectedBy(it()..isNotFinite(), which: ['is finite']);
+        1.must.beRejectedBy(would()..notBeFinite(), which: ['is finite']);
       });
     });
     group('isInfinite', () {
       test('succeeds for infinity', () {
-        checkThat(double.infinity).isInfinite();
+        (double.infinity).must.beInfinite();
       });
       test('succeeds for negative infinity', () {
-        checkThat(double.negativeInfinity).isInfinite();
+        (double.negativeInfinity).must.beInfinite();
       });
       test('fails for NaN', () {
-        checkThat(double.nan)
-            .isRejectedBy(it()..isInfinite(), which: ['is not infinite']);
+        (double.nan)
+            .must
+            .beRejectedBy(would()..beInfinite(), which: ['is not infinite']);
       });
       test('fails for finite numbers', () {
-        checkThat(1)
-            .isRejectedBy(it()..isInfinite(), which: ['is not infinite']);
+        1.must.beRejectedBy(would()..beInfinite(), which: ['is not infinite']);
       });
     });
 
     group('isNotInfinite', () {
       test('succeeds for finite numbers', () {
-        checkThat(1).isNotInfinite();
+        1.must.notBeInfinite();
       });
       test('succeeds for NaN', () {
-        checkThat(double.nan).isNotInfinite();
+        (double.nan).must.notBeInfinite();
       });
       test('fails for infinity', () {
-        checkThat(double.infinity)
-            .isRejectedBy(it()..isNotInfinite(), which: ['is infinite']);
+        (double.infinity)
+            .must
+            .beRejectedBy(would()..notBeInfinite(), which: ['is infinite']);
       });
       test('fails for negative infinity', () {
-        checkThat(double.negativeInfinity)
-            .isRejectedBy(it()..isNotInfinite(), which: ['is infinite']);
+        (double.negativeInfinity)
+            .must
+            .beRejectedBy(would()..notBeInfinite(), which: ['is infinite']);
       });
     });
     group('closeTo', () {
       test('succeeds for equal numbers', () {
-        checkThat(1).isCloseTo(1, 1);
+        1.must.beCloseTo(1, 1);
       });
       test('succeeds at less than delta away', () {
-        checkThat(1).isCloseTo(2, 2);
+        1.must.beCloseTo(2, 2);
       });
       test('succeeds at exactly delta away', () {
-        checkThat(1).isCloseTo(2, 1);
+        1.must.beCloseTo(2, 1);
       });
       test('fails for low values', () {
-        checkThat(1)
-            .isRejectedBy(it()..isCloseTo(3, 1), which: ['differs by <2>']);
+        1
+            .must
+            .beRejectedBy(would()..beCloseTo(3, 1), which: ['differs by <2>']);
       });
       test('fails for high values', () {
-        checkThat(5)
-            .isRejectedBy(it()..isCloseTo(3, 1), which: ['differs by <2>']);
+        5
+            .must
+            .beRejectedBy(would()..beCloseTo(3, 1), which: ['differs by <2>']);
       });
     });
   });

--- a/pkgs/checks/test/extensions/string_test.dart
+++ b/pkgs/checks/test/extensions/string_test.dart
@@ -10,58 +10,60 @@ import '../test_shared.dart';
 void main() {
   group('StringChecks', () {
     test('contains', () {
-      checkThat('bob').contains('bo');
-      checkThat('bob').isRejectedBy(it()..contains('kayleb'),
+      'bob'.must.contain('bo');
+      'bob'.must.beRejectedBy(would()..contain('kayleb'),
           which: ["Does not contain 'kayleb'"]);
     });
     test('length', () {
-      checkThat('bob').length.equals(3);
+      'bob'.must.haveLength.equal(3);
     });
     test('isEmpty', () {
-      checkThat('').isEmpty();
-      checkThat('bob').isRejectedBy(it()..isEmpty(), which: ['is not empty']);
+      ''.must.beEmpty();
+      'bob'.must.beRejectedBy(would()..beEmpty(), which: ['is not empty']);
     });
     test('isNotEmpty', () {
-      checkThat('bob').isNotEmpty();
-      checkThat('').isRejectedBy(it()..isNotEmpty(), which: ['is empty']);
+      'bob'.must.beNotEmpty();
+      ''.must.beRejectedBy(would()..beNotEmpty(), which: ['is empty']);
     });
     test('startsWith', () {
-      checkThat('bob').startsWith('bo');
-      checkThat('bob').isRejectedBy(it()..startsWith('kayleb'),
+      'bob'.must.startWith('bo');
+      'bob'.must.beRejectedBy(would()..startWith('kayleb'),
           which: ["does not start with 'kayleb'"]);
     });
     test('endsWith', () {
-      checkThat('bob').endsWith('ob');
-      checkThat('bob').isRejectedBy(it()..endsWith('kayleb'),
+      'bob'.must.endWith('ob');
+      'bob'.must.beRejectedBy(would()..endWith('kayleb'),
           which: ["does not end with 'kayleb'"]);
     });
 
     group('matches', () {
       test('succeeds for strings that match', () {
-        checkThat('123').matches(RegExp(r'\d\d\d'));
+        '123'.must.matchRegex(RegExp(r'\d\d\d'));
       });
       test('fails for non-matching strings', () {
-        checkThat('abc').isRejectedBy(it()..matches(RegExp(r'\d\d\d')),
+        'abc'.must.beRejectedBy(would()..matchRegex(RegExp(r'\d\d\d')),
             which: [r'does not match <RegExp: pattern=\d\d\d flags=>']);
       });
       test('can be described', () {
-        checkThat(it<String>()..matches(RegExp(r'\d\d\d')))
-            .description
-            .deepEquals([r'  matches <RegExp: pattern=\d\d\d flags=>']);
+        (would<String>()..matchRegex(RegExp(r'\d\d\d')))
+            .must
+            .haveDescription
+            .deeplyEqual([r'  matches <RegExp: pattern=\d\d\d flags=>']);
       });
     });
 
     group('containsInOrder', () {
       test('happy case', () {
-        checkThat('foo bar baz').containsInOrder(['foo', 'baz']);
+        'foo bar baz'.must.containInOrder(['foo', 'baz']);
       });
       test('reports when first substring is missing', () {
-        checkThat('baz').isRejectedBy(it()..containsInOrder(['foo', 'baz']),
+        'baz'.must.beRejectedBy(would()..containInOrder(['foo', 'baz']),
             which: ['does not have a match for the substring \'foo\'']);
       });
       test('reports when substring is missing following a match', () {
-        checkThat('foo bar')
-            .isRejectedBy(it()..containsInOrder(['foo', 'baz']), which: [
+        'foo bar'
+            .must
+            .beRejectedBy(would()..containInOrder(['foo', 'baz']), which: [
           'does not have a match for the substring \'baz\'',
           'following the other matches up to character 3'
         ]);
@@ -70,44 +72,44 @@ void main() {
 
     group('equals', () {
       test('succeeeds for happy case', () {
-        checkThat('foo').equals('foo');
+        'foo'.must.equal('foo');
       });
       test('succeeeds for equal empty strings', () {
-        checkThat('').equals('');
+        ''.must.equal('');
       });
       test('reports extra characters for long string', () {
-        checkThat('foobar').isRejectedBy(it()..equals('foo'),
+        'foobar'.must.beRejectedBy(would()..equal('foo'),
             which: ['is too long with unexpected trailing characters:', 'bar']);
       });
       test('reports extra characters for long string against empty', () {
-        checkThat('foo')
-            .isRejectedBy(it()..equals(''), which: ['is not the empty string']);
+        'foo'.must.beRejectedBy(would()..equal(''),
+            which: ['is not the empty string']);
       });
       test('reports truncated extra characters for very long string', () {
-        checkThat('foobar baz more stuff').isRejectedBy(it()..equals('foo'),
+        'foobar baz more stuff'.must.beRejectedBy(would()..equal('foo'),
             which: [
               'is too long with unexpected trailing characters:',
               'bar baz mo ...'
             ]);
       });
       test('reports missing characters for short string', () {
-        checkThat('foo').isRejectedBy(it()..equals('foobar'),
+        'foo'.must.beRejectedBy(would()..equal('foobar'),
             which: ['is too short with missing trailing characters:', 'bar']);
       });
       test('reports missing characters for empty string', () {
-        checkThat('').isRejectedBy(it()..equals('foo bar baz'),
+        ''.must.beRejectedBy(would()..equal('foo bar baz'),
             actual: ['an empty string'],
             which: ['is missing all expected characters:', 'foo bar ba ...']);
       });
       test('reports truncated missing characters for very short string', () {
-        checkThat('foo').isRejectedBy(it()..equals('foobar baz more stuff'),
+        'foo'.must.beRejectedBy(would()..equal('foobar baz more stuff'),
             which: [
               'is too short with missing trailing characters:',
               'bar baz mo ...'
             ]);
       });
       test('reports index of different character', () {
-        checkThat('hit').isRejectedBy(it()..equals('hat'), which: [
+        'hit'.must.beRejectedBy(would()..equal('hat'), which: [
           'differs at offset 1:',
           'hat',
           'hit',
@@ -116,8 +118,8 @@ void main() {
       });
       test('reports truncated index of different character in large string',
           () {
-        checkThat('blah blah blah hit blah blah blah').isRejectedBy(
-            it()..equals('blah blah blah hat blah blah blah'),
+        'blah blah blah hit blah blah blah'.must.beRejectedBy(
+            would()..equal('blah blah blah hat blah blah blah'),
             which: [
               'differs at offset 16:',
               '... lah blah hat blah bl ...',
@@ -129,19 +131,19 @@ void main() {
 
     group('equalsIgnoringCase', () {
       test('succeeeds for happy case', () {
-        checkThat('FOO').equalsIgnoringCase('foo');
-        checkThat('foo').equalsIgnoringCase('FOO');
+        'FOO'.must.equalIgnoringCase('foo');
+        'foo'.must.equalIgnoringCase('FOO');
       });
       test('reports original extra characters for long string', () {
-        checkThat('FOOBAR').isRejectedBy(it()..equalsIgnoringCase('foo'),
+        'FOOBAR'.must.beRejectedBy(would()..equalIgnoringCase('foo'),
             which: ['is too long with unexpected trailing characters:', 'BAR']);
       });
       test('reports original missing characters for short string', () {
-        checkThat('FOO').isRejectedBy(it()..equalsIgnoringCase('fooBAR'),
+        'FOO'.must.beRejectedBy(would()..equalIgnoringCase('fooBAR'),
             which: ['is too short with missing trailing characters:', 'BAR']);
       });
       test('reports index of different character with original characters', () {
-        checkThat('HiT').isRejectedBy(it()..equalsIgnoringCase('hAt'), which: [
+        'HiT'.must.beRejectedBy(would()..equalIgnoringCase('hAt'), which: [
           'differs at offset 1:',
           'hAt',
           'HiT',
@@ -152,29 +154,31 @@ void main() {
 
     group('equalsIgnoringWhitespace', () {
       test('allows differing internal whitespace', () {
-        checkThat('foo \t\n bar').equalsIgnoringWhitespace('foo bar');
+        'foo \t\n bar'.must.equalIgnoringQhitespace('foo bar');
       });
       test('allows extra leading/trailing whitespace', () {
-        checkThat(' foo ').equalsIgnoringWhitespace('foo');
+        ' foo '.must.equalIgnoringQhitespace('foo');
       });
       test('allows missing leading/trailing whitespace', () {
-        checkThat('foo').equalsIgnoringWhitespace(' foo ');
+        'foo'.must.equalIgnoringQhitespace(' foo ');
       });
       test('reports original extra characters for long string', () {
-        checkThat('foo \t bar \n baz')
-            .isRejectedBy(it()..equalsIgnoringWhitespace('foo bar'), which: [
+        'foo \t bar \n baz'
+            .must
+            .beRejectedBy(would()..equalIgnoringQhitespace('foo bar'), which: [
           'is too long with unexpected trailing characters:',
           ' baz'
         ]);
       });
       test('reports original missing characters for short string', () {
-        checkThat('foo  bar').isRejectedBy(
-            it()..equalsIgnoringWhitespace('foo bar baz'),
+        'foo  bar'.must.beRejectedBy(
+            would()..equalIgnoringQhitespace('foo bar baz'),
             which: ['is too short with missing trailing characters:', ' baz']);
       });
       test('reports index of different character with original characters', () {
-        checkThat('x  hit  x')
-            .isRejectedBy(it()..equalsIgnoringWhitespace('x hat x'), which: [
+        'x  hit  x'
+            .must
+            .beRejectedBy(would()..equalIgnoringQhitespace('x hat x'), which: [
           'differs at offset 3:',
           'x hat x',
           'x hit x',

--- a/pkgs/checks/test/failure_message_test.dart
+++ b/pkgs/checks/test/failure_message_test.dart
@@ -5,9 +5,9 @@ import 'package:test_api/hooks.dart' show TestFailure;
 void main() {
   group('failures', () {
     test('includes expected, actual, and which', () {
-      checkThat(() {
-        checkThat(1).isGreaterThan(2);
-      }).throwsFailure().equals('''
+      (() {
+        1.must.beGreaterThan(2);
+      }).must.throwsFailure().equal('''
 Expected: a int that:
   is greater than <2>
 Actual: <1>
@@ -15,9 +15,9 @@ Which: is not greater than <2>''');
     });
 
     test('includes matching portions of actual', () {
-      checkThat(() {
-        checkThat([]).length.equals(1);
-      }).throwsFailure().equals('''
+      (() {
+        [].must.haveLength.equal(1);
+      }).must.throwsFailure().equal('''
 Expected: a List<dynamic> that:
   has length that:
     equals <1>
@@ -27,27 +27,30 @@ Actual: a List<dynamic> that:
   Which: are not equal''');
     });
 
-    test('include a reason when provided', () {
-      checkThat(() {
-        checkThat(because: 'Some reason', 1).isGreaterThan(2);
-      }).throwsFailure().endsWith('Reason: Some reason');
-    });
+    // test('include a reason when provided', () {
+    //   (() {
+    //     (because: 'Some reason', 1).should.isGreaterThan(2);
+    //   }).should.throwsFailure().endsWith('Reason: Some reason');
+    // });
 
     test('retain type label following isNotNull', () {
-      checkThat(() {
-        checkThat<int?>(1).isNotNull().isGreaterThan(2);
-      }).throwsFailure().startsWith('Expected: a int? that:\n');
+      (() {
+        int? nullableIntNoPromotion() => 1;
+        var actual = nullableIntNoPromotion();
+        actual.must.beNonNull().beGreaterThan(2);
+      }).must.throwsFailure().startWith('Expected: a int? that:\n');
     });
 
-    test('retain reason following isNotNull', () {
-      checkThat(() {
-        checkThat<int?>(because: 'Some reason', 1).isNotNull().isGreaterThan(2);
-      }).throwsFailure().endsWith('Reason: Some reason');
-    });
+    // test('retain reason following isNotNull', () {
+    //   (() {
+    //     <int?>(because = 'Some reason', 1).should.isNotNull().isGreaterThan(2);
+    //   }).should.throwsFailure().endsWith('Reason: Some reason');
+    // });
   });
 }
 
 extension on Subject<void Function()> {
-  Subject<String> throwsFailure() =>
-      throws<TestFailure>().has((f) => f.message, 'message').isNotNull();
+  Subject<String> throwsFailure() => throwException<TestFailure>()
+      .have((f) => f.message, 'message')
+      .beNonNull();
 }

--- a/pkgs/checks/test/test_shared.dart
+++ b/pkgs/checks/test/test_shared.dart
@@ -6,7 +6,7 @@ import 'package:checks/checks.dart';
 import 'package:checks/context.dart';
 
 extension RejectionChecks<T> on Subject<T> {
-  void isRejectedBy(Condition<T> condition,
+  void beRejectedBy(Condition<T> condition,
       {Iterable<String>? actual, Iterable<String>? which}) {
     late T actualValue;
     var didRunCallback = false;
@@ -25,26 +25,26 @@ extension RejectionChecks<T> on Subject<T> {
     });
     if (didRunCallback) {
       rejection
-          .has((r) => r.actual, 'actual')
-          .deepEquals(actual ?? literal(actualValue));
+          .have((r) => r.actual, 'actual')
+          .deeplyEqual(actual ?? literal(actualValue));
     } else {
       rejection
-          .has((r) => r.actual, 'actual')
+          .have((r) => r.actual, 'actual')
           .context
           .expect(() => ['is left default'], (_) => null);
     }
     if (which == null) {
-      rejection.has((r) => r.which, 'which').isNull();
+      rejection.have((r) => r.which, 'which').beNull();
     } else {
-      rejection.has((r) => r.which, 'which').isNotNull().deepEquals(which);
+      rejection.have((r) => r.which, 'which').beNonNull().deeplyEqual(which);
     }
   }
 
-  Future<void> isRejectedByAsync(Condition<T> condition,
+  Future<void> beRejectedByAsync(Condition<T> condition,
       {Iterable<String>? actual, Iterable<String>? which}) async {
     late T actualValue;
     var didRunCallback = false;
-    final rejection = (await context.nestAsync<Rejection>(
+    final rejection = await context.nestAsync<Rejection>(
         'does not meet an async condition with a Rejection', (value) async {
       actualValue = value;
       didRunCallback = true;
@@ -56,29 +56,29 @@ extension RejectionChecks<T> on Subject<T> {
         ]);
       }
       return Extracted.value(failure.rejection);
-    }));
+    });
     if (didRunCallback) {
       rejection
-          .has((r) => r.actual, 'actual')
-          .deepEquals(actual ?? literal(actualValue));
+          .have((r) => r.actual, 'actual')
+          .deeplyEqual(actual ?? literal(actualValue));
     } else {
       rejection
-          .has((r) => r.actual, 'actual')
+          .have((r) => r.actual, 'actual')
           .context
           .expect(() => ['is left default'], (_) => null);
     }
     if (which == null) {
-      rejection.has((r) => r.which, 'which').isNull();
+      rejection.have((r) => r.which, 'which').beNull();
     } else {
-      rejection.has((r) => r.which, 'which').isNotNull().deepEquals(which);
+      rejection.have((r) => r.which, 'which').beNonNull().deeplyEqual(which);
     }
   }
 }
 
 extension ConditionChecks<T> on Subject<Condition<T>> {
-  Subject<Iterable<String>> get description =>
-      has((c) => describe<T>(c), 'description');
-  Future<Subject<Iterable<String>>> get asyncDescription async =>
+  Subject<Iterable<String>> get haveDescription =>
+      have((c) => describe<T>(c), 'description');
+  Future<Subject<Iterable<String>>> get haveAsyncDescription async =>
       context.nestAsync(
           'has description',
           (condition) async =>


### PR DESCRIPTION
Make the utility to get a `Subject` an extension method. Since it reads
after the value, change the phrasing to "must" and expectations to
"beSomeDescription".

This causes chained conditions to read poorly

```dart
actualIterable.must.haveLength.beGreaterThan(0);
```

Also needs a solution for passing a "reason" at the top level, but
hopefully which prevents passing a reason anywhere else.
