### PR TITLE
Fix root suite comparison on Windows

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Drop support for null unsafe Dart, bump SDK constraint to `3.0.0`.
 * Make some annotation classes `final`: `OnPlatform`, `Retry`, `Skip`, `Tags`,
   `TestOn`, `Timeout`.
+* Fix the `root_` fields in the JSON reporter when running a test on Windows
+  with an absolute path.
 
 ## 1.24.3
 

--- a/pkgs/test/test/runner/json_reporter_test.dart
+++ b/pkgs/test/test/runner/json_reporter_test.dart
@@ -559,7 +559,9 @@ void customTest(String name, dynamic Function() testFn) => test(name, testFn);
           [
             [
               suiteJson(0, path: path),
-              testStartJson(1, 'loading $path', groupIDs: []),
+              testStartJson(
+                  1, allOf(startsWith('loading '), endsWith('test.dart')),
+                  groupIDs: []),
               testDoneJson(1, hidden: true),
             ],
             [

--- a/pkgs/test/test/runner/json_reporter_test.dart
+++ b/pkgs/test/test/runner/json_reporter_test.dart
@@ -549,6 +549,7 @@ void customTest(String name, dynamic Function() testFn) => test(name, testFn);
     });
 
     test('the root suite from an absolute path', () {
+      final path = p.join(d.sandbox, 'test.dart');
       return _expectReport(
           '''
       customTest('success 1', () {});
@@ -557,8 +558,8 @@ void customTest(String name, dynamic Function() testFn) => test(name, testFn);
           useRelativePath: false,
           [
             [
-              suiteJson(0),
-              testStartJson(1, 'loading test.dart', groupIDs: []),
+              suiteJson(0, path: path),
+              testStartJson(1, 'loading $path', groupIDs: []),
               testDoneJson(1, hidden: true),
             ],
             [

--- a/pkgs/test/test/runner/json_reporter_test.dart
+++ b/pkgs/test/test/runner/json_reporter_test.dart
@@ -549,7 +549,7 @@ void customTest(String name, dynamic Function() testFn) => test(name, testFn);
     });
 
     test('the root suite from an absolute path', () {
-      final path = p.join(d.sandbox, 'test.dart');
+      final path = p.prettyUri(p.join(d.sandbox, 'test.dart'));
       return _expectReport(
           '''
       customTest('success 1', () {});

--- a/pkgs/test/test/runner/json_reporter_test.dart
+++ b/pkgs/test/test/runner/json_reporter_test.dart
@@ -558,7 +558,7 @@ void customTest(String name, dynamic Function() testFn) => test(name, testFn);
           useRelativePath: false,
           [
             [
-              suiteJson(0, path: path),
+              suiteJson(0, path: equalsIgnoringCase(path)),
               testStartJson(
                   1, allOf(startsWith('loading '), endsWith('test.dart')),
                   groupIDs: []),

--- a/pkgs/test/test/runner/json_reporter_utils.dart
+++ b/pkgs/test/test/runner/json_reporter_utils.dart
@@ -119,7 +119,7 @@ Map<String, Object> groupJson(int id,
 /// [skip] is `true`, the test is expected to be marked as skipped without a
 /// reason. If it's a [String], the test is expected to be marked as skipped
 /// with that reason.
-Map<String, Object> testStartJson(int id, String name,
+Map<String, Object> testStartJson(int id, Object /*String|Matcher*/ name,
     {int? suiteID,
     Iterable<int>? groupIDs,
     int? line,

--- a/pkgs/test/test/runner/json_reporter_utils.dart
+++ b/pkgs/test/test/runner/json_reporter_utils.dart
@@ -61,15 +61,16 @@ Map<String, Object> _allSuitesJson({int count = 1}) =>
 /// Returns the event emitted by the JSON reporter indicating that a suite has
 /// begun running.
 ///
-/// The [platform] defaults to `"vm"`, the [path] defaults to `"test.dart"`.
+/// The [platform] defaults to `'vm'`.
+/// The [path] defaults to `equals('test.dart')`.
 Map<String, Object> suiteJson(int id,
-        {String platform = 'vm', String path = 'test.dart'}) =>
+        {String platform = 'vm', Matcher? path}) =>
     {
       'type': 'suite',
       'suite': {
         'id': id,
         'platform': platform,
-        'path': path,
+        'path': path ?? 'test.dart',
       }
     };
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Drop support for null unsafe Dart, bump SDK constraint to `3.0.0`.
 * Add `final` modifier on some implementation classes: `Configuration`,
   `CustomRuntime`,`RuntimeSettings`, `SuiteConfiguration`. 
+* Fix the `root_` fields in the JSON reporter when running a test on Windows
+  with an absolute path.
 
 ## 0.5.3
 

--- a/pkgs/test_core/lib/src/runner/reporter/json.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/json.dart
@@ -303,7 +303,7 @@ class JsonReporter implements Reporter {
   /// all be `null`.
   Map<String, dynamic> _frameInfo(SuiteConfiguration suiteConfig, Trace? trace,
       Runtime runtime, String suitePath) {
-    var absoluteSuitePath = p.absolute(suitePath);
+    var absoluteSuitePath = p.canonicalize(p.absolute(suitePath));
     var frame = trace?.frames.first;
     if (frame == null || (suiteConfig.jsTrace && runtime.isJS)) {
       return {'line': null, 'column': null, 'url': null};
@@ -311,7 +311,7 @@ class JsonReporter implements Reporter {
 
     var rootFrame = trace?.frames.firstWhereOrNull((frame) =>
         frame.uri.scheme == 'file' &&
-        frame.uri.toFilePath() == absoluteSuitePath);
+        p.canonicalize(frame.uri.toFilePath()) == absoluteSuitePath);
     return {
       'line': frame.line,
       'column': frame.column,


### PR DESCRIPTION
Fixes #2037

Canonicalize paths when checking whether a stack frame is coming from
the test suite root.

Add a test case which runs with an absolute path argument. On windows,
this situation would have resulted in the `root_` location information
being missing because of a difference in the stack frame paths and the
suite path before canonicalization. This test fails on windows without
the canonicalization.

Make the test utils more flexible to handle the new output differences
across operation systems.
Allow a `Matcher` value for the `path` argument to `suiteJson`. This
optional argument had previously been unused. Use `equalsIgnoreCase`
because on windows there is a difference in the case of the drive
letter.
Allow a `Matcher` value for the `name` argument to `testStartJson`. Take
an `Object` to allow either `Matcher` or `String` for existing uses.
Check the "loading" output line loosely by checking only the start and
end.