### PR TITLE
Prepare to publish checks

### DIFF
--- a/pkgs/checks/CHANGELOG.md
+++ b/pkgs/checks/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.2-dev
+## 0.2.2
 
 -   Return the first failure from `softCheck` and `softCheckAsync` as
     documented, instead of the last failure when there are multiple failures.

--- a/pkgs/checks/pubspec.yaml
+++ b/pkgs/checks/pubspec.yaml
@@ -1,5 +1,5 @@
 name: checks
-version: 0.2.2-dev
+version: 0.2.2
 description: >-
   A framework for checking values against expectations and building custom
   expectations.
@@ -11,7 +11,7 @@ environment:
 dependencies:
   async: ^2.8.0
   meta: ^1.9.0
-  test_api: ^0.5.0
+  test_api: ">=0.5.0 <0.6.0"
 
 dev_dependencies:
   test: ^1.21.3


### PR DESCRIPTION
Expand the dependency range on `test_api` to allow the next major
version.
