### PR TITLE
Remove redundant type checks

### DIFF
--- a/pkgs/checks/test/context_test.dart
+++ b/pkgs/checks/test/context_test.dart
@@ -124,15 +124,13 @@ void main() {
         ..state.equals(State.failed)
         ..errors.unorderedMatches([
           it()
-            ..isA<AsyncError>()
-                .has((e) => e.error, 'error')
+            ..has((e) => e.error, 'error')
                 .isA<TestFailure>()
                 .has((f) => f.message, 'message')
                 .isNotNull()
                 .endsWith('Which: foo'),
           it()
-            ..isA<AsyncError>()
-                .has((e) => e.error, 'error')
+            ..has((e) => e.error, 'error')
                 .isA<String>()
                 .startsWith('This test failed after it had already completed.')
         ]);


### PR DESCRIPTION
The `unorderedMatches` expectation takes an `Iterable<Condition<T>>` so
the `it()` call gets the generic inferred and does not force a
`Subject<dynamic>` like `deepEquals` would when using a condition to
compare with an element.
