### PR TITLE
Fix typo in architecture.md

### DIFF
--- a/pkgs/test/doc/architecture.md
+++ b/pkgs/test/doc/architecture.md
@@ -100,6 +100,7 @@ to the `Engine`'s streams and exposes the information there to the user, usually
 by printing human-readable text. [`CompactReporter`][CompactReporter] is the
 default on Posix platforms, but others may be selected based on the
 `Configuration`. Nearly everything the user sees comes through the reporter.
+
 [Reporter]: https://github.com/dart-lang/test/tree/master/lib/src/runner/reporter.dart
 [CompactReporter]: https://github.com/dart-lang/test/tree/master/lib/src/runner/reporter/compact.dart
 


### PR DESCRIPTION
The missing space was breaking the links section. Now it renders correctly.

**Before:**

![Screenshot 2023-03-07 at 8 58 49 PM](https://user-images.githubusercontent.com/40357511/223538650-baf1ddb6-2fc9-4d3f-95d6-fb37e85aa4e3.png)

**After:**

![Screenshot 2023-03-07 at 8 58 07 PM](https://user-images.githubusercontent.com/40357511/223538550-b48b27e2-494d-4315-8050-00f2eca98342.png)