### PR TITLE
Add a hooks_testing library

### DIFF
--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -727,11 +727,14 @@ class _TestContext<T> implements Context<T>, _ClauseDescription {
     }
     _clauses.add(_ExpectationClause(clause));
     final outstandingWork = TestHandle.current.markPending();
-    final rejection = await _value.apply(
-        (actual) async => (await predicate(actual))?._fillActual(actual));
-    outstandingWork.complete();
-    if (rejection == null) return;
-    _fail(_failure(rejection));
+    try {
+      final rejection = await _value.apply(
+          (actual) async => (await predicate(actual))?._fillActual(actual));
+      if (rejection == null) return;
+      _fail(_failure(rejection));
+    } finally {
+      outstandingWork.complete();
+    }
   }
 
   @override
@@ -779,18 +782,21 @@ class _TestContext<T> implements Context<T>, _ClauseDescription {
           'Async expectations cannot be used on a synchronous subject');
     }
     final outstandingWork = TestHandle.current.markPending();
-    final result = await _value.mapAsync(
-        (actual) async => (await extract(actual))._fillActual(actual));
-    outstandingWork.complete();
-    final rejection = result._rejection;
-    if (rejection != null) {
-      _clauses.add(_ExpectationClause(label));
-      _fail(_failure(rejection));
+    try {
+      final result = await _value.mapAsync(
+          (actual) async => (await extract(actual))._fillActual(actual));
+      final rejection = result._rejection;
+      if (rejection != null) {
+        _clauses.add(_ExpectationClause(label));
+        _fail(_failure(rejection));
+      }
+      final value = result._value ?? _Absent<R>();
+      final context = _TestContext<R>._child(value, label, this);
+      _clauses.add(context);
+      await nestedCondition?.applyAsync(Subject<R>._(context));
+    } finally {
+      outstandingWork.complete();
     }
-    final value = result._value ?? _Absent<R>();
-    final context = _TestContext<R>._child(value, label, this);
-    _clauses.add(context);
-    await nestedCondition?.applyAsync(Subject<R>._(context));
   }
 
   CheckFailure _failure(Rejection rejection) =>

--- a/pkgs/checks/pubspec.yaml
+++ b/pkgs/checks/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   async: ^2.8.0
   meta: ^1.9.0
-  test_api: ^0.4.0
+  test_api: ^0.5.0
 
 dev_dependencies:
   test: ^1.21.3

--- a/pkgs/checks/pubspec_overrides.yaml
+++ b/pkgs/checks/pubspec_overrides.yaml
@@ -1,0 +1,7 @@
+dependency_overrides:
+  test_api:
+    path: ../test_api
+  test_core:
+    path: ../test_core
+  test:
+    path: ../test

--- a/pkgs/checks/test/context_test.dart
+++ b/pkgs/checks/test/context_test.dart
@@ -25,7 +25,7 @@ void main() {
         });
       });
       await pumpEventQueue();
-      check(monitor).status.equals(Status.running);
+      check(monitor).state.equals(State.running);
       callback();
       await monitor.onDone;
       check(monitor).didPass();
@@ -42,7 +42,7 @@ void main() {
         }, it());
       });
       await pumpEventQueue();
-      check(monitor).status.equals(Status.running);
+      check(monitor).state.equals(State.running);
       callback();
       await monitor.onDone;
       check(monitor).didPass();
@@ -59,9 +59,7 @@ void main() {
           callback = completer.complete;
         });
       });
-      check(monitor)
-        ..status.equals(Status.complete)
-        ..result.equals(Result.success);
+      check(monitor).state.equals(State.passed);
       callback();
       await pumpEventQueue();
       check(monitor)
