### PR TITLE
Prepare for the latest dart_flutter_team_lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -11,6 +11,7 @@ analyzer:
     # Ignoring a number of lints from dart_flutter_team_lints – for now
     avoid_catching_errors: ignore
     avoid_dynamic_calls: ignore
+    comment_references: ignore
     lines_longer_than_80_chars: ignore
     only_throw_errors: ignore
     unawaited_futures: ignore

--- a/pkgs/test/lib/src/runner/browser/browser.dart
+++ b/pkgs/test/lib/src/runner/browser/browser.dart
@@ -87,7 +87,7 @@ abstract class Browser {
       // resolve the ambiguity is to wait a brief amount of time and see if this
       // browser is actually closed.
       if (!_closed && exitCode < 0) {
-        await Future.delayed(Duration(milliseconds: 200));
+        await Future<void>.delayed(const Duration(milliseconds: 200));
       }
 
       if (!_closed && exitCode != 0) {

--- a/pkgs/test/lib/src/runner/browser/browser_manager.dart
+++ b/pkgs/test/lib/src/runner/browser/browser_manager.dart
@@ -138,7 +138,7 @@ class BrowserManager {
       completer.completeError(error, stackTrace);
     });
 
-    return completer.future.timeout(Duration(seconds: 30), onTimeout: () {
+    return completer.future.timeout(const Duration(seconds: 30), onTimeout: () {
       browser.close();
       if (attempt >= _maxRetries) {
         throw ApplicationException(
@@ -174,7 +174,7 @@ class BrowserManager {
     //
     // Start this canceled because we don't want it to start ticking until we
     // get some response from the iframe.
-    _timer = RestartableTimer(Duration(seconds: 3), () {
+    _timer = RestartableTimer(const Duration(seconds: 3), () {
       for (var controller in _controllers) {
         controller.setDebugging(true);
       }
@@ -335,7 +335,7 @@ class BrowserManager {
         _controllers.clear();
         return _browser.close();
       });
-  final _closeMemoizer = AsyncMemoizer();
+  final _closeMemoizer = AsyncMemoizer<void>();
 }
 
 /// An implementation of [Environment] for the browser.

--- a/pkgs/test/lib/src/runner/browser/chrome.dart
+++ b/pkgs/test/lib/src/runner/browser/chrome.dart
@@ -97,9 +97,8 @@ class Chrome extends Browser {
     return coverage;
   }
 
-  Chrome._(Future<Process> Function() startBrowser, this.remoteDebuggerUrl,
-      this._tabConnection, this._idToUrl)
-      : super(startBrowser);
+  Chrome._(super.startBrowser, this.remoteDebuggerUrl,
+      this._tabConnection, this._idToUrl);
 
   Future<Uri?> _sourceUriProvider(String sourceUrl, String scriptId) async {
     var script = _idToUrl[scriptId];
@@ -136,7 +135,7 @@ Future<WipConnection> _connect(
   // Wait for Chrome to be in a ready state.
   await process.stderr
       .transform(utf8.decoder)
-      .transform(LineSplitter())
+      .transform(const LineSplitter())
       .firstWhere((line) => line.startsWith('DevTools listening'));
 
   var chromeConnection = ChromeConnection('localhost', port);
@@ -147,7 +146,7 @@ Future<WipConnection> _connect(
     var tabs = await chromeConnection.getTabs();
     tab = tabs.firstWhereOrNull((tab) => tab.url == url.toString());
     if (tab == null) {
-      await Future.delayed(Duration(milliseconds: 100));
+      await Future<void>.delayed(const Duration(milliseconds: 100));
       if (attempt > 5) {
         throw StateError('Could not connect to test tab with url: $url');
       }

--- a/pkgs/test/lib/src/runner/browser/chrome.dart
+++ b/pkgs/test/lib/src/runner/browser/chrome.dart
@@ -97,8 +97,8 @@ class Chrome extends Browser {
     return coverage;
   }
 
-  Chrome._(super.startBrowser, this.remoteDebuggerUrl,
-      this._tabConnection, this._idToUrl);
+  Chrome._(super.startBrowser, this.remoteDebuggerUrl, this._tabConnection,
+      this._idToUrl);
 
   Future<Uri?> _sourceUriProvider(String sourceUrl, String scriptId) async {
     var script = _idToUrl[scriptId];

--- a/pkgs/test/lib/src/runner/browser/chromium.dart
+++ b/pkgs/test/lib/src/runner/browser/chromium.dart
@@ -5,12 +5,12 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:test/src/runner/browser/default_settings.dart';
 import 'package:test_api/src/backend/runtime.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/configuration.dart'; // ignore: implementation_imports
 import 'package:test_core/src/util/io.dart'; // ignore: implementation_imports
 
 import '../executable_settings.dart';
+import 'default_settings.dart';
 
 enum ChromiumBasedBrowser {
   chrome(Runtime.chrome),

--- a/pkgs/test/lib/src/runner/browser/dom.dart
+++ b/pkgs/test/lib/src/runner/browser/dom.dart
@@ -114,7 +114,7 @@ extension EventTargetExtension on EventTarget {
   void addEventListener(String type, EventListener? listener,
       [bool? useCapture]) {
     if (listener != null) {
-      js_util.callMethod(this, 'addEventListener',
+      js_util.callMethod<void>(this, 'addEventListener',
           <Object>[type, listener, if (useCapture != null) useCapture]);
     }
   }
@@ -122,7 +122,7 @@ extension EventTargetExtension on EventTarget {
   void removeEventListener(String type, EventListener? listener,
       [bool? useCapture]) {
     if (listener != null) {
-      js_util.callMethod(this, 'removeEventListener',
+      js_util.callMethod<void>(this, 'removeEventListener',
           <Object>[type, listener, if (useCapture != null) useCapture]);
     }
   }

--- a/pkgs/test/lib/src/runner/browser/platform.dart
+++ b/pkgs/test/lib/src/runner/browser/platform.dart
@@ -151,7 +151,7 @@ class BrowserPlatform extends PlatformPlugin
           .add(_wrapperHandler);
     }
 
-    var pipeline = shelf.Pipeline()
+    var pipeline = const shelf.Pipeline()
         .addMiddleware(PathHandler.nestedIn(_secret))
         .addHandler(cascade.handler);
 
@@ -305,7 +305,7 @@ class BrowserPlatform extends PlatformPlugin
   Future<void> _pubServeSuite(String path, Uri dartUrl, Runtime browser,
       SuiteConfiguration suiteConfig) {
     return _pubServePool.withResource(() async {
-      var timer = Timer(Duration(seconds: 1), () {
+      var timer = Timer(const Duration(seconds: 1), () {
         print('"pub serve" is compiling $path...');
       });
 
@@ -317,7 +317,7 @@ class BrowserPlatform extends PlatformPlugin
 
         if (response.statusCode != 200) {
           // Drain response to avoid VM hang.
-          response.drain();
+          response.drain<void>();
 
           throw LoadException(
               path,
@@ -328,7 +328,7 @@ class BrowserPlatform extends PlatformPlugin
 
         if (suiteConfig.jsTrace) {
           // Drain response to avoid VM hang.
-          response.drain();
+          response.drain<void>();
           return;
         }
         _mappers[path] = JSStackTraceMapper(await utf8.decodeStream(response),

--- a/pkgs/test/lib/src/runner/node/platform.dart
+++ b/pkgs/test/lib/src/runner/node/platform.dart
@@ -87,7 +87,7 @@ class NodePlatform extends PlatformPlugin
     }
     var pair = await _loadChannel(path, platform, suiteConfig);
     var controller = deserializeSuite(
-        path, platform, suiteConfig, PluginEnvironment(), pair.first, message);
+        path, platform, suiteConfig, const PluginEnvironment(), pair.first, message);
 
     controller.channel('test.node.mapper').sink.add(pair.last?.serialize());
 

--- a/pkgs/test/lib/src/runner/node/platform.dart
+++ b/pkgs/test/lib/src/runner/node/platform.dart
@@ -86,8 +86,8 @@ class NodePlatform extends PlatformPlugin
           'Unsupported compiler for the Node platform ${platform.compiler}.');
     }
     var pair = await _loadChannel(path, platform, suiteConfig);
-    var controller = deserializeSuite(
-        path, platform, suiteConfig, const PluginEnvironment(), pair.first, message);
+    var controller = deserializeSuite(path, platform, suiteConfig,
+        const PluginEnvironment(), pair.first, message);
 
     controller.channel('test.node.mapper').sink.add(pair.last?.serialize());
 

--- a/pkgs/test/lib/src/runner/wasm/platform.dart
+++ b/pkgs/test/lib/src/runner/wasm/platform.dart
@@ -140,7 +140,7 @@ class BrowserWasmPlatform extends PlatformPlugin
         .add(createStaticHandler(_root))
         .add(_wrapperHandler);
 
-    var pipeline = shelf.Pipeline()
+    var pipeline = const shelf.Pipeline()
         .addMiddleware(PathHandler.nestedIn(_secret))
         .addHandler(cascade.handler);
 

--- a/pkgs/test/test/common.dart
+++ b/pkgs/test/test/common.dart
@@ -3,4 +3,4 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'package:test/test.dart';
 
-void myTest(String name, Function() testFn) => test(name, testFn);
+void myTest(String name, void Function() testFn) => test(name, testFn);

--- a/pkgs/test/test/runner/browser/chrome_test.dart
+++ b/pkgs/test/test/runner/browser/chrome_test.dart
@@ -36,7 +36,7 @@ webSocket.addEventListener("open", function() {
   },
       // It's not clear why, but this test in particular seems to time out
       // when run in parallel with many other tests.
-      timeout: Timeout.factor(2));
+      timeout: const Timeout.factor(2));
 
   test("a process can be killed synchronously after it's started", () async {
     var server = await CodeServer.start();

--- a/pkgs/test/test/runner/browser/microsoft_edge_test.dart
+++ b/pkgs/test/test/runner/browser/microsoft_edge_test.dart
@@ -33,7 +33,7 @@ webSocket.addEventListener("open", function() {
     addTearDown(() => edge.close());
 
     expect(await (await webSocket).stream.first, equals('loaded!'));
-  }, timeout: Timeout.factor(2));
+  }, timeout: const Timeout.factor(2));
 
   test('reports an error in onExit', () {
     var edge = MicrosoftEdge(Uri.parse('https://dart.dev'), configuration(),

--- a/pkgs/test/test/runner/configuration/top_level_test.dart
+++ b/pkgs/test/test/runner/configuration/top_level_test.dart
@@ -92,7 +92,7 @@ void main() {
 
     // Wait a little bit to be sure that the tests don't start running without
     // our input.
-    await Future.delayed(Duration(seconds: 2));
+    await Future<void>.delayed(const Duration(seconds: 2));
     expect(nextLineFired, isFalse);
 
     test.stdin.writeln();

--- a/pkgs/test/test/runner/engine_test.dart
+++ b/pkgs/test/test/runner/engine_test.dart
@@ -60,7 +60,7 @@ void main() {
   });
 
   test('returns fail if any test does not complete', () async {
-    var completer = Completer();
+    var completer = Completer<void>();
     var engine = declareEngine(() {
       test('completes', () {});
       test('does not complete', () async {
@@ -161,7 +161,7 @@ void main() {
     var engine = declareEngine(() {
       // This ensures that the first test doesn't actually finish until the
       // second test runs.
-      var firstTestCompleter = Completer();
+      var firstTestCompleter = Completer<void>();
 
       group('group', () {
         tearDown(tearDownBody);
@@ -169,7 +169,7 @@ void main() {
         test('first test', () async {
           await firstTestCompleter.future;
           firstTestFinished = true;
-        }, timeout: Timeout(Duration.zero));
+        }, timeout: const Timeout(Duration.zero));
       });
 
       test('second test', () {
@@ -311,7 +311,7 @@ void main() {
           }
           // Simulate the test/loading taking some amount of time so that
           // we actually reach max concurrency.
-          await Future.delayed(Duration(milliseconds: 100));
+          await Future<void>.delayed(const Duration(milliseconds: 100));
           if (!isLoadSuite) {
             testsRunning--;
             testsLoaded--;

--- a/pkgs/test/test/runner/load_suite_test.dart
+++ b/pkgs/test/test/runner/load_suite_test.dart
@@ -55,11 +55,11 @@ void main() {
 
     var liveTest = (suite.group.entries.single as Test).load(suite);
     expect(liveTest.run(), completes);
-    await Future.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
     expect(liveTest.state.status, equals(Status.running));
 
     completer.complete(innerSuite);
-    await Future.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
     expectTestPassed(liveTest);
   });
 
@@ -84,7 +84,7 @@ void main() {
 
     var liveTest = (suite.group.entries.single as Test).load(suite);
     expect(liveTest.run(), completes);
-    await Future.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
     expect(liveTest.state.status, equals(Status.running));
 
     expect(liveTest.close(), completes);

--- a/pkgs/test/test/runner/parse_metadata_test.dart
+++ b/pkgs/test/test/runner/parse_metadata_test.dart
@@ -81,7 +81,7 @@ library foo;
 ''', {});
       expect(
           metadata.timeout.duration,
-          equals(Duration(
+          equals(const Duration(
               hours: 1,
               minutes: 2,
               seconds: 3,
@@ -102,7 +102,7 @@ library foo;
 ''', {});
       expect(
           metadata.timeout.duration,
-          equals(Duration(
+          equals(const Duration(
               hours: 1,
               minutes: 2,
               seconds: 3,
@@ -122,7 +122,7 @@ import 'dart:core' as core;
 ''', {});
       expect(
           metadata.timeout.duration,
-          equals(Duration(
+          equals(const Duration(
               hours: 1,
               minutes: 2,
               seconds: 3,

--- a/pkgs/test/test/runner/pause_after_load_test.dart
+++ b/pkgs/test/test/runner/pause_after_load_test.dart
@@ -56,7 +56,7 @@ void main() {
 
     // Wait a little bit to be sure that the tests don't start running without
     // our input.
-    await Future.delayed(Duration(seconds: 2));
+    await Future<void>.delayed(const Duration(seconds: 2));
     expect(nextLineFired, isFalse);
 
     test.stdin.writeln();
@@ -76,7 +76,7 @@ void main() {
 
     // Wait a little bit to be sure that the tests don't start running without
     // our input.
-    await Future.delayed(Duration(seconds: 2));
+    await Future<void>.delayed(const Duration(seconds: 2));
     expect(nextLineFired, isFalse);
 
     test.stdin.writeln();
@@ -122,7 +122,7 @@ void main() {
 
     // Wait a little bit to be sure that the tests don't start running without
     // our input.
-    await Future.delayed(Duration(seconds: 2));
+    await Future<void>.delayed(const Duration(seconds: 2));
     expect(nextLineFired, isFalse);
 
     test.stdin.writeln();
@@ -144,7 +144,7 @@ void main() {
 
     // Wait a little bit to be sure that the tests don't start running without
     // our input.
-    await Future.delayed(Duration(seconds: 2));
+    await Future<void>.delayed(const Duration(seconds: 2));
     expect(nextLineFired, isFalse);
 
     test.stdin.writeln();
@@ -165,7 +165,7 @@ void main() {
 
     // Wait a little bit to be sure that the tests don't start running without
     // our input.
-    await Future.delayed(Duration(seconds: 2));
+    await Future<void>.delayed(const Duration(seconds: 2));
     expect(nextLineFired, isFalse);
 
     test.stdin.writeln();
@@ -232,7 +232,7 @@ void main() {
 
     // Wait a little bit to be sure that the tests don't start running without
     // our input.
-    await Future.delayed(Duration(seconds: 2));
+    await Future<void>.delayed(const Duration(seconds: 2));
     expect(nextLineFired, isFalse);
 
     test.stdin.writeln();
@@ -272,7 +272,7 @@ void main() {
 
     // Wait a little bit to be sure that the tests don't start running without
     // our input.
-    await Future.delayed(Duration(seconds: 2));
+    await Future<void>.delayed(const Duration(seconds: 2));
     expect(nextLineFired, isFalse);
 
     test.stdin.writeln();

--- a/pkgs/test/test/runner/signal_test.dart
+++ b/pkgs/test/test/runner/signal_test.dart
@@ -70,7 +70,7 @@ void main() {
       // TODO(nweiz): Sending two signals in close succession can cause the
       // second one to be ignored, so we wait a bit before the second
       // one. Remove this hack when issue 23047 is fixed.
-      await Future.delayed(Duration(seconds: 1));
+      await Future<void>.delayed(const Duration(seconds: 1));
 
       await signalAndQuit(test);
     });
@@ -179,7 +179,7 @@ void main() {
       // TODO(nweiz): Sending two signals in close succession can cause the
       // second one to be ignored, so we wait a bit before the second
       // one. Remove this hack when issue 23047 is fixed.
-      await Future.delayed(Duration(seconds: 1));
+      await Future<void>.delayed(const Duration(seconds: 1));
       await signalAndQuit(test);
     });
 

--- a/pkgs/test/tool/host.dart
+++ b/pkgs/test/tool/host.dart
@@ -137,7 +137,7 @@ void main() {
 
     // Send periodic pings to the test runner so it can know when the browser is
     // paused for debugging.
-    Timer.periodic(Duration(seconds: 1),
+    Timer.periodic(const Duration(seconds: 1),
         (_) => serverChannel.sink.add({'command': 'ping'}));
 
     var play = dom.document.querySelector('#play');
@@ -167,7 +167,7 @@ MultiChannel<dynamic> _connectToServer() {
   var webSocket =
       dom.createWebSocket(_currentUrl.queryParameters['managerUrl']!);
 
-  var controller = StreamChannelController(sync: true);
+  var controller = StreamChannelController<Object?>(sync: true);
   webSocket.addEventListener('message', allowInterop((message) {
     controller.local.sink
         .add(jsonDecode((message as dom.MessageEvent).data as String));
@@ -205,7 +205,7 @@ StreamChannel<dynamic> _connectToIframe(String url, int id) {
   dom.window.console.log('Starting suite $suiteUrl');
   var iframe = dom.createHTMLIFrameElement();
   _iframes[id] = iframe;
-  var controller = StreamChannelController(sync: true);
+  var controller = StreamChannelController<Object?>(sync: true);
 
   late dom.Subscription windowSubscription;
   windowSubscription =

--- a/pkgs/test_api/lib/src/backend/declarer.dart
+++ b/pkgs/test_api/lib/src/backend/declarer.dart
@@ -60,7 +60,7 @@ class Declarer {
   final _setUpAlls = <dynamic Function()>[];
 
   /// The default timeout for synthetic tests.
-  final _timeout = Timeout(Duration(minutes: 12));
+  final _timeout = const Timeout(Duration(minutes: 12));
 
   /// The trace for the first call to [setUpAll].
   ///
@@ -70,7 +70,7 @@ class Declarer {
   Trace? _setUpAllTrace;
 
   /// The tear-down functions to run once for this group.
-  final _tearDownAlls = <Function()>[];
+  final _tearDownAlls = <void Function()>[];
 
   /// The trace for the first call to [tearDownAll].
   ///

--- a/pkgs/test_api/lib/src/backend/invoker.dart
+++ b/pkgs/test_api/lib/src/backend/invoker.dart
@@ -35,7 +35,7 @@ class LocalTest extends Test {
   final bool isScaffoldAll;
 
   /// The test body.
-  final Function() _body;
+  final void Function() _body;
 
   /// Whether the test is run in its own error zone.
   final bool _guarded;
@@ -170,7 +170,7 @@ class Invoker {
   Timer? _timeoutTimer;
 
   /// The tear-down functions to run when this test finishes.
-  final _tearDowns = <Function()>[];
+  final _tearDowns = <void Function()>[];
 
   /// Messages to print if and when this test fails.
   final _printsOnFailure = <String>[];
@@ -229,7 +229,7 @@ class Invoker {
     heartbeat();
     return runZoned(() async {
       while (tearDowns.isNotEmpty) {
-        var completer = Completer();
+        var completer = Completer<void>();
 
         addOutstandingCallback();
         _waitForOutstandingCallbacks(() {

--- a/pkgs/test_api/lib/src/backend/metadata.dart
+++ b/pkgs/test_api/lib/src/backend/metadata.dart
@@ -123,7 +123,7 @@ final class Metadata {
   /// Parses a user-provided [String] or [Iterable] into the value for [tags].
   ///
   /// Throws an [ArgumentError] if [tags] is not a [String] or an [Iterable].
-  static Set<String> _parseTags(tags) {
+  static Set<String> _parseTags(Object? tags) {
     if (tags == null) return {};
     if (tags is String) return {tags};
     if (tags is! Iterable) {
@@ -231,7 +231,7 @@ final class Metadata {
       bool? chainStackTraces,
       int? retry,
       Map<String, dynamic>? onPlatform,
-      tags,
+      Object? /* String|Iterable<String> */ tags,
       this.languageVersionComment})
       : testOn = testOn == null
             ? PlatformSelector.all
@@ -255,7 +255,7 @@ final class Metadata {
   }
 
   /// Deserializes the result of [Metadata.serialize] into a new [Metadata].
-  Metadata.deserialize(serialized)
+  Metadata.deserialize(Map serialized)
       : testOn = serialized['testOn'] == null
             ? PlatformSelector.all
             : PlatformSelector.parse(serialized['testOn'] as String),
@@ -269,18 +269,18 @@ final class Metadata {
         onPlatform = {
           for (var pair in serialized['onPlatform'] as List)
             PlatformSelector.parse(pair.first as String):
-                Metadata.deserialize(pair.last)
+                Metadata.deserialize(pair.last as Map)
         },
         forTag = (serialized['forTag'] as Map).map((key, nested) => MapEntry(
             BooleanSelector.parse(key as String),
-            Metadata.deserialize(nested))),
+            Metadata.deserialize(nested as Map))),
         languageVersionComment =
             serialized['languageVersionComment'] as String?;
 
   /// Deserializes timeout from the format returned by [_serializeTimeout].
-  static Timeout _deserializeTimeout(serialized) {
+  static Timeout _deserializeTimeout(Object? serialized) {
     if (serialized == 'none') return Timeout.none;
-    var scaleFactor = serialized['scaleFactor'];
+    var scaleFactor = (serialized as Map)['scaleFactor'];
     if (scaleFactor != null) return Timeout.factor(scaleFactor as num);
     return Timeout(
         Duration(microseconds: (serialized['duration'] as num).toInt()));
@@ -388,7 +388,7 @@ final class Metadata {
   /// [Metadata.deserialize].
   Map<String, dynamic> serialize() {
     // Make this a list to guarantee that the order is preserved.
-    var serializedOnPlatform = [];
+    var serializedOnPlatform = <List<Object>>[];
     onPlatform.forEach((key, value) {
       serializedOnPlatform.add([key.toString(), value.serialize()]);
     });

--- a/pkgs/test_api/lib/src/backend/remote_exception.dart
+++ b/pkgs/test_api/lib/src/backend/remote_exception.dart
@@ -84,6 +84,5 @@ final class RemoteException implements Exception {
 /// It's important to preserve [TestFailure]-ness, because tests have different
 /// results depending on whether an exception was a failure or an error.
 final class _RemoteTestFailure extends RemoteException implements TestFailure {
-  _RemoteTestFailure(super.message, super.type, super.toString)
-      : super._();
+  _RemoteTestFailure(super.message, super.type, super.toString) : super._();
 }

--- a/pkgs/test_api/lib/src/backend/remote_exception.dart
+++ b/pkgs/test_api/lib/src/backend/remote_exception.dart
@@ -84,6 +84,6 @@ final class RemoteException implements Exception {
 /// It's important to preserve [TestFailure]-ness, because tests have different
 /// results depending on whether an exception was a failure or an error.
 final class _RemoteTestFailure extends RemoteException implements TestFailure {
-  _RemoteTestFailure(String? message, String type, String toString)
-      : super._(message, type, toString);
+  _RemoteTestFailure(super.message, super.type, super.toString)
+      : super._();
 }

--- a/pkgs/test_api/lib/src/backend/remote_listener.dart
+++ b/pkgs/test_api/lib/src/backend/remote_listener.dart
@@ -76,7 +76,7 @@ final class RemoteListener {
           return;
         }
 
-        if (main is! Function()) {
+        if (main is! FutureOr<void> Function()) {
           _sendLoadException(
               channel, 'Top-level main() function takes arguments.');
           return;
@@ -98,7 +98,7 @@ final class RemoteListener {
         });
 
         if ((message['asciiGlyphs'] as bool?) ?? false) glyph.ascii = true;
-        var metadata = Metadata.deserialize(message['metadata']);
+        var metadata = Metadata.deserialize(message['metadata'] as Map);
         verboseChain = metadata.verboseTrace;
         var declarer = Declarer(
           metadata: metadata,

--- a/pkgs/test_api/lib/src/scaffolding/spawn_hybrid.dart
+++ b/pkgs/test_api/lib/src/scaffolding/spawn_hybrid.dart
@@ -170,7 +170,7 @@ StreamChannel _spawn(String uri, Object? message, {bool stayAlive = false}) {
   });
 
   if (!stayAlive) {
-    var disconnector = Disconnector();
+    var disconnector = Disconnector<void>();
     addTearDown(() => disconnector.disconnect());
     isolateChannel = isolateChannel.transform(disconnector);
   }

--- a/pkgs/test_api/test/backend/declarer_test.dart
+++ b/pkgs/test_api/test/backend/declarer_test.dart
@@ -228,7 +228,7 @@ void main() {
         });
 
         test('description', () {
-          Future.error('oh no');
+          Future<Never>.error('oh no');
           return pumpEventQueue().then((_) {
             hasTestFinished = true;
           });
@@ -336,7 +336,7 @@ void main() {
       var testGroup = entries.single as Group;
       expect(testGroup.name, equals('group'));
       expect(testGroup.entries, hasLength(1));
-      expect(testGroup.entries.single, TypeMatcher<Test>());
+      expect(testGroup.entries.single, const TypeMatcher<Test>());
       expect(testGroup.entries.single.name, 'group description');
     });
 
@@ -351,57 +351,57 @@ void main() {
       var testGroup = entries.single as Group;
       expect(testGroup.name, equals('Object'));
       expect(testGroup.entries, hasLength(1));
-      expect(testGroup.entries.single, TypeMatcher<Test>());
+      expect(testGroup.entries.single, const TypeMatcher<Test>());
       expect(testGroup.entries.single.name, 'Object description');
     });
 
     test("a test's timeout factor is applied to the group's", () {
       var entries = declare(() {
         group('group', () {
-          test('test', () {}, timeout: Timeout.factor(3));
-        }, timeout: Timeout.factor(2));
+          test('test', () {}, timeout: const Timeout.factor(3));
+        }, timeout: const Timeout.factor(2));
       });
 
       expect(entries, hasLength(1));
       var testGroup = entries.single as Group;
       expect(testGroup.metadata.timeout.scaleFactor, equals(2));
       expect(testGroup.entries, hasLength(1));
-      expect(testGroup.entries.single, TypeMatcher<Test>());
+      expect(testGroup.entries.single, const TypeMatcher<Test>());
       expect(testGroup.entries.single.metadata.timeout.scaleFactor, equals(6));
     });
 
     test("a test's timeout factor is applied to the group's duration", () {
       var entries = declare(() {
         group('group', () {
-          test('test', () {}, timeout: Timeout.factor(2));
-        }, timeout: Timeout(Duration(seconds: 10)));
+          test('test', () {}, timeout: const Timeout.factor(2));
+        }, timeout: const Timeout(Duration(seconds: 10)));
       });
 
       expect(entries, hasLength(1));
       var testGroup = entries.single as Group;
-      expect(
-          testGroup.metadata.timeout.duration, equals(Duration(seconds: 10)));
+      expect(testGroup.metadata.timeout.duration,
+          equals(const Duration(seconds: 10)));
       expect(testGroup.entries, hasLength(1));
-      expect(testGroup.entries.single, TypeMatcher<Test>());
+      expect(testGroup.entries.single, const TypeMatcher<Test>());
       expect(testGroup.entries.single.metadata.timeout.duration,
-          equals(Duration(seconds: 20)));
+          equals(const Duration(seconds: 20)));
     });
 
     test("a test's timeout duration is applied over the group's", () {
       var entries = declare(() {
         group('group', () {
-          test('test', () {}, timeout: Timeout(Duration(seconds: 15)));
-        }, timeout: Timeout(Duration(seconds: 10)));
+          test('test', () {}, timeout: const Timeout(Duration(seconds: 15)));
+        }, timeout: const Timeout(Duration(seconds: 10)));
       });
 
       expect(entries, hasLength(1));
       var testGroup = entries.single as Group;
-      expect(
-          testGroup.metadata.timeout.duration, equals(Duration(seconds: 10)));
+      expect(testGroup.metadata.timeout.duration,
+          equals(const Duration(seconds: 10)));
       expect(testGroup.entries, hasLength(1));
-      expect(testGroup.entries.single, TypeMatcher<Test>());
+      expect(testGroup.entries.single, const TypeMatcher<Test>());
       expect(testGroup.entries.single.metadata.timeout.duration,
-          equals(Duration(seconds: 15)));
+          equals(const Duration(seconds: 15)));
     });
 
     test('disallows asynchronous groups', () async {

--- a/pkgs/test_api/test/backend/invoker_test.dart
+++ b/pkgs/test_api/test/backend/invoker_test.dart
@@ -42,7 +42,7 @@ void main() {
     test('returns the current invoker in a test body after the test completes',
         () async {
       Status? status;
-      var completer = Completer();
+      var completer = Completer<Invoker>();
       var liveTest = _localTest(() {
         // Use the event loop to wait longer than a microtask for the test to
         // complete.
@@ -432,7 +432,8 @@ void main() {
         Invoker.current!.addOutstandingCallback();
       },
               metadata: Metadata(
-                  chainStackTraces: true, timeout: Timeout(Duration.zero)))
+                  chainStackTraces: true,
+                  timeout: const Timeout(Duration.zero)))
           .load(suite);
 
       expectStates(liveTest, [
@@ -443,7 +444,7 @@ void main() {
       expectErrors(liveTest, [
         (error) {
           expect(lastState!.status, equals(Status.complete));
-          expect(error, TypeMatcher<TimeoutException>());
+          expect(error, const TypeMatcher<TimeoutException>());
         }
       ]);
 
@@ -453,10 +454,11 @@ void main() {
     test('can be ignored', () {
       suite = Suite(Group.root([]), suitePlatform, ignoreTimeouts: true);
       var liveTest = _localTest(() async {
-        await Future.delayed(Duration(milliseconds: 10));
+        await Future<void>.delayed(const Duration(milliseconds: 10));
       },
               metadata: Metadata(
-                  chainStackTraces: true, timeout: Timeout(Duration.zero)))
+                  chainStackTraces: true,
+                  timeout: const Timeout(Duration.zero)))
           .load(suite);
 
       expectStates(liveTest, [

--- a/pkgs/test_api/test/backend/metadata_test.dart
+++ b/pkgs/test_api/test/backend/metadata_test.dart
@@ -242,7 +242,8 @@ void main() {
             PlatformSelector.parse('mac-os'): Metadata(skip: false)
           },
           forTag: {
-            BooleanSelector.parse('slow'): Metadata(timeout: const Timeout.factor(4))
+            BooleanSelector.parse('slow'):
+                Metadata(timeout: const Timeout.factor(4))
           });
       expect(metadata.serialize(), equals(metadata.change().serialize()));
     });

--- a/pkgs/test_api/test/backend/metadata_test.dart
+++ b/pkgs/test_api/test/backend/metadata_test.dart
@@ -135,8 +135,8 @@ void main() {
   group('onPlatform', () {
     test('parses a valid map', () {
       var metadata = Metadata.parse(onPlatform: {
-        'chrome': Timeout.factor(2),
-        'vm': [Skip(), Timeout.factor(3)]
+        'chrome': const Timeout.factor(2),
+        'vm': [const Skip(), const Timeout.factor(3)]
       });
 
       var key = metadata.onPlatform.keys.first;
@@ -157,28 +157,28 @@ void main() {
 
     test('refuses an invalid value', () {
       expect(() {
-        Metadata.parse(onPlatform: {'chrome': TestOn('chrome')});
+        Metadata.parse(onPlatform: {'chrome': const TestOn('chrome')});
       }, throwsArgumentError);
     });
 
     test('refuses an invalid value in a list', () {
       expect(() {
         Metadata.parse(onPlatform: {
-          'chrome': [TestOn('chrome')]
+          'chrome': [const TestOn('chrome')]
         });
       }, throwsArgumentError);
     });
 
     test('refuses an invalid platform selector', () {
       expect(() {
-        Metadata.parse(onPlatform: {'vm &&': Skip()});
+        Metadata.parse(onPlatform: {'vm &&': const Skip()});
       }, throwsFormatException);
     });
 
     test('refuses multiple Timeouts', () {
       expect(() {
         Metadata.parse(onPlatform: {
-          'chrome': [Timeout.factor(2), Timeout.factor(3)]
+          'chrome': [const Timeout.factor(2), const Timeout.factor(3)]
         });
       }, throwsArgumentError);
     });
@@ -186,7 +186,7 @@ void main() {
     test('refuses multiple Skips', () {
       expect(() {
         Metadata.parse(onPlatform: {
-          'chrome': [Skip(), Skip()]
+          'chrome': [const Skip(), const Skip()]
         });
       }, throwsArgumentError);
     });
@@ -194,7 +194,7 @@ void main() {
 
   group('validatePlatformSelectors', () {
     test('succeeds if onPlatform uses valid platforms', () {
-      Metadata.parse(onPlatform: {'vm || browser': Skip()})
+      Metadata.parse(onPlatform: {'vm || browser': const Skip()})
           .validatePlatformSelectors({'vm'});
     });
 
@@ -208,7 +208,7 @@ void main() {
 
     test('fails if onPlatform uses an invalid platform', () {
       expect(() {
-        Metadata.parse(onPlatform: {'unknown': Skip()})
+        Metadata.parse(onPlatform: {'unknown': const Skip()})
             .validatePlatformSelectors({'vm'});
       }, throwsFormatException);
     });
@@ -230,7 +230,7 @@ void main() {
     test('preserves all fields if no parameters are passed', () {
       var metadata = Metadata(
           testOn: PlatformSelector.parse('linux'),
-          timeout: Timeout.factor(2),
+          timeout: const Timeout.factor(2),
           skip: true,
           skipReason: 'just because',
           verboseTrace: true,
@@ -242,15 +242,15 @@ void main() {
             PlatformSelector.parse('mac-os'): Metadata(skip: false)
           },
           forTag: {
-            BooleanSelector.parse('slow'): Metadata(timeout: Timeout.factor(4))
+            BooleanSelector.parse('slow'): Metadata(timeout: const Timeout.factor(4))
           });
       expect(metadata.serialize(), equals(metadata.change().serialize()));
     });
 
     test('updates a changed field', () {
-      var metadata = Metadata(timeout: Timeout.factor(2));
-      expect(metadata.change(timeout: Timeout.factor(3)).timeout,
-          equals(Timeout.factor(3)));
+      var metadata = Metadata(timeout: const Timeout.factor(2));
+      expect(metadata.change(timeout: const Timeout.factor(3)).timeout,
+          equals(const Timeout.factor(3)));
     });
   });
 }

--- a/pkgs/test_api/test/frontend/fake_test.dart
+++ b/pkgs/test_api/test/frontend/fake_test.dart
@@ -11,16 +11,16 @@ void main() {
     fake = _FakeSample();
   });
   test('method invocation', () {
-    expect(() => fake.f(), throwsA(TypeMatcher<UnimplementedError>()));
+    expect(() => fake.f(), throwsA(const TypeMatcher<UnimplementedError>()));
   });
   test('getter', () {
-    expect(() => fake.x, throwsA(TypeMatcher<UnimplementedError>()));
+    expect(() => fake.x, throwsA(const TypeMatcher<UnimplementedError>()));
   });
   test('setter', () {
-    expect(() => fake.x = 0, throwsA(TypeMatcher<UnimplementedError>()));
+    expect(() => fake.x = 0, throwsA(const TypeMatcher<UnimplementedError>()));
   });
   test('operator', () {
-    expect(() => fake + 1, throwsA(TypeMatcher<UnimplementedError>()));
+    expect(() => fake + 1, throwsA(const TypeMatcher<UnimplementedError>()));
   });
 }
 

--- a/pkgs/test_api/test/frontend/timeout_test.dart
+++ b/pkgs/test_api/test/frontend/timeout_test.dart
@@ -22,9 +22,9 @@ void main() {
 
     group('for a relative timeout', () {
       test('successfully parses', () {
-        expect(Timeout.parse('1x'), equals(Timeout.factor(1)));
-        expect(Timeout.parse('2.5x'), equals(Timeout.factor(2.5)));
-        expect(Timeout.parse('1.2e3x'), equals(Timeout.factor(1.2e3)));
+        expect(Timeout.parse('1x'), equals(const Timeout.factor(1)));
+        expect(Timeout.parse('2.5x'), equals(const Timeout.factor(2.5)));
+        expect(Timeout.parse('1.2e3x'), equals(const Timeout.factor(1.2e3)));
       });
 
       test('rejects invalid input', () {
@@ -38,25 +38,25 @@ void main() {
 
     group('for an absolute timeout', () {
       test('successfully parses all supported units', () {
-        expect(Timeout.parse('2d'), equals(Timeout(Duration(days: 2))));
-        expect(Timeout.parse('2h'), equals(Timeout(Duration(hours: 2))));
-        expect(Timeout.parse('2m'), equals(Timeout(Duration(minutes: 2))));
-        expect(Timeout.parse('2s'), equals(Timeout(Duration(seconds: 2))));
+        expect(Timeout.parse('2d'), equals(const Timeout(Duration(days: 2))));
+        expect(Timeout.parse('2h'), equals(const Timeout(Duration(hours: 2))));
+        expect(Timeout.parse('2m'), equals(const Timeout(Duration(minutes: 2))));
+        expect(Timeout.parse('2s'), equals(const Timeout(Duration(seconds: 2))));
         expect(
-            Timeout.parse('2ms'), equals(Timeout(Duration(milliseconds: 2))));
+            Timeout.parse('2ms'), equals(const Timeout(Duration(milliseconds: 2))));
         expect(
-            Timeout.parse('2us'), equals(Timeout(Duration(microseconds: 2))));
+            Timeout.parse('2us'), equals(const Timeout(Duration(microseconds: 2))));
       });
 
       test('supports non-integer units', () {
         expect(
-            Timeout.parse('2.73d'), equals(Timeout(Duration(days: 1) * 2.73)));
+            Timeout.parse('2.73d'), equals(Timeout(const Duration(days: 1) * 2.73)));
       });
 
       test('supports multiple units', () {
         expect(
             Timeout.parse('1d 2h3m  4s5ms\t6us'),
-            equals(Timeout(Duration(
+            equals(const Timeout(Duration(
                 days: 1,
                 hours: 2,
                 minutes: 3,

--- a/pkgs/test_api/test/frontend/timeout_test.dart
+++ b/pkgs/test_api/test/frontend/timeout_test.dart
@@ -40,17 +40,19 @@ void main() {
       test('successfully parses all supported units', () {
         expect(Timeout.parse('2d'), equals(const Timeout(Duration(days: 2))));
         expect(Timeout.parse('2h'), equals(const Timeout(Duration(hours: 2))));
-        expect(Timeout.parse('2m'), equals(const Timeout(Duration(minutes: 2))));
-        expect(Timeout.parse('2s'), equals(const Timeout(Duration(seconds: 2))));
         expect(
-            Timeout.parse('2ms'), equals(const Timeout(Duration(milliseconds: 2))));
+            Timeout.parse('2m'), equals(const Timeout(Duration(minutes: 2))));
         expect(
-            Timeout.parse('2us'), equals(const Timeout(Duration(microseconds: 2))));
+            Timeout.parse('2s'), equals(const Timeout(Duration(seconds: 2))));
+        expect(Timeout.parse('2ms'),
+            equals(const Timeout(Duration(milliseconds: 2))));
+        expect(Timeout.parse('2us'),
+            equals(const Timeout(Duration(microseconds: 2))));
       });
 
       test('supports non-integer units', () {
-        expect(
-            Timeout.parse('2.73d'), equals(Timeout(const Duration(days: 1) * 2.73)));
+        expect(Timeout.parse('2.73d'),
+            equals(Timeout(const Duration(days: 1) * 2.73)));
       });
 
       test('supports multiple units', () {

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.5.9-wip
+
 ## 0.5.8
 
 * Move scaffolding definitions to a non-deprecated library.

--- a/pkgs/test_core/lib/src/bootstrap/vm.dart
+++ b/pkgs/test_core/lib/src/bootstrap/vm.dart
@@ -9,13 +9,13 @@ import 'dart:isolate';
 import 'package:stream_channel/isolate_channel.dart';
 import 'package:stream_channel/stream_channel.dart';
 
-import 'package:test_core/src/runner/plugin/remote_platform_helpers.dart';
-import 'package:test_core/src/runner/plugin/shared_platform_helpers.dart';
+import '../runner/plugin/remote_platform_helpers.dart';
+import '../runner/plugin/shared_platform_helpers.dart';
 
 /// Bootstraps a vm test to communicate with the test runner over an isolate.
 void internalBootstrapVmTest(Function Function() getMain, SendPort sendPort) {
   var platformChannel =
-      MultiChannel(IsolateChannel<Object?>.connectSend(sendPort));
+      MultiChannel<Object?>(IsolateChannel<Object?>.connectSend(sendPort));
   var testControlChannel = platformChannel.virtualChannel()
     ..pipe(serializeSuite(getMain));
   platformChannel.sink.add(testControlChannel.id);

--- a/pkgs/test_core/lib/src/executable.dart
+++ b/pkgs/test_core/lib/src/executable.dart
@@ -10,11 +10,11 @@ import 'package:path/path.dart' as p;
 import 'package:source_span/source_span.dart';
 import 'package:stack_trace/stack_trace.dart';
 import 'package:test_api/src/backend/util/pretty_print.dart'; // ignore: implementation_imports
-import 'package:test_core/src/runner/no_tests_found_exception.dart';
 
 import 'runner.dart';
 import 'runner/application_exception.dart';
 import 'runner/configuration.dart';
+import 'runner/no_tests_found_exception.dart';
 import 'runner/version.dart';
 import 'util/errors.dart';
 import 'util/exit_codes.dart' as exit_codes;
@@ -64,7 +64,7 @@ Future<void> _execute(List<String> args) async {
   final signals = Platform.isWindows
       ? ProcessSignal.sigint.watch()
       : Platform.isFuchsia // Signals don't exist on Fuchsia.
-          ? Stream.empty()
+          ? const Stream<Never>.empty()
           : StreamGroup.merge(
               [ProcessSignal.sigterm.watch(), ProcessSignal.sigint.watch()]);
 

--- a/pkgs/test_core/lib/src/runner.dart
+++ b/pkgs/test_core/lib/src/runner.dart
@@ -16,7 +16,6 @@ import 'package:test_api/src/backend/operating_system.dart'; // ignore: implemen
 import 'package:test_api/src/backend/suite.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/test.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/util/pretty_print.dart'; // ignore: implementation_imports
-import 'package:test_core/src/runner/reporter/multiplex.dart';
 
 import 'runner/configuration.dart';
 import 'runner/configuration/reporters.dart';
@@ -29,6 +28,7 @@ import 'runner/no_tests_found_exception.dart';
 import 'runner/reporter.dart';
 import 'runner/reporter/compact.dart';
 import 'runner/reporter/expanded.dart';
+import 'runner/reporter/multiplex.dart';
 import 'runner/runner_suite.dart';
 import 'util/io.dart';
 
@@ -66,7 +66,7 @@ class Runner {
   CancelableOperation? _debugOperation;
 
   /// The memoizer for ensuring [close] only runs once.
-  final _closeMemo = AsyncMemoizer();
+  final _closeMemo = AsyncMemoizer<void>();
   bool get _closed => _closeMemo.hasRun;
 
   /// Sinks created for each file reporter (if there are any).
@@ -128,7 +128,9 @@ class Runner {
           var subscription =
               _suiteSubscription = suites.listen(_engine.suiteSink.add);
           var results = await Future.wait(<Future>[
-            subscription.asFuture().then((_) => _engine.suiteSink.close()),
+            subscription
+                .asFuture<void>()
+                .then((_) => _engine.suiteSink.close()),
             _engine.run()
           ], eagerError: true);
           success = results.last as bool?;
@@ -175,7 +177,7 @@ class Runner {
     if (unsupportedRuntimes.isEmpty) return;
 
     // Human-readable names for all unsupported runtimes.
-    var unsupportedNames = [];
+    var unsupportedNames = <String>[];
 
     // If the user tried to run on one or more unsupported browsers, figure out
     // whether we should warn about the individual browsers or whether all
@@ -223,7 +225,7 @@ class Runner {
         if (!_engine.isIdle) {
           // Wait a bit to print this message, since printing it eagerly looks weird
           // if the tests then finish immediately.
-          timer = Timer(Duration(seconds: 1), () {
+          timer = Timer(const Duration(seconds: 1), () {
             // Pause the reporter while we print to ensure that we don't interfere
             // with its output.
             _reporter.pause();
@@ -465,7 +467,7 @@ class Runner {
     }).listen(null);
 
     var results = await Future.wait(<Future>[
-      subscription.asFuture().then((_) => _engine.suiteSink.close()),
+      subscription.asFuture<void>().then((_) => _engine.suiteSink.close()),
       _engine.run()
     ], eagerError: true);
     return results.last as bool;

--- a/pkgs/test_core/lib/src/runner/compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/compiler_pool.dart
@@ -25,7 +25,7 @@ abstract class CompilerPool {
   bool get closed => _closeMemo.hasRun;
 
   /// The memoizer for running [close] exactly once.
-  final _closeMemo = AsyncMemoizer();
+  final _closeMemo = AsyncMemoizer<void>();
 
   /// Creates a compiler pool that multiple instances of a compiler at once.
   CompilerPool() : _pool = Pool(Configuration.current.concurrency);

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -217,7 +217,7 @@ void _parseTestSelection(
   final col = uri.queryParameters['col'];
 
   if (names != null && names.isNotEmpty && fullName != null) {
-    throw FormatException(
+    throw const FormatException(
       'Cannot specify both "name=<...>" and "full-name=<...>".',
     );
   }
@@ -270,13 +270,13 @@ class _Parser {
     var shardIndex = _parseOption('shard-index', int.parse);
     var totalShards = _parseOption('total-shards', int.parse);
     if ((shardIndex == null) != (totalShards == null)) {
-      throw FormatException(
+      throw const FormatException(
           '--shard-index and --total-shards may only be passed together.');
     } else if (shardIndex != null) {
       if (shardIndex < 0) {
-        throw FormatException('--shard-index may not be negative.');
+        throw const FormatException('--shard-index may not be negative.');
       } else if (shardIndex >= totalShards!) {
-        throw FormatException(
+        throw const FormatException(
             '--shard-index must be less than --total-shards.');
       }
     }
@@ -304,7 +304,7 @@ class _Parser {
     var compilerSelections = _ifParsed<List<String>>('compiler')
         ?.map(CompilerSelection.parse)
         .toList();
-    if (_ifParsed('use-data-isolate-strategy') == true) {
+    if (_ifParsed<bool>('use-data-isolate-strategy') == true) {
       compilerSelections ??= [];
       compilerSelections.add(CompilerSelection.parse('vm:source'));
     }
@@ -393,7 +393,7 @@ class _Parser {
   Map<String, String>? _parseFileReporterOption() =>
       _parseOption('file-reporter', (value) {
         if (!value.contains(':')) {
-          throw FormatException(
+          throw const FormatException(
               'option must be in the form <reporter>:<filepath>, e.g. '
               '"json:reports/tests.json"');
         }

--- a/pkgs/test_core/lib/src/runner/dart2js_compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/dart2js_compiler_pool.dart
@@ -100,7 +100,7 @@ class Dart2JsCompilerPool extends CompilerPool {
     var map = jsonDecode(File(mapPath).readAsStringSync());
     var root = map['sourceRoot'] as String;
 
-    map['sources'] = map['sources'].map((source) {
+    map['sources'] = map['sources'].map((Object? source) {
       var url = Uri.parse('$root$source');
       if (url.scheme != '' && url.scheme != 'file') return source;
       if (url.path.endsWith('/runInBrowser.dart')) return '';

--- a/pkgs/test_core/lib/src/runner/debugger.dart
+++ b/pkgs/test_core/lib/src/runner/debugger.dart
@@ -70,7 +70,7 @@ class _Debugger {
 
   /// A completer that's used to manually unpause the test if the debugger is
   /// closed.
-  final _pauseCompleter = CancelableCompleter();
+  final _pauseCompleter = CancelableCompleter<void>();
 
   /// The subscription to [_suite.onDebugging].
   StreamSubscription<bool>? _onDebuggingSubscription;

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -100,7 +100,7 @@ class Engine {
   }
 
   /// A group of futures for each test suite.
-  final _group = FutureGroup();
+  final _group = FutureGroup<void>();
 
   /// All of the engine's stream subscriptions.
   final _subscriptions = <StreamSubscription>{};

--- a/pkgs/test_core/lib/src/runner/environment.dart
+++ b/pkgs/test_core/lib/src/runner/environment.dart
@@ -39,7 +39,7 @@ class PluginEnvironment implements Environment {
   @override
   final supportsDebugging = false;
   @override
-  Stream get onRestart => StreamController.broadcast().stream;
+  Stream get onRestart => StreamController<void>.broadcast().stream;
 
   const PluginEnvironment();
 

--- a/pkgs/test_core/lib/src/runner/hybrid_listener.dart
+++ b/pkgs/test_core/lib/src/runner/hybrid_listener.dart
@@ -33,7 +33,7 @@ final _transformer = StreamSinkTransformer<dynamic, dynamic>.fromHandlers(
 /// The [data] argument contains two values: a [SendPort] that communicates with
 /// the main isolate, and a message to pass to `hybridMain()`.
 void listen(Function Function() getMain, List data) {
-  var channel = IsolateChannel.connectSend(data.first as SendPort);
+  var channel = IsolateChannel<Object?>.connectSend(data.first as SendPort);
   var message = data.last;
 
   Chain.capture(() {
@@ -52,10 +52,10 @@ void listen(Function Function() getMain, List data) {
       if (main is! Function) {
         _sendError(channel, 'Top-level hybridMain is not a function.');
         return;
-      } else if (main is! Function(StreamChannel) &&
-          main is! Function(StreamChannel, Never)) {
-        if (main is Function(StreamChannel<Never>) ||
-            main is Function(StreamChannel<Never>, Never)) {
+      } else if (main is! void Function(StreamChannel) &&
+          main is! void Function(StreamChannel, Never)) {
+        if (main is void Function(StreamChannel<Never>) ||
+            main is void Function(StreamChannel<Never>, Never)) {
           _sendError(
               channel,
               'The first parameter to the top-level hybridMain() must be a '
@@ -72,7 +72,7 @@ void listen(Function Function() getMain, List data) {
       // errors and distinguish user data events from control events sent by the
       // listener.
       var transformedChannel = channel.transformSink(_transformer);
-      if (main is Function(StreamChannel)) {
+      if (main is void Function(StreamChannel)) {
         main(transformedChannel);
       } else {
         main(transformedChannel, message);
@@ -88,7 +88,7 @@ void listen(Function Function() getMain, List data) {
 }
 
 /// Sends a message over [channel] indicating an error from user code.
-void _sendError(StreamChannel channel, error, [StackTrace? stackTrace]) {
+void _sendError(StreamChannel channel, Object error, [StackTrace? stackTrace]) {
   channel.sink.add({
     'type': 'error',
     'error': RemoteException.serialize(error, stackTrace ?? Chain.current())

--- a/pkgs/test_core/lib/src/runner/live_suite_controller.dart
+++ b/pkgs/test_core/lib/src/runner/live_suite_controller.dart
@@ -66,12 +66,12 @@ class LiveSuiteController {
   /// The future group that backs [LiveSuite.onComplete].
   ///
   /// This contains all the futures from tests that are run in this suite.
-  final _onCompleteGroup = FutureGroup();
+  final _onCompleteGroup = FutureGroup<void>();
 
   /// The completer that backs [LiveSuite.onClose].
   ///
   /// This is completed when the live suite is closed.
-  final _onCloseCompleter = Completer();
+  final _onCloseCompleter = Completer<void>();
 
   /// The controller for [LiveSuite.onTestStarted].
   final _onTestStartedController =
@@ -150,5 +150,5 @@ class LiveSuiteController {
           _onCloseCompleter.complete();
         }
       });
-  final _closeMemo = AsyncMemoizer();
+  final _closeMemo = AsyncMemoizer<void>();
 }

--- a/pkgs/test_core/lib/src/runner/load_suite.dart
+++ b/pkgs/test_core/lib/src/runner/load_suite.dart
@@ -28,7 +28,7 @@ import 'suite.dart';
 /// compiled with dart2js doesn't trigger it, but short enough that it fires
 /// before the host kills it. For example, Google's Forge service has a
 /// 15-minute timeout.
-final _timeout = Duration(minutes: 12);
+final _timeout = const Duration(minutes: 12);
 
 /// A [Suite] emitted by a [Loader] that provides a test-like interface for
 /// loading a test file.
@@ -201,7 +201,7 @@ class LoadSuite extends Suite implements RunnerSuite {
     if (liveTest.errors.isEmpty) return await suite;
 
     var error = liveTest.errors.first;
-    await Future.error(error.error, error.stackTrace);
+    await Future<void>.error(error.error, error.stackTrace);
     throw 'unreachable';
   }
 

--- a/pkgs/test_core/lib/src/runner/loader.dart
+++ b/pkgs/test_core/lib/src/runner/loader.dart
@@ -11,10 +11,10 @@ import 'package:source_span/source_span.dart';
 import 'package:test_api/src/backend/group.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/invoker.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/runtime.dart'; // ignore: implementation_imports
-import 'package:test_core/src/runner/compiler_selection.dart';
 import 'package:yaml/yaml.dart';
 
 import '../util/io.dart';
+import 'compiler_selection.dart';
 import 'configuration.dart';
 import 'hack_register_platform.dart';
 import 'load_exception.dart';
@@ -141,7 +141,7 @@ class Loader {
     return StreamGroup.merge(
         Directory(dir).listSync(recursive: true).map((entry) {
       if (entry is! File || !_config.filename.matches(p.basename(entry.path))) {
-        return Stream.empty();
+        return const Stream.empty();
       }
 
       return loadFile(entry.path, suiteConfig);
@@ -232,13 +232,13 @@ class Loader {
               if (retriesLeft > 0) {
                 retriesLeft--;
                 print('Retrying load of $path in 1s ($retriesLeft remaining)');
-                await Future.delayed(Duration(seconds: 1));
+                await Future<void>.delayed(const Duration(seconds: 1));
                 continue;
               }
               if (error is LoadException) {
                 rethrow;
               }
-              await Future.error(LoadException(path, error), stackTrace);
+              await Future<void>.error(LoadException(path, error), stackTrace);
               return null;
             }
           }
@@ -301,5 +301,5 @@ class Loader {
         _platformCallbacks.clear();
         _suites.clear();
       });
-  final _closeMemo = AsyncMemoizer();
+  final _closeMemo = AsyncMemoizer<void>();
 }

--- a/pkgs/test_core/lib/src/runner/plugin/environment.dart
+++ b/pkgs/test_core/lib/src/runner/plugin/environment.dart
@@ -13,7 +13,7 @@ class PluginEnvironment implements Environment {
   @override
   final supportsDebugging = false;
   @override
-  Stream get onRestart => StreamController.broadcast().stream;
+  Stream<void> get onRestart => StreamController<void>.broadcast().stream;
 
   const PluginEnvironment();
 

--- a/pkgs/test_core/lib/src/runner/plugin/platform_helpers.dart
+++ b/pkgs/test_core/lib/src/runner/plugin/platform_helpers.dart
@@ -131,7 +131,7 @@ class _Deserializer {
 
   /// Deserializes [group] into a concrete [Group].
   Group deserializeGroup(Map group) {
-    var metadata = Metadata.deserialize(group['metadata']);
+    var metadata = Metadata.deserialize(group['metadata'] as Map);
     return Group(
         group['name'] as String,
         (group['entries'] as List).map((entry) {
@@ -153,7 +153,7 @@ class _Deserializer {
   Test? _deserializeTest(Map? test) {
     if (test == null) return null;
 
-    var metadata = Metadata.deserialize(test['metadata']);
+    var metadata = Metadata.deserialize(test['metadata'] as Map);
     var trace =
         test['trace'] == null ? null : Trace.parse(test['trace'] as String);
     var testChannel = _channel.virtualChannel((test['channel'] as num).toInt());

--- a/pkgs/test_core/lib/src/runner/reporter/compact.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/compact.dart
@@ -191,7 +191,7 @@ class CompactReporter implements Reporter {
       _stopwatch.start();
 
       // Keep updating the time even when nothing else is happening.
-      _subscriptions.add(Stream.periodic(Duration(seconds: 1))
+      _subscriptions.add(Stream<void>.periodic(const Duration(seconds: 1))
           .listen((_) => _progressLine(_lastProgressMessage ?? '')));
     }
 
@@ -252,7 +252,7 @@ class CompactReporter implements Reporter {
   }
 
   /// A callback called when [liveTest] throws [error].
-  void _onError(LiveTest liveTest, error, StackTrace stackTrace) {
+  void _onError(LiveTest liveTest, Object error, StackTrace stackTrace) {
     if (!liveTest.test.metadata.chainStackTraces &&
         !liveTest.suite.isLoadSuite) {
       _shouldPrintStackTraceChainingNotice = true;

--- a/pkgs/test_core/lib/src/runner/reporter/expanded.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/expanded.dart
@@ -200,7 +200,7 @@ class ExpandedReporter implements Reporter {
   }
 
   /// A callback called when [liveTest] throws [error].
-  void _onError(LiveTest liveTest, error, StackTrace stackTrace) {
+  void _onError(LiveTest liveTest, Object error, StackTrace stackTrace) {
     if (!liveTest.test.metadata.chainStackTraces &&
         !liveTest.suite.isLoadSuite) {
       _shouldPrintStackTraceChainingNotice = true;

--- a/pkgs/test_core/lib/src/runner/reporter/json.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/json.dart
@@ -261,7 +261,7 @@ class JsonReporter implements Reporter {
   }
 
   /// A callback called when [liveTest] throws [error].
-  void _onError(LiveTest liveTest, error, StackTrace stackTrace) {
+  void _onError(LiveTest liveTest, Object error, StackTrace stackTrace) {
     _emit('error', {
       'testID': _liveTestIDs[liveTest],
       'error': error.toString(),

--- a/pkgs/test_core/lib/src/runner/runner_suite.dart
+++ b/pkgs/test_core/lib/src/runner/runner_suite.dart
@@ -48,7 +48,7 @@ class RunnerSuite extends Suite {
   /// debugging mode and doesn't support suite channels.
   factory RunnerSuite(Environment environment, SuiteConfiguration config,
       Group group, SuitePlatform platform,
-      {String? path, Function()? onClose}) {
+      {String? path, void Function()? onClose}) {
     var controller =
         RunnerSuiteController._local(environment, config, onClose: onClose);
     var suite = RunnerSuite._(controller, group, platform, path: path);
@@ -95,7 +95,7 @@ class RunnerSuiteController {
   final MultiChannel? _suiteChannel;
 
   /// The function to call when the suite is closed.
-  final Function()? _onClose;
+  final FutureOr<void> Function()? _onClose;
 
   /// The backing value for [suite.isDebugging].
   bool _isDebugging = false;
@@ -112,7 +112,7 @@ class RunnerSuiteController {
   RunnerSuiteController(this._environment, this._config, this._suiteChannel,
       Future<Group> groupFuture, SuitePlatform platform,
       {String? path,
-      Function()? onClose,
+      void Function()? onClose,
       Future<Map<String, dynamic>> Function()? gatherCoverage})
       : _onClose = onClose,
         _gatherCoverage = gatherCoverage {
@@ -123,7 +123,7 @@ class RunnerSuiteController {
   /// Used by [RunnerSuite.new] to create a runner suite that's not loaded from
   /// an external source.
   RunnerSuiteController._local(this._environment, this._config,
-      {Function()? onClose,
+      {void Function()? onClose,
       Future<Map<String, dynamic>> Function()? gatherCoverage})
       : _suiteChannel = null,
         _onClose = onClose,
@@ -171,5 +171,5 @@ class RunnerSuiteController {
         var onClose = _onClose;
         if (onClose != null) await onClose();
       });
-  final _closeMemo = AsyncMemoizer();
+  final _closeMemo = AsyncMemoizer<void>();
 }

--- a/pkgs/test_core/lib/src/runner/spawn_hybrid.dart
+++ b/pkgs/test_core/lib/src/runner/spawn_hybrid.dart
@@ -50,14 +50,14 @@ StreamChannel spawnHybridUri(String url, Object? message, Suite suite) {
           onExit: onExitPort.sendPort);
 
       // Ensure that we close [port] and [channel] when the isolate exits.
-      var disconnector = Disconnector();
+      var disconnector = Disconnector<void>();
       onExitPort.listen((_) {
         disconnector.disconnect();
         port.close();
         onExitPort.close();
       });
 
-      return IsolateChannel.connectReceive(port)
+      return IsolateChannel<Object?>.connectReceive(port)
           .transform(disconnector)
           .transformSink(StreamSinkTransformer.fromHandlers(handleDone: (sink) {
         // If the user closes the stream channel, kill the isolate.
@@ -76,7 +76,7 @@ StreamChannel spawnHybridUri(String url, Object? message, Suite suite) {
             'type': 'error',
             'error': RemoteException.serialize(error, stackTrace)
           })),
-          NullStreamSink());
+          NullStreamSink<void>());
     }
   }());
 }

--- a/pkgs/test_core/lib/src/runner/vm/environment.dart
+++ b/pkgs/test_core/lib/src/runner/vm/environment.dart
@@ -5,8 +5,9 @@
 import 'dart:async';
 
 import 'package:async/async.dart';
-import 'package:test_core/src/runner/environment.dart'; // ignore: implementation_imports
 import 'package:vm_service/vm_service.dart';
+
+import '../environment.dart'; // ignore: implementation_imports
 
 /// The environment in which VM tests are loaded.
 class VMEnvironment implements Environment {
@@ -25,12 +26,12 @@ class VMEnvironment implements Environment {
   Uri? get remoteDebuggerUrl => null;
 
   @override
-  Stream get onRestart => StreamController.broadcast().stream;
+  Stream<void> get onRestart => StreamController<void>.broadcast().stream;
 
   @override
-  CancelableOperation displayPause() {
+  CancelableOperation<void> displayPause() {
     var completer =
-        CancelableCompleter(onCancel: () => _client.resume(_isolate.id!));
+        CancelableCompleter<void>(onCancel: () => _client.resume(_isolate.id!));
 
     completer.complete(_client.pause(_isolate.id!).then((_) => _client
         .onDebugEvent

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -14,7 +14,6 @@ import 'package:path/path.dart' as p;
 import 'package:stream_channel/isolate_channel.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test_api/backend.dart';
-import 'package:test_core/src/runner/vm/test_compiler.dart';
 import 'package:vm_service/vm_service.dart' hide Isolate;
 import 'package:vm_service/vm_service_io.dart';
 
@@ -30,6 +29,7 @@ import '../../util/io.dart';
 import '../../util/package_config.dart';
 import '../package_version.dart';
 import 'environment.dart';
+import 'test_compiler.dart';
 
 var _shouldPauseAfterTests = false;
 
@@ -136,7 +136,7 @@ class VMPlatform extends PlatformPlugin {
       environment = VMEnvironment(url, isolateRef, client);
     }
 
-    environment ??= PluginEnvironment();
+    environment ??= const PluginEnvironment();
 
     var controller = deserializeSuite(
         path, platform, suiteConfig, environment, channel.cast(), message,

--- a/pkgs/test_core/lib/src/runner/vm/test_compiler.dart
+++ b/pkgs/test_core/lib/src/runner/vm/test_compiler.dart
@@ -65,7 +65,7 @@ class TestCompiler {
 }
 
 class _TestCompilerForLanguageVersion {
-  final _closeMemo = AsyncMemoizer();
+  final _closeMemo = AsyncMemoizer<void>();
   final _compilePool = Pool(1);
   final String _dillCachePath;
   FrontendServerClient? _frontendServerClient;

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -66,8 +66,10 @@ final lineSplitter = StreamTransformer<List<int>, String>(
 ///
 /// Also returns an empty stream for Fuchsia since Fuchsia components can't
 /// access stdin.
-StreamQueue<String> get stdinLines => _stdinLines ??= StreamQueue(
-    Platform.isFuchsia ? Stream<String>.empty() : lineSplitter.bind(stdin));
+StreamQueue<String> get stdinLines =>
+    _stdinLines ??= StreamQueue(Platform.isFuchsia
+        ? const Stream<String>.empty()
+        : lineSplitter.bind(stdin));
 
 StreamQueue<String>? _stdinLines;
 
@@ -239,7 +241,8 @@ extension RetryDelete on FileSystemEntity {
       } on FileSystemException {
         if (attempt == 2) rethrow;
         attempt++;
-        await Future.delayed(Duration(milliseconds: pow(10, attempt).toInt()));
+        await Future<void>.delayed(
+            Duration(milliseconds: pow(10, attempt).toInt()));
       }
     }
   }

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.5.8
+version: 0.5.9-wip
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 


### PR DESCRIPTION
Eagerly apply autofixes and manual fixes in the code before landing
dependabot PRs #2124 and #2125

Ignore the `comment_references` lint since there are false positives
(likely amongst true positives) in these packages.
