### PR TITLE
Make tests compatible with Strict CSP

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.24.2-dev
+
+* Copy an existing nonce from a script on the test HTML page to the script
+  created by the test runner host javascript. This only impacts environments
+  testing with custom HTML that includes a nonce.
+
 ## 1.24.1
 
 * Handle a missing `'compiler'` value when running a test compiled against a

--- a/pkgs/test/lib/dart.js
+++ b/pkgs/test/lib/dart.js
@@ -65,7 +65,14 @@ script.onerror = function(event) {
   var message = "Failed to load script at " + script.src +
       (event.message ? ": " + event.message : ".");
   sendLoadException(message);
-}
+};
+
+Array.from(document.querySelectorAll('script')).some(currentScript => {
+  if (currentScript.nonce) {
+    script.nonce = currentScript.nonce;
+    return true;
+  }
+});
 
 var parent = link.parentNode;
 document.currentScript = script;

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.24.1
+version: 1.24.2-dev
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test


### PR DESCRIPTION
This propagates the nonce from any script on the page to the script created by dart.js.