### PR TITLE
Deprecate the export of package:matcher APIs

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.24.1-dev
 
+* Deprecate the export of `package:matcher` APIs. Add an import to
+  `package:matcher/expect.dart`.
+
 ## 1.24.0
 
 * Support the `--compiler` flag, which can be used to configure which compiler

--- a/pkgs/test/lib/test.dart
+++ b/pkgs/test/lib/test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+library test;
+
+@Deprecated('import `package:matcher/expect.dart`')
 export 'package:matcher/expect.dart';
 // Deprecated exports not surfaced through focused libraries.
 // ignore: deprecated_member_use


### PR DESCRIPTION
Tests should import the matching framework, either `package:matcher/expect.dart`, or `package:checks/checks.dart`, or some third party alternative.

Blocked by https://github.com/dart-lang/sdk/issues/48997