### PR TITLE
Remove "compiling" messages

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.24.5-wip
 
+* Change "compiling <path>" to "loading <path>" message in all cases. Surface
+  the "loading" messages in the situations where previously only "compiling"
+  message would be used.
+
 ## 1.24.4
 
 * Drop support for null unsafe Dart, bump SDK constraint to `3.0.0`.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
 
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.6.1
-  test_core: 0.5.4
+  test_core: 0.5.5
 
   typed_data: ^1.3.0
   web_socket_channel: ^2.0.0

--- a/pkgs/test/test/runner/browser/runner_test.dart
+++ b/pkgs/test/test/runner/browser/runner_test.dart
@@ -40,7 +40,7 @@ void main() {
           test.stdout,
           containsInOrder([
             'Error: Compilation failed.',
-            '-1: compiling test.dart [E]',
+            '-1: loading test.dart [E]',
             'Failed to load "test.dart": dart2js failed.'
           ]));
       await test.shouldExit(1);
@@ -53,7 +53,7 @@ void main() {
       expect(
           test.stdout,
           containsInOrder([
-            '-1: compiling test.dart [E]',
+            '-1: loading test.dart [E]',
             'Failed to load "test.dart": oh no'
           ]));
       await test.shouldExit(1);
@@ -66,7 +66,7 @@ void main() {
       expect(
           test.stdout,
           containsInOrder([
-            '-1: compiling test.dart [E]',
+            '-1: loading test.dart [E]',
             'Failed to load "test.dart": No top-level main() function defined.'
           ]));
       await test.shouldExit(1);
@@ -79,7 +79,7 @@ void main() {
       expect(
           test.stdout,
           containsInOrder([
-            '-1: compiling test.dart [E]',
+            '-1: loading test.dart [E]',
             'Failed to load "test.dart": Top-level main getter is not a function.'
           ]));
       await test.shouldExit(1);
@@ -92,7 +92,7 @@ void main() {
       expect(
           test.stdout,
           containsInOrder([
-            '-1: compiling test.dart [E]',
+            '-1: loading test.dart [E]',
             'Failed to load "test.dart": Top-level main() function takes arguments.'
           ]));
       await test.shouldExit(1);
@@ -113,7 +113,7 @@ void main() {
       expect(
           test.stdout,
           containsInOrder([
-            '-1: compiling test.dart [E]',
+            '-1: loading test.dart [E]',
             'Failed to load "test.dart": "test.html" must contain '
                 '<script src="packages/test/dart.js"></script>.'
           ]));
@@ -135,7 +135,7 @@ void main() {
       expect(
           test.stdout,
           containsInOrder([
-            '-1: compiling test.dart [E]',
+            '-1: loading test.dart [E]',
             'Failed to load "test.dart": Expected exactly 1 '
                 '<link rel="x-dart-test"> in test.html, found 0.'
           ]));
@@ -159,7 +159,7 @@ void main() {
       expect(
           test.stdout,
           containsInOrder([
-            '-1: compiling test.dart [E]',
+            '-1: loading test.dart [E]',
             'Failed to load "test.dart": Expected exactly 1 '
                 '<link rel="x-dart-test"> in test.html, found 2.'
           ]));
@@ -182,7 +182,7 @@ void main() {
       expect(
           test.stdout,
           containsInOrder([
-            '-1: compiling test.dart [E]',
+            '-1: loading test.dart [E]',
             'Failed to load "test.dart": Expected <link rel="x-dart-test"> in '
                 'test.html to have an "href" attribute.'
           ]));
@@ -205,7 +205,7 @@ void main() {
       expect(
           test.stdout,
           containsInOrder([
-            '-1: compiling test.dart [E]',
+            '-1: loading test.dart [E]',
             'Failed to load "test.dart": Failed to load script at '
           ]));
       await test.shouldExit(1);
@@ -248,7 +248,7 @@ void main() {
       expect(
           test.stdout,
           containsInOrder([
-            '-1: compiling test.dart [E]',
+            '-1: loading test.dart [E]',
             'Failed to load "test.dart": "test.html" must contain '
                 '<script src="packages/test/dart.js"></script>.'
           ]));
@@ -272,7 +272,7 @@ void main() {
         expect(
             test.stdout,
             containsInOrder([
-              '-1: compiling test.dart [E]',
+              '-1: loading test.dart [E]',
               'Failed to load "test.dart": "html_template.html.tpl" does not exist or is not readable'
             ]));
         await test.shouldExit(1);
@@ -295,7 +295,7 @@ void main() {
         expect(
             test.stdout,
             containsInOrder([
-              '-1: compiling test.dart [E]',
+              '-1: loading test.dart [E]',
               'Failed to load "test.dart": "html_template.html.tpl" must contain exactly one {{testScript}} placeholder'
             ]));
         await test.shouldExit(1);
@@ -320,7 +320,7 @@ void main() {
         expect(
             test.stdout,
             containsInOrder([
-              '-1: compiling test.dart [E]',
+              '-1: loading test.dart [E]',
               'Failed to load "test.dart": "html_template.html.tpl" must contain exactly one {{testScript}} placeholder'
             ]));
         await test.shouldExit(1);
@@ -340,7 +340,7 @@ void main() {
         expect(
             test.stdout,
             containsInOrder([
-              '-1: compiling test.dart [E]',
+              '-1: loading test.dart [E]',
               'Failed to load "test.dart": "html_template.html.tpl" must contain '
                   '<script src="packages/test/dart.js"></script>.'
             ]));
@@ -366,7 +366,7 @@ void main() {
         expect(
             test.stdout,
             containsInOrder([
-              '-1: compiling test.dart [E]',
+              '-1: loading test.dart [E]',
               'Failed to load "test.dart": template file "test.html" cannot be named '
                   'like the test file.'
             ]));

--- a/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
+++ b/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
@@ -76,14 +76,10 @@ void main() {
         test('fails gracefully if a test file throws in main', () async {
           await d.file('test.dart', _throwingTest).create();
           var test = await runTest(testArgs);
-          var compileOrLoadMessage =
-              compiler == Compiler.dart2js ? 'compiling' : 'loading';
-
           expect(
               test.stdout,
               containsInOrder([
-                '-1: [${runtime.name}, ${compiler.name}] $compileOrLoadMessage '
-                    'test.dart [E]',
+                '-1: [${runtime.name}, ${compiler.name}] loading test.dart [E]',
                 'Failed to load "test.dart": oh no'
               ]));
           await test.shouldExit(1);

--- a/pkgs/test/test/runner/expanded_reporter_test.dart
+++ b/pkgs/test/test/runner/expanded_reporter_test.dart
@@ -28,6 +28,7 @@ void main() {
         test('success 1', () {});
         test('success 2', () {});
         test('success 3', () {});''', '''
+        +0: loading test.dart
         +0: success 1
         +1: success 2
         +2: success 3
@@ -39,6 +40,7 @@ void main() {
         test('failure 1', () => throw TestFailure('oh no'));
         test('failure 2', () => throw TestFailure('oh no'));
         test('failure 3', () => throw TestFailure('oh no'));''', '''
+        +0: loading test.dart
         +0: failure 1
         +0 -1: failure 1 [E]
           oh no
@@ -79,6 +81,7 @@ void main() {
         test('success 1', () {});
         test('failure 2', () => throw TestFailure('oh no'));
         test('success 2', () {});''', '''
+        +0: loading test.dart
         +0: failure 1
         +0 -1: failure 1 [E]
           oh no
@@ -100,6 +103,7 @@ void main() {
            'really gosh dang long test name. Even longer than that. No, yet '
                'longer. A little more... okay, that should do it.',
            () {});''', '''
+        +0: loading test.dart
         +0: really gosh dang long test name. Even longer than that. No, yet longer. A little more... okay, that should do it.
         +1: All tests passed!''');
   });
@@ -116,6 +120,7 @@ void main() {
           Future.microtask(completer.complete);
         });
         test('wait', () => completer.future);''', '''
+        +0: loading test.dart
         +0: failures
         +0 -1: failures [E]
           first error
@@ -149,6 +154,7 @@ void main() {
           print("three");
           print("four");
         });''', '''
+        +0: loading test.dart
         +0: test
         one
         two
@@ -177,6 +183,7 @@ void main() {
           waitStarted.complete();
           return testDone.future;
         });''', '''
+        +0: loading test.dart
         +0: test
         +1: wait
         +1: test
@@ -211,6 +218,7 @@ void main() {
         });
 
         test('wait', () => completer.future);''', '''
+        +0: loading test.dart
         +0: test
         one
         two
@@ -239,6 +247,7 @@ void main() {
           test('skip 1', () {}, skip: true);
           test('skip 2', () {}, skip: true);
           test('skip 3', () {}, skip: true);''', '''
+          +0: loading test.dart
           +0: skip 1
           +0 ~1: skip 2
           +0 ~2: skip 3
@@ -252,6 +261,7 @@ void main() {
             test('test 2', () {});
             test('test 3', () {});
           }, skip: true);''', '''
+          +0: loading test.dart
           +0: skip test 1
           +0 ~1: skip test 2
           +0 ~2: skip test 3
@@ -264,6 +274,7 @@ void main() {
           test('success 1', () {});
           test('skip 2', () {}, skip: true);
           test('success 2', () {});''', '''
+          +0: loading test.dart
           +0: skip 1
           +0 ~1: success 1
           +1 ~1: skip 2
@@ -279,6 +290,7 @@ void main() {
           test('failure 2', () => throw TestFailure('oh no'));
           test('skip 2', () {}, skip: true);
           test('success 2', () {});''', '''
+          +0: loading test.dart
           +0: failure 1
           +0 -1: failure 1 [E]
             oh no
@@ -300,6 +312,7 @@ void main() {
       return _expectReport('''
           test('skip 1', () {}, skip: 'some reason');
           test('skip 2', () {}, skip: 'or another');''', '''
+          +0: loading test.dart
           +0: skip 1
             Skip: some reason
           +0 ~1: skip 2
@@ -311,6 +324,7 @@ void main() {
       return _expectReport('''
           test('skip 1', () {}, skip: 'some reason');
           test('skip 2', () {}, skip: 'or another');''', '''
+          +0: loading test.dart
           +0: skip 1
           +1: skip 2
           +2: All tests passed!''', args: ['--run-skipped']);
@@ -320,6 +334,7 @@ void main() {
   test('Directs users to enable stack trace chaining if disabled', () async {
     await _expectReport(
         '''test('failure 1', () => throw TestFailure('oh no'));''', '''
+        +0: loading test.dart
         +0: failure 1
         +0 -1: failure 1 [E]
           oh no

--- a/pkgs/test/test/runner/json_file_reporter_test.dart
+++ b/pkgs/test/test/runner/json_file_reporter_test.dart
@@ -25,6 +25,7 @@ void main() {
       test('success 2', () {});
       test('success 3', () {});
     ''', '''
+      +0: loading test.dart
       +0: success 1
       +1: success 2
       +2: success 3
@@ -52,6 +53,7 @@ void main() {
       test('failure 2', () => throw new TestFailure('oh no'));
       test('failure 3', () => throw new TestFailure('oh no'));
     ''', '''
+      +0: loading test.dart
       +0: failure 1
       +0 -1: failure 1 [E]
         oh no

--- a/pkgs/test/test/runner/json_reporter_test.dart
+++ b/pkgs/test/test/runner/json_reporter_test.dart
@@ -495,7 +495,7 @@ void main() {
           [
             [
               suiteJson(0, platform: 'chrome'),
-              testStartJson(1, 'compiling test.dart', groupIDs: []),
+              testStartJson(1, 'loading test.dart', groupIDs: []),
               printJson(
                   1,
                   isA<String>().having((s) => s.split('\n'), 'lines',
@@ -599,7 +599,7 @@ void customTest(String name, dynamic Function() testFn) => test(name, testFn);
         [
           [
             suiteJson(0, platform: 'chrome'),
-            testStartJson(1, 'compiling test.dart', groupIDs: []),
+            testStartJson(1, 'loading test.dart', groupIDs: []),
             printJson(
                 1,
                 isA<String>().having((s) => s.split('\n'), 'lines',

--- a/pkgs/test/test/runner/node/runner_test.dart
+++ b/pkgs/test/test/runner/node/runner_test.dart
@@ -40,7 +40,7 @@ void main() {
           test.stdout,
           containsInOrder([
             'Error: Compilation failed.',
-            '-1: compiling test.dart [E]',
+            '-1: loading test.dart [E]',
             'Failed to load "test.dart": dart2js failed.'
           ]));
       await test.shouldExit(1);
@@ -53,7 +53,7 @@ void main() {
       expect(
           test.stdout,
           containsInOrder([
-            '-1: compiling test.dart [E]',
+            '-1: loading test.dart [E]',
             'Failed to load "test.dart": oh no'
           ]));
       await test.shouldExit(1);
@@ -66,7 +66,7 @@ void main() {
       expect(
           test.stdout,
           containsInOrder([
-            '-1: compiling test.dart [E]',
+            '-1: loading test.dart [E]',
             'Failed to load "test.dart": No top-level main() function defined.'
           ]));
       await test.shouldExit(1);
@@ -79,7 +79,7 @@ void main() {
       expect(
           test.stdout,
           containsInOrder([
-            '-1: compiling test.dart [E]',
+            '-1: loading test.dart [E]',
             'Failed to load "test.dart": Top-level main getter is not a function.'
           ]));
       await test.shouldExit(1);
@@ -92,7 +92,7 @@ void main() {
       expect(
           test.stdout,
           containsInOrder([
-            '-1: compiling test.dart [E]',
+            '-1: loading test.dart [E]',
             'Failed to load "test.dart": Top-level main() function takes arguments.'
           ]));
       await test.shouldExit(1);

--- a/pkgs/test/test/runner/pub_serve_test.dart
+++ b/pkgs/test/test/runner/pub_serve_test.dart
@@ -132,7 +132,7 @@ void main() {
         expect(
             test.stdout,
             containsInOrder([
-              '-1: compiling ${p.join("test", "my_test.dart")} [E]',
+              '-1: loading ${p.join("test", "my_test.dart")} [E]',
               'Failed to load "${p.join("test", "my_test.dart")}":',
               '404 Not Found',
               'Make sure "pub serve" is serving the test/ directory.'
@@ -153,7 +153,7 @@ void main() {
       expect(
           test.stdout,
           containsInOrder([
-            '-1: compiling ${p.join("test", "my_test.dart")} [E]',
+            '-1: loading ${p.join("test", "my_test.dart")} [E]',
             'Failed to load "${p.join("test", "my_test.dart")}":',
             '404 Not Found',
             'Make sure "pub serve" is serving the test/ directory.'
@@ -294,7 +294,7 @@ void main() {
     expect(
         test.stdout,
         containsInOrder([
-          '-1: compiling ${p.join("test", "my_test.dart")} [E]',
+          '-1: loading ${p.join("test", "my_test.dart")} [E]',
           'Failed to load "${p.join("test", "my_test.dart")}":',
           'Error getting http://localhost:54321/my_test.dart.browser_test.dart.js'
               '.map: $message',
@@ -312,7 +312,7 @@ void main() {
     expect(
         test.stdout,
         containsInOrder([
-          '-1: compiling ${p.join("test", "my_test.dart")} [E]',
+          '-1: loading ${p.join("test", "my_test.dart")} [E]',
           'Failed to load "${p.join("test", "my_test.dart")}":',
           'Error getting http://localhost:54321/my_test.dart.node_test.dart.js:'
               ' $message',

--- a/pkgs/test/test/runner/signal_test.dart
+++ b/pkgs/test/test/runner/signal_test.dart
@@ -49,7 +49,7 @@ void main() {
 
       var test = await _runTest(['-p', 'chrome', 'test.dart']);
       await expectLater(
-          test.stdout, emitsThrough(endsWith('compiling test.dart')));
+          test.stdout, emitsThrough(endsWith('loading test.dart')));
       await signalAndQuit(test);
 
       expectTempDirEmpty(skip: 'Failing on Travis.');

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.5-wip
+
+* Change "compiling <path>" to "loading <path>" message in all cases. Surface
+  the "loading" messages in the situations where previously only "compiling"
+  message would be used.
+
 ## 0.5.4
 
 * Drop support for null unsafe Dart, bump SDK constraint to `3.0.0`.

--- a/pkgs/test_core/lib/src/runner/loader.dart
+++ b/pkgs/test_core/lib/src/runner/loader.dart
@@ -215,12 +215,7 @@ class Loader {
           continue;
         }
 
-        var name =
-            (platform.runtime.isJS && platformConfig.precompiledPath == null
-                    ? 'compiling '
-                    : 'loading ') +
-                path;
-        yield LoadSuite(name, platformConfig, platform, () async {
+        yield LoadSuite('loading $path', platformConfig, platform, () async {
           var memo = _platformPlugins[platform.runtime]!;
 
           var retriesLeft = suiteConfig.metadata.retry;

--- a/pkgs/test_core/lib/src/runner/reporter/expanded.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/expanded.dart
@@ -171,9 +171,9 @@ class ExpandedReporter implements Reporter {
     } else if (_engine.active.isEmpty &&
         _engine.activeSuiteLoads.length == 1 &&
         _engine.activeSuiteLoads.first == liveTest &&
-        liveTest.test.name.startsWith('compiling ')) {
-      // Print a progress line for load tests that come from compiling JS, since
-      // that takes a long time.
+        liveTest.test.name.startsWith('loading ')) {
+      // Print a progress line for ongoing suite loading synthetic test since it
+      // may be slow (or stuck) depending on the platform.
       _progressLine(_description(liveTest));
     }
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.5.4
+version: 0.5.5-wip
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 


### PR DESCRIPTION
All platforms will use the "loading" message. This had been a heuristic
for the dart2js tests because originally it was the standout amongst the
otherwise run-from-source options with the VM and dartium.

The number of platforms has since expanded, and flutter appears as a
dart2js platform that isn't precompiled, because the test runner has a
different way to trigger the precompiled path than `flutter test` which
precompiles always.
