### PR TITLE
Register a service extension to return the test target library

### DIFF
--- a/pkgs/test_api/lib/service_extensions.dart
+++ b/pkgs/test_api/lib/service_extensions.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export 'src/service_extensions.dart';

--- a/pkgs/test_api/lib/src/service_extensions.dart
+++ b/pkgs/test_api/lib/src/service_extensions.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:developer';
+import 'dart:isolate';
+
+const _testPackageRootExtension = 'ext.test.testPackageRoot';
+
+/// Registers a service extension [_testPackageRootExtension] that returns the
+/// package root of the test being executed, which should be passed in as the
+/// [packageRootFileUri] parameter.
+///
+/// The value of [packageRootFileUri] should be equivalent to the current
+/// working directory where the test runner was started. This is because the
+/// test runner (started by `dart test` or `flutter test`) must be started from
+/// a package root that contains the `.dart_tool/package_config.json` file, and
+/// all test targets must be contained within that package root.
+///
+/// [packageRootFileUri] is expected to be a file uri (i.e. starting
+/// with 'file://').
+///
+/// The value of [packageRootFileUri] is passed in as a parameter here instead
+/// of computing the current working directory because we need to avoid a
+/// dependency on dart:io from pacakge:test_api.
+///
+/// Example usage:
+///
+/// registerTestPackageRootServiceExtension(
+///   Uri.file(Directory.current.absolute.path).toString(),
+/// );
+void registerTestPackageRootServiceExtension(String packageRootFileUri) {
+  if (!packageRootFileUri.startsWith('file://')) {
+    throw ArgumentError.value(
+      packageRootFileUri,
+      'rootPathFileUri',
+      'must be a file:// URI String',
+    );
+  }
+
+  registerExtension(_testPackageRootExtension, (method, parameters) async {
+    return ServiceExtensionResponse.result(
+      json.encode({'value': packageRootFileUri}),
+    );
+  });
+}

--- a/pkgs/test_core/lib/src/executable.dart
+++ b/pkgs/test_core/lib/src/executable.dart
@@ -150,6 +150,7 @@ Future<void> _execute(List<String> args) async {
   try {
     runner = Runner(configuration);
     _setupTestTargetLibraryExtension(configuration);
+    print('registering extension');
     exitCode = (await runner.run()) ? 0 : 1;
   } on ApplicationException catch (error) {
     stderr.writeln(error.message);

--- a/pkgs/test_core/lib/src/executable.dart
+++ b/pkgs/test_core/lib/src/executable.dart
@@ -204,9 +204,10 @@ void _setupTestTargetLibraryExtension(Configuration configuration) {
   // [configuration.testSelections] must be part of the same Dart package.
   final testTarget = configuration.testSelections.keys.first;
   final testTargetAbsolutePath = File(testTarget).absolute.path;
+  final packageRootFileUri = Uri.file(testTargetAbsolutePath).toString();
   registerExtension('ext.test.testTargetLibrary', (method, parameters) async {
     return ServiceExtensionResponse.result(
-      json.encode({'value': testTargetAbsolutePath}),
+      json.encode({'value': packageRootFileUri}),
     );
   });
 }


### PR DESCRIPTION
This adds a service extension on the test runner isolate that will allow other tools (e.g. DevTools) to get the test target root from the test runner isolate. See https://github.com/flutter/devtools/pull/7206 for an example of how this service extension will be used.

Fixes https://github.com/flutter/flutter/issues/143170.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
