### PR TITLE
fix a bug where test html files were not created in precompiled mode

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 1.25.1-wip
+## 1.25.1
+
+* Fix a bug where in precompiled mode, html files for tests were no longer
+  created.
 
 ## 1.25.0
 

--- a/pkgs/test/lib/src/runner/browser/compilers/compiler_support.dart
+++ b/pkgs/test/lib/src/runner/browser/compilers/compiler_support.dart
@@ -3,13 +3,26 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
 
+import 'package:path/path.dart' as p;
+import 'package:shelf/shelf.dart' as shelf;
 import 'package:test_api/backend.dart' show StackTraceMapper, SuitePlatform;
+import 'package:test_core/src/runner/configuration.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/suite.dart'; // ignore: implementation_imports
 import 'package:web_socket_channel/web_socket_channel.dart'; // ignore: implementation_imports
 
 /// The shared interface for all compiler support libraries.
-abstract interface class CompilerSupport {
+abstract class CompilerSupport {
+  /// The global test runner configuration.
+  final Configuration config;
+
+  /// The default template path.
+  final String defaultTemplatePath;
+
+  CompilerSupport(this.config, this.defaultTemplatePath);
+
   /// The URL at which this compiler serves its tests.
   ///
   /// Each compiler serves its tests under a different directory.
@@ -34,4 +47,26 @@ abstract interface class CompilerSupport {
 
   /// Closes down anything necessary for this implementation.
   Future<void> close();
+
+  /// A handler that serves html wrapper files used to bootstrap tests.
+  shelf.Response htmlWrapperHandler(shelf.Request request) {
+    var path = p.fromUri(request.url);
+
+    if (path.endsWith('.html')) {
+      var test = p.setExtension(path, '.dart');
+      var scriptBase = htmlEscape.convert(p.basename(test));
+      var link = '<link rel="x-dart-test" href="$scriptBase">';
+      var testName = htmlEscape.convert(test);
+      var template = config.customHtmlTemplatePath ?? defaultTemplatePath;
+      var contents = File(template).readAsStringSync();
+      var processedContents = contents
+          // Checked during loading phase that there is only one {{testScript}} placeholder.
+          .replaceFirst('{{testScript}}', link)
+          .replaceAll('{{testName}}', testName);
+      return shelf.Response.ok(processedContents,
+          headers: {'Content-Type': 'text/html'});
+    }
+
+    return shelf.Response.notFound('Not found.');
+  }
 }

--- a/pkgs/test/lib/src/runner/browser/compilers/dart2js.dart
+++ b/pkgs/test/lib/src/runner/browser/compilers/dart2js.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:http_multi_server/http_multi_server.dart';
@@ -30,7 +29,7 @@ import '../../../util/path_handler.dart';
 import 'compiler_support.dart';
 
 /// Support for Dart2Js compiled tests.
-class Dart2JsSupport implements CompilerSupport {
+class Dart2JsSupport extends CompilerSupport {
   /// Whether [close] has been called.
   bool _closed = false;
 
@@ -46,12 +45,6 @@ class Dart2JsSupport implements CompilerSupport {
 
   /// The [Dart2JsCompilerPool] managing active instances of `dart2js`.
   final _compilerPool = Dart2JsCompilerPool();
-
-  /// The global test runner configuration.
-  final Configuration _config;
-
-  /// The default template path.
-  final String _defaultTemplatePath;
 
   /// Mappers for Dartifying stack traces, indexed by test path.
   final _mappers = <String, StackTraceMapper>{};
@@ -81,14 +74,14 @@ class Dart2JsSupport implements CompilerSupport {
   @override
   Uri get serverUrl => _server.url.resolve('$_secret/');
 
-  Dart2JsSupport._(this._config, this._defaultTemplatePath, this._server,
+  Dart2JsSupport._(super.config, super.defaultTemplatePath, this._server,
       this._root, String faviconPath) {
     var cascade = shelf.Cascade()
         .add(_webSocketHandler.handler)
         .add(packagesDirHandler())
         .add(_pathHandler.handler)
         .add(createStaticHandler(_root))
-        .add(_wrapperHandler);
+        .add(htmlWrapperHandler);
 
     var pipeline = const shelf.Pipeline()
         .addMiddleware(PathHandler.nestedIn(_secret))
@@ -109,28 +102,6 @@ class Dart2JsSupport implements CompilerSupport {
     var server = shelf_io.IOServer(await HttpMultiServer.loopback(0));
     return Dart2JsSupport._(
         config, defaultTemplatePath, server, root, faviconPath);
-  }
-
-  /// A handler that serves wrapper files used to bootstrap tests.
-  shelf.Response _wrapperHandler(shelf.Request request) {
-    var path = p.fromUri(request.url);
-
-    if (path.endsWith('.html')) {
-      var test = p.setExtension(path, '.dart');
-      var scriptBase = htmlEscape.convert(p.basename(test));
-      var link = '<link rel="x-dart-test" href="$scriptBase">';
-      var testName = htmlEscape.convert(test);
-      var template = _config.customHtmlTemplatePath ?? _defaultTemplatePath;
-      var contents = File(template).readAsStringSync();
-      var processedContents = contents
-          // Checked during loading phase that there is only one {{testScript}} placeholder.
-          .replaceFirst('{{testScript}}', link)
-          .replaceAll('{{testName}}', testName);
-      return shelf.Response.ok(processedContents,
-          headers: {'Content-Type': 'text/html'});
-    }
-
-    return shelf.Response.notFound('Not found.');
   }
 
   @override

--- a/pkgs/test/lib/src/runner/browser/compilers/dart2js.dart
+++ b/pkgs/test/lib/src/runner/browser/compilers/dart2js.dart
@@ -29,7 +29,7 @@ import '../../../util/path_handler.dart';
 import 'compiler_support.dart';
 
 /// Support for Dart2Js compiled tests.
-class Dart2JsSupport extends CompilerSupport {
+class Dart2JsSupport extends CompilerSupport with JsHtmlWrapper {
   /// Whether [close] has been called.
   bool _closed = false;
 

--- a/pkgs/test/lib/src/runner/browser/compilers/dart2wasm.dart
+++ b/pkgs/test/lib/src/runner/browser/compilers/dart2wasm.dart
@@ -29,7 +29,7 @@ import '../browser_manager.dart';
 import 'compiler_support.dart';
 
 /// Support for Dart2Wasm compiled tests.
-class Dart2WasmSupport implements CompilerSupport {
+class Dart2WasmSupport extends CompilerSupport {
   /// Whether [close] has been called.
   bool _closed = false;
 
@@ -45,12 +45,6 @@ class Dart2WasmSupport implements CompilerSupport {
 
   /// The [WasmCompilerPool] managing active instances of `dart2wasm`.
   final _compilerPool = WasmCompilerPool();
-
-  /// The global test runner configuration.
-  final Configuration _config;
-
-  /// The default template path.
-  final String _defaultTemplatePath;
 
   /// The `package:test` side wrapper for the Dart2Wasm runtime.
   final String _jsRuntimeWrapper;
@@ -83,14 +77,14 @@ class Dart2WasmSupport implements CompilerSupport {
   @override
   Uri get serverUrl => _server.url.resolve('$_secret/');
 
-  Dart2WasmSupport._(this._config, this._defaultTemplatePath,
+  Dart2WasmSupport._(super.config, super.defaultTemplatePath,
       this._jsRuntimeWrapper, this._server, this._root, String faviconPath) {
     var cascade = shelf.Cascade()
         .add(_webSocketHandler.handler)
         .add(packagesDirHandler())
         .add(_pathHandler.handler)
         .add(createStaticHandler(_root))
-        .add(_wrapperHandler);
+        .add(htmlWrapperHandler);
 
     var pipeline = const shelf.Pipeline()
         .addMiddleware(PathHandler.nestedIn(_secret))
@@ -114,8 +108,11 @@ class Dart2WasmSupport implements CompilerSupport {
         server, root, faviconPath);
   }
 
-  /// A handler that serves wrapper files used to bootstrap tests.
-  shelf.Response _wrapperHandler(shelf.Request request) {
+  /// A handler that serves wrapper html files used to bootstrap tests.
+  ///
+  /// This is slightly different from normal tests.
+  @override
+  shelf.Response htmlWrapperHandler(shelf.Request request) {
     var path = p.fromUri(request.url);
 
     if (path.endsWith('.html')) {
@@ -123,7 +120,7 @@ class Dart2WasmSupport implements CompilerSupport {
       var scriptBase = htmlEscape.convert(p.basename(test));
       var link = '<link rel="x-dart-test" href="$scriptBase">';
       var testName = htmlEscape.convert(test);
-      var template = _config.customHtmlTemplatePath ?? _defaultTemplatePath;
+      var template = config.customHtmlTemplatePath ?? defaultTemplatePath;
       var contents = File(template).readAsStringSync();
       var jsRuntime = p.basename('$test.browser_test.dart.mjs');
       var wasmData = '<data id="WasmBootstrapInfo" '

--- a/pkgs/test/lib/src/runner/browser/platform.dart
+++ b/pkgs/test/lib/src/runner/browser/platform.dart
@@ -63,6 +63,7 @@ class BrowserPlatform extends PlatformPlugin
       _compilerSupport.putIfAbsent(compiler, () {
         if (_config.suiteDefaults.precompiledPath != null) {
           return PrecompiledSupport.start(
+              compiler: compiler,
               config: _config,
               defaultTemplatePath: _defaultTemplatePath,
               root: _config.suiteDefaults.precompiledPath!,

--- a/pkgs/test/lib/src/runner/browser/platform.dart
+++ b/pkgs/test/lib/src/runner/browser/platform.dart
@@ -63,6 +63,8 @@ class BrowserPlatform extends PlatformPlugin
       _compilerSupport.putIfAbsent(compiler, () {
         if (_config.suiteDefaults.precompiledPath != null) {
           return PrecompiledSupport.start(
+              config: _config,
+              defaultTemplatePath: _defaultTemplatePath,
               root: _config.suiteDefaults.precompiledPath!,
               faviconPath: _faviconPath);
         }

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.25.1-wip
+version: 1.25.1
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test


### PR DESCRIPTION
I think this should fix the failures we have been seeing on the bots for package:build.

Moved the logic for the test html wrapper into the base class for all modes of browser tests, so that it can be shared with the precompiled mode.  The dart2wasm mode overrides that behavior since it does things a bit different.