### PR TITLE
[checks] Fix isNotEmpty rejection

### DIFF
--- a/pkgs/checks/lib/src/extensions/iterable.dart
+++ b/pkgs/checks/lib/src/extensions/iterable.dart
@@ -52,7 +52,7 @@ extension IterableChecks<T> on Subject<Iterable<T>> {
   void isNotEmpty() {
     context.expect(() => const ['is not empty'], (actual) {
       if (actual.isNotEmpty) return null;
-      return Rejection(which: ['is not empty']);
+      return Rejection(which: ['is empty']);
     });
   }
 

--- a/pkgs/checks/test/extensions/iterable_test.dart
+++ b/pkgs/checks/test/extensions/iterable_test.dart
@@ -54,7 +54,7 @@ void main() {
   test('isNotEmpty', () {
     check(_testIterable).isNotEmpty();
     check(Iterable<int>.empty())
-        .isRejectedBy(it()..isNotEmpty(), which: ['is not empty']);
+        .isRejectedBy(it()..isNotEmpty(), which: ['is empty']);
   });
 
   test('contains', () {


### PR DESCRIPTION
Saw this error which didn't make sense:

```
Expected: a DownloadFolder that:
  has contents that:
    is not empty
Actual: a DownloadFolder that:
  has contents that:
  Actual: []
  Which: is not empty
```

This is a copy-paste oversight from `isEmpty`. The rejection should be inverted (as it is for `isEmpty`)!
