### PR TITLE
Update frontend_server_client constraint to allow version 4.0.0

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -8,6 +8,8 @@
 * **BREAKING**: Removed `Configuration.pubServeUrl` and support for it.
 * Fix running of tests defined under `lib/` with relative imports to other
   libraries in the package.
+* Update the `package:frontend_server_client` constraint to allow version
+  `4.0.0`.
 
 ## 0.5.9
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   boolean_selector: ^2.1.0
   collection: ^1.15.0
   coverage: ^1.0.0
-  frontend_server_client: '>=3.2.0 <4.0.0'
+  frontend_server_client: '>=3.2.0 <=4.0.0'
   glob: ^2.0.0
   io: ^1.0.0
   meta: ^1.3.0

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   boolean_selector: ^2.1.0
   collection: ^1.15.0
   coverage: ^1.0.0
-  frontend_server_client: '>=3.2.0 <=4.0.0'
+  frontend_server_client: '>=3.2.0 <5.0.0'
   glob: ^2.0.0
   io: ^1.0.0
   meta: ^1.3.0


### PR DESCRIPTION
Updating to `package:frontend_server_client v4.0.0` is only a breaking change for dependents that set the `debug` argument of `FrontendServerClient.start` to true, and`package:test_core` never does that.