@@ -72,8 +70,7 @@ void main() {
 }
 
 extension _MonitorChecks on Subject<TestCaseMonitor> {
-  Subject<Status> get status => has((m) => m.status, 'status');
-  Subject<Result> get result => has((m) => m.result, 'result');
+  Subject<State> get state => has((m) => m.state, 'state');
   Subject<Iterable<AsyncError>> get errors => has((m) => m.errors, 'errors');
   Subject<StreamQueue<AsyncError>> get onError =>
       has((m) => m.onError, 'onError').withQueue;
@@ -84,8 +81,7 @@ extension _MonitorChecks on Subject<TestCaseMonitor> {
   /// future in addition to checking there have been no errors yet.
   void didPass() {
     errors.isEmpty();
-    status.equals(Status.complete);
-    result.equals(Result.success);
+    state.equals(State.passed);
     onError.context.expectUnawaited(() => ['emits no further errors'],
         (actual, reject) async {
       await for (var error in actual.rest) {
@@ -103,8 +99,7 @@ extension _MonitorChecks on Subject<TestCaseMonitor> {
   ///
   /// Returns the message from the failure.
   Subject<String> didFail(Result expectedResult) {
-    status.equals(Status.complete);
-    result.equals(Result.failure);
+    state.equals(State.failed);
     return errors.single
         .isA<AsyncError>()
         .has((a) => a.error, 'error')

--- a/pkgs/checks/test/context_test.dart
+++ b/pkgs/checks/test/context_test.dart
@@ -1,0 +1,115 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:async/async.dart' hide Result;
+import 'package:checks/checks.dart';
+import 'package:checks/context.dart';
+import 'package:test/scaffolding.dart';
+import 'package:test_api/hooks.dart';
+import 'package:test_api/hooks_testing.dart';
+
+void main() {
+  group('Context', () {
+    test('expectAsync holds test open', () async {
+      late void Function() callback;
+      final monitor = TestCaseMonitor.start(() {
+        check(null).context.expectAsync(() => [''], (actual) async {
+          final completer = Completer<void>();
+          callback = completer.complete;
+          await completer.future;
+          return null;
+        });
+      });
+      await pumpEventQueue();
+      check(monitor).status.equals(Status.running);
+      callback();
+      await monitor.onDone;
+      check(monitor).didPass();
+    });
+
+    test('nestAsync holds test open', () async {
+      late void Function() callback;
+      final monitor = TestCaseMonitor.start(() {
+        check(null).context.nestAsync(() => [''], (actual) async {
+          final completer = Completer<void>();
+          callback = completer.complete;
+          await completer.future;
+          return Extracted.value(null);
+        }, it());
+      });
+      await pumpEventQueue();
+      check(monitor).status.equals(Status.running);
+      callback();
+      await monitor.onDone;
+      check(monitor).didPass();
+    });
+
+    test('expectUnawaited can fail the test after it completes', () async {
+      late void Function() callback;
+      final monitor = await TestCaseMonitor.run(() {
+        check(null).context.expectUnawaited(() => [''], (actual, reject) {
+          final completer = Completer<void>()
+            ..future.then((_) {
+              reject(Rejection(which: ['']));
+            });
+          callback = completer.complete;
+        });
+      });
+      check(monitor)
+        ..status.equals(Status.complete)
+        ..result.equals(Result.success);
+      callback();
+      await pumpEventQueue();
+      check(monitor)
+          .didFail(Result.error)
+          .contains('This test failed after it had already completed.');
+    });
+  });
+}
+
+extension _MonitorChecks on Subject<TestCaseMonitor> {
+  Subject<Status> get status => has((m) => m.status, 'status');
+  Subject<Result> get result => has((m) => m.result, 'result');
+  Subject<Iterable<AsyncError>> get errors => has((m) => m.errors, 'errors');
+  Subject<StreamQueue<AsyncError>> get onError =>
+      has((m) => m.onError, 'onError').withQueue;
+
+  /// Expects that the monitored test is completed as success with no errors.
+  ///
+  /// Sets up an unawaited expectation that the test does not emit errors in the
+  /// future in addition to checking there have been no errors yet.
+  void didPass() {
+    errors.isEmpty();
+    status.equals(Status.complete);
+    result.equals(Result.success);
+    onError.context.expectUnawaited(() => ['emits no further errors'],
+        (actual, reject) async {
+      await for (var error in actual.rest) {
+        reject(Rejection(which: [
+          ...prefixFirst('threw late error', literal(error.error)),
+          ...(const LineSplitter().convert(
+              TestHandle.current.formatStackTrace(error.stackTrace).toString()))
+        ]));
+      }
+    });
+  }
+
+  /// Expects that the monitored test is completed as [expectedResult] with
+  /// exactly 1 TestFailure.
+  ///
+  /// Returns the message from the failure.
+  Subject<String> didFail(Result expectedResult) {
+    status.equals(Status.complete);
+    result.equals(Result.failure);
+    return errors.single
+        .isA<AsyncError>()
+        .has((a) => a.error, 'error')
+        .isA<TestFailure>()
+        .has((f) => f.message, 'message')
+        .isNotNull();
+  }
+}

--- a/pkgs/checks/test/test_shared.dart
+++ b/pkgs/checks/test/test_shared.dart
@@ -59,7 +59,7 @@ extension RejectionChecks<T> on Subject<T> {
         ]);
       }
       return Extracted.value(failure.rejection);
-    }, _LazyCondition((rejection) {
+    }, LazyCondition((rejection) {
       if (didRunCallback) {
         rejection
             .has((r) => r.actual, 'actual')
@@ -96,9 +96,9 @@ extension ConditionChecks<T> on Subject<Condition<T>> {
 ///
 /// Allows basing the following condition in `isRejectedByAsync` on the actual
 /// value.
-class _LazyCondition<T> implements Condition<T> {
+class LazyCondition<T> implements Condition<T> {
   final FutureOr<void> Function(Subject<T>) _apply;
-  _LazyCondition(this._apply);
+  LazyCondition(this._apply);
 
   @override
   void apply(Subject<T> subject) {

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -6,6 +6,8 @@
   major release.
 * **BREAKING** Add required `defaultCompiler` and `supportedCompilers` fields
   to `Runtime`.
+* Add `package:test_api/hooks_testing.dart` library for writing tests against
+  code that uses `package:test_api/hooks.dart`.
 
 ## 0.4.18
 

--- a/pkgs/test_api/lib/hooks_testing.dart
+++ b/pkgs/test_api/lib/hooks_testing.dart
@@ -106,13 +106,13 @@ class TestCaseMonitor {
   ///
   /// A test may have more than one error if there were unhandled asynchronous
   /// errors surfaced after the test is done.
-  Iterable<AsyncError> get errors => _liveTest.errors;
+  Iterable<Object> get errors => _liveTest.errors.map((a) => a.error);
 
   /// A stream of errors surfaced by the test.
   ///
   /// This stream will not close, asynchronous errors may be surfaced within the
   /// test's error zone at any point.
-  Stream<AsyncError> get onError => _liveTest.onError;
+  Stream<Object> get onError => _liveTest.onError.map((a) => a.error);
 }
 
 /// Returns a local [LiveTest] that runs [body].

--- a/pkgs/test_api/lib/hooks_testing.dart
+++ b/pkgs/test_api/lib/hooks_testing.dart
@@ -1,0 +1,130 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'src/backend/group.dart';
+import 'src/backend/invoker.dart';
+import 'src/backend/live_test.dart';
+import 'src/backend/metadata.dart';
+import 'src/backend/runtime.dart';
+import 'src/backend/state.dart';
+import 'src/backend/suite.dart';
+import 'src/backend/suite_platform.dart';
+
+export 'src/backend/state.dart' show Result, Status;
+export 'src/backend/test_failure.dart' show TestFailure;
+
+/// A monitor for the behavior of a callback when it is run as the body of a
+/// test case.
+///
+/// Allows running a callback as the body of a local test case and querying for
+/// the current [status], [result], and [errors] from the test.
+///
+/// Use [run] to run a test body and query for the success or failure.
+///
+/// Use [start] to start a test and query for whether it has finished running.
+class TestCaseMonitor {
+  final LiveTest _liveTest;
+  final _done = Completer<void>();
+  TestCaseMonitor._(FutureOr<void> Function() body)
+      : _liveTest = _createTest(body);
+
+  /// Run [body] as a test case and return a [TestCaseMonitor] with the result.
+  ///
+  /// The [status] of the returned result will always be [Status.complete].
+  /// The [result] and [errors] will reflect the latest state of the test.
+  /// {@template result-late-fail}
+  /// Note that a test can change result from success to failure even after it
+  /// has already completed if the test surfaces an unawaited asynchronous
+  /// error.
+  /// {@endtemplate}
+  ///
+  /// ```dart
+  /// final monitor = await TestCaseMonitor.run(() {
+  ///   fail('oh no!');
+  /// });
+  /// assert(monitor.result == Result.failure);
+  /// assert((monitor.errors.single.error as TestFailure).message == 'oh no!');
+  /// ```
+  static Future<TestCaseMonitor> run(FutureOr<void> Function() body) async {
+    final monitor = TestCaseMonitor.start(body);
+    await monitor.onDone;
+    return monitor;
+  }
+
+  /// Start [body] as a test case and return a [TestCaseMonitor] with the status
+  /// and result.
+  ///
+  /// The [status] of the test will be [Status.running] until it completes.
+  /// The [result] and [errors] will reflect the latest state of the test.
+  /// {@macro result-late-fail}
+  ///
+  /// ```dart
+  /// late void Function() completeWork;
+  /// final monitor = TestCaseMonitor.start(() {
+  ///   final outstandingWork = TestHandle.current.markPending();
+  ///   completeWork = outstandingWork.complete;
+  /// });
+  /// await pumpEventQueue();
+  /// assert(monitor.status == Status.running);
+  /// completeWork();
+  /// await monitor.onDone;
+  /// assert(monitor.status == Status.complete);
+  /// ```
+  /// The [result] and [errors] will reflect the latest state of the test.
+  static TestCaseMonitor start(FutureOr<void> Function() body) =>
+      TestCaseMonitor._(body).._start();
+
+  void _start() {
+    _liveTest.run().whenComplete(_done.complete);
+  }
+
+  /// A future that completes after this test has finished running, or has
+  /// surfaced an error.
+  Future<void> get onDone => _done.future;
+
+  /// The run status for the test.
+  Status get status => _liveTest.state.status;
+
+  /// The result for the test.
+  ///
+  /// A test that is still running may have a result of [Result.success] because
+  /// it has not failed _yet_. The result should only be read after the test is
+  /// done.
+  ///
+  /// {@macro result-late-fail}
+  ///
+  /// A failed test my be a [Result.failure] if the test failed with a
+  /// [TestFailure] exception, or a [Result.error] if it failed with any other
+  /// type of exception.
+  Result get result => _liveTest.state.result;
+
+  /// The errors surfaced by the test.
+  ///
+  /// A test with any errors will have a failing [result].
+  ///
+  /// {@macro result-late-fail}
+  ///
+  /// A test may have more than one error if there were unhandled asynchronous
+  /// errors surfaced after the test is done.
+  Iterable<AsyncError> get errors => _liveTest.errors;
+
+  /// A stream of errors surfaced by the test.
+  ///
+  /// This stream will not close, asynchronous errors may be surfaced within the
+  /// test's error zone at any point.
+  Stream<AsyncError> get onError => _liveTest.onError;
+}
+
+/// Returns a local [LiveTest] that runs [body].
+LiveTest _createTest(FutureOr<void> Function() body) {
+  var test = LocalTest('test', Metadata(chainStackTraces: true), body);
+  var suite = Suite(Group.root([test]), _suitePlatform, ignoreTimeouts: false);
+  return test.load(suite);
+}
+
+/// A dummy suite platform to use for testing suites.
+final _suitePlatform =
+    SuitePlatform(Runtime.vm, compiler: Runtime.vm.defaultCompiler);

--- a/pkgs/test_api/lib/hooks_testing.dart
+++ b/pkgs/test_api/lib/hooks_testing.dart
@@ -58,7 +58,7 @@ class TestCaseMonitor {
   /// and result.
   ///
   /// The [state] will start as [State.pending] if queried synchronously, but it
-  /// will fil to [State.running]. After `onDone` completes the state will be
+  /// will switch to [State.running]. After `onDone` completes the state will be
   /// one of [State.passed], [State.skipped], or [State.failed].
   ///
   /// {@macro result-late-fail}

--- a/pkgs/test_api/lib/hooks_testing.dart
+++ b/pkgs/test_api/lib/hooks_testing.dart
@@ -106,13 +106,13 @@ class TestCaseMonitor {
   ///
   /// A test may have more than one error if there were unhandled asynchronous
   /// errors surfaced after the test is done.
-  Iterable<Object> get errors => _liveTest.errors.map((a) => a.error);
+  Iterable<AsyncError> get errors => _liveTest.errors;
 
   /// A stream of errors surfaced by the test.
   ///
   /// This stream will not close, asynchronous errors may be surfaced within the
   /// test's error zone at any point.
-  Stream<Object> get onError => _liveTest.onError.map((a) => a.error);
+  Stream<AsyncError> get onError => _liveTest.onError;
 }
 
 /// Returns a local [LiveTest] that runs [body].

--- a/pkgs/test_api/lib/hooks_testing.dart
+++ b/pkgs/test_api/lib/hooks_testing.dart
@@ -100,7 +100,7 @@ class TestCaseMonitor {
 
   /// The errors surfaced by the test.
   ///
-  /// A test with any errors will have a failing [result].
+  /// A test with any errors will have a [state] of [State.failed].
   ///
   /// {@macro result-late-fail}
   ///

--- a/pkgs/test_api/test/frontend/expect_async_test.dart
+++ b/pkgs/test_api/test/frontend/expect_async_test.dart
@@ -154,7 +154,7 @@ void main() {
       });
 
       await pumpEventQueue();
-      expect(monitor.status, equals(Status.running));
+      expect(monitor.state, equals(State.running));
       callback();
       await monitor.onDone;
 
@@ -183,15 +183,15 @@ void main() {
       });
 
       await pumpEventQueue();
-      expect(monitor.status, equals(Status.running));
+      expect(monitor.state, equals(State.running));
       callback();
 
       await pumpEventQueue();
-      expect(monitor.status, equals(Status.running));
+      expect(monitor.state, equals(State.running));
       callback();
 
       await pumpEventQueue();
-      expect(monitor.status, equals(Status.running));
+      expect(monitor.state, equals(State.running));
       callback();
 
       await monitor.onDone;
@@ -279,10 +279,10 @@ void main() {
 
         future = () async {
           await pumpEventQueue();
-          expect(monitor.status, equals(Status.running));
+          expect(monitor.state, equals(State.running));
           callback();
           await pumpEventQueue();
-          expect(monitor.status, equals(Status.running));
+          expect(monitor.state, equals(State.running));
           done = true;
           callback();
         }();

--- a/pkgs/test_api/test/frontend/expect_async_test.dart
+++ b/pkgs/test_api/test/frontend/expect_async_test.dart
@@ -6,41 +6,40 @@ import 'dart:async';
 
 import 'package:fake_async/fake_async.dart';
 import 'package:test/test.dart';
-import 'package:test_api/src/backend/live_test.dart';
-import 'package:test_api/src/backend/state.dart';
+import 'package:test_api/hooks_testing.dart';
 
-import '../utils.dart';
+import '../utils_new.dart';
 
 void main() {
   group('supports a function with this many arguments:', () {
     test('0', () async {
       var callbackRun = false;
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expectAsync0(() {
           callbackRun = true;
         })();
       });
 
-      expectTestPassed(liveTest);
+      expectTestPassed(monitor);
       expect(callbackRun, isTrue);
     });
 
     test('1', () async {
       var callbackRun = false;
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expectAsync1((int arg) {
           expect(arg, equals(1));
           callbackRun = true;
         })(1);
       });
 
-      expectTestPassed(liveTest);
+      expectTestPassed(monitor);
       expect(callbackRun, isTrue);
     });
 
     test('2', () async {
       var callbackRun = false;
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expectAsync2((arg1, arg2) {
           expect(arg1, equals(1));
           expect(arg2, equals(2));
@@ -48,13 +47,13 @@ void main() {
         })(1, 2);
       });
 
-      expectTestPassed(liveTest);
+      expectTestPassed(monitor);
       expect(callbackRun, isTrue);
     });
 
     test('3', () async {
       var callbackRun = false;
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expectAsync3((arg1, arg2, arg3) {
           expect(arg1, equals(1));
           expect(arg2, equals(2));
@@ -63,13 +62,13 @@ void main() {
         })(1, 2, 3);
       });
 
-      expectTestPassed(liveTest);
+      expectTestPassed(monitor);
       expect(callbackRun, isTrue);
     });
 
     test('4', () async {
       var callbackRun = false;
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expectAsync4((arg1, arg2, arg3, arg4) {
           expect(arg1, equals(1));
           expect(arg2, equals(2));
@@ -79,13 +78,13 @@ void main() {
         })(1, 2, 3, 4);
       });
 
-      expectTestPassed(liveTest);
+      expectTestPassed(monitor);
       expect(callbackRun, isTrue);
     });
 
     test('5', () async {
       var callbackRun = false;
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expectAsync5((arg1, arg2, arg3, arg4, arg5) {
           expect(arg1, equals(1));
           expect(arg2, equals(2));
@@ -96,13 +95,13 @@ void main() {
         })(1, 2, 3, 4, 5);
       });
 
-      expectTestPassed(liveTest);
+      expectTestPassed(monitor);
       expect(callbackRun, isTrue);
     });
 
     test('6', () async {
       var callbackRun = false;
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expectAsync6((arg1, arg2, arg3, arg4, arg5, arg6) {
           expect(arg1, equals(1));
           expect(arg2, equals(2));
@@ -114,7 +113,7 @@ void main() {
         })(1, 2, 3, 4, 5, 6);
       });
 
-      expectTestPassed(liveTest);
+      expectTestPassed(monitor);
       expect(callbackRun, isTrue);
     });
   });
@@ -122,46 +121,55 @@ void main() {
   group('with optional arguments', () {
     test('allows them to be passed', () async {
       var callbackRun = false;
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expectAsync1(([arg = 1]) {
           expect(arg, equals(2));
           callbackRun = true;
         })(2);
       });
 
-      expectTestPassed(liveTest);
+      expectTestPassed(monitor);
       expect(callbackRun, isTrue);
     });
 
     test('allows them not to be passed', () async {
       var callbackRun = false;
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expectAsync1(([arg = 1]) {
           expect(arg, equals(1));
           callbackRun = true;
         })();
       });
 
-      expectTestPassed(liveTest);
+      expectTestPassed(monitor);
       expect(callbackRun, isTrue);
     });
   });
 
   group('by default', () {
-    test("won't allow the test to complete until it's called", () {
-      return expectTestBlocks(
-          () => expectAsync0(() {}), (callback) => callback());
+    test("won't allow the test to complete until it's called", () async {
+      late void Function() callback;
+      final monitor = TestCaseMonitor.start(() {
+        callback = expectAsync0(() {});
+      });
+
+      await pumpEventQueue();
+      expect(monitor.status, equals(Status.running));
+      callback();
+      await monitor.onDone;
+
+      expectTestPassed(monitor);
     });
 
     test('may only be called once', () async {
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         var callback = expectAsync0(() {});
         callback();
         callback();
       });
 
       expectTestFailed(
-          liveTest, 'Callback called more times than expected (1).');
+          monitor, 'Callback called more times than expected (1).');
     });
   });
 
@@ -169,36 +177,31 @@ void main() {
     test(
         "won't allow the test to complete until it's called at least that "
         'many times', () async {
-      late LiveTest liveTest;
-      late Future future;
-      liveTest = createTest(() {
-        var callback = expectAsync0(() {}, count: 3);
-
-        future = () async {
-          await pumpEventQueue();
-          expect(liveTest.state.status, equals(Status.running));
-          callback();
-
-          await pumpEventQueue();
-          expect(liveTest.state.status, equals(Status.running));
-          callback();
-
-          await pumpEventQueue();
-          expect(liveTest.state.status, equals(Status.running));
-          callback();
-        }();
+      late void Function() callback;
+      final monitor = TestCaseMonitor.start(() {
+        callback = expectAsync0(() {}, count: 3);
       });
 
-      await liveTest.run();
-      expectTestPassed(liveTest);
-      // Ensure that the outer test doesn't complete until the inner future
-      // completes.
-      await future;
+      await pumpEventQueue();
+      expect(monitor.status, equals(Status.running));
+      callback();
+
+      await pumpEventQueue();
+      expect(monitor.status, equals(Status.running));
+      callback();
+
+      await pumpEventQueue();
+      expect(monitor.status, equals(Status.running));
+      callback();
+
+      await monitor.onDone;
+
+      expectTestPassed(monitor);
     });
 
     test("will throw an error if it's called more than that many times",
         () async {
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         var callback = expectAsync0(() {}, count: 3);
         callback();
         callback();
@@ -207,7 +210,7 @@ void main() {
       });
 
       expectTestFailed(
-          liveTest, 'Callback called more times than expected (3).');
+          monitor, 'Callback called more times than expected (3).');
     });
 
     group('0,', () {
@@ -216,12 +219,12 @@ void main() {
       });
 
       test("will throw an error if it's ever called", () async {
-        var liveTest = await runTestBody(() {
+        var monitor = await TestCaseMonitor.run(() {
           expectAsync0(() {}, count: 0)();
         });
 
         expectTestFailed(
-            liveTest, 'Callback called more times than expected (0).');
+            monitor, 'Callback called more times than expected (0).');
       });
     });
   });
@@ -241,7 +244,7 @@ void main() {
 
     test("will throw an error if it's called more than that many times",
         () async {
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         var callback = expectAsync0(() {}, max: 3);
         callback();
         callback();
@@ -250,7 +253,7 @@ void main() {
       });
 
       expectTestFailed(
-          liveTest, 'Callback called more times than expected (3).');
+          monitor, 'Callback called more times than expected (3).');
     });
 
     test('-1, will allow the callback to be called any number of times', () {
@@ -268,25 +271,25 @@ void main() {
   group('expectAsyncUntil()', () {
     test("won't allow the test to complete until isDone returns true",
         () async {
-      late LiveTest liveTest;
+      late TestCaseMonitor monitor;
       late Future future;
-      liveTest = createTest(() {
+      monitor = TestCaseMonitor.start(() {
         var done = false;
         var callback = expectAsyncUntil0(() {}, () => done);
 
         future = () async {
           await pumpEventQueue();
-          expect(liveTest.state.status, equals(Status.running));
+          expect(monitor.status, equals(Status.running));
           callback();
           await pumpEventQueue();
-          expect(liveTest.state.status, equals(Status.running));
+          expect(monitor.status, equals(Status.running));
           done = true;
           callback();
         }();
       });
+      await monitor.onDone;
 
-      await liveTest.run();
-      expectTestPassed(liveTest);
+      expectTestPassed(monitor);
       // Ensure that the outer test doesn't complete until the inner future
       // completes.
       await future;
@@ -302,77 +305,77 @@ void main() {
   });
 
   test('allows errors', () async {
-    var liveTest = await runTestBody(() {
+    var monitor = await TestCaseMonitor.run(() {
       expect(expectAsync0(() => throw 'oh no'), throwsA('oh no'));
     });
 
-    expectTestPassed(liveTest);
+    expectTestPassed(monitor);
   });
 
   test('may be called in a non-test zone', () async {
-    var liveTest = await runTestBody(() {
+    var monitor = await TestCaseMonitor.run(() {
       var callback = expectAsync0(() {});
       Zone.root.run(callback);
     });
-    expectTestPassed(liveTest);
+    expectTestPassed(monitor);
   });
 
   test('may be called in a FakeAsync zone that does not run further', () async {
-    var liveTest = await runTestBody(() {
+    var monitor = await TestCaseMonitor.run(() {
       FakeAsync().run((_) {
         var callback = expectAsync0(() {});
         callback();
       });
     });
-    expectTestPassed(liveTest);
+    expectTestPassed(monitor);
   });
 
   group('old-style expectAsync()', () {
     test('works with no arguments', () async {
       var callbackRun = false;
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expectAsync(() {
           callbackRun = true;
         })();
       });
 
-      expectTestPassed(liveTest);
+      expectTestPassed(monitor);
       expect(callbackRun, isTrue);
     });
 
     test('works with dynamic arguments', () async {
       var callbackRun = false;
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expectAsync((arg1, arg2) {
           callbackRun = true;
         })(1, 2);
       });
 
-      expectTestPassed(liveTest);
+      expectTestPassed(monitor);
       expect(callbackRun, isTrue);
     });
 
     test('works with non-nullable arguments', () async {
       var callbackRun = false;
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expectAsync((int arg1, int arg2) {
           callbackRun = true;
         })(1, 2);
       });
 
-      expectTestPassed(liveTest);
+      expectTestPassed(monitor);
       expect(callbackRun, isTrue);
     });
 
     test('works with 6 arguments', () async {
       var callbackRun = false;
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expectAsync((arg1, arg2, arg3, arg4, arg5, arg6) {
           callbackRun = true;
         })(1, 2, 3, 4, 5, 6);
       });
 
-      expectTestPassed(liveTest);
+      expectTestPassed(monitor);
       expect(callbackRun, isTrue);
     });
 

--- a/pkgs/test_api/test/frontend/expect_test.dart
+++ b/pkgs/test_api/test/frontend/expect_test.dart
@@ -4,7 +4,7 @@
 
 import 'package:test/test.dart';
 
-import '../utils.dart';
+import '../utils_new.dart';
 
 void main() {
   group('returned Future from expectLater()', () {

--- a/pkgs/test_api/test/frontend/matcher/completion_test.dart
+++ b/pkgs/test_api/test/frontend/matcher/completion_test.dart
@@ -72,7 +72,7 @@ void main() {
         expect(completer.future, completes);
       });
       await pumpEventQueue();
-      expect(monitor.status, Status.running);
+      expect(monitor.state, State.running);
       completer.complete();
       await monitor.onDone;
       expectTestPassed(monitor);
@@ -83,8 +83,7 @@ void main() {
         expect(Future.error('X'), completes);
       });
 
-      expect(monitor.status, equals(Status.complete));
-      expect(monitor.result, equals(Result.error));
+      expect(monitor.state, equals(State.failed));
       expect(monitor.errors, hasLength(1));
       expect(monitor.errors.first.error, equals('X'));
     });
@@ -121,7 +120,7 @@ void main() {
         expect(completer.future, completion(isNull));
       });
       await pumpEventQueue();
-      expect(monitor.status, Status.running);
+      expect(monitor.state, State.running);
       completer.complete(null);
       await monitor.onDone;
       expectTestPassed(monitor);
@@ -132,8 +131,7 @@ void main() {
         expect(Future.error('X'), completion(isNull));
       });
 
-      expect(monitor.status, equals(Status.complete));
-      expect(monitor.result, equals(Result.error));
+      expect(monitor.state, equals(State.failed));
       expect(monitor.errors, hasLength(1));
       expect(monitor.errors.first.error, equals('X'));
     });

--- a/pkgs/test_api/test/frontend/matcher/completion_test.dart
+++ b/pkgs/test_api/test/frontend/matcher/completion_test.dart
@@ -84,7 +84,7 @@ void main() {
       });
 
       expect(monitor.state, equals(State.failed));
-      expect(monitor.errors, ['X']);
+      expect(monitor.errors, [isAsyncError(equals('X'))]);
     });
 
     test('with a failure', () async {
@@ -131,7 +131,7 @@ void main() {
       });
 
       expect(monitor.state, equals(State.failed));
-      expect(monitor.errors, ['X']);
+      expect(monitor.errors, [isAsyncError(equals('X'))]);
     });
 
     test('with a failure', () async {

--- a/pkgs/test_api/test/frontend/matcher/completion_test.dart
+++ b/pkgs/test_api/test/frontend/matcher/completion_test.dart
@@ -5,18 +5,18 @@
 import 'dart:async';
 
 import 'package:test/test.dart';
-import 'package:test_api/src/backend/state.dart';
+import 'package:test_api/hooks_testing.dart';
 
-import '../../utils.dart';
+import '../../utils_new.dart';
 
 void main() {
   group('[doesNotComplete]', () {
     test('fails when provided a non future', () async {
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expect(10, doesNotComplete);
       });
 
-      expectTestFailed(liveTest, contains('10 is not a Future'));
+      expectTestFailed(monitor, contains('10 is not a Future'));
     });
 
     test('succeeds when a future does not complete', () {
@@ -25,33 +25,33 @@ void main() {
     });
 
     test('fails when a future does complete', () async {
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         var completer = Completer();
         completer.complete(null);
         expect(completer.future, doesNotComplete);
       });
 
       expectTestFailed(
-          liveTest,
+          monitor,
           'Future was not expected to complete but completed with a value of'
           ' null');
     });
 
     test('fails when a future completes after the expect', () async {
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         var completer = Completer();
         expect(completer.future, doesNotComplete);
         completer.complete(null);
       });
 
       expectTestFailed(
-          liveTest,
+          monitor,
           'Future was not expected to complete but completed with a value of'
           ' null');
     });
 
     test('fails when a future eventually completes', () async {
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         var completer = Completer();
         expect(completer.future, doesNotComplete);
         Future(() async {
@@ -60,46 +60,50 @@ void main() {
       });
 
       expectTestFailed(
-          liveTest,
+          monitor,
           'Future was not expected to complete but completed with a value of'
           ' null');
     });
   });
   group('[completes]', () {
-    test('blocks the test until the Future completes', () {
-      return expectTestBlocks(() {
-        var completer = Completer();
+    test('blocks the test until the Future completes', () async {
+      final completer = Completer<void>();
+      final monitor = TestCaseMonitor.start(() {
         expect(completer.future, completes);
-        return completer;
-      }, (completer) => completer.complete());
+      });
+      await pumpEventQueue();
+      expect(monitor.status, Status.running);
+      completer.complete();
+      await monitor.onDone;
+      expectTestPassed(monitor);
     });
 
     test('with an error', () async {
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expect(Future.error('X'), completes);
       });
 
-      expect(liveTest.state.status, equals(Status.complete));
-      expect(liveTest.state.result, equals(Result.error));
-      expect(liveTest.errors, hasLength(1));
-      expect(liveTest.errors.first.error, equals('X'));
+      expect(monitor.status, equals(Status.complete));
+      expect(monitor.result, equals(Result.error));
+      expect(monitor.errors, hasLength(1));
+      expect(monitor.errors.first.error, equals('X'));
     });
 
     test('with a failure', () async {
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expect(Future.error(TestFailure('oh no')), completes);
       });
 
-      expectTestFailed(liveTest, 'oh no');
+      expectTestFailed(monitor, 'oh no');
     });
 
     test('with a non-future', () async {
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expect(10, completes);
       });
 
       expectTestFailed(
-          liveTest,
+          monitor,
           'Expected: completes successfully\n'
           '  Actual: <10>\n'
           '   Which: was not a Future\n');
