### PR TITLE
Add types to Browser implementation url arguments

### DIFF
--- a/pkgs/test/lib/src/runner/browser/firefox.dart
+++ b/pkgs/test/lib/src/runner/browser/firefox.dart
@@ -30,13 +30,14 @@ class Firefox extends Browser {
   @override
   final name = 'Firefox';
 
-  Firefox(url, {ExecutableSettings? settings})
+  Firefox(Uri url, {ExecutableSettings? settings})
       : super(() =>
             _startBrowser(url, settings ?? defaultSettings[Runtime.firefox]!));
 
   /// Starts a new instance of Firefox open to the given [url], which may be a
   /// [Uri] or a [String].
-  static Future<Process> _startBrowser(url, ExecutableSettings settings) async {
+  static Future<Process> _startBrowser(
+      Uri url, ExecutableSettings settings) async {
     var dir = createTempDir();
     File(p.join(dir, 'prefs.js')).writeAsStringSync(_preferences);
 

--- a/pkgs/test/lib/src/runner/browser/internet_explorer.dart
+++ b/pkgs/test/lib/src/runner/browser/internet_explorer.dart
@@ -18,13 +18,13 @@ class InternetExplorer extends Browser {
   @override
   final name = 'Internet Explorer';
 
-  InternetExplorer(url, {ExecutableSettings? settings})
+  InternetExplorer(Uri url, {ExecutableSettings? settings})
       : super(() => _startBrowser(
             url, settings ?? defaultSettings[Runtime.internetExplorer]!));
 
   /// Starts a new instance of Internet Explorer open to the given [url], which
   /// may be a [Uri] or a [String].
-  static Future<Process> _startBrowser(url, ExecutableSettings settings) {
+  static Future<Process> _startBrowser(Uri url, ExecutableSettings settings) {
     return Process.start(settings.executable, [
       '-extoff',
       '$url',

--- a/pkgs/test/lib/src/runner/browser/safari.dart
+++ b/pkgs/test/lib/src/runner/browser/safari.dart
@@ -27,7 +27,8 @@ class Safari extends Browser {
 
   /// Starts a new instance of Safari open to the given [url], which may be a
   /// [Uri] or a [String].
-  static Future<Process> _startBrowser(Uri url, ExecutableSettings settings) async {
+  static Future<Process> _startBrowser(
+      Uri url, ExecutableSettings settings) async {
     var dir = createTempDir();
 
     // Safari will only open files (not general URLs) via the command-line

--- a/pkgs/test/lib/src/runner/browser/safari.dart
+++ b/pkgs/test/lib/src/runner/browser/safari.dart
@@ -21,13 +21,13 @@ class Safari extends Browser {
   @override
   final name = 'Safari';
 
-  Safari(url, {ExecutableSettings? settings})
+  Safari(Uri url, {ExecutableSettings? settings})
       : super(() =>
             _startBrowser(url, settings ?? defaultSettings[Runtime.safari]!));
 
   /// Starts a new instance of Safari open to the given [url], which may be a
   /// [Uri] or a [String].
-  static Future<Process> _startBrowser(url, ExecutableSettings settings) async {
+  static Future<Process> _startBrowser(Uri url, ExecutableSettings settings) async {
     var dir = createTempDir();
 
     // Safari will only open files (not general URLs) via the command-line

--- a/pkgs/test/test/runner/browser/chrome_test.dart
+++ b/pkgs/test/test/runner/browser/chrome_test.dart
@@ -45,7 +45,7 @@ webSocket.addEventListener("open", function() {
   });
 
   test('reports an error in onExit', () {
-    var chrome = Chrome(Uri.parse('http://dart-lang.org'), configuration(),
+    var chrome = Chrome(Uri.https('dart.dev'), configuration(),
         settings: ExecutableSettings(
             linuxExecutable: '_does_not_exist',
             macOSExecutable: '_does_not_exist',

--- a/pkgs/test/test/runner/browser/firefox_test.dart
+++ b/pkgs/test/test/runner/browser/firefox_test.dart
@@ -42,7 +42,7 @@ webSocket.addEventListener("open", function() {
   });
 
   test('reports an error in onExit', () {
-    var firefox = Firefox('http://dart-lang.org',
+    var firefox = Firefox(Uri.https('dart.dev'),
         settings: ExecutableSettings(
             linuxExecutable: '_does_not_exist',
             macOSExecutable: '_does_not_exist',

--- a/pkgs/test/test/runner/browser/internet_explorer_test.dart
+++ b/pkgs/test/test/runner/browser/internet_explorer_test.dart
@@ -43,7 +43,7 @@ webSocket.addEventListener("open", function() {
   });
 
   test('reports an error in onExit', () {
-    var ie = InternetExplorer('http://dart-lang.org',
+    var ie = InternetExplorer(Uri.https('dart.dev'),
         settings: ExecutableSettings(
             linuxExecutable: '_does_not_exist',
             macOSExecutable: '_does_not_exist',

--- a/pkgs/test/test/runner/browser/safari_test.dart
+++ b/pkgs/test/test/runner/browser/safari_test.dart
@@ -43,7 +43,7 @@ webSocket.addEventListener("open", function() {
   });
 
   test('reports an error in onExit', () {
-    var safari = Safari('http://dart-lang.org',
+    var safari = Safari(Uri.https('dart.dev'),
         settings: ExecutableSettings(
             linuxExecutable: '_does_not_exist',
             macOSExecutable: '_does_not_exist',


### PR DESCRIPTION
Towards #2095

Restrict to Uri arguments instead of the looser `dynamic` which in
practice allowed Strings (which were correctly formatted) or Uri
instances. Take Uri so the format is enforced and the `.toString()` can
be trusted.

Update (unused in practice) test args from dart-lang.org to dart.dev
