### PR TITLE
Allow null descriptions

### DIFF
--- a/pkgs/test_api/lib/src/scaffolding/test_structure.dart
+++ b/pkgs/test_api/lib/src/scaffolding/test_structure.dart
@@ -70,7 +70,7 @@ Declarer get _declarer => Zone.current[#test.declarer] as Declarer;
 /// avoid this flag if possible and instead use the test runner flag `-n` to
 /// filter tests by name.
 @isTest
-void test(Object description, dynamic Function() body,
+void test(Object? description, dynamic Function() body,
     {String? testOn,
     Timeout? timeout,
     Object? skip,
@@ -148,7 +148,7 @@ void test(Object description, dynamic Function() body,
 /// avoid this flag if possible, and instead use the test runner flag `-n` to
 /// filter tests by name.
 @isTestGroup
-void group(Object description, dynamic Function() body,
+void group(Object? description, dynamic Function() body,
     {String? testOn,
     Timeout? timeout,
     Object? skip,

--- a/pkgs/test_core/lib/scaffolding.dart
+++ b/pkgs/test_core/lib/scaffolding.dart
@@ -133,7 +133,7 @@ Declarer get _declarer {
 /// avoid this flag if possible and instead use the test runner flag `-n` to
 /// filter tests by name.
 @isTest
-void test(Object description, dynamic Function() body,
+void test(Object? description, dynamic Function() body,
     {String? testOn,
     Timeout? timeout,
     Object? skip,
@@ -211,7 +211,7 @@ void test(Object description, dynamic Function() body,
 /// avoid this flag if possible, and instead use the test runner flag `-n` to
 /// filter tests by name.
 @isTestGroup
-void group(Object description, dynamic Function() body,
+void group(Object? description, dynamic Function() body,
     {String? testOn,
     Timeout? timeout,
     Object? skip,


### PR DESCRIPTION
The change from an implicit `dynamic` to `Object` is statically breaking
for any usage passing a variable or any expression with type `dynamic`
or `Object?`.
