### PR TITLE
Add `because` usage in examples

### DIFF
--- a/pkgs/checks/CHANGELOG.md
+++ b/pkgs/checks/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.2.2-dev
 
+-   Add example `because` usage and mention the "reason" name in the migration
+    guide.
+
 ## 0.2.1
 
 -   Add a link to file issues with feedback in the README.

--- a/pkgs/checks/README.md
+++ b/pkgs/checks/README.md
@@ -102,6 +102,22 @@ check(someString)
     ..isLessThan(100));
 ```
 
+If a failure may not be have enough context about the actual or expected values
+when an expectation fails, add a "Reason" in the failure message by passing a
+`because:` argument to `check()`.
+
+```dart
+check(
+  because: 'log lines must start with the severity',
+  logLines,
+).every(it()
+  ..anyOf([
+    it()..startsWith('ERROR'),
+    it()..startsWith('WARNING'),
+    it()..startsWith('INFO'),
+  ]));
+```
+
 ## Writing custom expectations
 
 Expectations are written as extension on `Subject` with specific generics. The

--- a/pkgs/checks/doc/migrating_from_matcher.md
+++ b/pkgs/checks/doc/migrating_from_matcher.md
@@ -54,6 +54,13 @@ check(actual).equals(expected);
 check(actualCollection).deepEquals(expected);
 ```
 
+If you use the `reason` argument to `expect`, rename it to `because`.
+
+```dart
+expect(actual, expectation(), reason: 'some explanation');
+check(because: 'some explanation', actual).expectation();
+```
+
 ### Differences in behavior from matcher
 
 -   The `equals` Matcher performed a deep equality check on collections.

--- a/pkgs/checks/example/example.dart
+++ b/pkgs/checks/example/example.dart
@@ -15,7 +15,10 @@ void main() {
 
     final someString = 'abcdefghijklmnopqrstuvwxyz';
 
-    check(someString)
+    check(
+      because: 'It should contain the beginning, middle and end',
+      someString,
+    )
       ..startsWith('a')
       ..endsWith('z')
       ..contains('lmno');

--- a/pkgs/checks/example/example.dart
+++ b/pkgs/checks/example/example.dart
@@ -16,7 +16,7 @@ void main() {
     final someString = 'abcdefghijklmnopqrstuvwxyz';
 
     check(
-      because: 'It should contain the beginning, middle and end',
+      because: 'it should contain the beginning, middle and end',
       someString,
     )
       ..startsWith('a')


### PR DESCRIPTION
Closes #1938

Add a description of `because` in the README and an example using it.

Add a `because` argument to one of the examples in `example.dart`.

Call out the rename from `reason` to `because` in the migration guide.
