### PR TITLE
Make compiler optional in calls to currentPlatform

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 1.24.8-wip
+## 1.24.8
+
+* Support version `0.5.8` of `package:test_core`.
 
 ## 1.24.7
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.24.8-wip
+version: 1.24.8
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test
@@ -35,7 +35,7 @@ dependencies:
 
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.6.1
-  test_core: 0.5.7
+  test_core: 0.5.8
 
   typed_data: ^1.3.0
   web_socket_channel: ^2.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.8
+
+* Allow omitting the `Compiler` argument to `currentPlatform`.
+
 ## 0.5.7
 
 * Pass --disable-program-split to dart2js to fix tests which use deferred

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -48,7 +48,7 @@ final currentOS = OperatingSystem.findByIoName(Platform.operatingSystem);
 /// [inGoogle] determined automatically.
 ///
 /// If [runtime] is a browser, this will set [os] to [OperatingSystem.none].
-SuitePlatform currentPlatform(Runtime runtime, Compiler? compiler) =>
+SuitePlatform currentPlatform(Runtime runtime, [Compiler? compiler]) =>
     SuitePlatform(runtime,
         compiler: compiler,
         os: runtime.isBrowser ? OperatingSystem.none : currentOS,

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -48,6 +48,7 @@ final currentOS = OperatingSystem.findByIoName(Platform.operatingSystem);
 /// [inGoogle] determined automatically.
 ///
 /// If [runtime] is a browser, this will set [os] to [OperatingSystem.none].
+// TODO: https://github.com/dart-lang/test/issues/2119 - require compiler
 SuitePlatform currentPlatform(Runtime runtime, [Compiler? compiler]) =>
     SuitePlatform(runtime,
         compiler: compiler,

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.5.7
+version: 0.5.8
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 


### PR DESCRIPTION
Allow backwards compatibility with current callers. This might make it
easier to land https://github.com/flutter/engine/pull/46592
