### PR TITLE
feat(test): add MOZ_AUTOMATION=1 to ff test runner

### DIFF
--- a/pkgs/test/lib/src/runner/browser/firefox.dart
+++ b/pkgs/test/lib/src/runner/browser/firefox.dart
@@ -47,7 +47,8 @@ class Firefox extends Browser {
       '--no-remote',
       ...settings.arguments,
     ], environment: {
-      'MOZ_CRASHREPORTER_DISABLE': '1'
+      'MOZ_CRASHREPORTER_DISABLE': '1',
+      'MOZ_AUTOMATION': '1',
     });
 
     unawaited(process.exitCode.then((_) => Directory(dir).deleteWithRetry()));


### PR DESCRIPTION
this ensures that ff launcher on windows wait for browser instead of creating detached instance and quitting
for more info see ff wiki:
https://wiki.mozilla.org/Platform/Integration/InjectEject/Launcher_Process/#Starting_Firefox_via_Automation_.2F_Scripting

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
