### PR TITLE
Fix path to launch firefox on macOS

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.25.3-wip
 
 * Remove outdated StreamMatcher link from README table of contents.
+* Fix path to launch firefox on macOS.
 
 ## 1.25.2
 

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.25.3-wip
 
 * Remove outdated StreamMatcher link from README table of contents.
-* Fix path to launch firefox on macOS.
+* Add support for the new firefox binary location on macOS.
 
 ## 1.25.2
 

--- a/pkgs/test/lib/src/runner/browser/default_settings.dart
+++ b/pkgs/test/lib/src/runner/browser/default_settings.dart
@@ -9,25 +9,30 @@ import '../executable_settings.dart';
 
 /// Default settings for starting browser executables.
 final defaultSettings = UnmodifiableMapView({
-  Runtime.chrome: ExecutableSettings(
-      linuxExecutable: 'google-chrome',
-      macOSExecutable:
-          '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-      windowsExecutable: r'Google\Chrome\Application\chrome.exe',
-      environmentOverride: 'CHROME_EXECUTABLE'),
+  Runtime.chrome: ExecutableSettings(linuxExecutables: [
+    'google-chrome'
+  ], macOSExecutables: [
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+  ], windowsExecutables: [
+    r'Google\Chrome\Application\chrome.exe'
+  ], environmentOverride: 'CHROME_EXECUTABLE'),
   Runtime.edge: ExecutableSettings(
-    linuxExecutable: 'microsoft-edge-stable',
-    windowsExecutable: r'Microsoft\Edge\Application\msedge.exe',
-    macOSExecutable:
-        '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+    linuxExecutables: ['microsoft-edge-stable'],
+    windowsExecutables: [r'Microsoft\Edge\Application\msedge.exe'],
+    macOSExecutables: [
+      '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge'
+    ],
     environmentOverride: 'MS_EDGE_EXECUTABLE',
   ),
-  Runtime.firefox: ExecutableSettings(
-      linuxExecutable: 'firefox',
-      macOSExecutable: '/Applications/Firefox.app/Contents/MacOS/firefox',
-      windowsExecutable: r'Mozilla Firefox\firefox.exe',
-      environmentOverride: 'FIREFOX_EXECUTABLE'),
+  Runtime.firefox: ExecutableSettings(linuxExecutables: [
+    'firefox'
+  ], macOSExecutables: [
+    '/Applications/Firefox.app/Contents/MacOS/firefox',
+    '/Applications/Firefox.app/Contents/MacOS/firefox-bin'
+  ], windowsExecutables: [
+    r'Mozilla Firefox\firefox.exe'
+  ], environmentOverride: 'FIREFOX_EXECUTABLE'),
   Runtime.safari: ExecutableSettings(
-      macOSExecutable: '/Applications/Safari.app/Contents/MacOS/Safari',
+      macOSExecutables: ['/Applications/Safari.app/Contents/MacOS/Safari'],
       environmentOverride: 'SAFARI_EXECUTABLE'),
 });

--- a/pkgs/test/lib/src/runner/browser/default_settings.dart
+++ b/pkgs/test/lib/src/runner/browser/default_settings.dart
@@ -24,7 +24,7 @@ final defaultSettings = UnmodifiableMapView({
   ),
   Runtime.firefox: ExecutableSettings(
       linuxExecutable: 'firefox',
-      macOSExecutable: '/Applications/Firefox.app/Contents/MacOS/firefox-bin',
+      macOSExecutable: '/Applications/Firefox.app/Contents/MacOS/firefox',
       windowsExecutable: r'Mozilla Firefox\firefox.exe',
       environmentOverride: 'FIREFOX_EXECUTABLE'),
   Runtime.safari: ExecutableSettings(

--- a/pkgs/test/lib/src/runner/node/platform.dart
+++ b/pkgs/test/lib/src/runner/node/platform.dart
@@ -49,9 +49,9 @@ class NodePlatform extends PlatformPlugin
   /// it.
   final _settings = {
     Runtime.nodeJS: ExecutableSettings(
-        linuxExecutable: 'node',
-        macOSExecutable: 'node',
-        windowsExecutable: 'node.exe')
+        linuxExecutables: ['node'],
+        macOSExecutables: ['node'],
+        windowsExecutables: ['node.exe'])
   };
 
   NodePlatform() : _config = Configuration.current;

--- a/pkgs/test/test/runner/browser/chrome_test.dart
+++ b/pkgs/test/test/runner/browser/chrome_test.dart
@@ -47,9 +47,9 @@ webSocket.addEventListener("open", function() {
   test('reports an error in onExit', () {
     var chrome = Chrome(Uri.https('dart.dev'), configuration(),
         settings: ExecutableSettings(
-            linuxExecutable: '_does_not_exist',
-            macOSExecutable: '_does_not_exist',
-            windowsExecutable: '_does_not_exist'));
+            linuxExecutables: ['_does_not_exist'],
+            macOSExecutables: ['_does_not_exist'],
+            windowsExecutables: ['_does_not_exist']));
     expect(
         chrome.onExit,
         throwsA(isApplicationException(

--- a/pkgs/test/test/runner/browser/firefox_test.dart
+++ b/pkgs/test/test/runner/browser/firefox_test.dart
@@ -44,9 +44,9 @@ webSocket.addEventListener("open", function() {
   test('reports an error in onExit', () {
     var firefox = Firefox(Uri.https('dart.dev'),
         settings: ExecutableSettings(
-            linuxExecutable: '_does_not_exist',
-            macOSExecutable: '_does_not_exist',
-            windowsExecutable: '_does_not_exist'));
+            linuxExecutables: ['_does_not_exist'],
+            macOSExecutables: ['_does_not_exist'],
+            windowsExecutables: ['_does_not_exist']));
     expect(
         firefox.onExit,
         throwsA(isApplicationException(

--- a/pkgs/test/test/runner/browser/microsoft_edge_test.dart
+++ b/pkgs/test/test/runner/browser/microsoft_edge_test.dart
@@ -38,9 +38,9 @@ webSocket.addEventListener("open", function() {
   test('reports an error in onExit', () {
     var edge = MicrosoftEdge(Uri.parse('https://dart.dev'), configuration(),
         settings: ExecutableSettings(
-            linuxExecutable: '_does_not_exist',
-            macOSExecutable: '_does_not_exist',
-            windowsExecutable: '_does_not_exist'));
+            linuxExecutables: ['_does_not_exist'],
+            macOSExecutables: ['_does_not_exist'],
+            windowsExecutables: ['_does_not_exist']));
     expect(
         edge.onExit,
         throwsA(isApplicationException(

--- a/pkgs/test/test/runner/browser/safari_test.dart
+++ b/pkgs/test/test/runner/browser/safari_test.dart
@@ -45,9 +45,9 @@ webSocket.addEventListener("open", function() {
   test('reports an error in onExit', () {
     var safari = Safari(Uri.https('dart.dev'),
         settings: ExecutableSettings(
-            linuxExecutable: '_does_not_exist',
-            macOSExecutable: '_does_not_exist',
-            windowsExecutable: '_does_not_exist'));
+            linuxExecutables: ['_does_not_exist'],
+            macOSExecutables: ['_does_not_exist'],
+            windowsExecutables: ['_does_not_exist']));
     expect(
         safari.onExit,
         throwsA(isApplicationException(


### PR DESCRIPTION
Fix firefox startup path, as `dart test -p firefox` can no longer be executed on macOS.

close #2194 

I checked the workflow and both macos and firefox are removed from the execution environment. In relation to PR, do I need to add macos and firefox execution patterns to the workflow?

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
