### PR TITLE
Add error for empty groups

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.24.3-wip
 
 * Fix compatibility with wasm number semantics.
+* Consider empty `group` to be test failures.
 
 ## 1.24.2
 

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.5.3-wip
 
 * Fix compatibility with wasm number semantics.
+* Consider empty `group` to be test failures.
 
 ## 0.5.2
 

--- a/pkgs/test_api/lib/src/backend/declarer.dart
+++ b/pkgs/test_api/lib/src/backend/declarer.dart
@@ -13,6 +13,7 @@ import 'group_entry.dart';
 import 'invoker.dart';
 import 'metadata.dart';
 import 'test.dart';
+import 'test_failure.dart';
 
 /// A class that manages the state of tests as they're declared.
 ///
@@ -327,6 +328,11 @@ class Declarer {
       }
       return entry;
     }).toList();
+    if (entries.isEmpty) {
+      entries.add(LocalTest(_name ?? 'Empty group', _metadata, () {
+        throw TestFailure('No tests declared in group');
+      }));
+    }
 
     return Group(_name ?? '', entries,
         metadata: _metadata,

--- a/pkgs/test_api/test/backend/declarer_test.dart
+++ b/pkgs/test_api/test/backend/declarer_test.dart
@@ -410,6 +410,17 @@ void main() {
       });
     });
 
+    test('disallows empty groups', () async {
+      var entries = declare(() {
+        group('group', () {});
+      });
+
+      expect(entries, hasLength(1));
+      var testGroup = entries.single as Group;
+      expect(testGroup.entries, hasLength(1));
+      await _runTest(testGroup.entries.single as Test, shouldFail: true);
+    });
+
     group('.setUp()', () {
       test('is scoped to the group', () async {
         var setUpRun = false;

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.5.3-wip
 
 * Fix compatibility with wasm number semantics.
+* Consider empty `group` to be test failures.
 
 ## 0.5.2
 


### PR DESCRIPTION
Closes #1961

After declaring a group check for declared tests, if there were none add
a synthetic test that fails with an error about the empty group.
