### PR TITLE
Read message href from message source

### DIFF
--- a/pkgs/test/lib/dart.js
+++ b/pkgs/test/lib/dart.js
@@ -12,7 +12,6 @@ window.onload = function() {
 // This mimics a MultiChannel-formatted message.
 var sendLoadException = function(message) {
   window.parent.postMessage({
-    "href": window.location.href,
     "data": [0, {"type": "loadException", "message": message}],
     "exception": true,
   }, window.location.origin);

--- a/pkgs/test/lib/src/runner/browser/dom.dart
+++ b/pkgs/test/lib/src/runner/browser/dom.dart
@@ -135,7 +135,12 @@ extension MessageEventExtension on MessageEvent {
   external String get origin;
   List<MessagePort> get ports =>
       js_util.getProperty<List>(this, 'ports').cast<MessagePort>();
+  external MessageEventSource source;
 }
+
+@JS()
+@staticInterop
+class MessageEventSource {}
 
 @JS()
 @staticInterop

--- a/pkgs/test/lib/src/runner/browser/post_message_channel.dart
+++ b/pkgs/test/lib/src/runner/browser/post_message_channel.dart
@@ -50,10 +50,8 @@ StreamChannel<Object?> postMessageChannel() {
 
   // Send a ready message once we're listening so the host knows it's safe to
   // start sending events.
-  // TODO(nweiz): Stop manually adding href here once issue 22554 is fixed.
   _postParentMessage(
-      jsify({'href': dom.window.location.href, 'ready': true}) as Object,
-      dom.window.location.origin);
+      jsify({'ready': true}) as Object, dom.window.location.origin);
 
   return controller.foreign;
 }

--- a/pkgs/test/lib/src/runner/browser/static/host.dart.js
+++ b/pkgs/test/lib/src/runner/browser/static/host.dart.js
@@ -16954,7 +16954,7 @@
       if (A._asString($event.origin) !== A._asString(t1._as(self.window.location).origin))
         return;
       t2 = _this.iframe;
-      if (!J.$eq$(J.$index$asx(A.dartify($event.data), "href"), A._asStringQ(t2.src)))
+      if (A._asString(t1._as(t1._as($event.source).location).href) !== A._asStringQ(t2.src))
         return;
       $event.stopPropagation();
       if (J.$eq$(J.$index$asx(A.dartify($event.data), "ready"), true)) {

--- a/pkgs/test/tool/host.dart
+++ b/pkgs/test/tool/host.dart
@@ -209,10 +209,7 @@ StreamChannel<dynamic> _connectToIframe(String url, int id) {
     // running, but it's good practice to check the origin anyway.
     var message = event as dom.MessageEvent;
     if (message.origin != dom.window.location.origin) return;
-
-    // TODO(nweiz): Stop manually checking href here once issue 22554 is
-    // fixed.
-    if (message.data['href'] != iframe.src) return;
+    if ((message.source as dom.Window).location.href != iframe.src) return;
 
     message.stopPropagation();
 


### PR DESCRIPTION
The linked issue (https://github.com/dart-lang/sdk/issues/22554) impacts
`dart:html` but does not impact usage through `@JS()` interop.

- Add a `source` field to `MessageEvent`. It is typed as
  `MessageEventSource` which is an empty interface. A source will be
  either a `WindowProxy`, a `MessagePort` or a `ServiceWorker`. For our
  use case it will always be a `WindowProxy`. The proxy has the same API
  as `Window` and static JS interop does not do nominal type checking,
  it is safe to cast it directly to `Window`.
- Stop manually adding the iframe `href` in sent messages.
