### PR TITLE
Retry filesystem deletes

### DIFF
--- a/pkgs/test/lib/src/runner/browser/chrome.dart
+++ b/pkgs/test/lib/src/runner/browser/chrome.dart
@@ -88,8 +88,8 @@ class Chrome extends Browser {
           remoteDebuggerCompleter.complete(null);
         }
 
-        unawaited(process.exitCode
-            .then((_) => Directory(dir).deleteWithRetry()));
+        unawaited(
+            process.exitCode.then((_) => Directory(dir).deleteWithRetry()));
 
         return process;
       }

--- a/pkgs/test/lib/src/runner/browser/chrome.dart
+++ b/pkgs/test/lib/src/runner/browser/chrome.dart
@@ -89,7 +89,7 @@ class Chrome extends Browser {
         }
 
         unawaited(process.exitCode
-            .then((_) => Directory(dir).deleteSync(recursive: true)));
+            .then((_) => Directory(dir).deleteWithRetry()));
 
         return process;
       }

--- a/pkgs/test/lib/src/runner/browser/firefox.dart
+++ b/pkgs/test/lib/src/runner/browser/firefox.dart
@@ -50,8 +50,7 @@ class Firefox extends Browser {
       'MOZ_CRASHREPORTER_DISABLE': '1'
     });
 
-    unawaited(process.exitCode
-        .then((_) => Directory(dir).deleteWithRetry()));
+    unawaited(process.exitCode.then((_) => Directory(dir).deleteWithRetry()));
 
     return process;
   }

--- a/pkgs/test/lib/src/runner/browser/firefox.dart
+++ b/pkgs/test/lib/src/runner/browser/firefox.dart
@@ -51,7 +51,7 @@ class Firefox extends Browser {
     });
 
     unawaited(process.exitCode
-        .then((_) => Directory(dir).deleteSync(recursive: true)));
+        .then((_) => Directory(dir).deleteWithRetry()));
 
     return process;
   }

--- a/pkgs/test/lib/src/runner/browser/platform.dart
+++ b/pkgs/test/lib/src/runner/browser/platform.dart
@@ -472,7 +472,7 @@ class BrowserPlatform extends PlatformPlugin
         ]);
 
         if (_config.pubServeUrl == null) {
-          Directory(_compiledDir!).deleteWithRetry();
+          await Directory(_compiledDir!).deleteWithRetry();
         } else {
           _http!.close();
         }

--- a/pkgs/test/lib/src/runner/browser/platform.dart
+++ b/pkgs/test/lib/src/runner/browser/platform.dart
@@ -472,7 +472,7 @@ class BrowserPlatform extends PlatformPlugin
         ]);
 
         if (_config.pubServeUrl == null) {
-          Directory(_compiledDir!).deleteSync(recursive: true);
+          Directory(_compiledDir!).deleteWithRetry();
         } else {
           _http!.close();
         }

--- a/pkgs/test/lib/src/runner/browser/safari.dart
+++ b/pkgs/test/lib/src/runner/browser/safari.dart
@@ -41,7 +41,7 @@ class Safari extends Browser {
         settings.executable, settings.arguments.toList()..add(redirect));
 
     unawaited(process.exitCode
-        .then((_) => Directory(dir).deleteSync(recursive: true)));
+        .then((_) => Directory(dir).deleteWithRetry()));
 
     return process;
   }

--- a/pkgs/test/lib/src/runner/browser/safari.dart
+++ b/pkgs/test/lib/src/runner/browser/safari.dart
@@ -40,8 +40,7 @@ class Safari extends Browser {
     var process = await Process.start(
         settings.executable, settings.arguments.toList()..add(redirect));
 
-    unawaited(process.exitCode
-        .then((_) => Directory(dir).deleteWithRetry()));
+    unawaited(process.exitCode.then((_) => Directory(dir).deleteWithRetry()));
 
     return process;
   }

--- a/pkgs/test/lib/src/runner/node/platform.dart
+++ b/pkgs/test/lib/src/runner/node/platform.dart
@@ -298,7 +298,7 @@ class NodePlatform extends PlatformPlugin
         await _compilers.close();
 
         if (_config.pubServeUrl == null) {
-          Directory(_compiledDir).deleteWithRetry();
+          await Directory(_compiledDir).deleteWithRetry();
         } else {
           _http!.close();
         }

--- a/pkgs/test/lib/src/runner/node/platform.dart
+++ b/pkgs/test/lib/src/runner/node/platform.dart
@@ -298,7 +298,7 @@ class NodePlatform extends PlatformPlugin
         await _compilers.close();
 
         if (_config.pubServeUrl == null) {
-          Directory(_compiledDir).deleteSync(recursive: true);
+          Directory(_compiledDir).deleteWithRetry();
         } else {
           _http!.close();
         }

--- a/pkgs/test/lib/src/runner/wasm/platform.dart
+++ b/pkgs/test/lib/src/runner/wasm/platform.dart
@@ -358,9 +358,8 @@ class BrowserWasmPlatform extends PlatformPlugin
             browser.then((b) => b?.close()),
           _server.close(),
           _compilers.close(),
+          Directory(_compiledDir).deleteWithRetry(),
         ]);
-
-        Directory(_compiledDir).deleteWithRetry();
       });
   final _closeMemo = AsyncMemoizer<void>();
 }

