### PR TITLE
Prepare to publish

### DIFF
--- a/integration_tests/spawn_hybrid/pubspec.yaml
+++ b/integration_tests/spawn_hybrid/pubspec.yaml
@@ -18,7 +18,3 @@ dependency_overrides:
     path: ../../pkgs/test_api
   test_core:
     path: ../../pkgs/test_core
-  matcher:
-    git:
-      url: https://github.com/dart-lang/matcher.git
-      ref: 3fc9b3c35c3c0465ebef9158971f8203a4fc9416

--- a/integration_tests/wasm/pubspec.yaml
+++ b/integration_tests/wasm/pubspec.yaml
@@ -11,7 +11,3 @@ dependency_overrides:
     path: ../../pkgs/test_api
   test_core:
     path: ../../pkgs/test_core
-  matcher:
-    git:
-      url: https://github.com/dart-lang/matcher.git
-      ref: 3fc9b3c35c3c0465ebef9158971f8203a4fc9416

--- a/legacy_tests/nnbd_opted_in/pubspec.yaml
+++ b/legacy_tests/nnbd_opted_in/pubspec.yaml
@@ -12,7 +12,3 @@ dependency_overrides:
     path: ../../pkgs/test_api
   test_core:
     path: ../../pkgs/test_core
-  matcher:
-    git:
-      url: https://github.com/dart-lang/matcher.git
-      ref: 3fc9b3c35c3c0465ebef9158971f8203a4fc9416

--- a/legacy_tests/nnbd_opted_in_with_optout/pubspec.yaml
+++ b/legacy_tests/nnbd_opted_in_with_optout/pubspec.yaml
@@ -12,7 +12,3 @@ dependency_overrides:
     path: ../../pkgs/test_api
   test_core:
     path: ../../pkgs/test_core
-  matcher:
-    git:
-      url: https://github.com/dart-lang/matcher.git
-      ref: 3fc9b3c35c3c0465ebef9158971f8203a4fc9416

--- a/legacy_tests/nnbd_opted_out/pubspec.yaml
+++ b/legacy_tests/nnbd_opted_out/pubspec.yaml
@@ -12,7 +12,3 @@ dependency_overrides:
     path: ../../pkgs/test_api
   test_core:
     path: ../../pkgs/test_core
-  matcher:
-    git:
-      url: https://github.com/dart-lang/matcher.git
-      ref: 3fc9b3c35c3c0465ebef9158971f8203a4fc9416

--- a/legacy_tests/spawn_hybrid_with_optout/pubspec.yaml
+++ b/legacy_tests/spawn_hybrid_with_optout/pubspec.yaml
@@ -12,7 +12,3 @@ dependency_overrides:
     path: ../../pkgs/test_api
   test_core:
     path: ../../pkgs/test_core
-  matcher:
-    git:
-      url: https://github.com/dart-lang/matcher.git
-      ref: 3fc9b3c35c3c0465ebef9158971f8203a4fc9416

--- a/legacy_tests/unit_tests/pubspec.yaml
+++ b/legacy_tests/unit_tests/pubspec.yaml
@@ -16,7 +16,3 @@ dependency_overrides:
     path: ../../pkgs/test_api
   test_core:
     path: ../../pkgs/test_core
-  matcher:
-    git:
-      url: https://github.com/dart-lang/matcher.git
-      ref: 3fc9b3c35c3c0465ebef9158971f8203a4fc9416

--- a/pkgs/checks/pubspec_overrides.yaml
+++ b/pkgs/checks/pubspec_overrides.yaml
@@ -5,7 +5,3 @@ dependency_overrides:
     path: ../test_core
   test:
     path: ../test
-  matcher:
-    git:
-      url: https://github.com/dart-lang/matcher.git
-      ref: 3b48930a01f678e2921cea16563af67460e6f765

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.24.0-dev
+## 1.24.0
 
 * Support the `--compiler` flag, which can be used to configure which compiler
   to use.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.24.0-dev
+version: 1.24.0
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test

--- a/pkgs/test/pubspec_overrides.yaml
+++ b/pkgs/test/pubspec_overrides.yaml
@@ -3,7 +3,3 @@ dependency_overrides:
     path: ../test_core
   test_api:
     path: ../test_api
-  matcher:
-    git:
-      url: https://github.com/dart-lang/matcher.git
-      ref: 3fc9b3c35c3c0465ebef9158971f8203a4fc9416

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.0-dev
+## 0.5.0
 
 * Add `Compiler` class, exposed through `backend.dart`.
 * Support compiler identifiers in platform selectors.

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.5.0-dev
+version: 0.5.0
 description: >-
   The user facing API for structuring Dart tests and checking expectations.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_api

--- a/pkgs/test_api/pubspec_overrides.yaml
+++ b/pkgs/test_api/pubspec_overrides.yaml
@@ -3,7 +3,3 @@ dependency_overrides:
     path: ../test
   test_core:
     path: ../test_core
-  matcher:
-    git:
-      url: https://github.com/dart-lang/matcher.git
-      ref: 3b48930a01f678e2921cea16563af67460e6f765

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.0-dev
+## 0.5.0
 
 * Support the `--compiler` flag, which can be used to configure which compiler
   to use.

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.5.0-dev
+version: 0.5.0
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 

--- a/pkgs/test_core/pubspec_overrides.yaml
+++ b/pkgs/test_core/pubspec_overrides.yaml
@@ -1,7 +1,3 @@
 dependency_overrides:
   test_api:
     path: ../test_api
-  matcher:
-    git:
-      url: https://github.com/dart-lang/matcher.git
-      ref: 3fc9b3c35c3c0465ebef9158971f8203a4fc9416


### PR DESCRIPTION
Remove dependency overrides for matcher.
Drop `-dev` version suffix.
