### PR TITLE
Add shorthands for Iterable length checks

### DIFF
--- a/pkgs/checks/lib/src/extensions/iterable.dart
+++ b/pkgs/checks/lib/src/extensions/iterable.dart
@@ -13,6 +13,74 @@ extension IterableChecks<T> on Subject<Iterable<T>> {
   Subject<T> get last => has((l) => l.last, 'last element');
   Subject<T> get single => has((l) => l.single, 'single element');
 
+  /// Checks that the number of values in [Iterable] is exactly [length]
+  void hasLength(int length) {
+    if (length < 0) {
+      throw ArgumentError('length must be greater than 0');
+    }
+    context.expect(() => ['has length <$length>'], (actual) {
+      if (actual.length == length) return null;
+      return Rejection(
+          which: ['does not have length $length but <${actual.length}>']);
+    });
+  }
+
+  /// Checks that the number of values in [Iterable] is greater than [length]
+  void hasLengthGreaterThan(int length) {
+    if (length < 0) {
+      throw ArgumentError('length must be greater than 0');
+    }
+    context.expect(() => ['has length greater than <$length>'], (actual) {
+      if (actual.length > length) return null;
+      return Rejection(which: [
+        'does not have length greater than $length but <${actual.length}>'
+      ]);
+    });
+  }
+
+  /// Checks that the number of values in [Iterable] is greater than or equal to
+  /// [length]
+  void hasLengthGreaterThanOrEqualTo(int length) {
+    if (length < 0) {
+      throw ArgumentError('length must be greater than 0');
+    }
+    context.expect(() => ['has length greater than or equal to <$length>'],
+        (actual) {
+      if (actual.length >= length) return null;
+      return Rejection(which: [
+        'does not have length greater than or equal to $length but <${actual.length}>'
+      ]);
+    });
+  }
+
+  /// Checks that the number of values in [Iterable] is less than [length]
+  void hasLengthLessThan(int length) {
+    if (length < 0) {
+      throw ArgumentError('length must be greater than 0');
+    }
+    context.expect(() => ['has length less than <$length>'], (actual) {
+      if (actual.length < length) return null;
+      return Rejection(which: [
+        'does not have length less than $length but <${actual.length}>'
+      ]);
+    });
+  }
+
+  /// Checks that the number of values in [Iterable] is less than or equal to
+  /// [length]
+  void hasLengthLessThanOrEqualTo(int length) {
+    if (length < 0) {
+      throw ArgumentError('length must be greater than 0');
+    }
+    context.expect(() => ['has length less than or equal to $length'],
+        (actual) {
+      if (actual.length <= length) return null;
+      return Rejection(which: [
+        'does not have length less than or equal to $length but <${actual.length}>'
+      ]);
+    });
+  }
+
   void isEmpty() {
     context.expect(() => const ['is empty'], (actual) {
       if (actual.isEmpty) return null;

--- a/pkgs/checks/test/extensions/iterable_test.dart
+++ b/pkgs/checks/test/extensions/iterable_test.dart
@@ -23,6 +23,38 @@ void main() {
     check([42]).single.equals(42);
   });
 
+  test('hasLength', () {
+    check([]).hasLength(0);
+    check([3, 4]).isRejectedBy(it()..hasLength(1),
+        which: ['does not have length 1 but <2>']);
+  });
+
+  test('hasLengthGreaterThan', () {
+    check([1]).hasLengthGreaterThan(0);
+    check([]).isRejectedBy(it()..hasLengthGreaterThan(1),
+        which: ['does not have length greater than 1 but <0>']);
+  });
+
+  test('hasLengthGreaterThan', () {
+    check([1]).hasLengthGreaterThanOrEqualTo(0);
+    check([1]).hasLengthGreaterThanOrEqualTo(1);
+    check([]).isRejectedBy(it()..hasLengthGreaterThanOrEqualTo(1),
+        which: ['does not have length greater than or equal to 1 but <0>']);
+  });
+
+  test('hasLengthLessThan', () {
+    check([]).hasLengthLessThan(1);
+    check([1]).isRejectedBy(it()..hasLengthLessThan(0),
+        which: ['does not have length less than 0 but <1>']);
+  });
+
+  test('hasLengthLessThanOrEqualTo', () {
+    check([]).hasLengthLessThanOrEqualTo(0);
+    check([]).hasLengthLessThanOrEqualTo(1);
+    check([1]).isRejectedBy(it()..hasLengthLessThanOrEqualTo(0),
+        which: ['does not have length less than or equal to 0 but <1>']);
+  });
+
   test('isEmpty', () {
     check([]).isEmpty();
     check(_testIterable).isRejectedBy(it()..isEmpty(), which: ['is not empty']);


### PR DESCRIPTION
A list length can be checked with:

```dart
check([]).length.equals(2);
```

It also shows some checks in auto-completion that are not useful and might be missleading.

```dart
check([]).length
  ..isCloseTo(0, 0.001) // always int, never double
  ..isInfinite() // would never return if it would be inifinite
  ..isNegative() // is by design always positive
  ..isNaN() // can't be nan
  ..isNull(); // is never null
```

---

This PR creates shorthand APIs, making it easier to check the length of a list.

```dart
check([1]).hasLength(1);
check([1]).hasLengthGreaterThan(0);
check([1]).hasLengthGreaterThanOrEqualTo(0);
check([]).hasLengthLessThanOrEqualTo(0);
```

This is the first kind of this PRs. @natebosch Please let me know if that's a direction you'd like to see `package:checks` move to

