### PR TITLE
Add async examples to README

### DIFF
--- a/pkgs/checks/doc/migrating_from_matcher.md
+++ b/pkgs/checks/doc/migrating_from_matcher.md
@@ -50,7 +50,8 @@ below][#improvements-you-can-expect].
 
 ## Migrating from Matchers
 
-Replace calls to `expect` with a call to `check` passing the first argument.
+Replace calls to `expect` or `expectLater` with a call to `check` passing the
+first argument.
 When a direct replacement is available, change the second argument from calling
 a function returning a Matcher, to calling the relevant extension method on the
 `Subject`.
@@ -66,6 +67,9 @@ expect(actual, expected);
 check(actual).equals(expected);
 // or maybe
 check(actualCollection).deepEquals(expected);
+
+await expectLater(actual, completes());
+await check(actual).completes();
 ```
 
 If you use the `reason` argument to `expect`, rename it to `because`.

--- a/pkgs/checks/test/extensions/async_test.dart
+++ b/pkgs/checks/test/extensions/async_test.dart
@@ -127,6 +127,12 @@ fake trace''');
     group('emits', () {
       test('succeeds for a stream that emits a value', () async {
         await check(_countingStream(5)).emits(it()..equals(0));
+        await check(_countingStream(3)).withQueue.inOrder([
+          it()..emits(it()..equals(1)),
+          it()..emits(it()..equals(2)),
+          it()..emits(it()..equals(3)),
+          it()..isDone(),
+        ]);
       });
       test('fails for a stream that closes without emitting', () async {
         await check(_countingStream(0)).isRejectedByAsync(

--- a/pkgs/checks/test/extensions/async_test.dart
+++ b/pkgs/checks/test/extensions/async_test.dart
@@ -127,12 +127,6 @@ fake trace''');
     group('emits', () {
       test('succeeds for a stream that emits a value', () async {
         await check(_countingStream(5)).emits(it()..equals(0));
-        await check(_countingStream(3)).withQueue.inOrder([
-          it()..emits(it()..equals(1)),
-          it()..emits(it()..equals(2)),
-          it()..emits(it()..equals(3)),
-          it()..isDone(),
-        ]);
       });
       test('fails for a stream that closes without emitting', () async {
         await check(_countingStream(0)).isRejectedByAsync(


### PR DESCRIPTION
Towards #1928

Add a section in the README about async expectations. Give examples of
awaiting the result, and describe that when the result is not awaited
the test runner is still aware of the work. Describe that some
expectations cannot be awaited.

Describe the reason that `StreamQueue` is used for stream expectations
and give examples of using the `withQueue` and a manual wrapping.

Mention that both `expect` and `expectLater` are migrated to the same
`check` call in the migration guide. Give an example of migrated an
awaited expectation.
