### PR TITLE
More loosely handle error message from SDK

### DIFF
--- a/pkgs/test/test/runner/configuration/top_level_error_test.dart
+++ b/pkgs/test/test/runner/configuration/top_level_error_test.dart
@@ -275,7 +275,7 @@ void main() {
 
       var test = await runTest(['test.dart']);
       expect(test.stderr,
-          containsInOrder(['Invalid name: Unterminated group(foo', '^^^^^^']));
+          containsInOrder(['Invalid name: Unterminated group', '^^^^^^']));
       await test.shouldExit(exit_codes.data);
     });
   });


### PR DESCRIPTION
A recent dev version of the SDK changed the formatting for a regex parse
error that we were depending on in a test - a space was introduced where
it was missing between "group" and the text of the group, "Unterminated
group (foo". The test is using the `contains` matcher for the values in
`containsInOrder`, so we can make the expectation looser to allow either
format.
