### PR TITLE
Extend the timeout for runtime_matrix_test

### DIFF
--- a/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
+++ b/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
+@Timeout.factor(2)
 library;
 
 import 'dart:io';


### PR DESCRIPTION
This test invokes the test runner in each case, and when the outer test
timeout is faster than a timeout within the sub-process it prevents us
from getting potentially useful output. Double the outer timeout so that
any timeouts from the sub-process runner have a better chance at firing
and emitting output before the test is killed.
