### PR TITLE
Handle absolute paths on Windows

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.23.1
+
+* Fix running paths by absolute path (with drive letter) on windows.
+
 ## 1.23.0
 
 * Avoid empty expandable groups for tests without extra output in Github

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.23.0
+version: 1.23.1
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test
@@ -33,7 +33,7 @@ dependencies:
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.4.18
-  test_core: 0.4.23
+  test_core: 0.4.24
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -380,6 +380,13 @@ $_usage''');
       await test.shouldExit(0);
     });
 
+    test('with platform specific absolute paths', () async {
+      await d.dir('foo', [d.file('test.dart', _success)]).create();
+      var test = await runTest([d.path(p.join('foo', 'test.dart'))]);
+      expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
+      await test.shouldExit(0);
+    });
+
     test('with platform specific relative paths containing query params',
         () async {
       await d.dir('foo', [d.file('test.dart', _success)]).create();

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.24
+
+* Fix running paths by absolute path (with drive letter) on windows.
+
 # 0.4.23
 
 * Avoid empty expandable groups for tests without extra output in Github

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -178,13 +178,11 @@ Configuration parse(List<String> args) => _Parser(args).parse();
 void _parseTestSelection(
     String option, Map<String, Set<TestSelection>> selections) {
   final uri = Uri.parse(option);
-  // Restore the path to how it was given (namely, we want to report paths
-  // with their original separators).
-  var path = Uri.decodeComponent(uri.path);
-  // Strip out the leading slash before the drive letter on windows.
-  if (Platform.isWindows && path.startsWith('/')) {
-    path = path.substring(1);
-  }
+  final path = uri.isScheme('file')
+      ? uri.toFilePath()
+      // If not a File URI but has query params, chop at the '?'
+      // to give us exactly the path.
+      : option.split('?').first;
 
   final names = uri.queryParametersAll['name'];
   final fullName = uri.queryParameters['full-name'];

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -177,11 +177,13 @@ Configuration parse(List<String> args) => _Parser(args).parse();
 
 void _parseTestSelection(
     String option, Map<String, Set<TestSelection>> selections) {
-  // If given a path that starts with what looks like a drive letter, convert it
-  // into a file scheme URI. We can't parse using `Uri.file` because we do
-  // support query parameters which aren't valid file uris.
-  if (option.indexOf(':') == 1) {
-    option = 'file:///$option';
+  if (Platform.isWindows) {
+    // If given a path that starts with what looks like a drive letter, convert it
+    // into a file scheme URI. We can't parse using `Uri.file` because we do
+    // support query parameters which aren't valid file uris.
+    if (option.indexOf(':') == 1) {
+      option = 'file:///$option';
+    }
   }
   final uri = Uri.parse(option);
   // Decode the path segment. Specifically, on github actions back slashes on

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.4.23
+version: 0.4.24
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 


### PR DESCRIPTION
Since the latest `package:test` rolled into the SDK, some DAP tests started failing to run tests with `dart test`. They use absolute paths on Windows: https://github.com/dart-lang/sdk/issues/51348

This seems to fix the issue for me - it avoids using the URI to compute the file path if it's not a `file://` URI and instead uses the raw input (but chops it at the `?` to handle query params on non-URI paths).

@jakemac53 