### PR TITLE
updates to package:checks docs

### DIFF
--- a/pkgs/checks/README.md
+++ b/pkgs/checks/README.md
@@ -1,6 +1,43 @@
 [![pub package](https://img.shields.io/pub/v/checks.svg)](https://pub.dev/packages/checks)
 [![package publisher](https://img.shields.io/pub/publisher/checks.svg)](https://pub.dev/packages/checks/publisher)
 
+`package:checks` ia a library for expressing test expectations and features a
+literate API.
+
+## package:checks preview
+
+`package:checks` is in preview; to provide feedback on the API, please file
+[an issue][] with questions, suggestions, feature requests, or general
+feedback.
+
+For documentation about migrating from `package:matcher` to `checks`, see the
+[migration guide][].
+
+[an issue]:https://github.com/dart-lang/test/issues/new?labels=package%3Achecks&template=03_checks_feedback.md
+[migration guide]:https://github.com/dart-lang/test/blob/master/pkgs/checks/doc/migrating_from_matcher.md
+
+## Quickstart
+
+1. Add a `dev_dependency` on `checks: ^0.2.0`.
+
+1. Add an import for `package:checks/checks.dart`.
+
+1. Use `checks` in your test code:
+
+```dart
+void main() {
+  test('sample test', () {
+    // test code here
+    ...
+
+    check(actual).equals(expected);
+    check(someList).isNotEmpty();
+    check(someObject).isA<Map>();
+    check(someString)..startsWith('a')..endsWith('z')..contains('lmno');
+  });
+}
+```
+
 ## Checking expectations with `checks`
 
 Expectations start with `check`. This utility returns a `Subject`, and
@@ -105,15 +142,3 @@ extension CustomChecks on Subject<CustomType> {
   Subject<Bar> get someField => has((a) => a.someField, 'someField');
 }
 ```
-
-## Migrating from `matcher` (`expect`) expectations
-
-See the [migration guide][].
-
-[migration guide]:https://github.com/dart-lang/test/blob/master/pkgs/checks/doc/migrating_from_matcher.md
-
-## Giving feedback while `checks` is in preview
-
-File [an issue][] with questions, suggestions, feature requests, or feedback.
-
-[an issue]:https://github.com/dart-lang/test/issues/new?labels=package%3Achecks&template=03_checks_feedback.md

--- a/pkgs/checks/doc/migrating_from_matcher.md
+++ b/pkgs/checks/doc/migrating_from_matcher.md
@@ -1,3 +1,5 @@
+## Migrating from package:matcher
+
 `package:checks` is currently in preview. Once this package reaches a stable
 version, it will be the recommended package by the Dart team to use for most
 tests.
@@ -16,8 +18,7 @@ high potential for minor or major breaking changes during the preview window.
 Once this package is stable, yes! The experience of using `checks` improves on
 `matcher`.
 
-
-# Trying Checks as a Preview
+## Trying Checks as a Preview
 
 1.  Add a `dev_dependency` on `checks: ^0.2.0`.
 
@@ -33,7 +34,7 @@ Once this package is stable, yes! The experience of using `checks` improves on
 
 1.  Migrate the test cases.
 
-# Migrating from Matchers
+## Migrating from Matchers
 
 Replace calls to `expect` with a call to `check` passing the first argument.
 When a direct replacement is available, change the second argument from calling
@@ -53,7 +54,7 @@ check(actual).equals(expected);
 check(actualCollection).deepEquals(expected);
 ```
 
-## Differences in behavior from matcher
+### Differences in behavior from matcher
 
 -   The `equals` Matcher performed a deep equality check on collections.
     `.equals()` expectation will only correspond to [operator ==] so some tests
@@ -78,7 +79,7 @@ check(actualCollection).deepEquals(expected);
 [matches]:https://pub.dev/documentation/matcher/latest/matcher/Matcher/matches.html
 [allMatches]:https://api.dart.dev/stable/2.19.1/dart-core/Pattern/allMatches.html
 
-## Matchers with replacements under a different name
+### Matchers with replacements under a different name
 
 -   `anyElement` -> `Subject<Iterable>.any`
 -   `everyElement` -> `Subject<Iterable>.every`
@@ -90,7 +91,7 @@ check(actualCollection).deepEquals(expected);
 -   `same` -> `identicalTo`
 -   `stringContainsInOrder` -> `Subject<String>.containsInOrder`
 
-## Members from `package:test/expect.dart` without a direct replacement
+### Members from `package:test/expect.dart` without a direct replacement
 
 -   `checks` does not ship with any type checking matchers for specific types.
     Instead of, for example,  `isArgumentError` use `isA<ArgumentError>`, and


### PR DESCRIPTION
updates to package:checks docs:
- move the preview status and migrating guide info to the top of the readme so it's more noticable
- add a brief 'Quickstart' section
- minor edits to the migrating guide

I think we may also want to convert the two bullet lists at the end of the migrating guide to a cookbook style faq, and possible break that out into a separate doc? If we do, we should also add verbiage to ask for issues and PRs to help maintain the migrating faq.
