### PR TITLE
Fix "Improvements" link in `package:checks` migration guide

### DIFF
--- a/pkgs/checks/doc/migrating_from_matcher.md
+++ b/pkgs/checks/doc/migrating_from_matcher.md
@@ -28,7 +28,7 @@ behavior and signature changes to align with modern Dart idioms.
 high potential for minor or major breaking changes during the preview window.
 Once this package is stable, yes! The experience of using `checks` improves on
 `matcher`. See some of the [improvements to look forward to in checks
-below][#improvements-you-can-expect].
+below](#improvements-you-can-expect).
 
 [matcher]: https://pub.dev/packages/matcher
 


### PR DESCRIPTION
The link to the "Improvements you can expect" section was broken.