### PR TITLE
Remove always null observatoryUrl for browsers

### DIFF
--- a/pkgs/test/lib/src/runner/browser/browser.dart
+++ b/pkgs/test/lib/src/runner/browser/browser.dart
@@ -21,12 +21,6 @@ import 'package:typed_data/typed_data.dart';
 abstract class Browser {
   String get name;
 
-  /// The Observatory URL for this browser.
-  ///
-  /// This will complete to `null` for browsers that aren't running the Dart VM,
-  /// or if the Observatory URL can't be found.
-  Future<Uri?> get observatoryUrl async => null;
-
   /// The remote debugger URL for this browser.
   ///
   /// This will  complete to `null` for browsers that don't support remote

--- a/pkgs/test/lib/src/runner/browser/browser_manager.dart
+++ b/pkgs/test/lib/src/runner/browser/browser_manager.dart
@@ -201,10 +201,9 @@ class BrowserManager {
   }
 
   /// Loads [_BrowserEnvironment].
-  Future<_BrowserEnvironment> _loadBrowserEnvironment() async {
-    return _BrowserEnvironment(this, await _browser.observatoryUrl,
-        await _browser.remoteDebuggerUrl, _onRestartController.stream);
-  }
+  Future<_BrowserEnvironment> _loadBrowserEnvironment() async =>
+      _BrowserEnvironment(
+          this, await _browser.remoteDebuggerUrl, _onRestartController.stream);
 
   /// Tells the browser the load a test suite from the URL [url].
   ///
@@ -339,7 +338,7 @@ class _BrowserEnvironment implements Environment {
   final supportsDebugging = true;
 
   @override
-  final Uri? observatoryUrl;
+  Null get observatoryUrl => null;
 
   @override
   final Uri? remoteDebuggerUrl;
@@ -347,8 +346,7 @@ class _BrowserEnvironment implements Environment {
   @override
   final Stream<void> onRestart;
 
-  _BrowserEnvironment(this._manager, this.observatoryUrl,
-      this.remoteDebuggerUrl, this.onRestart);
+  _BrowserEnvironment(this._manager, this.remoteDebuggerUrl, this.onRestart);
 
   @override
   CancelableOperation<void> displayPause() => _manager._displayPause();


### PR DESCRIPTION
There are no browsers which override `observatoryUrl` to return
non-null. Remove the field entirely and override the field in the
browser `Environment` with a getter that always returns null.
