### PR TITLE
Allow accessing the current test/suite metadata

### DIFF
--- a/pkgs/test_api/lib/src/backend/declarer.dart
+++ b/pkgs/test_api/lib/src/backend/declarer.dart
@@ -106,6 +106,8 @@ class Declarer {
   /// The current zone-scoped declarer.
   static Declarer? get current => Zone.current[#test.declarer] as Declarer?;
 
+  static Metadata? get currentMetadata => current?._metadata;
+
   /// All the test and group names that have been declared in the entire suite.
   ///
   /// If duplicate test names are allowed, this is not tracked and it will be
@@ -184,7 +186,9 @@ class Declarer {
       return;
     }
 
+    final newName = [if (_metadata.name != null) ..._metadata.name!, name];
     var newMetadata = Metadata.parse(
+        name: newName,
         testOn: testOn,
         timeout: timeout,
         skip: skip,
@@ -216,7 +220,18 @@ class Declarer {
       },
           // Make the declarer visible to running tests so that they'll throw
           // useful errors when calling `test()` and `group()` within a test.
-          zoneValues: {#test.declarer: this});
+          zoneValues: {
+            #test.declarer: Declarer._(
+                _parent,
+                _name,
+                metadata,
+                _platformVariables,
+                _collectTraces,
+                _trace,
+                _noRetry,
+                _fullTestName,
+                _seenNames),
+          });
     }, trace: _collectTraces ? Trace.current(2) : null, guarded: false));
 
     if (solo) {
@@ -241,6 +256,7 @@ class Declarer {
     }
 
     var newMetadata = Metadata.parse(
+        name: [if (_metadata.name != null) ..._metadata.name!, name],
         testOn: testOn,
         timeout: timeout,
         skip: skip,

--- a/pkgs/test_api/test/backend/metadata_test.dart
+++ b/pkgs/test_api/test/backend/metadata_test.dart
@@ -10,6 +10,45 @@ import 'package:test_api/src/backend/runtime.dart';
 import 'package:test_api/src/backend/suite_platform.dart';
 
 void main() {
+  group('current', () {
+    final originalMetadata = Metadata.current;
+    group(
+      'tags',
+      () {
+        test(
+          'inherited from the parent group',
+          () {
+            expect(Metadata.current?.tags, equals(['tag-1', 'tag-2', 'tag-3']));
+          },
+          tags: ['tag-3'],
+        );
+        test(
+          'inherited from the parent group (2)',
+          () {
+            expect(Metadata.current?.tags, equals(['tag-1', 'tag-2']));
+          },
+        );
+      },
+      tags: ['tag-1', 'tag-2'],
+    );
+    group('group 1', () {
+      group('group 1.a', () {
+        group('group 1.a.I', () {
+          test('name is correct', () {
+            expect(
+                Metadata.current?.name,
+                equals([
+                  ...originalMetadata?.name ?? [],
+                  'group 1',
+                  'group 1.a',
+                  'group 1.a.I',
+                  'name is correct'
+                ]));
+          });
+        });
+      });
+    });
+  });
   group('tags', () {
     test('parses an Iterable', () {
       expect(


### PR DESCRIPTION
This PR makes the current test metadata accessible from the tests. This allows test to access their name ofr instance.