@@ -111,52 +115,56 @@ void main() {
   });
 
   group('[completion]', () {
-    test('blocks the test until the Future completes', () {
-      return expectTestBlocks(() {
-        var completer = Completer();
+    test('blocks the test until the Future completes', () async {
+      final completer = Completer<Object?>();
+      final monitor = TestCaseMonitor.start(() {
         expect(completer.future, completion(isNull));
-        return completer;
-      }, (completer) => completer.complete());
+      });
+      await pumpEventQueue();
+      expect(monitor.status, Status.running);
+      completer.complete(null);
+      await monitor.onDone;
+      expectTestPassed(monitor);
     });
 
     test('with an error', () async {
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expect(Future.error('X'), completion(isNull));
       });
 
-      expect(liveTest.state.status, equals(Status.complete));
-      expect(liveTest.state.result, equals(Result.error));
-      expect(liveTest.errors, hasLength(1));
-      expect(liveTest.errors.first.error, equals('X'));
+      expect(monitor.status, equals(Status.complete));
+      expect(monitor.result, equals(Result.error));
+      expect(monitor.errors, hasLength(1));
+      expect(monitor.errors.first.error, equals('X'));
     });
 
     test('with a failure', () async {
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expect(Future.error(TestFailure('oh no')), completion(isNull));
       });
 
-      expectTestFailed(liveTest, 'oh no');
+      expectTestFailed(monitor, 'oh no');
     });
 
     test('with a non-future', () async {
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expect(10, completion(equals(10)));
       });
 
       expectTestFailed(
-          liveTest,
+          monitor,
           'Expected: completes to a value that <10>\n'
           '  Actual: <10>\n'
           '   Which: was not a Future\n');
     });
 
     test('with an incorrect value', () async {
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         expect(Future.value('a'), completion(equals('b')));
       });
 
       expectTestFailed(
-          liveTest,
+          monitor,
           allOf([
             startsWith("Expected: completes to a value that 'b'\n"
                 '  Actual: <'),

--- a/pkgs/test_api/test/frontend/matcher/completion_test.dart
+++ b/pkgs/test_api/test/frontend/matcher/completion_test.dart
@@ -84,8 +84,7 @@ void main() {
       });
 
       expect(monitor.state, equals(State.failed));
-      expect(monitor.errors, hasLength(1));
-      expect(monitor.errors.first.error, equals('X'));
+      expect(monitor.errors, ['X']);
     });
 
     test('with a failure', () async {
@@ -132,8 +131,7 @@ void main() {
       });
 
       expect(monitor.state, equals(State.failed));
-      expect(monitor.errors, hasLength(1));
-      expect(monitor.errors.first.error, equals('X'));
+      expect(monitor.errors, ['X']);
     });
 
     test('with a failure', () async {

--- a/pkgs/test_api/test/frontend/matcher/prints_test.dart
+++ b/pkgs/test_api/test/frontend/matcher/prints_test.dart
@@ -177,7 +177,7 @@ void main() {
         expect(() => completer.future, prints(isEmpty));
       });
       await pumpEventQueue();
-      expect(monitor.status, Status.running);
+      expect(monitor.state, State.running);
       completer.complete();
       await monitor.onDone;
       expectTestPassed(monitor);

--- a/pkgs/test_api/test/frontend/matcher/throws_test.dart
+++ b/pkgs/test_api/test/frontend/matcher/throws_test.dart
@@ -240,7 +240,7 @@ void main() {
       test("won't let the test end until the Future completes", () async {
         late void Function() callback;
         final monitor = TestCaseMonitor.start(() {
-        final completer = Completer<void>();
+          final completer = Completer<void>();
           expect(completer.future, throwsA('oh no'));
           callback = () => completer.completeError('oh no');
         });

--- a/pkgs/test_api/test/frontend/matcher/throws_test.dart
+++ b/pkgs/test_api/test/frontend/matcher/throws_test.dart
@@ -153,7 +153,7 @@ void main() {
           callback = () => completer.completeError('oh no');
         });
         await pumpEventQueue();
-        expect(monitor.status, Status.running);
+        expect(monitor.state, State.running);
         callback();
         await monitor.onDone;
         expectTestPassed(monitor);
@@ -245,7 +245,7 @@ void main() {
           callback = () => completer.completeError('oh no');
         });
         await pumpEventQueue();
-        expect(monitor.status, Status.running);
+        expect(monitor.state, State.running);
         callback();
         await monitor.onDone;
 

--- a/pkgs/test_api/test/frontend/matcher/throws_type_test.dart
+++ b/pkgs/test_api/test/frontend/matcher/throws_type_test.dart
@@ -3,8 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
+import 'package:test_api/hooks_testing.dart';
 
-import '../../utils.dart';
+import '../../utils_new.dart';
 
 void main() {
   group('[throwsArgumentError]', () {
@@ -13,7 +14,7 @@ void main() {
     });
 
     test('fails when a non-ArgumentError is thrown', () async {
-      var liveTest = await runTestBody(() {
+      var liveTest = await TestCaseMonitor.run(() {
         expect(() => throw Exception(), throwsArgumentError);
       });
 
@@ -29,7 +30,7 @@ void main() {
     });
 
     test('fails when a non-ConcurrentModificationError is thrown', () async {
-      var liveTest = await runTestBody(() {
+      var liveTest = await TestCaseMonitor.run(() {
         expect(() => throw Exception(), throwsConcurrentModificationError);
       });
 
@@ -49,7 +50,7 @@ void main() {
     });
 
     test('fails when a non-CyclicInitializationError is thrown', () async {
-      var liveTest = await runTestBody(() {
+      var liveTest = await TestCaseMonitor.run(() {
         expect(() => throw Exception(), throwsCyclicInitializationError);
       });
 
@@ -64,7 +65,7 @@ void main() {
     });
 
     test('fails when a non-Exception is thrown', () async {
-      var liveTest = await runTestBody(() {
+      var liveTest = await TestCaseMonitor.run(() {
         expect(() => throw 'oh no', throwsException);
       });
 
@@ -79,7 +80,7 @@ void main() {
     });
 
     test('fails when a non-FormatException is thrown', () async {
-      var liveTest = await runTestBody(() {
+      var liveTest = await TestCaseMonitor.run(() {
         expect(() => throw Exception(), throwsFormatException);
       });
 
@@ -96,7 +97,7 @@ void main() {
     });
 
     test('fails when a non-NoSuchMethodError is thrown', () async {
-      var liveTest = await runTestBody(() {
+      var liveTest = await TestCaseMonitor.run(() {
         expect(() => throw Exception(), throwsNoSuchMethodError);
       });
 
@@ -111,7 +112,7 @@ void main() {
     });
 
     test('fails when a non-RangeError is thrown', () async {
-      var liveTest = await runTestBody(() {
+      var liveTest = await TestCaseMonitor.run(() {
         expect(() => throw Exception(), throwsRangeError);
       });
 
@@ -126,7 +127,7 @@ void main() {
     });
 
     test('fails when a non-StateError is thrown', () async {
-      var liveTest = await runTestBody(() {
+      var liveTest = await TestCaseMonitor.run(() {
         expect(() => throw Exception(), throwsStateError);
       });
 
@@ -141,7 +142,7 @@ void main() {
     });
 
     test('fails when a non-UnimplementedError is thrown', () async {
-      var liveTest = await runTestBody(() {
+      var liveTest = await TestCaseMonitor.run(() {
         expect(() => throw Exception(), throwsUnimplementedError);
       });
 
@@ -156,7 +157,7 @@ void main() {
     });
 
     test('fails when a non-UnsupportedError is thrown', () async {
-      var liveTest = await runTestBody(() {
+      var liveTest = await TestCaseMonitor.run(() {
         expect(() => throw Exception(), throwsUnsupportedError);
       });
 

--- a/pkgs/test_api/test/frontend/never_called_test.dart
+++ b/pkgs/test_api/test/frontend/never_called_test.dart
@@ -4,8 +4,9 @@
 
 import 'package:term_glyph/term_glyph.dart' as glyph;
 import 'package:test/test.dart';
+import 'package:test_api/hooks_testing.dart';
 
-import '../utils.dart';
+import '../utils_new.dart';
 
 void main() {
   setUpAll(() {
@@ -13,32 +14,32 @@ void main() {
   });
 
   test("doesn't throw if it isn't called", () async {
-    var liveTest = await runTestBody(() {
+    var monitor = await TestCaseMonitor.run(() {
       const Stream.empty().listen(neverCalled);
     });
 
-    expectTestPassed(liveTest);
+    expectTestPassed(monitor);
   });
 
   group("if it's called", () {
     test('throws', () async {
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         neverCalled();
       });
 
       expectTestFailed(
-          liveTest,
+          monitor,
           'Callback should never have been called, but it was called with no '
           'arguments.');
     });
 
     test('pretty-prints arguments', () async {
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         neverCalled(1, 'foo\nbar');
       });
 
       expectTestFailed(
-          liveTest,
+          monitor,
           'Callback should never have been called, but it was called with:\n'
           '* <1>\n'
           "* 'foo\\n'\n"
@@ -46,18 +47,18 @@ void main() {
     });
 
     test('keeps the test alive', () async {
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         pumpEventQueue(times: 10).then(neverCalled);
       });
 
       expectTestFailed(
-          liveTest,
+          monitor,
           'Callback should never have been called, but it was called with:\n'
           '* <null>');
     });
 
     test("can't be caught", () async {
-      var liveTest = await runTestBody(() {
+      var monitor = await TestCaseMonitor.run(() {
         try {
           neverCalled();
         } catch (_) {
@@ -66,7 +67,7 @@ void main() {
       });
 
       expectTestFailed(
-          liveTest,
+          monitor,
           'Callback should never have been called, but it was called with '
           'no arguments.');
     });

--- a/pkgs/test_api/test/frontend/stream_matcher_test.dart
+++ b/pkgs/test_api/test/frontend/stream_matcher_test.dart
@@ -8,7 +8,7 @@ import 'package:async/async.dart';
 import 'package:term_glyph/term_glyph.dart' as glyph;
 import 'package:test/test.dart';
 
-import '../utils.dart';
+import '../utils_new.dart';
 
 void main() {
   setUpAll(() {

--- a/pkgs/test_api/test/utils.dart
+++ b/pkgs/test_api/test/utils.dart
@@ -6,14 +6,10 @@ import 'dart:collection';
 
 import 'package:test/test.dart';
 import 'package:test_api/src/backend/declarer.dart';
-import 'package:test_api/src/backend/group.dart';
 import 'package:test_api/src/backend/group_entry.dart';
-import 'package:test_api/src/backend/invoker.dart';
 import 'package:test_api/src/backend/live_test.dart';
-import 'package:test_api/src/backend/metadata.dart';
 import 'package:test_api/src/backend/runtime.dart';
 import 'package:test_api/src/backend/state.dart';
-import 'package:test_api/src/backend/suite.dart';
 import 'package:test_api/src/backend/suite_platform.dart';
 import 'package:test_core/src/runner/engine.dart';
 import 'package:test_core/src/runner/plugin/environment.dart';

--- a/pkgs/test_api/test/utils_new.dart
+++ b/pkgs/test_api/test/utils_new.dart
@@ -15,10 +15,10 @@ void expectTestPassed(TestCaseMonitor monitor) {
   // to the running test, because they're definitely unexpected and it is most
   // useful for the error to point directly to the throw point.
   for (var error in monitor.errors) {
-    Zone.current.handleUncaughtError(error.error, error.stackTrace);
+    Zone.current.handleUncaughtError(error, StackTrace.empty);
   }
   monitor.onError.listen((error) {
-    Zone.current.handleUncaughtError(error.error, error.stackTrace);
+    Zone.current.handleUncaughtError(error, StackTrace.empty);
   });
 
   expect(monitor.state, State.passed);
@@ -28,8 +28,7 @@ void expectTestPassed(TestCaseMonitor monitor) {
 /// matches [message].
 void expectTestFailed(TestCaseMonitor monitor, message) {
   expect(monitor.state, State.failed);
-  expect(monitor.errors, hasLength(1));
-  expect(monitor.errors.first.error, isTestFailure(message));
+  expect(monitor.errors, [isTestFailure(message)]);
 }
 
 /// Returns a matcher that matches a [TestFailure] with the given [message].

--- a/pkgs/test_api/test/utils_new.dart
+++ b/pkgs/test_api/test/utils_new.dart
@@ -21,15 +21,13 @@ void expectTestPassed(TestCaseMonitor monitor) {
     Zone.current.handleUncaughtError(error.error, error.stackTrace);
   });
 
-  expect(monitor.status, Status.complete);
-  expect(monitor.result, Result.success);
+  expect(monitor.state, State.passed);
 }
 
 /// Asserts that [liveTest] failed with a single [TestFailure] whose message
 /// matches [message].
 void expectTestFailed(TestCaseMonitor monitor, message) {
-  expect(monitor.status, Status.complete);
-  expect(monitor.result, Result.failure);
+  expect(monitor.state, State.failed);
   expect(monitor.errors, hasLength(1));
   expect(monitor.errors.first.error, isTestFailure(message));
 }

--- a/pkgs/test_api/test/utils_new.dart
+++ b/pkgs/test_api/test/utils_new.dart
@@ -15,10 +15,10 @@ void expectTestPassed(TestCaseMonitor monitor) {
   // to the running test, because they're definitely unexpected and it is most
   // useful for the error to point directly to the throw point.
   for (var error in monitor.errors) {
-    Zone.current.handleUncaughtError(error, StackTrace.empty);
+    Zone.current.handleUncaughtError(error.error, error.stackTrace);
   }
   monitor.onError.listen((error) {
-    Zone.current.handleUncaughtError(error, StackTrace.empty);
+    Zone.current.handleUncaughtError(error.error, error.stackTrace);
   });
 
   expect(monitor.state, State.passed);
@@ -28,8 +28,13 @@ void expectTestPassed(TestCaseMonitor monitor) {
 /// matches [message].
 void expectTestFailed(TestCaseMonitor monitor, message) {
   expect(monitor.state, State.failed);
-  expect(monitor.errors, [isTestFailure(message)]);
+  expect(monitor.errors, [isAsyncError(isTestFailure(message))]);
 }
+
+/// Returns a matcher that matches a [AsyncError] with an `error` field matching
+/// [errorMatcher].
+Matcher isAsyncError(Matcher errorMatcher) =>
+    isA<AsyncError>().having((e) => e.error, 'error', errorMatcher);
 
 /// Returns a matcher that matches a [TestFailure] with the given [message].
 ///

--- a/pkgs/test_api/test/utils_new.dart
+++ b/pkgs/test_api/test/utils_new.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:test_api/expect.dart';
+import 'package:test_api/hooks_testing.dart';
+
+/// Asserts that [liveTest] has completed and passed.
+///
+/// If the test had any errors, they're surfaced nicely into the outer test.
+void expectTestPassed(TestCaseMonitor monitor) {
+  // Since the test is expected to pass, we forward any current or future errors
+  // to the running test, because they're definitely unexpected and it is most
+  // useful for the error to point directly to the throw point.
+  for (var error in monitor.errors) {
+    Zone.current.handleUncaughtError(error.error, error.stackTrace);
+  }
+  monitor.onError.listen((error) {
+    Zone.current.handleUncaughtError(error.error, error.stackTrace);
+  });
+
+  expect(monitor.status, Status.complete);
+  expect(monitor.result, Result.success);
+}
+
+/// Asserts that [liveTest] failed with a single [TestFailure] whose message
+/// matches [message].
+void expectTestFailed(TestCaseMonitor monitor, message) {
+  expect(monitor.status, Status.complete);
+  expect(monitor.result, Result.failure);
+  expect(monitor.errors, hasLength(1));
+  expect(monitor.errors.first.error, isTestFailure(message));
+}
+
+/// Returns a matcher that matches a [TestFailure] with the given [message].
+///
+/// [message] can be a string or a [Matcher].
+Matcher isTestFailure(message) => const TypeMatcher<TestFailure>()
+    .having((e) => e.message, 'message', message);
+
+/// Returns a matcher that matches a callback or Future that throws a
+/// [TestFailure] with the given [message].
+///
+/// [message] can be a string or a [Matcher].
+Matcher throwsTestFailure(message) => throwsA(isTestFailure(message));


### PR DESCRIPTION
Previous test for methods like `expect`, `expectLater`, and
`expectAsync` used internal details of the test runner like `LiveTest`
to check behaviors such as holding the test open and specific failure
behavior.

Add an abstraction `TestCaseMonitor` to hide the implementation details
of creating and running a `LocalTest`. Expose only the parts of
`LiveTest` which are used by current tests - the status, result and
errors.
The new class is defined in a new library `hooks_testing` since it is
intended primarily for writing tests for code that uses the `hooks`
library.

Migrate tests under `test_api/test/frontend` for the tests which will be
migrating to `package:matcher` to use the new APIs. Move to a
`utils_new.dart` file which will be moved along with these tests, and
the old `utils.dart` file will remain for testing the scaffolding APIs.
Do not replace the `expectTestsBlock` utility, the usage of this utility
is not any more clear or readable than spelling out the full behavior in
the test.

Add tests for the behavior of holding the test for pending work, and for
unawaited failures.
Add utilities for testing against a `TestMonitor` locally within the
test.
