### PR TITLE
remove the self_validate step from the mono_repo config

### DIFF
--- a/mono_repo.yaml
+++ b/mono_repo.yaml
@@ -1,5 +1,4 @@
 # See with https://github.com/dart-lang/mono_repo for details on this file
-self_validate: analyze_and_format
 
 github:
   # Setting just `cron` keeps the defaults for `push` and `pull_request`


### PR DESCRIPTION
- remove the `self_validate` step from the mono-repo config - as its currently implemented, it will cause dependebot dep bump PRs to fail

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

#### Contribution guidelines:

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for a week or two of latency for initial review feedback.

---
