### PR TITLE
Rerun publish workflow on more PR changes

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,6 +5,7 @@ name: Publish
 on:
   pull_request:
     branches: [ master ]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+*' ]
 


### PR DESCRIPTION
This is particularly important for the `labeled` type, otherwise adding
the `publish-ignore-warnings` will not get picked up until another
commit is pushed to the branch.
