### PR TITLE
support enabling experiments when using the dart2wasm compiler

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Handle missing package configs.
 * Document the silent reporter in CLI help output.
+* Support enabling experiments with the dart2wasm compiler.
 
 ## 0.6.0
 

--- a/pkgs/test_core/lib/src/runner/wasm_compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/wasm_compiler_pool.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
+import '../util/dart.dart';
 import '../util/io.dart';
 import '../util/package_config.dart';
 import 'compiler_pool.dart';
@@ -44,6 +45,8 @@ class WasmCompilerPool extends CompilerPool {
         '--dart-sdk=$sdkRoot',
         '--platform=$platformDill',
         '--packages=${(await packageConfigUri).path}',
+        for (var experiment in enabledExperiments)
+          '--enable-experiment=$experiment',
         wrapperPath,
         outWasmPath,
       ]);


### PR DESCRIPTION
We don't appear to have any tests for experiments right now, nor any really good way of adding them. I did manually test though 🤷‍♂️  