### PR TITLE
publish test_core v0.5.6

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.6-wip
+## 0.5.6
 
 * Add support for discontinuing after the first failing test with `--fail-fast`.
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.5.6-wip
+version: 0.5.6
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 


### PR DESCRIPTION
I published `test` without realizing I also needed to publish test_core 😱 