### PR TITLE
Flush stdin before test

### DIFF
--- a/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
+++ b/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
@@ -160,8 +160,9 @@ final _testWithStdOutAndErr = '''
 import 'dart:io';
 import 'package:test/test.dart';
 
-void main() {
+void main() async {
   stdout.writeln('hello');
+  await stdout.flush();
   stderr.writeln('world');
   test('success', () {});
 }''';


### PR DESCRIPTION
On windows we sometimes see the stdout come with no newline between
`hello` and the test runner output for the first running test. Flush
stdout to see if it more reliably includes the newline.
