### PR TITLE
Prepare to publish package:checks

### DIFF
--- a/pkgs/checks/CHANGELOG.md
+++ b/pkgs/checks/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0-wip
+## 0.3.0
 
 -   **Breaking Changes**
     -   Remove the `Condition` class and the `it()` utility. Replace calls to

--- a/pkgs/checks/pubspec.yaml
+++ b/pkgs/checks/pubspec.yaml
@@ -1,5 +1,5 @@
 name: checks
-version: 0.3.0-wip
+version: 0.3.0
 description: >-
   A framework for checking values against expectations and building custom
   expectations.
@@ -11,7 +11,7 @@ environment:
 dependencies:
   async: ^2.8.0
   meta: ^1.9.0
-  test_api: ">=0.5.0 <0.7.0"
+  test_api: ">=0.5.0 <0.8.0"
 
 dev_dependencies:
   dart_flutter_team_lints: ^2.0.0


### PR DESCRIPTION
Expand constraint on `package:test_api` to allow the latest
`package:test`.