--- a/pkgs/test/lib/src/runner/wasm/platform.dart
+++ b/pkgs/test/lib/src/runner/wasm/platform.dart
@@ -360,7 +360,7 @@ class BrowserWasmPlatform extends PlatformPlugin
           _compilers.close(),
         ]);
 
-        Directory(_compiledDir).deleteSync(recursive: true);
+        Directory(_compiledDir).deleteWithRetry();
       });
   final _closeMemo = AsyncMemoizer<void>();
 }

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -158,11 +158,10 @@ class VMPlatform extends PlatformPlugin {
   }
 
   @override
-  Future close() => _closeMemo.runOnce(() {
-        final dispose = _compiler.dispose();
-        _tempDir.deleteWithRetry();
-        return dispose;
-      });
+  Future close() => _closeMemo.runOnce(() => Future.wait([
+        _compiler.dispose(),
+        _tempDir.deleteWithRetry(),
+      ]));
 
   Uri _absolute(String path) {
     final uri = p.toUri(path);

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -26,6 +26,7 @@ import '../../runner/plugin/platform_helpers.dart';
 import '../../runner/plugin/shared_platform_helpers.dart';
 import '../../runner/runner_suite.dart';
 import '../../runner/suite.dart';
+import '../../util/io.dart';
 import '../../util/package_config.dart';
 import '../package_version.dart';
 import 'environment.dart';
@@ -157,8 +158,11 @@ class VMPlatform extends PlatformPlugin {
   }
 
   @override
-  Future close() => _closeMemo.runOnce(() =>
-      Future.wait([_compiler.dispose(), _tempDir.delete(recursive: true)]));
+  Future close() => _closeMemo.runOnce(() {
+        final dispose = _compiler.dispose();
+        _tempDir.deleteWithRetry();
+        return dispose;
+      });
 
   Uri _absolute(String path) {
     final uri = p.toUri(path);

--- a/pkgs/test_core/lib/src/runner/vm/test_compiler.dart
+++ b/pkgs/test_core/lib/src/runner/vm/test_compiler.dart
@@ -13,6 +13,7 @@ import 'package:pool/pool.dart';
 import 'package:test_api/backend.dart'; // ignore: deprecated_member_use
 
 import '../../util/dart.dart';
+import '../../util/io.dart';
 import '../../util/package_config.dart';
 import '../package_version.dart';
 
@@ -182,7 +183,7 @@ class _TestCompilerForLanguageVersion {
         _frontendServerClient?.kill();
         _frontendServerClient = null;
         if (_outputDillDirectory.existsSync()) {
-          _outputDillDirectory.deleteSync(recursive: true);
+          _outputDillDirectory.deleteWithRetry();
         }
       });
 }

--- a/pkgs/test_core/lib/src/runner/vm/test_compiler.dart
+++ b/pkgs/test_core/lib/src/runner/vm/test_compiler.dart
@@ -183,7 +183,7 @@ class _TestCompilerForLanguageVersion {
         _frontendServerClient?.kill();
         _frontendServerClient = null;
         if (_outputDillDirectory.existsSync()) {
-          _outputDillDirectory.deleteWithRetry();
+          await _outputDillDirectory.deleteWithRetry();
         }
       });
 }

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -234,7 +234,7 @@ extension RetryDelete on FileSystemEntity {
         deleteSync(recursive: true);
         return;
       } on FileSystemException {
-        // Ignore and retry
+        if (i == 2) rethrow;
       }
     }
   }

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'dart:core' as core;
 import 'dart:core';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:async/async.dart';
 import 'package:path/path.dart' as p;
@@ -228,13 +229,14 @@ Future<Uri> getRemoteDebuggerUrl(Uri base) async {
 }
 
 extension RetryDelete on FileSystemEntity {
-  void deleteWithRetry() {
+  Future<void> deleteWithRetry() async {
     for (var i = 0; i < 3; i++) {
       try {
-        deleteSync(recursive: true);
+        await delete(recursive: true);
         return;
       } on FileSystemException {
         if (i == 2) rethrow;
+        await Future.delayed(Duration(milliseconds: pow(10, i).toInt()));
       }
     }
   }

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -230,13 +230,14 @@ Future<Uri> getRemoteDebuggerUrl(Uri base) async {
 
 extension RetryDelete on FileSystemEntity {
   Future<void> deleteWithRetry() async {
-    for (var i = 0; i < 3; i++) {
+    var attempt = 0;
+    while (true) {
       try {
         await delete(recursive: true);
         return;
       } on FileSystemException {
-        if (i == 2) rethrow;
-        await Future.delayed(Duration(milliseconds: pow(10, i).toInt()));
+        if (attempt == 2) rethrow;
+        await Future.delayed(Duration(milliseconds: pow(10, attempt).toInt()));
       }
     }
   }

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -237,6 +237,7 @@ extension RetryDelete on FileSystemEntity {
         return;
       } on FileSystemException {
         if (attempt == 2) rethrow;
+        attempt++;
         await Future.delayed(Duration(milliseconds: pow(10, attempt).toInt()));
       }
     }


### PR DESCRIPTION
We frequently see CI failures with exceptions pointing to various
deletes which fail because of processes still having the file or
directory open. Add a synchronous retry to see if it helps at all.

It may become necessary to make it asynchronous and add a small backoff.
