### PR TITLE
Support deferred loading in browser tests

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Simplify the initialization of the per-suite message channel within browser
   tests. See https://github.com/dart-lang/test/issues/2065
 * Add a timeout to browser test suite loads.
+* Support deferred loaded libraries in browser tests.
 
 ## 1.24.6
 

--- a/pkgs/test/lib/src/runner/browser/platform.dart
+++ b/pkgs/test/lib/src/runner/browser/platform.dart
@@ -398,14 +398,13 @@ class BrowserPlatform extends PlatformPlugin
 
         // Set up the stack trace mapper for source maps, unless JS stack
         // traces are enabled.
-        if (!suiteConfig.jsTrace && outputPath.endsWith('.js.map')) {
-          final relativePath = p.relative(outputPath, from: dir);
-          _mappers[relativePath.substring(
-                  0, relativePath.length - '.js.map'.length)] =
-              JSStackTraceMapper(File(outputPath).readAsStringSync(),
-                  mapUrl: p.toUri(outputPath),
-                  sdkRoot: Uri.parse('org-dartlang-sdk:///sdk'),
-                  packageMap: (await currentPackageConfig).toPackageMap());
+        if (!suiteConfig.jsTrace && outputPath.endsWith('$dartPath.js.map')) {
+          // TODO: What about deferred loaded libraries? Do we need multiple mappers?
+          _mappers[dartPath] = JSStackTraceMapper(
+              File(outputPath).readAsStringSync(),
+              mapUrl: p.toUri(outputPath),
+              sdkRoot: Uri.parse('org-dartlang-sdk:///sdk'),
+              packageMap: (await currentPackageConfig).toPackageMap());
         }
       }
     });

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
 
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.6.1
-  test_core: 0.5.6
+  test_core: 0.5.7
 
   typed_data: ^1.3.0
   web_socket_channel: ^2.0.0

--- a/pkgs/test/test/runner/browser/runner_test.dart
+++ b/pkgs/test/test/runner/browser/runner_test.dart
@@ -591,6 +591,28 @@ void main() {
         await test.shouldExit(0);
       }, tags: 'chrome');
     });
+
+    test('with deferred libraries', () async {
+      await d.file('deferred.dart', '''
+int x = 1;
+''').create();
+      await d.file('test.dart', '''
+import 'package:test/test.dart';
+
+import 'deferred.dart' deferred as d;
+
+void main() {
+  test("success", () async {
+    await d.loadLibrary();
+    expect(d.x, 1);
+  });
+}
+''').create();
+      var test = await runTest(['-p', 'chrome', 'test.dart']);
+
+      expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
+      await test.shouldExit(0);
+    }, tags: 'chrome');
   });
 
   group('runs failing tests', () {

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 0.5.7-wip
 
+* Update the CompilerPool to be generic, so that custom compiler pools can
+  return their own data for each compile step.
+* Update `withTempDir` to be generic so that you can get return values out of
+  the provided callback.
+
+
 ## 0.5.6
 
 * Add support for discontinuing after the first failing test with `--fail-fast`.

--- a/pkgs/test_core/lib/src/runner/compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/compiler_pool.dart
@@ -14,7 +14,7 @@ import 'suite.dart';
 /// A pool of compiler instances.
 ///
 /// This limits the number of compiler instances running concurrently.
-abstract class CompilerPool {
+abstract class CompilerPool<T> {
   /// The test runner configuration.
   final config = Configuration.current;
 
@@ -33,7 +33,7 @@ abstract class CompilerPool {
   /// Compiles [code] to [path] using [_pool] and [compileInternal].
   ///
   /// Should not be overridden.
-  Future<void> compile(
+  Future<T?> compile(
           String code, String path, SuiteConfiguration suiteConfig) =>
       _pool.withResource(() {
         if (closed) return null;
@@ -43,7 +43,7 @@ abstract class CompilerPool {
   /// The actual function a given compiler pool should implement to compile a
   /// suite.
   @protected
-  Future<void> compileInternal(
+  Future<T?> compileInternal(
       String code, String path, SuiteConfiguration suiteConfig);
 
   /// Shuts down the compiler pool, invoking `closeInternal` exactly once.

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -109,7 +109,7 @@ String createTempDir() =>
 ///
 /// Returns a future that completes to the value that the future returned from
 /// [fn] completes to.
-Future withTempDir(Future Function(String) fn) {
+Future<T> withTempDir<T>(Future<T> Function(String) fn) {
   return Future.sync(() {
     var tempDir = createTempDir();
     return Future.sync(() => fn(tempDir))


### PR DESCRIPTION
Fixes https://github.com/dart-lang/test/issues/2088.

- Updates the CompilerPool to be generic so that compilers can return custom values from each compile.
- Updates the Dart2JsCompilerPool to return a list of absolute file paths for the compiled files.
- Updates the browser platform to serve all compiled files instead of hard-coding the expected ones.
- Add a test