### PR TITLE
Add note about why we are replacing matcher

### DIFF
--- a/pkgs/checks/doc/migrating_from_matcher.md
+++ b/pkgs/checks/doc/migrating_from_matcher.md
@@ -161,17 +161,22 @@ expect(actual, _ // many unrelated suggestions
 check(actual)._ // specific suggestions
 ```
 
-Expectations are checked at runtime and `async` expectations cause errors when
-they are used in places where a synchronous answer is required. With `matcher`
-the definition of synchronous and asynchronous matchers was originally split
-across the `matcher` and `test` packages. Asynchronous matchers used the same
-interface, but required special usage that was not implemented in the `matcher`
-package, so asynchronous matchers passed to places required a synchronous
-response would always appear to match but cause unhandled asynchronous errors.
+Expectations in `checks` are limited at runtime and `async` expectations cause
+errors when they are used in places where a synchronous answer is required. With
+`matcher` an asynchronous matcher used to get a synchronous match would always
+pass, but could cause unhandled async errors, or when using `not` would always
+fail even if the expectation would succeed asynchronously. The reason for the
+poor compatibility is due to some history of implementation - asynchronous
+matchers were written in `test` alongside `expect`, and synchronous matchers
+have no dependency on the asynchronous implementation. The exceptions that
+happen when an expectation from `checks` is misapplied should result in fewer
+missed or misleading failures.
 
 Asynchronous expectations always return a `Future`, and with the
-`unawaited_futures` lint should more safely ensure that asynchronous expectation
-work is completed within the test body. With `matcher` it was up to the author
-to correctly use `await expecLater` for asynchronous cases, and `expect` for
-synchronous cases, and if `expect` was used with an asynchronous matcher the
-expectation could fail at any point.
+[`unawaited_futures` lint][unawaited lint] should more safely ensure that
+asynchronous expectation work is completed within the test body. With `matcher`
+it was up to the author to correctly use `await expecLater` for asynchronous
+cases, and `expect` for synchronous cases, and if `expect` was used with an
+asynchronous matcher the expectation could fail at any point.
+
+[unawaited lint]:https://dart-lang.github.io/linter/lints/unawaited_futures.html

--- a/pkgs/checks/doc/migrating_from_matcher.md
+++ b/pkgs/checks/doc/migrating_from_matcher.md
@@ -13,6 +13,14 @@ these members it will be possible to add a dependency on `package:matcher` and
 continue to use them. `package:matcher` will get deprecated and will not see new
 development, but the existing features will continue to work.
 
+**Why is the Dart team moving away from matcher?** The `matcher` package has a
+design which is fundamentally incompatible with using static types to validate
+correct use. With an entirely new design, the static types in `checks` give
+confidence that the expectation is appropriate for the value, and can narrow
+autocomplete choices in the IDE for a better editing experience. The clean break
+from the legacy implementation and API also gives an opportunity to make small
+behavior and signature changes to align with modern Dart idioms.
+
 **Should I start using checks over matcher for new tests?** There is still a
 high potential for minor or major breaking changes during the preview window.
 Once this package is stable, yes! The experience of using `checks` improves on

--- a/pkgs/checks/doc/migrating_from_matcher.md
+++ b/pkgs/checks/doc/migrating_from_matcher.md
@@ -161,16 +161,18 @@ expect(actual, _ // many unrelated suggestions
 check(actual)._ // specific suggestions
 ```
 
-Expectations in `checks` are limited at runtime and `async` expectations cause
-errors when they are used in places where a synchronous answer is required. With
-`matcher` an asynchronous matcher used to get a synchronous match would always
-pass, but could cause unhandled async errors, or when using `not` would always
-fail even if the expectation would succeed asynchronously. The reason for the
-poor compatibility is due to some history of implementation - asynchronous
-matchers were written in `test` alongside `expect`, and synchronous matchers
-have no dependency on the asynchronous implementation. The exceptions that
-happen when an expectation from `checks` is misapplied should result in fewer
-missed or misleading failures.
+Asynchronous matchers in `matcher` are a subtype of synchronous matchers, but do
+not satisfy the same behavior contract. Some APIs which use a matcher could not
+validate whether it would satisfy the behavior it needs, and it could result in
+a false success, false failure, or misleading errors. APIs which correctly use
+asynchronous matchers need to do a type check and change their interaction based
+on the runtime type. Asynchronous expectations in `checks` are refused at
+runtime when a synchronous answer is required. The error will help solve the
+specific misuse, instead of resulting in a confusing error, or worse a missed
+failure. The reason for the poor compatibility in `matcher` is due to some
+history of implementation - asynchronous matchers were written in `test`
+alongside `expect`, and synchronous matchers have no dependency on the
+asynchronous implementation.
 
 Asynchronous expectations always return a `Future`, and with the
 [`unawaited_futures` lint][unawaited lint] should more safely ensure that


### PR DESCRIPTION
In the migration guide doc, add a question and answer about why the Dart
team is moving away from the matcher package. Describes how and why
`checks` can offer a better UX than we could possibly do with `matcher`.
