### PR TITLE
Tweak dart2js source map rewriting

### DIFF
--- a/pkgs/test_core/lib/src/runner/dart2js_compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/dart2js_compiler_pool.dart
@@ -107,7 +107,7 @@ class Dart2JsCompilerPool extends CompilerPool {
           switch (Uri.parse('$root$source')) {
             Uri(hasScheme: true) && final uri => uri.toString(),
             Uri(:final path) when path.endsWith('/runInBrowser.dart') => '',
-            final uri => mapUri.resolveUri(uri),
+            final uri => mapUri.resolveUri(uri).toString(),
           }
       ],
     );

--- a/pkgs/test_core/lib/src/runner/dart2js_compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/dart2js_compiler_pool.dart
@@ -93,18 +93,18 @@ class Dart2JsCompilerPool extends CompilerPool {
     });
   }
 
-  // TODO(nweiz): Remove this when sdk#17544 is fixed.
   /// Fix up the source map at [mapPath] so that it points to absolute file:
   /// URIs that are resolvable by the browser.
   void _fixSourceMap(String mapPath) {
     var map = jsonDecode(File(mapPath).readAsStringSync());
     var root = map['sourceRoot'] as String;
 
-    map['sources'] = map['sources'].map((Object? source) {
+    final mapUri = p.toUri(mapPath);
+    map['sources'] = (map['sources'] as List).map((Object? source) {
       var url = Uri.parse('$root$source');
-      if (url.scheme != '' && url.scheme != 'file') return source;
+      if (url.hasScheme) return url.toString();
       if (url.path.endsWith('/runInBrowser.dart')) return '';
-      return p.toUri(mapPath).resolveUri(url).toString();
+      return mapUri.resolveUri(url).toString();
     }).toList();
 
     File(mapPath).writeAsStringSync(jsonEncode(map));

--- a/pkgs/test_core/lib/src/runner/dart2js_compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/dart2js_compiler_pool.dart
@@ -96,14 +96,14 @@ class Dart2JsCompilerPool extends CompilerPool {
   /// Fix up the source map at [mapPath] so that it points to absolute file:
   /// URIs that are resolvable by the browser.
   void _fixSourceMap(String mapPath) {
-    var map = jsonDecode(File(mapPath).readAsStringSync());
+    var map = jsonDecode(File(mapPath).readAsStringSync()) as Map;
     var root = map['sourceRoot'] as String;
 
     final mapUri = p.toUri(mapPath);
     map.update(
       'sources',
-      () => [
-        for (Object? source in map['sources'] as List)
+      (sources) => [
+        for (var source in sources as List<Object?>)
           switch (Uri.parse('$root$source')) {
             Uri(hasScheme: true) && final uri => uri.toString(),
             Uri(:final path) when path.endsWith('/runInBrowser.dart') => '',

--- a/pkgs/test_core/lib/src/runner/dart2js_compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/dart2js_compiler_pool.dart
@@ -100,17 +100,17 @@ class Dart2JsCompilerPool extends CompilerPool {
     var root = map['sourceRoot'] as String;
 
     final mapUri = p.toUri(mapPath);
-    map.update(
-      'sources',
-      (sources) => [
-        for (var source in sources as List<Object?>)
-          switch (Uri.parse('$root$source')) {
-            Uri(hasScheme: true) && final uri => uri.toString(),
-            Uri(:final path) when path.endsWith('/runInBrowser.dart') => '',
-            final uri => mapUri.resolveUri(uri).toString(),
-          }
-      ],
-    );
+    map.cast<String, List<Object?>>().update(
+          'sources',
+          (sources) => [
+            for (var source in sources)
+              switch (Uri.parse('$root$source')) {
+                Uri(hasScheme: true) && final uri => uri.toString(),
+                Uri(:final path) when path.endsWith('/runInBrowser.dart') => '',
+                final uri => mapUri.resolveUri(uri).toString(),
+              }
+          ],
+        );
 
     File(mapPath).writeAsStringSync(jsonEncode(map));
   }

--- a/pkgs/test_core/lib/src/runner/dart2js_compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/dart2js_compiler_pool.dart
@@ -100,12 +100,17 @@ class Dart2JsCompilerPool extends CompilerPool {
     var root = map['sourceRoot'] as String;
 
     final mapUri = p.toUri(mapPath);
-    map['sources'] = (map['sources'] as List).map((Object? source) {
-      var url = Uri.parse('$root$source');
-      if (url.hasScheme) return url.toString();
-      if (url.path.endsWith('/runInBrowser.dart')) return '';
-      return mapUri.resolveUri(url).toString();
-    }).toList();
+    map.update(
+      'sources',
+      () => [
+        for (Object? source in map['sources'] as List)
+          switch (Uri.parse('$root$source')) {
+            Uri(hasScheme: true) && final uri => uri.toString(),
+            Uri(:final path) when path.endsWith('/runInBrowser.dart') => '',
+            final uri => mapUri.resolveUri(uri),
+          }
+      ],
+    );
 
     File(mapPath).writeAsStringSync(jsonEncode(map));
   }


### PR DESCRIPTION
- Remove a TODO referencing a closed issue. The issue was deduped to
  another which was closed without changes. Manual testing in a browser
  shows that the rewriting is still necessary.
- Extract a variable for the source map path as a Uri instead of
  computing it within the loop.
- Directly return URIs which are already `file://`. This would be a
  slight behavior change for the `runInBrowser.dart` synthetic source if
  it was ever put in the source map file with an absolute `file://`
  URI, but with the current (and apparently planned) dart2js output they
  do not have the file scheme. This is not a behavior change for any
  other cases where the source is a `file` URI, since it is no necessary
  to call `resolveUri` with an absolute path, and all `file` URI are
  absolute.

A sample run with a `Stopwatch` shows this reduces the non-IO overhead
by about 75% (out of 165ms in my sample with multiple suites).
