### PR TITLE
mark flaky windows test as skipped

### DIFF
--- a/pkgs/test/lib/src/runner/browser/compilers/dart2wasm.dart
+++ b/pkgs/test/lib/src/runner/browser/compilers/dart2wasm.dart
@@ -116,7 +116,6 @@ class Dart2WasmSupport implements CompilerSupport {
   /// A handler that serves wrapper files used to bootstrap tests.
   shelf.Response _wrapperHandler(shelf.Request request) {
     var path = p.fromUri(request.url);
-    print(request.url);
 
     if (path.endsWith('.html')) {
       var test = '${p.withoutExtension(path)}.dart';

--- a/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
+++ b/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
@@ -109,7 +109,7 @@ void main() {
             expect(test.stderr, emits('world'));
             await test.shouldExit(0);
           },
-              skip: Platform.isWindows
+              skip: Platform.isWindows && compiler == Compiler.exe
                   ? 'https://github.com/dart-lang/test/issues/2150'
                   : null);
         }

--- a/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
+++ b/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
@@ -108,7 +108,10 @@ void main() {
             expect(test.stdout, emitsThrough('hello'));
             expect(test.stderr, emits('world'));
             await test.shouldExit(0);
-          });
+          },
+              skip: Platform.isWindows
+                  ? 'https://github.com/dart-lang/test/issues/2150'
+                  : null);
         }
       },
           skip: compiler == Compiler.dart2wasm


### PR DESCRIPTION
See https://github.com/dart-lang/test/issues/2150

Also removes an accidental debug print that was landed