### PR TITLE
Fix Dart2Wasm spelling

### DIFF
--- a/pkgs/test_api/lib/src/backend/compiler.dart
+++ b/pkgs/test_api/lib/src/backend/compiler.dart
@@ -8,7 +8,7 @@ enum Compiler {
   dart2js('Dart2Js', 'dart2js'),
 
   /// Experimental Dart to Wasm compiler.
-  dart2wasm('Dart2WASM', 'dart2wasm'),
+  dart2wasm('Dart2Wasm', 'dart2wasm'),
 
   /// Compiles dart code to a native executable.
   exe('Exe', 'exe'),


### PR DESCRIPTION
Abbreviation for WebAssembly is Wasm[1].

The Dart-to-Wasm backend is called `Dart2Wasm`, command line tool is called `dart2wasm`.

Rest of the uses in `package:test` looks correct.

[1]: https://webassembly.github.io/spec/core/intro/introduction.html#introduction