### PR TITLE
Remove deprecation of test_api top level libraries

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.24.2-dev
+## 1.24.2
 
 * Copy an existing nonce from a script on the test HTML page to the script
   created by the test runner host javascript. This only impacts environments

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.24.2-dev
+version: 1.24.2
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test
@@ -32,8 +32,8 @@ dependencies:
   webkit_inspection_protocol: ^1.0.0
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.5.1
-  test_core: 0.5.1
+  test_api: 0.5.2
+  test_core: 0.5.2
   # Use a tight version constraint to ensure that a constraint on matcher
   # properly constrains all features it provides.
   matcher: '>=0.12.15 <0.12.16'

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.2
+
+* Remove deprecation for the `scaffolding.dart` and `backend.dart` libraries.
+* Export `registerException` from the `scaffolding.dart` library.
+
 ## 0.5.1
 
 * Handle a missing `'compiler'` value when running a test compiled against a

--- a/pkgs/test_api/lib/backend.dart
+++ b/pkgs/test_api/lib/backend.dart
@@ -2,10 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Deprecated('package:test_api is not intended for general use. '
-    'Please use package:test.')
-library test_api.backend;
-
 export 'src/backend/compiler.dart' show Compiler;
 export 'src/backend/metadata.dart' show Metadata;
 export 'src/backend/platform_selector.dart' show PlatformSelector;

--- a/pkgs/test_api/lib/scaffolding.dart
+++ b/pkgs/test_api/lib/scaffolding.dart
@@ -8,8 +8,6 @@
 /// {@canonicalFor tags.Tags}
 /// {@canonicalFor test_on.TestOn}
 /// {@canonicalFor timeout.Timeout}
-@Deprecated('package:test_api is not intended for general use. '
-    'Please use package:test.')
 library test_api.scaffolding;
 
 export 'src/backend/configuration/on_platform.dart' show OnPlatform;
@@ -22,4 +20,4 @@ export 'src/scaffolding/spawn_hybrid.dart' show spawnHybridUri, spawnHybridCode;
 export 'src/scaffolding/test_structure.dart'
     show group, test, setUp, setUpAll, tearDown, tearDownAll, addTearDown;
 export 'src/scaffolding/utils.dart'
-    show pumpEventQueue, printOnFailure, markTestSkipped;
+    show markTestSkipped, printOnFailure, pumpEventQueue, registerException;

--- a/pkgs/test_api/lib/test_api.dart
+++ b/pkgs/test_api/lib/test_api.dart
@@ -10,5 +10,3 @@ export 'package:matcher/expect.dart';
 
 export 'hooks.dart' show TestFailure;
 export 'scaffolding.dart';
-// Not yet deprecated, but not exposed through focused libraries.
-export 'src/scaffolding/utils.dart' show registerException;

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.5.1
+version: 0.5.2
 description: >-
   The user facing API for structuring Dart tests and checking expectations.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_api

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.5.2
 
+* Use the version `0.5.2` of `packge:test_api`.
+
 ## 0.5.1
 
 * Start adding experimental support for native_assets.yaml, when

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.5.2
+
 ## 0.5.1
 
 * Start adding experimental support for native_assets.yaml, when

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.5.1
+version: 0.5.2
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 
@@ -30,7 +30,7 @@ dependencies:
   # matcher is tightly constrained by test_api
   matcher: ^0.12.11
   # Use an exact version until the test_api package is stable.
-  test_api: 0.5.1
+  test_api: 0.5.2
 
 dev_dependencies:
   lints: '>=1.0.0 <3.0.0'


### PR DESCRIPTION
Closes #1990

The `scaffolding` library should not be deprecated to avoid marking the useful APIs as deprecated during autocomplete.

The `backend` library is no longer deprecated because it _is_ intended for use in `flutter_test`, and the deprecation isn't likely to be blocking any uses.

Export `registerException` from the scaffolding library. This had originally been held back from the focused libraries because it isn't a great API, but it's too entrenched to be worth deprecating at this point, so it may as well be fully supported.