### PR TITLE
Update package:vm_service to 12.0.0

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add a 'silent' reporter option. Keep it hidden in the CLI args help since it
   is not useful in the general case, but can be useful for tests of the test
   runner.
+* Update to `package:vm_service` `12.0.0`
 
 ## 0.5.6
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,4 +1,4 @@
-name: test_core
+name: test_core 
 version: 0.5.7-wip
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   stream_channel: ^2.1.0
   # Use an exact version until the test_api package is stable.
   test_api: 0.6.1
-  vm_service: ">=6.0.0 <12.0.0"
+  vm_service: ">=6.0.0 <13.0.0"
   yaml: ^3.0.0
 
 dev_dependencies:

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,4 +1,4 @@
-name: test_core 
+name: test_core
 version: 0.5.7-wip
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core


### PR DESCRIPTION
This will require a release to unblock rolling this new version of vm_service through to Flutter.