### PR TITLE
Annotate `has` with `@useResult`

### DIFF
--- a/pkgs/checks/lib/src/extensions/core.dart
+++ b/pkgs/checks/lib/src/extensions/core.dart
@@ -3,12 +3,14 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:checks/context.dart';
+import 'package:meta/meta.dart' as meta;
 
 extension CoreChecks<T> on Subject<T> {
   /// Extracts a property of the value for further expectations.
   ///
   /// Sets up a clause that the value "has [name] that:" followed by any
   /// expectations applied to the returned [Subject].
+  @meta.useResult
   Subject<R> has<R>(R Function(T) extract, String name) {
     return context.nest(() => ['has $name'], (T value) {
       try {

--- a/pkgs/checks/test/extensions/core_test.dart
+++ b/pkgs/checks/test/extensions/core_test.dart
@@ -20,7 +20,7 @@ void main() {
       check(1).has((v) => v.isOdd, 'isOdd').isTrue();
 
       check(2).isRejectedBy(
-          it()..has((v) => throw UnimplementedError(), 'isOdd'),
+          it()..has((v) => throw UnimplementedError(), 'isOdd').isNotNull(),
           which: ['threw while trying to read property']);
     });
 


### PR DESCRIPTION
The API is intended for extracting properties that cannot fail, and a
further expectation should always be made about the property.

This should solve one potential confusion in the usage compared to the
similar `TypeMatcher.having` which took a third matcher argument. This
may have prevented the confusion in #1930
