### PR TITLE
Fix timeouts when async predicate throws

### DIFF
--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -727,11 +727,14 @@ class _TestContext<T> implements Context<T>, _ClauseDescription {
     }
     _clauses.add(_ExpectationClause(clause));
     final outstandingWork = TestHandle.current.markPending();
-    final rejection = await _value.apply(
-        (actual) async => (await predicate(actual))?._fillActual(actual));
-    outstandingWork.complete();
-    if (rejection == null) return;
-    _fail(_failure(rejection));
+    try {
+      final rejection = await _value.apply(
+          (actual) async => (await predicate(actual))?._fillActual(actual));
+      if (rejection == null) return;
+      _fail(_failure(rejection));
+    } finally {
+      outstandingWork.complete();
+    }
   }
 
   @override
@@ -779,18 +782,21 @@ class _TestContext<T> implements Context<T>, _ClauseDescription {
           'Async expectations cannot be used on a synchronous subject');
     }
     final outstandingWork = TestHandle.current.markPending();
-    final result = await _value.mapAsync(
-        (actual) async => (await extract(actual))._fillActual(actual));
-    outstandingWork.complete();
-    final rejection = result._rejection;
-    if (rejection != null) {
-      _clauses.add(_ExpectationClause(label));
-      _fail(_failure(rejection));
+    try {
+      final result = await _value.mapAsync(
+          (actual) async => (await extract(actual))._fillActual(actual));
+      final rejection = result._rejection;
+      if (rejection != null) {
+        _clauses.add(_ExpectationClause(label));
+        _fail(_failure(rejection));
+      }
+      final value = result._value ?? _Absent<R>();
+      final context = _TestContext<R>._child(value, label, this);
+      _clauses.add(context);
+      await nestedCondition?.applyAsync(Subject<R>._(context));
+    } finally {
+      outstandingWork.complete();
     }
-    final value = result._value ?? _Absent<R>();
-    final context = _TestContext<R>._child(value, label, this);
-    _clauses.add(context);
-    await nestedCondition?.applyAsync(Subject<R>._(context));
   }
 
   CheckFailure _failure(Rejection rejection) =>


### PR DESCRIPTION
A predicate or extraction callback is not supposed to throw - it should
return a Rejection to indicate a failure - however if an exception is
thrown the test should fail for that exception and immediately be done.

Move the `outstandingWork.complete()` call to a `finally` block so it
is never skipped. Move it after the nested condition is applied to also
fix a potential bug if the `Condition` is a callback that does any async
work outside calls to the context. This isn't a typical pattern, but
could become more typical if we drop the `Condition` abstraction.
