### PR TITLE
Only run edge tests on windows

### DIFF
--- a/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
+++ b/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
@@ -19,7 +19,8 @@ void main() {
   for (var runtime in Runtime.builtIn) {
     for (var compiler in runtime.supportedCompilers) {
       // Ignore the platforms we can't run on this OS.
-      if (runtime == Runtime.internetExplorer && !Platform.isWindows ||
+      if ((runtime == Runtime.internetExplorer || runtime == Runtime.edge) &&
+              !Platform.isWindows ||
           runtime == Runtime.safari && !Platform.isMacOS) {
         continue;
       }


### PR DESCRIPTION
Add condition for the new edge runtime in the compiler matrix test.
