### PR TITLE
Include stack trace for exception in has

### DIFF
--- a/pkgs/checks/lib/src/extensions/core.dart
+++ b/pkgs/checks/lib/src/extensions/core.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:checks/context.dart';
 import 'package:meta/meta.dart' as meta;
 
@@ -12,12 +14,14 @@ extension CoreChecks<T> on Subject<T> {
   /// expectations applied to the returned [Subject].
   @meta.useResult
   Subject<R> has<R>(R Function(T) extract, String name) {
-    return context.nest(() => ['has $name'], (T value) {
+    return context.nest(() => ['has $name'], (value) {
       try {
         return Extracted.value(extract(value));
-      } catch (_) {
-        return Extracted.rejection(
-            which: ['threw while trying to read property']);
+      } catch (e, st) {
+        return Extracted.rejection(which: [
+          ...prefixFirst('threw while trying to read $name: ', literal(e)),
+          ...(const LineSplitter()).convert(st.toString())
+        ]);
       }
     });
   }

--- a/pkgs/checks/test/extensions/core_test.dart
+++ b/pkgs/checks/test/extensions/core_test.dart
@@ -19,9 +19,17 @@ void main() {
     test('has', () {
       check(1).has((v) => v.isOdd, 'isOdd').isTrue();
 
-      check(2).isRejectedBy(
-          it()..has((v) => throw UnimplementedError(), 'isOdd').isNotNull(),
-          which: ['threw while trying to read property']);
+      check(null).isRejectedBy(
+          it()
+            ..has((v) {
+              Error.throwWithStackTrace(
+                  UnimplementedError(), StackTrace.fromString('fake trace'));
+            }, 'foo')
+                .isNotNull(),
+          which: [
+            'threw while trying to read foo: <UnimplementedError>',
+            'fake trace'
+          ]);
     });
 
     test('which', () {


### PR DESCRIPTION
Makes the error more clear when `has` is used in a way that is not
intended.
