### PR TITLE
Remove the matcher export from test_api

### DIFF
--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   test_core: 0.5.3
   # Use a tight version constraint to ensure that a constraint on matcher
   # properly constrains all features it provides.
-  matcher: '>=0.12.15 <0.12.17'
+  matcher: '>=0.12.16 <0.12.17'
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   test_core: 0.5.3
   # Use a tight version constraint to ensure that a constraint on matcher
   # properly constrains all features it provides.
-  matcher: '>=0.12.15 <0.12.16'
+  matcher: '>=0.12.15 <0.12.17'
 
 dev_dependencies:
   fake_async: ^1.0.0

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -32,8 +32,8 @@ dependencies:
   webkit_inspection_protocol: ^1.0.0
   yaml: ^3.0.0
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.5.2
-  test_core: 0.5.2
+  test_api: 0.6.0
+  test_core: 0.5.3
   # Use a tight version constraint to ensure that a constraint on matcher
   # properly constrains all features it provides.
   matcher: '>=0.12.15 <0.12.16'

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.6.0-dev
+## 0.6.0-wip
 
 * Remove the `package:test_api/expect.dart' library. `test` will export from
   `package:matcher` directly.

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.0-dev
+
+* Remove the `package:test_api/expect.dart' library. `test` will export from
+  `package:matcher` directly.
+
 ## 0.5.2
 
 * Remove deprecation for the `scaffolding.dart` and `backend.dart` libraries.

--- a/pkgs/test_api/lib/expect.dart
+++ b/pkgs/test_api/lib/expect.dart
@@ -1,5 +1,0 @@
-// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
-// for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
-
-export 'package:matcher/expect.dart';

--- a/pkgs/test_api/lib/src/expect/async_matcher.dart
+++ b/pkgs/test_api/lib/src/expect/async_matcher.dart
@@ -1,5 +1,0 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
-// for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
-
-export 'package:matcher/src/expect/async_matcher.dart';

--- a/pkgs/test_api/lib/test_api.dart
+++ b/pkgs/test_api/lib/test_api.dart
@@ -6,7 +6,5 @@
     'Please use package:test.')
 library test_api;
 
-export 'package:matcher/expect.dart';
-
 export 'hooks.dart' show TestFailure;
 export 'scaffolding.dart';

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -27,4 +27,3 @@ dev_dependencies:
   lints: '>=1.0.0 <3.0.0'
   test: any
   test_core: any
-  matcher: any

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -27,3 +27,4 @@ dev_dependencies:
   lints: '>=1.0.0 <3.0.0'
   test: any
   test_core: any
+  matcher: any

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.5.2
+version: 0.6.0-dev
 description: >-
   The user facing API for structuring Dart tests and checking expectations.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_api
@@ -17,10 +17,6 @@ dependencies:
   stream_channel: ^2.1.0
   string_scanner: ^1.1.0
   term_glyph: ^1.2.0
-
-  # Use a tight version constraint to ensure that a constraint on matcher
-  # properly constrains all features it provides.
-  matcher: '>=0.12.15 <0.12.16'
 
 dev_dependencies:
   analyzer: '>=2.1.0 <6.0.0'

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.6.0-dev
+version: 0.6.0-wip
 description: >-
   The user facing API for structuring Dart tests and checking expectations.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_api

--- a/pkgs/test_api/pubspec_overrides.yaml
+++ b/pkgs/test_api/pubspec_overrides.yaml
@@ -3,3 +3,7 @@ dependency_overrides:
     path: ../test
   test_core:
     path: ../test_core
+  matcher:
+    git:
+      url: https://github.com/dart-lang/matcher.git
+      ref: 3262428d5a701b514eb20ee27b3e02a92cde5761

--- a/pkgs/test_api/pubspec_overrides.yaml
+++ b/pkgs/test_api/pubspec_overrides.yaml
@@ -3,7 +3,3 @@ dependency_overrides:
     path: ../test
   test_core:
     path: ../test_core
-  matcher:
-    git:
-      url: https://github.com/dart-lang/matcher.git
-      ref: 3262428d5a701b514eb20ee27b3e02a92cde5761

--- a/pkgs/test_core/lib/test_core.dart
+++ b/pkgs/test_core/lib/test_core.dart
@@ -7,7 +7,5 @@
 library test_core;
 
 export 'package:test_api/hooks.dart' show TestFailure;
-// Not yet deprecated, but not exposed through focused libraries.
-export 'package:test_api/test_api.dart' show registerException;
 
 export 'scaffolding.dart';

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -27,10 +27,8 @@ dependencies:
   stream_channel: ^2.1.0
   vm_service: ">=6.0.0 <12.0.0"
   yaml: ^3.0.0
-  # matcher is tightly constrained by test_api
-  matcher: ^0.12.11
   # Use an exact version until the test_api package is stable.
-  test_api: 0.5.2
+  test_api: 0.6.0
 
 dev_dependencies:
   lints: '>=1.0.0 <3.0.0'


### PR DESCRIPTION
`package:test` exports directly from `package:matcher`. Resolves a
cyclic dependency between `matcher` and `test_api`.
