### PR TITLE
Tighten types in test utils

### DIFF
--- a/pkgs/test/test/utils.dart
+++ b/pkgs/test/test/utils.dart
@@ -41,7 +41,7 @@ State? lastState;
 ///
 /// The most recent emitted state is stored in [_lastState].
 void expectStates(LiveTest liveTest, Iterable<State> statesIter) {
-  var states = Queue.from(statesIter);
+  var states = Queue.of(statesIter);
   liveTest.onStateChange.listen(expectAsync1((state) {
     lastState = state;
     expect(state, equals(states.removeFirst()));
@@ -50,8 +50,9 @@ void expectStates(LiveTest liveTest, Iterable<State> statesIter) {
 
 /// Asserts that errors will be emitted via [liveTest.onError] that match
 /// [validators], in order.
-void expectErrors(LiveTest liveTest, Iterable<Function> validatorsIter) {
-  var validators = Queue.from(validatorsIter);
+void expectErrors(
+    LiveTest liveTest, Iterable<void Function(Object)> validatorsIter) {
+  var validators = Queue.of(validatorsIter);
   liveTest.onError.listen(expectAsync1((error) {
     validators.removeFirst()(error.error);
   }, count: validators.length, max: validators.length));

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.6.2-wip
+
 ## 0.6.1
 
 * Drop support for null unsafe Dart, bump SDK constraint to `3.0.0`.

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.6.1
+version: 0.6.2-wip
 description: >-
   The user facing API for structuring Dart tests and checking expectations.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_api

--- a/pkgs/test_api/test/utils.dart
+++ b/pkgs/test_api/test/utils.dart
@@ -27,7 +27,7 @@ State? lastState;
 ///
 /// The most recent emitted state is stored in [_lastState].
 void expectStates(LiveTest liveTest, Iterable<State> statesIter) {
-  var states = Queue.from(statesIter);
+  var states = Queue.of(statesIter);
   liveTest.onStateChange.listen(expectAsync1((state) {
     lastState = state;
     expect(state, equals(states.removeFirst()));
@@ -36,8 +36,9 @@ void expectStates(LiveTest liveTest, Iterable<State> statesIter) {
 
 /// Asserts that errors will be emitted via [liveTest.onError] that match
 /// [validators], in order.
-void expectErrors(LiveTest liveTest, Iterable<Function> validatorsIter) {
-  var validators = Queue.from(validatorsIter);
+void expectErrors(
+    LiveTest liveTest, Iterable<void Function(Object)> validatorsIter) {
+  var validators = Queue.of(validatorsIter);
   liveTest.onError.listen(expectAsync1((error) {
     validators.removeFirst()(error.error);
   }, count: validators.length, max: validators.length));


### PR DESCRIPTION
Towards #2095

Use `Queue.of` to infer the collection type from the argument instead of
`Queue.from` which ignores the argument type.

Expand a bare `Function` to a full signature function type.
