### PR TITLE
Make State and Result enums

### DIFF
--- a/pkgs/test_api/lib/src/backend/state.dart
+++ b/pkgs/test_api/lib/src/backend/state.dart
@@ -44,12 +44,12 @@ class State {
 }
 
 /// Where the test is in its process of running.
-final class Status {
+enum Status {
   /// The test has not yet begun running.
-  static const pending = Status._('pending');
+  pending('pending'),
 
   /// The test is currently running.
-  static const running = Status._('running');
+  running('running'),
 
   /// The test has finished running.
   ///
@@ -58,53 +58,43 @@ final class Status {
   /// first error or when all [expectAsync] callbacks have been called and any
   /// returned [Future] has completed, but it's possible for further processing
   /// to happen, which may cause further errors.
-  static const complete = Status._('complete');
+  complete('complete');
 
   /// The name of the status.
   final String name;
 
-  factory Status.parse(String name) {
-    switch (name) {
-      case 'pending':
-        return Status.pending;
-      case 'running':
-        return Status.running;
-      case 'complete':
-        return Status.complete;
-      default:
-        throw ArgumentError('Invalid status name "$name".');
-    }
-  }
+  factory Status.parse(String name) =>
+      Status.values.firstWhere((s) => s.name == name);
 
-  const Status._(this.name);
+  const Status(this.name);
 
   @override
   String toString() => name;
 }
 
 /// The outcome of the test, as far as it's known.
-final class Result {
+enum Result {
   /// The test has not yet failed in any way.
   ///
   /// Note that this doesn't mean that the test won't fail in the future.
-  static const success = Result._('success');
+  success('success'),
 
   /// The test, or some part of it, has been skipped.
   ///
   /// This implies that the test hasn't failed *yet*. However, it this doesn't
   /// mean that the test won't fail in the future.
-  static const skipped = Result._('skipped');
+  skipped('skipped'),
 
   /// The test has failed.
   ///
   /// A failure is specifically caused by a [TestFailure] being thrown; any
   /// other exception causes an error.
-  static const failure = Result._('failure');
+  failure('failure'),
 
   /// The test has crashed.
   ///
   /// Any exception other than a [TestFailure] is considered to be an error.
-  static const error = Result._('error');
+  error('error');
 
   /// The name of the result.
   final String name;
@@ -121,22 +111,10 @@ final class Result {
   /// error.
   bool get isFailing => !isPassing;
 
-  factory Result.parse(String name) {
-    switch (name) {
-      case 'success':
-        return Result.success;
-      case 'skipped':
-        return Result.skipped;
-      case 'failure':
-        return Result.failure;
-      case 'error':
-        return Result.error;
-      default:
-        throw ArgumentError('Invalid result name "$name".');
-    }
-  }
+  factory Result.parse(String name) =>
+      Result.values.firstWhere((r) => r.name == name);
 
-  const Result._(this.name);
+  const Result(this.name);
 
   @override
   String toString() => name;

--- a/pkgs/test_api/lib/src/backend/state.dart
+++ b/pkgs/test_api/lib/src/backend/state.dart
@@ -60,8 +60,7 @@ enum Status {
   /// to happen, which may cause further errors.
   complete;
 
-  factory Status.parse(String name) =>
-      Status.values.firstWhere((s) => s.name == name);
+  factory Status.parse(String name) => Status.values.byName(name);
 
   @override
   String toString() => name;
@@ -103,8 +102,7 @@ enum Result {
   /// error.
   bool get isFailing => !isPassing;
 
-  factory Result.parse(String name) =>
-      Result.values.firstWhere((r) => r.name == name);
+  factory Result.parse(String name) => Result.values.byName(name);
 
   @override
   String toString() => name;

--- a/pkgs/test_api/lib/src/backend/state.dart
+++ b/pkgs/test_api/lib/src/backend/state.dart
@@ -46,10 +46,10 @@ class State {
 /// Where the test is in its process of running.
 enum Status {
   /// The test has not yet begun running.
-  pending('pending'),
+  pending,
 
   /// The test is currently running.
-  running('running'),
+  running,
 
   /// The test has finished running.
   ///
@@ -58,15 +58,10 @@ enum Status {
   /// first error or when all [expectAsync] callbacks have been called and any
   /// returned [Future] has completed, but it's possible for further processing
   /// to happen, which may cause further errors.
-  complete('complete');
-
-  /// The name of the status.
-  final String name;
+  complete;
 
   factory Status.parse(String name) =>
       Status.values.firstWhere((s) => s.name == name);
-
-  const Status(this.name);
 
   @override
   String toString() => name;
@@ -77,27 +72,24 @@ enum Result {
   /// The test has not yet failed in any way.
   ///
   /// Note that this doesn't mean that the test won't fail in the future.
-  success('success'),
+  success,
 
   /// The test, or some part of it, has been skipped.
   ///
   /// This implies that the test hasn't failed *yet*. However, it this doesn't
   /// mean that the test won't fail in the future.
-  skipped('skipped'),
+  skipped,
 
   /// The test has failed.
   ///
   /// A failure is specifically caused by a [TestFailure] being thrown; any
   /// other exception causes an error.
-  failure('failure'),
+  failure,
 
   /// The test has crashed.
   ///
   /// Any exception other than a [TestFailure] is considered to be an error.
-  error('error');
-
-  /// The name of the result.
-  final String name;
+  error;
 
   /// Whether this is a passing result.
   ///
@@ -113,8 +105,6 @@ enum Result {
 
   factory Result.parse(String name) =>
       Result.values.firstWhere((r) => r.name == name);
-
-  const Result(this.name);
 
   @override
   String toString() => name;


### PR DESCRIPTION
These are used in the other test runner implementation packages, but the
usage should not be impacted. Implement the `parse` methods by iterating
over the values instead of a manual `switch` statement.
