### PR TITLE
Fix running browser tests that use deferred loading

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Simplify the initialization of the per-suite message channel within browser
   tests. See https://github.com/dart-lang/test/issues/2065
 * Add a timeout to browser test suite loads.
+* Fix running of browser tests that use deferred loaded libraries.
 
 ## 1.24.6
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
 
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.6.1
-  test_core: 0.5.6
+  test_core: 0.5.7
 
   typed_data: ^1.3.0
   web_socket_channel: ^2.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.5.7-wip
 
+* Pass --disable-program-split to dart2js to fix tests which use deferred
+  loading.
+
 ## 0.5.6
 
 * Add support for discontinuing after the first failing test with `--fail-fast`.

--- a/pkgs/test_core/lib/src/runner/dart2js_compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/dart2js_compiler_pool.dart
@@ -53,6 +53,7 @@ class Dart2JsCompilerPool extends CompilerPool {
         wrapperPath,
         '--out=$path',
         '--packages=${await packageConfigUri}',
+        '--disable-program-split',
         ..._extraArgs,
         ...suiteConfig.dart2jsArgs
       ];


### PR DESCRIPTION
Fixes https://github.com/dart-lang/test/issues/2088

Pass `--disable-program-split` so that no splitting actually happens.

I [first tried fixing this](https://github.com/dart-lang/test/pull/2089) more "properly" by serving all the output files but this was a lot more complex and supporting stack trace mapping in particular was looking very challenging.