### PR TITLE
Add more logging around iframe startup

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.25.1-wip
+
 ## 1.25.0
 
 * Handle paths with leading `/` when spawning test isolates.

--- a/pkgs/test/lib/src/runner/browser/compilers/dart2js.dart
+++ b/pkgs/test/lib/src/runner/browser/compilers/dart2js.dart
@@ -142,10 +142,12 @@ class Dart2JsSupport implements CompilerSupport {
       var bootstrapContent = '''
         ${suiteConfig.metadata.languageVersionComment ?? await rootPackageLanguageVersionComment}
         import 'package:test/src/bootstrap/browser.dart';
+        import 'package:test/src/runner/browser/dom.dart' as dom;
 
         import '${await absoluteUri(dartPath)}' as test;
 
         void main() {
+          dom.window.console.log('Startup for test path $dartPath');
           internalBootstrapBrowserTest(() => test.main);
         }
       ''';

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.25.0
+version: 1.25.1-wip
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test

--- a/pkgs/test/tool/host.dart
+++ b/pkgs/test/tool/host.dart
@@ -246,6 +246,7 @@ StreamChannel<dynamic> _connectToIframe(String url, int id) {
 
   iframe.src = url;
   dom.document.body!.appendChild(iframe);
+  dom.window.console.log('Appended iframe with src $url');
 
   return controller.foreign;
 }


### PR DESCRIPTION
We see are getting some logs from the browser that shows some of the
test suites have a "Starting suite" output but no "sending channel to
host" output. Add more logging to the console to further narrow down
where things may be getting stuck.

- Add a log statement after appending the iframe to the page.
- Add a log statement at the beginning of the `main` that is loaded in
  the iframe.
