### PR TITLE
Only grab the first failure in softCheck

### DIFF
--- a/pkgs/checks/CHANGELOG.md
+++ b/pkgs/checks/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.2.2-dev
 
+-   Return the first failure from `softCheck` and `softCheckAsync` as
+    documented, instead of the last failure when there are multiple failures.
 -   Add example `because` usage and mention the "reason" name in the migration
     guide.
 

--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -96,7 +96,7 @@ CheckFailure? softCheck<T>(T value, Condition<T> condition) {
   final subject = Subject<T>._(_TestContext._root(
     value: _Present(value),
     fail: (f) {
-      failure = f;
+      failure ??= f;
     },
     allowAsync: false,
     allowUnawaited: false,
@@ -119,7 +119,7 @@ Future<CheckFailure?> softCheckAsync<T>(T value, Condition<T> condition) async {
   final subject = Subject<T>._(_TestContext._root(
     value: _Present(value),
     fail: (f) {
-      failure = f;
+      failure ??= f;
     },
     allowAsync: true,
     allowUnawaited: false,

--- a/pkgs/checks/test/soft_check_test.dart
+++ b/pkgs/checks/test/soft_check_test.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:checks/checks.dart';
+import 'package:test/scaffolding.dart';
+
+import 'test_shared.dart';
+
+void main() {
+  group('softCheck', () {
+    test('returns the first failure', () {
+      check(0).isRejectedBy(
+          it()
+            ..isGreaterThan(1)
+            ..isGreaterThan(2),
+          which: ['is not greater than <1>']);
+    });
+  });
+  group('softCheckAsync', () {
+    test('returns the first failure', () async {
+      check(Future.value(0)).isRejectedByAsync(
+          it()
+            ..completes(it()..isGreaterThan(1))
+            ..completes(it()..isGreaterThan(2)),
+          actual: ['<0>'],
+          which: ['is not greater than <1>']);
+    });
+  });
+}

--- a/pkgs/checks/test/soft_check_test.dart
+++ b/pkgs/checks/test/soft_check_test.dart
@@ -23,7 +23,6 @@ void main() {
           it()
             ..completes(it()..isGreaterThan(1))
             ..completes(it()..isGreaterThan(2)),
-          actual: ['<0>'],
           which: ['is not greater than <1>']);
     });
   });

--- a/pkgs/checks/test/soft_check_test.dart
+++ b/pkgs/checks/test/soft_check_test.dart
@@ -23,6 +23,7 @@ void main() {
           it()
             ..completes(it()..isGreaterThan(1))
             ..completes(it()..isGreaterThan(2)),
+          actual: ['<0>'],
           which: ['is not greater than <1>']);
     });
   });


### PR DESCRIPTION
The doc comments mention that the first failure is returned, but this
wasn't the behavior. Use a null aware assignment to only use the first
reported failure, and add tests for soft checks that fail for multiple
reasons.
