### PR TITLE
feat(runner): add env overrides for safari and ff

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -5,6 +5,8 @@
   `TestOn`, `Timeout`.
 * Fix the `root_` fields in the JSON reporter when running a test on Windows
   with an absolute path.
+* Add support for `SAFARI_EXECUTABLE`, `FIREFOX_EXECUTABLE` and
+  `MS_EDGE_EXECUTABLE` for custom browser installations.
 
 ## 1.24.3
 

--- a/pkgs/test/lib/src/runner/browser/default_settings.dart
+++ b/pkgs/test/lib/src/runner/browser/default_settings.dart
@@ -30,6 +30,6 @@ final defaultSettings = UnmodifiableMapView({
   Runtime.internetExplorer:
       ExecutableSettings(windowsExecutable: r'Internet Explorer\iexplore.exe'),
   Runtime.safari: ExecutableSettings(
-    macOSExecutable: '/Applications/Safari.app/Contents/MacOS/Safari',
-    environmentOverride: 'SAFARI_EXECUTABLE'),
+      macOSExecutable: '/Applications/Safari.app/Contents/MacOS/Safari',
+      environmentOverride: 'SAFARI_EXECUTABLE'),
 });

--- a/pkgs/test/lib/src/runner/browser/default_settings.dart
+++ b/pkgs/test/lib/src/runner/browser/default_settings.dart
@@ -25,9 +25,11 @@ final defaultSettings = UnmodifiableMapView({
   Runtime.firefox: ExecutableSettings(
       linuxExecutable: 'firefox',
       macOSExecutable: '/Applications/Firefox.app/Contents/MacOS/firefox-bin',
-      windowsExecutable: r'Mozilla Firefox\firefox.exe'),
+      windowsExecutable: r'Mozilla Firefox\firefox.exe',
+      environmentOverride: 'FIREFOX_EXECUTABLE'),
   Runtime.internetExplorer:
       ExecutableSettings(windowsExecutable: r'Internet Explorer\iexplore.exe'),
   Runtime.safari: ExecutableSettings(
-      macOSExecutable: '/Applications/Safari.app/Contents/MacOS/Safari'),
+    macOSExecutable: '/Applications/Safari.app/Contents/MacOS/Safari',
+    environmentOverride: 'SAFARI_EXECUTABLE'),
 });

--- a/pkgs/test/test/runner/browser/firefox_test.dart
+++ b/pkgs/test/test/runner/browser/firefox_test.dart
@@ -81,6 +81,20 @@ void main() {
     await test.shouldExit(1);
   });
 
+  test('can override firefox location with FIREFOX_EXECUTABLE var', () async {
+    await d.file('test.dart', '''
+import 'package:test/test.dart';
+
+void main() {
+  test("success", () {});
+}
+''').create();
+    var test = await runTest(['-p', 'firefox', 'test.dart'],
+        environment: {'FIREFOX_EXECUTABLE': '/some/bad/path'});
+    expect(test.stdout, emitsThrough(contains('Failed to run Firefox:')));
+    await test.shouldExit(1);
+  });
+
   test('not impacted by CHROME_EXECUTABLE var', () async {
     await d.file('test.dart', '''
 import 'dart:html';

--- a/pkgs/test/test/runner/browser/microsoft_edge_test.dart
+++ b/pkgs/test/test/runner/browser/microsoft_edge_test.dart
@@ -74,4 +74,18 @@ void main() {
     expect(test.stdout, emitsThrough(contains('-1: Some tests failed.')));
     await test.shouldExit(1);
   });
+
+  test('can override edge location with MS_EDGE_EXECUTABLE var', () async {
+    await d.file('test.dart', '''
+import 'package:test/test.dart';
+
+void main() {
+  test("success", () {});
+}
+''').create();
+    var test = await runTest(['-p', 'edge', 'test.dart'],
+        environment: {'MS_EDGE_EXECUTABLE': '/some/bad/path'});
+    expect(test.stdout, emitsThrough(contains('Failed to run Edge:')));
+    await test.shouldExit(1);
+  });
 }

--- a/pkgs/test/test/runner/browser/safari_test.dart
+++ b/pkgs/test/test/runner/browser/safari_test.dart
@@ -81,4 +81,18 @@ void main() {
     expect(test.stdout, emitsThrough(contains('-1: Some tests failed.')));
     await test.shouldExit(1);
   });
+
+  test('can override safari location with SAFARI_EXECUTABLE var', () async {
+    await d.file('test.dart', '''
+import 'package:test/test.dart';
+
+void main() {
+  test("success", () {});
+}
+''').create();
+    var test = await runTest(['-p', 'safari', 'test.dart'],
+        environment: {'SAFARI_EXECUTABLE': '/some/bad/path'});
+    expect(test.stdout, emitsThrough(contains('Failed to run Safari:')));
+    await test.shouldExit(1);
+  });
 }


### PR DESCRIPTION
adds `SAFARI_EXECUTABLE` and `FIREFOX_EXECUTABLE`
this allows you to use FF Developer Edition and Safari Technology Preview.
Also there are already `MS_EDGE_EXECUTABLE` that were missing test.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
