### PR TITLE
Document the silent reporter

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.25.1-wip
 
+* Document the silent reporter in CLI help output.
+
 ## 1.25.0
 
 * Handle paths with leading `/` when spawning test isolates.

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -110,6 +110,7 @@ Output:
           [expanded] (default)        A separate line for each update.
           [github]                    A custom reporter for GitHub Actions (the default reporter when running on GitHub Actions).
           [json]                      A machine-readable format (see https://dart.dev/go/test-docs/json_reporter.md).
+          [silent]                    A reporter with no output. May be useful when only the exit code is meaningful.
 
     --file-reporter                   Enable an additional reporter writing test results to a file.
                                       Should be in the form <reporter>:<filepath>, Example: "json:reports/tests.json"

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.6.1-wip
 
-- Handle missing package configs.
+* Handle missing package configs.
+* Document the silent reporter in CLI help output.
 
 ## 0.6.0
 

--- a/pkgs/test_core/lib/src/runner/configuration/args.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/args.dart
@@ -139,7 +139,7 @@ final ArgParser _parser = (() {
 
   var reporterDescriptions = <String, String>{
     for (final MapEntry(:key, :value) in allReporters.entries)
-      if (!value.hidden) key: value.description
+      key: value.description
   };
 
   parser.addSeparator('Output:');

--- a/pkgs/test_core/lib/src/runner/configuration/reporters.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/reporters.dart
@@ -22,8 +22,7 @@ typedef ReporterFactory = Reporter Function(Configuration, Engine, StringSink);
 class ReporterDetails {
   final String description;
   final ReporterFactory factory;
-  final bool hidden;
-  ReporterDetails(this.description, this.factory, {this.hidden = false});
+  ReporterDetails(this.description, this.factory);
 }
 
 /// All reporters and their corresponding details.
@@ -48,7 +47,8 @@ final _allReporters = <String, ReporterDetails>{
           printPlatform: config.suiteDefaults.runtimes.length > 1 ||
               config.suiteDefaults.compilerSelections != null)),
   'github': ReporterDetails(
-      'A custom reporter for GitHub Actions (the default reporter when running on GitHub Actions).',
+      'A custom reporter for GitHub Actions '
+      '(the default reporter when running on GitHub Actions).',
       (config, engine, sink) => GithubReporter.watch(engine, sink,
           printPath: config.testSelections.length > 1 ||
               Directory(config.testSelections.keys.single).existsSync(),
@@ -60,8 +60,8 @@ final _allReporters = <String, ReporterDetails>{
       (config, engine, sink) =>
           JsonReporter.watch(engine, sink, isDebugRun: config.debug)),
   'silent': ReporterDetails(
-      hidden: true,
-      'A reporter with no output.',
+      'A reporter with no output. '
+      'May be useful when only the exit code is meaningful.',
       (config, engine, sink) => SilentReporter()),
 };
 


### PR DESCRIPTION
Towards #2162

Unhide the silent reporter. This was originally introduced hidden
because we expected it to only be useful for our own CI infrastructure,
since a failure without any output cannot be investigated - it must be
reproduced in a separate run to even find which test case failed.

We now have an external request for failing without any output on stdio
and there is no strong reason to keep the silent reporter hidden.

Remove the support for hidden reporters entirely - it can easily be
reintroduced if we have another reporter which isn't user facing.

Expand the reporter description. Break a long description string into a
adjacent literals to avoid lines over 80 columns.
