### PR TITLE
Use a raw string for console logging with path

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,8 +1,13 @@
+## 1.25.2
+
+* Fix a bug running browser tests with paths containing windows directory
+  separator follow by a character which is an invalid Dart string escape
+  sequence.
+
 ## 1.25.1
 
 * Fix a bug where in precompiled mode, html files for tests were no longer
   created.
-
 * Support the latest version of `package:js`.
 * Document the silent reporter in CLI help output.
 

--- a/pkgs/test/lib/src/runner/browser/compilers/dart2js.dart
+++ b/pkgs/test/lib/src/runner/browser/compilers/dart2js.dart
@@ -118,7 +118,7 @@ class Dart2JsSupport extends CompilerSupport with JsHtmlWrapper {
         import '${await absoluteUri(dartPath)}' as test;
 
         void main() {
-          dom.window.console.log('Startup for test path $dartPath');
+          dom.window.console.log(r'Startup for test path $dartPath');
           internalBootstrapBrowserTest(() => test.main);
         }
       ''';

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.25.1
+version: 1.25.2
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test


### PR DESCRIPTION
Fixes #2176

On windows a path can include a `\` followed by a letter that is not a
valid escape code in a Dart string. Prefix the string with `r` to make
it a raw string and log the path directly.
