### PR TITLE
Fix improperly rendered changelog entry

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -11,9 +11,9 @@
 
 ## 1.24.5
 
-* Change "compiling <path>" to "loading <path>" message in all cases. Surface
-  the "loading" messages in the situations where previously only "compiling"
-  message would be used.
+* Change `compiling <path>` to `loading <path>` message in all cases. Surface
+  the "loading" messages in the situations where previously only the
+  "compiling" message would be used.
 * Support browser tests where the frame creates the message channel.
 
 ## 1.24.4
@@ -38,7 +38,7 @@
 * Copy an existing nonce from a script on the test HTML page to the script
   created by the test runner host javascript. This only impacts environments
   testing with custom HTML that includes a nonce.
-* Support the Microsoft Edge browser (use the `edge` platform in your the test
+* Support the Microsoft Edge browser (use the `edge` platform in your test
   configuration file or `-p edge` on the command line).
 
 ## 1.24.1


### PR DESCRIPTION
Due to the `<`, these entries were cut off on pub.dev, potentially causing confusion. This PR switches the messages to code syntax so they are legible in both raw and rendered form.


**Original rendered output (from https://pub.dev/packages/test/changelog#1245):**
<img width="500" alt="image" src="https://github.com/dart-lang/test/assets/18372958/4e1ac29e-8708-440a-bc6a-a92e5353f468">
 
