### PR TITLE
Filter test by line when kernel is compiled with --filesystem-scheme.

### DIFF
--- a/pkgs/test_core/lib/src/runner.dart
+++ b/pkgs/test_core/lib/src/runner.dart
@@ -323,8 +323,24 @@ class Runner {
             var absoluteSuitePath = File(path).absolute.uri.toFilePath();
 
             bool matchLineAndCol(Frame frame) {
-              if (frame.uri.scheme != 'file' ||
-                  frame.uri.toFilePath() != absoluteSuitePath) {
+              if (frame.uri.scheme != 'file') {
+                // In this case, this is either a package: URI, or the kernel is
+                // compiled using --filesystem-scheme.
+
+                if (frame.uri.scheme == 'package') {
+                  // It is unlikely that the test case is specified in a
+                  // package: URI. Ignore this case.
+                  return false;
+                }
+
+                // Now we can assume that the kernel is compiled using
+                // --filesystem-scheme.
+                // In this case, because we don't know the --filesystem-root, as
+                // long as the file path matches we assume it is the same file.
+                if (!absoluteSuitePath.endsWith(frame.uri.path)) {
+                  return false;
+                }
+              } else if (frame.uri.toFilePath() != absoluteSuitePath) {
                 return false;
               }
               if (line != null && frame.line != line) {

--- a/pkgs/test_core/lib/src/runner.dart
+++ b/pkgs/test_core/lib/src/runner.dart
@@ -323,25 +323,23 @@ class Runner {
             var absoluteSuitePath = File(path).absolute.uri.toFilePath();
 
             bool matchLineAndCol(Frame frame) {
-              if (frame.uri.scheme != 'file') {
-                // In this case, this is either a package: URI, or the kernel is
-                // compiled using --filesystem-scheme.
-
-                if (frame.uri.scheme == 'package') {
+              switch (frame.uri.scheme) {
+                case 'file':
+                  if (frame.uri.toFilePath() != absoluteSuitePath) {
+                    return false;
+                  }
+                case 'package':
                   // It is unlikely that the test case is specified in a
                   // package: URI. Ignore this case.
                   return false;
-                }
-
-                // Now we can assume that the kernel is compiled using
-                // --filesystem-scheme.
-                // In this case, because we don't know the --filesystem-root, as
-                // long as the file path matches we assume it is the same file.
-                if (!absoluteSuitePath.endsWith(frame.uri.path)) {
-                  return false;
-                }
-              } else if (frame.uri.toFilePath() != absoluteSuitePath) {
-                return false;
+                default:
+                  // Now we can assume that the kernel is compiled using
+                  // --filesystem-scheme.
+                  // In this case, because we don't know the --filesystem-root, as
+                  // long as the file path matches we assume it is the same file.
+                  if (!absoluteSuitePath.endsWith(frame.uri.path)) {
+                    return false;
+                  }
               }
               if (line != null && frame.line != line) {
                 return false;


### PR DESCRIPTION
Filtering by line number is hardcoded to assume that test cases are specified in `file://` uri. If the kernel is compiled with `--filesystem-scheme`, filtering by line did not work.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
