### PR TITLE
Let the IsolateChannel close the RecievePort

### DIFF
--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -80,9 +80,7 @@ class VMPlatform extends PlatformPlugin {
         rethrow;
       }
       outerChannel = MultiChannel(IsolateChannel.connectReceive(receivePort));
-      cleanupCallbacks
-        ..add(receivePort.close)
-        ..add(isolate.kill);
+      cleanupCallbacks.add(isolate.kill);
     }
     cleanupCallbacks.add(outerChannel.sink.close);
 


### PR DESCRIPTION
The `IsolateChannel` should close the receive port when we call
`outerChannel.sink.close` which is also added to the `cleanupCallbacks`.

This was originally added in #1280 to try to fix cases where the test
runner could hang after running some tests specifically on the test
runner CI when running the test as a subprocess. It looks like when
it was introduced there was no call to `outerChannel.sink.close()`.
A cleanup callback to close the sink was added in #1941 which made
this unnecessary.