### PR TITLE
More smoothly handle missing compiler info

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 1.24.1-dev
+## 1.24.1
+
+* Handle a missing `'compiler'` value when running a test compiled against a
+  newer `test_api` than the runner back end is using. The expectation was that
+  the json protocol is only used across packages compatible with the same major
+  version of the `test_api` package, but `flutter test` does not check the
+  version of packages in the pub solve for user test code.
 
 ## 1.24.0
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.24.1-dev
+version: 1.24.1
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test
@@ -32,7 +32,7 @@ dependencies:
   webkit_inspection_protocol: ^1.0.0
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.5.0
+  test_api: 0.5.1
   test_core: 0.5.1
   # Use a tight version constraint to ensure that a constraint on matcher
   # properly constrains all features it provides.

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.5.1
+
+* Handle a missing `'compiler'` value when running a test compiled against a
+  newer `test_api` than the runner back end is using. The expectation was that
+  the json protocol is only used across packages compatible with the same major
+  version of the `test_api` package, but `flutter test` does not check the
+  version of packages in the pub solve for user test code.
+
 ## 0.5.0
 
 * Add `Compiler` class, exposed through `backend.dart`.

--- a/pkgs/test_api/lib/src/backend/suite_platform.dart
+++ b/pkgs/test_api/lib/src/backend/suite_platform.dart
@@ -52,7 +52,9 @@ class SuitePlatform {
   factory SuitePlatform.deserialize(Object serialized) {
     var map = serialized as Map;
     return SuitePlatform(Runtime.deserialize(map['runtime'] as Object),
-        compiler: Compiler.deserialize(map['compiler'] as Object),
+        compiler: map.containsKey('compiler')
+            ? Compiler.deserialize(map['compiler'] as Object)
+            : null,
         os: OperatingSystem.find(map['os'] as String),
         inGoogle: map['inGoogle'] as bool);
   }

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.5.0
+version: 0.5.1
 description: >-
   The user facing API for structuring Dart tests and checking expectations.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_api

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.1-dev
+## 0.5.1
 
 * Start adding experimental support for native_assets.yaml, when
   `--enable-experiment=native_assets` is passed.

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.5.1-dev
+version: 0.5.1
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 
@@ -30,7 +30,7 @@ dependencies:
   # matcher is tightly constrained by test_api
   matcher: ^0.12.11
   # Use an exact version until the test_api package is stable.
-  test_api: 0.5.0
+  test_api: 0.5.1
 
 dev_dependencies:
   lints: '>=1.0.0 <3.0.0'


### PR DESCRIPTION
Towards #1977

The constructor signature uses a nullable argument to smooth over the
compatibility across versions which allowed us to land in monolithic
repositories without needing to roll `test_api` and `flutter_test`
atomically. This extends the same backwards compatibility to the json
API used between the runner and tests to smooth over compatibility with
`flutter test` which may try to run test compiled against a newer API
than it uses to communicate with them.
