### PR TITLE
use test_api/backend.dart instead of test_core/backend.dart

### DIFF
--- a/pkgs/test_core/lib/src/runner/compiler_selection.dart
+++ b/pkgs/test_core/lib/src/runner/compiler_selection.dart
@@ -3,7 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:source_span/source_span.dart';
-import 'package:test_core/backend.dart';
+// ignore: deprecated_member_use
+import 'package:test_api/backend.dart';
 
 /// A compiler with which the user has chosen to run tests.
 class CompilerSelection {

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -7,11 +7,10 @@ import 'dart:math';
 
 import 'package:args/args.dart';
 import 'package:boolean_selector/boolean_selector.dart';
+import 'package:test_api/backend.dart'; // ignore: deprecated_member_use
 import 'package:test_api/scaffolding.dart' // ignore: deprecated_member_use
     show
         Timeout;
-import 'package:test_core/backend.dart';
-import 'package:test_core/test_core.dart';
 
 import '../../util/io.dart';
 import '../compiler_selection.dart';


### PR DESCRIPTION
this cleans up the internal build rules a bit (avoids adding a new dep)