### PR TITLE
Add assume and expectThat utilities

### DIFF
--- a/pkgs/checks/lib/checks.dart
+++ b/pkgs/checks/lib/checks.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'src/checks.dart' show checkThat, Subject, Skip, it;
+export 'src/checks.dart' show checkThat, Subject, Skip, it, assume, expectThat;
 export 'src/extensions/async.dart'
     show ChainAsync, FutureChecks, StreamChecks, StreamQueueWrap;
 export 'src/extensions/core.dart'

--- a/pkgs/checks/pubspec.yaml
+++ b/pkgs/checks/pubspec.yaml
@@ -11,8 +11,12 @@ environment:
 dependencies:
   async: ^2.8.0
   meta: ^1.9.0
-  test_api: ^0.4.0
+  test_api: ^0.4.19
 
 dev_dependencies:
   test: ^1.21.3
   lints: ^2.0.0
+
+dependency_overrides:
+  test_api:
+    path: ../test_api

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.19-dev
+
+* Guarantee that `TestHandle.current` returns a consistent instance for a given
+  test.
+
 ## 0.4.18
 
 * Don't run `tearDown` until the test body and outstanding work is complete,

--- a/pkgs/test_api/lib/hooks.dart
+++ b/pkgs/test_api/lib/hooks.dart
@@ -13,16 +13,20 @@ import 'src/backend/stack_trace_formatter.dart';
 export 'src/backend/test_failure.dart' show TestFailure;
 export 'src/scaffolding/utils.dart' show pumpEventQueue;
 
+final _handles = Expando<TestHandle>();
+
 class TestHandle {
-  /// Returns handle for the currently running test.
+  /// Returns a handle for the currently running test.
   ///
   /// This must be called from within the zone that the test is running in. If
   /// the current zone is not a test's zone throws [OutsideTestException].
+  ///
+  /// This handle will be consistent during the lifetime of a given test.
   static TestHandle get current {
     final invoker = Invoker.current;
     if (invoker == null) throw OutsideTestException();
-    return TestHandle._(
-        invoker, StackTraceFormatter.current ?? _defaultFormatter);
+    return _handles[invoker] ??=
+        TestHandle._(invoker, StackTraceFormatter.current ?? _defaultFormatter);
   }
 
   static final _defaultFormatter = StackTraceFormatter();

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.4.18
+version: 0.4.19-dev
 description: >-
   The user facing API for structuring Dart tests and checking expectations.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_api


### PR DESCRIPTION
assume marks the test as skipped. This is not useful currently, but
could be useful if it make the test runner not treat exceptions as
failures anymore.

expectThat does not throw an exception when it fails, instead it
collects failures and throws them in a teardown all together.

Add an `_isSkipped` field to `_TestContext` and remove
`_SkippedContext`. The field can be set late which allows us to bail out
of subsequent expectations on a given subject without throwing. This
avoids figuring out how to treat failure messages for an expectations
following another expectation that had failed. Current failure message
formatting relies on the fact that you only see clauses which were
successful.

Neither of these is very easy to test without sharing some testing
utilities from the test runner because it involves making expectations
about the state of the test runner. Another possibility is to run a
subprocess and make expectations about the reporter output.
