### PR TITLE
Add an ignore for an SDK deprecation

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.5.7-wip
+
 ## 0.5.6
 
 * Add support for discontinuing after the first failing test with `--fail-fast`.

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -118,8 +118,7 @@ class VMPlatform extends PlatformPlugin {
       }
       var info =
           await Service.controlWebServer(enable: true, silenceOutput: true);
-      // ignore: deprecated_member_use, Remove when SDK constraint can be bumped
-      // to 3.2.0
+      // ignore: deprecated_member_use, Remove when SDK constraint is at 3.2.0
       var isolateID = Service.getIsolateID(isolate!)!;
 
       var libraryPath = _absolute(path).toString();

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -118,6 +118,8 @@ class VMPlatform extends PlatformPlugin {
       }
       var info =
           await Service.controlWebServer(enable: true, silenceOutput: true);
+      // ignore: deprecated_member_use, Remove when SDK constraint can be bumped
+      // to 3.2.0
       var isolateID = Service.getIsolateID(isolate!)!;
 
       var libraryPath = _absolute(path).toString();

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.5.6
+version: 0.5.7-wip
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 


### PR DESCRIPTION
We cannot move to the new API until the minimum SDK can be safely
bumped.
