### PR TITLE
Minor readme improvements

### DIFF
--- a/pkgs/checks/CHANGELOG.md
+++ b/pkgs/checks/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.2.1-dev
+
 # 0.2.0
 
 -   **Breaking Changes**

--- a/pkgs/checks/README.md
+++ b/pkgs/checks/README.md
@@ -27,7 +27,7 @@ value - for instance reading a field or awaiting the result of a Future.
 
 ```dart
 check(someString).length.equals(expectedLength);
-(await check(someFuture).completes()).equals(expectedCompletion);
+await check(someFuture).completes(it()..equals(expectedCompletion));
 ```
 
 Fields can be extracted from objects for checking further properties with the
@@ -102,3 +102,9 @@ extension CustomChecks on Subject<CustomType> {
   Subject<Bar> get someField => has((a) => a.someField, 'someField');
 }
 ```
+
+# Migrating from `matcher` (`expect`) expectations
+
+See the [migration guide][].
+
+[migration guide]:https://github.com/dart-lang/test/blob/master/pkgs/checks/doc/migrating_from_matcher.md

--- a/pkgs/checks/pubspec.yaml
+++ b/pkgs/checks/pubspec.yaml
@@ -1,5 +1,5 @@
 name: checks
-version: 0.2.0
+version: 0.2.1-dev
 description: >-
   A framework for checking values against expectations and building custom
   expectations.


### PR DESCRIPTION
Link to the migration guide so that there is a link from the pub and
docs sites.

Fix an example usage of `completes` after #1896
