### PR TITLE
Add support for Microsoft Edge

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Copy an existing nonce from a script on the test HTML page to the script
   created by the test runner host javascript. This only impacts environments
   testing with custom HTML that includes a nonce.
+* Support the Microsoft Edge browser (use the `edge` platform in your the test
+  configuration file or `-p edge` on the command line).
 
 ## 1.24.1
 

--- a/pkgs/test/dart_test.yaml
+++ b/pkgs/test/dart_test.yaml
@@ -43,6 +43,9 @@ tags:
     add_tags: [dart2js]
     test_on: windows
     skip: https://github.com/dart-lang/test/issues/1614
+  edge:
+    add_tags: [dart2js]
+    test_on: windows
 
   # Tests that run pub. These tests may need to be excluded when there are local
   # dependency_overrides.

--- a/pkgs/test/lib/src/executable.dart
+++ b/pkgs/test/lib/src/executable.dart
@@ -15,6 +15,7 @@ Future<void> main(List<String> args) async {
   registerPlatformPlugin([Runtime.nodeJS], () => NodePlatform());
   registerPlatformPlugin([
     Runtime.chrome,
+    Runtime.edge,
     Runtime.firefox,
     Runtime.safari,
     Runtime.internetExplorer

--- a/pkgs/test/lib/src/runner/browser/browser_manager.dart
+++ b/pkgs/test/lib/src/runner/browser/browser_manager.dart
@@ -24,6 +24,7 @@ import 'browser.dart';
 import 'chrome.dart';
 import 'firefox.dart';
 import 'internet_explorer.dart';
+import 'microsoft_edge.dart';
 import 'safari.dart';
 
 /// A class that manages the connection to a single running browser.
@@ -163,6 +164,8 @@ class BrowserManager {
         return Safari(url, settings: settings);
       case Runtime.internetExplorer:
         return InternetExplorer(url, settings: settings);
+      case Runtime.edge:
+        return MicrosoftEdge(url, configuration, settings: settings);
       default:
         throw ArgumentError('$browser is not a browser.');
     }

--- a/pkgs/test/lib/src/runner/browser/chrome.dart
+++ b/pkgs/test/lib/src/runner/browser/chrome.dart
@@ -9,7 +9,6 @@ import 'dart:io';
 import 'package:collection/collection.dart';
 import 'package:coverage/coverage.dart';
 import 'package:path/path.dart' as p;
-import 'package:test/src/runner/browser/chromium.dart';
 import 'package:test_api/src/backend/runtime.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/configuration.dart'; // ignore: implementation_imports
 import 'package:test_core/src/util/io.dart'; // ignore: implementation_imports
@@ -17,6 +16,7 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import '../executable_settings.dart';
 import 'browser.dart';
+import 'chromium.dart';
 import 'default_settings.dart';
 
 /// A class for running an instance of Chrome.

--- a/pkgs/test/lib/src/runner/browser/chromium.dart
+++ b/pkgs/test/lib/src/runner/browser/chromium.dart
@@ -1,0 +1,63 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:test/src/runner/browser/default_settings.dart';
+import 'package:test_api/src/backend/runtime.dart'; // ignore: implementation_imports
+import 'package:test_core/src/runner/configuration.dart'; // ignore: implementation_imports
+import 'package:test_core/src/util/io.dart'; // ignore: implementation_imports
+
+import '../executable_settings.dart';
+
+enum ChromiumBasedBrowser {
+  chrome(Runtime.chrome),
+  microsoftEdge(Runtime.edge);
+
+  final Runtime runtime;
+
+  const ChromiumBasedBrowser(this.runtime);
+
+  Future<Process> spawn(
+    Uri url,
+    Configuration configuration, {
+    ExecutableSettings? settings,
+    List<String> additionalArgs = const [],
+  }) async {
+    settings ??= defaultSettings[runtime];
+
+    var dir = createTempDir();
+    var args = [
+      '--user-data-dir=$dir',
+      url.toString(),
+      '--enable-logging=stdout',
+      '--v=1',
+      '--disable-extensions',
+      '--disable-popup-blocking',
+      '--bwsi',
+      '--no-first-run',
+      '--no-default-browser-check',
+      '--disable-default-apps',
+      '--disable-translate',
+      '--disable-dev-shm-usage',
+      if (settings!.headless && !configuration.pauseAfterLoad) ...[
+        '--headless',
+        '--disable-gpu',
+      ],
+      if (!configuration.debug)
+        // We don't actually connect to the remote debugger, but Chrome will
+        // close as soon as the page is loaded if we don't turn it on.
+        '--remote-debugging-port=0',
+      ...settings.arguments,
+      ...additionalArgs,
+    ];
+
+    var process = await Process.start(settings.executable, args);
+
+    unawaited(process.exitCode.then((_) => Directory(dir).deleteWithRetry()));
+
+    return process;
+  }
+}

--- a/pkgs/test/lib/src/runner/browser/default_settings.dart
+++ b/pkgs/test/lib/src/runner/browser/default_settings.dart
@@ -15,6 +15,11 @@ final defaultSettings = UnmodifiableMapView({
           '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
       windowsExecutable: r'Google\Chrome\Application\chrome.exe',
       environmentOverride: 'CHROME_EXECUTABLE'),
+  Runtime.edge: ExecutableSettings(
+    linuxExecutable: 'microsoft-edge-stable',
+    windowsExecutable: r'Microsoft\Edge\Application\msedge.exe',
+    environmentOverride: 'MS_EDGE_EXECUTABLE',
+  ),
   Runtime.firefox: ExecutableSettings(
       linuxExecutable: 'firefox',
       macOSExecutable: '/Applications/Firefox.app/Contents/MacOS/firefox-bin',
@@ -22,5 +27,5 @@ final defaultSettings = UnmodifiableMapView({
   Runtime.internetExplorer:
       ExecutableSettings(windowsExecutable: r'Internet Explorer\iexplore.exe'),
   Runtime.safari: ExecutableSettings(
-      macOSExecutable: '/Applications/Safari.app/Contents/MacOS/Safari')
+      macOSExecutable: '/Applications/Safari.app/Contents/MacOS/Safari'),
 });

--- a/pkgs/test/lib/src/runner/browser/default_settings.dart
+++ b/pkgs/test/lib/src/runner/browser/default_settings.dart
@@ -18,6 +18,8 @@ final defaultSettings = UnmodifiableMapView({
   Runtime.edge: ExecutableSettings(
     linuxExecutable: 'microsoft-edge-stable',
     windowsExecutable: r'Microsoft\Edge\Application\msedge.exe',
+    macOSExecutable:
+        '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
     environmentOverride: 'MS_EDGE_EXECUTABLE',
   ),
   Runtime.firefox: ExecutableSettings(

--- a/pkgs/test/lib/src/runner/browser/microsoft_edge.dart
+++ b/pkgs/test/lib/src/runner/browser/microsoft_edge.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_core/src/runner/configuration.dart'; // ignore: implementation_imports
+
+import '../executable_settings.dart';
+import 'browser.dart';
+import 'chromium.dart';
+
+/// A class for running an instance of Microsoft Edge, a Chromium-based browser.
+class MicrosoftEdge extends Browser {
+  @override
+  String get name => 'Edge';
+
+  MicrosoftEdge(Uri url, Configuration configuration,
+      {ExecutableSettings? settings})
+      : super(() => ChromiumBasedBrowser.microsoftEdge.spawn(
+              url,
+              configuration,
+              settings: settings,
+            ));
+}

--- a/pkgs/test/test/runner/browser/microsoft_edge_test.dart
+++ b/pkgs/test/test/runner/browser/microsoft_edge_test.dart
@@ -1,0 +1,76 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+@Tags(['chrome'])
+
+import 'package:test/src/runner/browser/microsoft_edge.dart';
+import 'package:test/src/runner/executable_settings.dart';
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+import '../../io.dart';
+import '../../utils.dart';
+import 'code_server.dart';
+
+void main() {
+  setUpAll(precompileTestExecutable);
+
+  test('starts edge with the given URL', () async {
+    var server = await CodeServer.start();
+
+    server.handleJavaScript('''
+var webSocket = new WebSocket(window.location.href.replace("http://", "ws://"));
+webSocket.addEventListener("open", function() {
+  webSocket.send("loaded!");
+});
+''');
+    var webSocket = server.handleWebSocket();
+
+    var edge = MicrosoftEdge(server.url, configuration());
+    addTearDown(() => edge.close());
+
+    expect(await (await webSocket).stream.first, equals('loaded!'));
+  }, timeout: Timeout.factor(2));
+
+  test('reports an error in onExit', () {
+    var edge = MicrosoftEdge(Uri.parse('https://dart.dev'), configuration(),
+        settings: ExecutableSettings(
+            linuxExecutable: '_does_not_exist',
+            macOSExecutable: '_does_not_exist',
+            windowsExecutable: '_does_not_exist'));
+    expect(
+        edge.onExit,
+        throwsA(isApplicationException(
+            startsWith('Failed to run Edge: $noSuchFileMessage'))));
+  });
+
+  test('can run successful tests', () async {
+    await d.file('test.dart', '''
+import 'package:test/test.dart';
+
+void main() {
+  test("success", () {});
+}
+''').create();
+
+    var test = await runTest(['-p', 'edge', 'test.dart']);
+    expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
+    await test.shouldExit(0);
+  });
+
+  test('can run failing tests', () async {
+    await d.file('test.dart', '''
+import 'package:test/test.dart';
+
+void main() {
+  test("failure", () => throw TestFailure("oh no"));
+}
+''').create();
+
+    var test = await runTest(['-p', 'edge', 'test.dart']);
+    expect(test.stdout, emitsThrough(contains('-1: Some tests failed.')));
+    await test.shouldExit(1);
+  });
+}

--- a/pkgs/test/test/runner/browser/microsoft_edge_test.dart
+++ b/pkgs/test/test/runner/browser/microsoft_edge_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
-@Tags(['chrome'])
+@Tags(['edge'])
 
 import 'package:test/src/runner/browser/microsoft_edge.dart';
 import 'package:test/src/runner/executable_settings.dart';

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -120,7 +120,7 @@ Output:
 
 final _runtimes = '[vm (default), chrome, firefox'
     '${Platform.isMacOS ? ', safari' : ''}'
-    '${Platform.isWindows ? ', ie' : ''}, node, '
+    '${Platform.isWindows ? ', ie' : ''}, edge, node, '
     'experimental-chrome-wasm]';
 
 final _runtimeCompilers = [
@@ -129,6 +129,7 @@ final _runtimeCompilers = [
   '[firefox]: dart2js (default)',
   if (Platform.isMacOS) '[safari]: dart2js (default)',
   if (Platform.isWindows) '[ie]: dart2js (default)',
+  '[edge]: dart2js (default)',
   '[node]: dart2js (default)',
   '[experimental-chrome-wasm]: dart2wasm (default)',
 ].map((str) => '                                      $str').join('\n');

--- a/pkgs/test_api/lib/src/backend/runtime.dart
+++ b/pkgs/test_api/lib/src/backend/runtime.dart
@@ -34,6 +34,11 @@ class Runtime {
       'Internet Explorer', 'ie', Compiler.dart2js, [Compiler.dart2js],
       isBrowser: true, isJS: true);
 
+  /// Microsoft Edge (based on Chromium).
+  static const Runtime edge = Runtime(
+      'Microsoft Edge', 'edge', Compiler.dart2js, [Compiler.dart2js],
+      isBrowser: true, isJS: true, isBlink: true);
+
   /// The command-line Node.js VM.
   static const Runtime nodeJS = Runtime(
       'Node.js', 'node', Compiler.dart2js, [Compiler.dart2js],
@@ -56,6 +61,7 @@ class Runtime {
     Runtime.firefox,
     Runtime.safari,
     Runtime.internetExplorer,
+    Runtime.edge,
     Runtime.nodeJS,
     Runtime.experimentalChromeWasm,
   ];


### PR DESCRIPTION
This adds support for the (Chromium-based) Microsoft Edge browser as a test platform. Since the browser is so similar to Chrome in general, I've moved most of the code supplying the startup arguments to `chromium.dart`.  So most of the functionality is shared between Chrome and MS Edge. I wasn't sure if the debug protocol used by Chrome is supported by Edge as-is, so I opted to not support that for now.

Closes #1142