### PR TITLE
config dependabot to send daily PRs for major version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,20 @@ updates:
       interval: "monthly"
     labels:
       - "autosubmit"
+
+  # Check daily for major version dependency updates for packages which depend
+  # on package:analyzer.
+  - package-ecosystem: "pub"
+    directory: "pkgs/test"
+    schedule:
+      interval: "daily"
+    versioning-strategy: increase-if-necessary
+    reviewers:
+      - "natebosch"
+  - package-ecosystem: "pub"
+    directory: "pkgs/test_core"
+    schedule:
+      interval: "daily"
+    versioning-strategy: increase-if-necessary
+    reviewers:
+      - "natebosch"


### PR DESCRIPTION
- config dependabot to send daily PRs for major version bumps

We could choose to expand this to the 2 other packages in this mono-repo, but this at least captures the two packages w/ regular deps on package:analyzer.

@natebosch - this PR also assigns you as the reviewer; happy enough to leave this blank as well (or, switch to using an CODEOWNERS file in this repo to auto-assign PRs, ala https://github.com/dart-lang/tools/blob/main/CODEOWNERS).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
