### PR TITLE
Avoid exceptions for iterable getters

### DIFF
--- a/pkgs/checks/lib/src/extensions/iterable.dart
+++ b/pkgs/checks/lib/src/extensions/iterable.dart
@@ -9,9 +9,38 @@ import 'core.dart';
 
 extension IterableChecks<T> on Subject<Iterable<T>> {
   Subject<int> get length => has((l) => l.length, 'length');
-  Subject<T> get first => has((l) => l.first, 'first element');
-  Subject<T> get last => has((l) => l.last, 'last element');
-  Subject<T> get single => has((l) => l.single, 'single element');
+
+  Subject<T> get first => context.nest(() => ['has first element'], (actual) {
+        final iterator = actual.iterator;
+        if (!iterator.moveNext()) {
+          return Extracted.rejection(which: ['has no elements']);
+        }
+        return Extracted.value(iterator.current);
+      });
+
+  Subject<T> get last => context.nest(() => ['has last element'], (actual) {
+        final iterator = actual.iterator;
+        if (!iterator.moveNext()) {
+          return Extracted.rejection(which: ['has no elements']);
+        }
+        var current = iterator.current;
+        while (iterator.moveNext()) {
+          current = iterator.current;
+        }
+        return Extracted.value(current);
+      });
+
+  Subject<T> get single => context.nest(() => ['has single element'], (actual) {
+        final iterator = actual.iterator;
+        if (!iterator.moveNext()) {
+          return Extracted.rejection(which: ['has no elements']);
+        }
+        final value = iterator.current;
+        if (iterator.moveNext()) {
+          return Extracted.rejection(which: ['has more than one element']);
+        }
+        return Extracted.value(value);
+      });
 
   void isEmpty() {
     context.expect(() => const ['is empty'], (actual) {

--- a/pkgs/checks/test/extensions/iterable_test.dart
+++ b/pkgs/checks/test/extensions/iterable_test.dart
@@ -13,14 +13,37 @@ void main() {
   test('length', () {
     check(_testIterable).length.equals(2);
   });
-  test('first', () {
-    check(_testIterable).first.equals(0);
+
+  group('first', () {
+    test('succeeds for happy case', () {
+      check(_testIterable).first.equals(0);
+    });
+    test('rejects empty iterabls', () {
+      check([]).isRejectedBy(it()..first.equals(0), which: ['has no elements']);
+    });
   });
-  test('last', () {
-    check(_testIterable).last.equals(1);
+
+  group('last', () {
+    test('succeeds for happy case', () {
+      check(_testIterable).last.equals(1);
+    });
+    test('rejects empty iterabls', () {
+      check([]).isRejectedBy(it()..last.equals(0), which: ['has no elements']);
+    });
   });
-  test('single', () {
-    check([42]).single.equals(42);
+
+  group('single', () {
+    test('succeeds for happy case', () {
+      check([42]).single.equals(42);
+    });
+    test('rejects empty iterable', () {
+      check([])
+          .isRejectedBy(it()..single.equals(0), which: ['has no elements']);
+    });
+    test('rejects iterable with too many elements', () {
+      check(_testIterable).isRejectedBy(it()..single.equals(0),
+          which: ['has more than one element']);
+    });
   });
 
   test('isEmpty', () {

--- a/pkgs/checks/test/extensions/iterable_test.dart
+++ b/pkgs/checks/test/extensions/iterable_test.dart
@@ -18,7 +18,7 @@ void main() {
     test('succeeds for happy case', () {
       check(_testIterable).first.equals(0);
     });
-    test('rejects empty iterabls', () {
+    test('rejects empty iterable', () {
       check([]).isRejectedBy(it()..first.equals(0), which: ['has no elements']);
     });
   });
@@ -27,7 +27,7 @@ void main() {
     test('succeeds for happy case', () {
       check(_testIterable).last.equals(1);
     });
-    test('rejects empty iterabls', () {
+    test('rejects empty iterable', () {
       check([]).isRejectedBy(it()..last.equals(0), which: ['has no elements']);
     });
   });


### PR DESCRIPTION
The `has` utility is intended for reading fields that cannot throw. For
`single`, `first`, and `last`, which may throw for unexpected numbers of
elements, implement with `context.next` and test with specific
rejections for the length.
