### PR TITLE
Strip leading slash when spawning isolate

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.24.10
+
+* Handle paths with leading `/` when spawning test isolates.
+
 ## 1.24.9
 
 * Update the vm_service constraint to allow version `13.x`.

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.24.10
+## 1.24.10-wip
 
 * Handle paths with leading `/` when spawning test isolates.
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.24.9
+version: 1.24.10-wip
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test
@@ -35,7 +35,7 @@ dependencies:
 
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.6.1
-  test_core: 0.5.9
+  test_core: 0.5.10
 
   typed_data: ^1.3.0
   web_socket_channel: ^2.0.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.10-wip
+
+* Handle paths with leading `/` when spawning test isolates.
+
 ## 0.5.9
 
 * Update the vm_service constraint to allow version `13.x`.

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -199,18 +199,7 @@ void _parseTestSelection(
     }
   }
   final uri = Uri.parse(option);
-  // Decode the path segment. Specifically, on github actions back slashes on
-  // windows end up being encoded into the URI instead of converted into forward
-  // slashes.
-  var path = Uri.decodeComponent(uri.path);
-  // Strip out the leading slash before the drive letter on windows.
-  if (Platform.isWindows &&
-      path.startsWith('/') &&
-      path.length >= 3 &&
-      path[2] == ':') {
-    path = path.substring(1);
-  }
-
+  final path = Uri.decodeComponent(uri.path).stripDriveLetterLeadingSlash;
   final names = uri.queryParametersAll['name'];
   final fullName = uri.queryParameters['full-name'];
   final line = uri.queryParameters['line'];

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -263,8 +263,9 @@ stderr: ${processResult.stderr}''');
 
   Future<Isolate> _spawnPrecompiledIsolate(String testPath, SendPort message,
       String precompiledPath, Compiler compiler) async {
-    testPath =
-        _absolute('${p.join(precompiledPath, testPath)}.vm_test.dart').path;
+    testPath = _absolute('${p.join(precompiledPath, testPath)}.vm_test.dart')
+        .path
+        .stripDriveLetterLeadingSlash;
     switch (compiler) {
       case Compiler.kernel:
         var dillTestpath =

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -247,3 +247,19 @@ extension RetryDelete on FileSystemEntity {
     }
   }
 }
+
+extension WindowsFilePaths on String {
+  /// Strip out the leading slash before the drive letter on windows.
+  ///
+  /// In some windows environments full paths get passed with `/` before the
+  /// drive letter. Normalize paths to exclude this slash when it exists.
+  String get stripDriveLetterLeadingSlash {
+    if (Platform.isWindows &&
+        startsWith('/') &&
+        length >= 3 &&
+        this[2] == ':') {
+      return substring(1);
+    }
+    return this;
+  }
+}

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.5.9
+version: 0.5.10-wip
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 


### PR DESCRIPTION
Pull out a small utility for stripping leading slashes on windows from
the arg parsing code so it can be reused when spawning isolates by path.

It's still not clear what specific conditions lead to paths which look
like this, but the behavior is triggering for this path in another CI
system.
