### PR TITLE
Drop a TODO about running browser after compile

### DIFF
--- a/pkgs/test/lib/src/runner/browser/platform.dart
+++ b/pkgs/test/lib/src/runner/browser/platform.dart
@@ -274,7 +274,6 @@ class BrowserPlatform extends PlatformPlugin
 
     if (_closed) return null;
 
-    // TODO(nweiz): Don't start the browser until all the suites are compiled.
     var browserManager = await _browserManagerFor(browser);
     if (_closed || browserManager == null) return null;
 


### PR DESCRIPTION
Starting the browser and running the first suite shouldn't be delayed by
compilation of all other suites. We may want to increase parallelization
of compiles at some point. I do not expect to make the change suggested
in the TODO.
