### PR TITLE
Add some console logging to browser test startup

### DIFF
--- a/pkgs/test/lib/src/runner/browser/dom.dart
+++ b/pkgs/test/lib/src/runner/browser/dom.dart
@@ -14,6 +14,7 @@ extension WindowExtension on Window {
   @pragma('dart2js:as:trust')
   Window get parent => js_util.getProperty<dynamic>(this, 'parent') as Window;
   external Location get location;
+  Console get console => js_util.getProperty(this, 'console') as Console;
   CSSStyleDeclaration? getComputedStyle(Element elt, [String? pseudoElt]) =>
       js_util.callMethod(this, 'getComputedStyle', <Object>[
         elt,
@@ -31,6 +32,15 @@ extension WindowExtension on Window {
 
 @JS('window')
 external Window get window;
+
+@JS()
+@staticInterop
+class Console {}
+
+extension ConsoleExtension on Console {
+  external void log(Object? object);
+  external void warn(Object? object);
+}
 
 @JS()
 @staticInterop

--- a/pkgs/test/lib/src/runner/browser/post_message_channel.dart
+++ b/pkgs/test/lib/src/runner/browser/post_message_channel.dart
@@ -13,6 +13,7 @@ import 'dom.dart' as dom;
 ///
 /// Sends a [MessagePort] to the host page for the channel.
 StreamChannel<Object?> postMessageChannel() {
+  dom.window.console.log('Suite starting, sending channel to host');
   var controller = StreamChannelController<Object?>(sync: true);
   var channel = dom.createMessageChannel();
   dom.window.parent


### PR DESCRIPTION
Add support for console log and warn level in the dom library.
Switch an existing `print` to a `console.warn` for an error. Use
`console.log` consistently otherwise. This is less important in the host
(where a `print` will anyways log to the console) than it is in the
remote listener (where a `print` could be intercepted and forwarded to
the test runner).

Refactor an `if`/`else` chain over a map field to a `switch` with
destructuring for all the patterns that can be handled. Add a default
case with a console warning instead of silently treating potentially
non-matching commands as `'closeSuite'`. This also changes some
potential cast failures into falling through to the warning case which
should be easier to debug.

Add a message from the frame when it is connecting back to the host.
