### PR TITLE
Remove unused href field from error report

### DIFF
--- a/pkgs/test/lib/dart.js
+++ b/pkgs/test/lib/dart.js
@@ -12,8 +12,6 @@ window.onload = function() {
 // This mimics a MultiChannel-formatted message.
 var sendLoadException = function(message) {
   window.parent.postMessage({
-    // TODO: https://github.com/dart-lang/test/issues/2065 -  remove href
-    "href": window.location.href,
     "data": [0, {"type": "loadException", "message": message}],
     "exception": true,
   }, window.location.origin);


### PR DESCRIPTION
Originally the href was added manually to the data to work around a
`dart:html` limitation. A different workaround for the host side was
implemented in #2066, but the frame side was not changed in the same
commit to allow some cross-compatibility. Remove the final manual href
field now that no host implementations would read it.
