### PR TITLE
Dart 3 compatibility: change `extends Iterator` to `implements Iterator`

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.5.3-wip
+
 ## 0.5.2
 
 * Use the version `0.5.2` of `packge:test_api`.

--- a/pkgs/test_core/lib/src/util/string_literal_iterator.dart
+++ b/pkgs/test_core/lib/src/util/string_literal_iterator.dart
@@ -36,7 +36,7 @@ const _verticalTab = 0xB;
 ///
 /// In addition to exposing the values of the runes themselves, this also
 /// exposes the offset of the current rune in the Dart source file.
-class StringLiteralIterator extends Iterator<int> {
+class StringLiteralIterator implements Iterator<int> {
   @override
   int get current => _current!;
   int? _current;

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.5.2
+version: 0.5.3-wip
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 


### PR DESCRIPTION
Otherwise in Dart language 3 there will be an error:

    The class 'Iterator' can't be extended outside of its library because it's an interface class. [INVALID_USE_OF_TYPE_OUTSIDE_LIBRARY]