### PR TITLE
Rename some extensions for consistency

### DIFF
--- a/pkgs/checks/lib/checks.dart
+++ b/pkgs/checks/lib/checks.dart
@@ -2,12 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'src/checks.dart' show check, Subject, Skip, it;
+export 'src/checks.dart' show SkipExtension, Subject, check, it;
 export 'src/extensions/async.dart'
-    show ChainAsync, FutureChecks, StreamChecks, StreamQueueWrap;
-export 'src/extensions/core.dart'
-    show BoolChecks, CoreChecks, NullabilityChecks;
-export 'src/extensions/function.dart' show ThrowsCheck;
+    show ChainAsync, FutureChecks, StreamChecks, WithQueueExtension;
+export 'src/extensions/core.dart' show BoolChecks, CoreChecks, NullableChecks;
+export 'src/extensions/function.dart' show FunctionChecks;
 export 'src/extensions/iterable.dart' show IterableChecks;
 export 'src/extensions/map.dart' show MapChecks;
 export 'src/extensions/math.dart' show NumChecks;

--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -24,7 +24,7 @@ class Subject<T> {
   Subject._(this._context);
 }
 
-extension Skip<T> on Subject<T> {
+extension SkipExtension<T> on Subject<T> {
   /// Mark the currently running test as skipped and return a [Subject] that
   /// will ignore all expectations.
   ///

--- a/pkgs/checks/lib/src/extensions/async.dart
+++ b/pkgs/checks/lib/src/extensions/async.dart
@@ -454,7 +454,7 @@ extension ChainAsync<T> on Future<Subject<T>> {
   }
 }
 
-extension StreamQueueWrap<T> on Subject<Stream<T>> {
+extension WithQueueExtension<T> on Subject<Stream<T>> {
   /// Wrap the stream in a [StreamQueue] to allow using checks from
   /// [StreamChecks].
   ///

--- a/pkgs/checks/lib/src/extensions/core.dart
+++ b/pkgs/checks/lib/src/extensions/core.dart
@@ -116,7 +116,7 @@ extension BoolChecks on Subject<bool> {
   }
 }
 
-extension NullabilityChecks<T> on Subject<T?> {
+extension NullableChecks<T> on Subject<T?> {
   Subject<T> isNotNull() {
     return context.nest<T>(() => ['is not null'], (actual) {
       if (actual == null) return Extracted.rejection();

--- a/pkgs/checks/lib/src/extensions/function.dart
+++ b/pkgs/checks/lib/src/extensions/function.dart
@@ -4,7 +4,7 @@
 
 import 'package:checks/context.dart';
 
-extension ThrowsCheck<T> on Subject<T Function()> {
+extension FunctionChecks<T> on Subject<T Function()> {
   /// Expects that a function throws synchronously when it is called.
   ///
   /// If the function synchronously throws a value of type [E], return a


### PR DESCRIPTION
These are technically user facing, but not likely to be referenced.

Rename `ThrowsCheck` to `FunctionChecks`, and `NullabilityChecks` to
`NullableChecks`. All extensions that define expectation methods are
named `*Checks` based on the type they support, plus `CoreChecks` for
any type.

Rename `Skip` to `SkipExtension` to avoid conflict with `Skip` from
`package:test`.

Rename `StreamQueueWrap` to `WithQueueExtension`.
