### PR TITLE
regenerate mono_repo with the latest

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v6.4.2
+# Created with package:mono_repo v6.5.7
 name: Dart CI
 on:
   push:
@@ -36,7 +36,7 @@ jobs:
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - name: mono_repo self validate
-        run: dart pub global activate mono_repo 6.4.2
+        run: dart pub global activate mono_repo 6.5.7
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v6.4.2
+# Created with package:mono_repo v6.5.7
 
 # Support built in commands on windows out of the box.
 # When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")


### PR DESCRIPTION
We recently had some dependabot cls that are failing due ([1](https://github.com/dart-lang/test/pull/2052), [2](https://github.com/dart-lang/test/pull/2051)) to the mono_repo self validate task, which I thought we had fixed. I am hoping that just updating the version of mono_repo that is used will fix that?
