### PR TITLE
Allow the next semver major versions of shelf_web_socket and web_socket_channel

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,12 +1,14 @@
-## 1.25.4
+## 1.25.5
 
-* Add `@doNotSubmit` to more declarations of the `solo` parameter.
 * Update the `package:web_socket_channel` version constraint to allow `3.x`.
 * Update the `package:shelf_web_socket` version constraint to allow `2.x`.
 
+## 1.25.4
+
+* Add `@doNotSubmit` to more declarations of the `solo` parameter.
+
 ## 1.25.3
 
-* Remove outdated StreamMatcher link from README table of contents.
 * Remove outdated StreamMatcher link from README table of contents.
 * Document the silent reporter in CLI help output.
 * Support enabling experiments with the dart2wasm compiler.

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.25.3-wip
 
 * Remove outdated StreamMatcher link from README table of contents.
+* Update the `package:web_socket_channel` version constraint to allow `3.x`.
+* Update the `package:shelf_web_socket` version constraint to allow `2.x`.
 
 ## 1.25.2
 

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.25.3-wip
+## 1.25.3
 
 * Remove outdated StreamMatcher link from README table of contents.
 * Update the `package:web_socket_channel` version constraint to allow `3.x`.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.25.4
+version: 1.25.5
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   shelf: ^1.0.0
   shelf_packages_handler: ^3.0.0
   shelf_static: ^1.0.0
-  shelf_web_socket: ^1.0.0
+  shelf_web_socket: '>=1.0.0 <3.0.0'
   source_span: ^1.8.0
   stack_trace: ^1.10.0
   stream_channel: ^2.1.0
@@ -38,7 +38,7 @@ dependencies:
   test_core: 0.6.1
 
   typed_data: ^1.3.0
-  web_socket_channel: ^2.0.0
+  web_socket_channel: '>=2.0.0 <4.0.0'
   webkit_inspection_protocol: ^1.0.0
   yaml: ^3.0.0
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.25.3-wip
+version: 1.25.3
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test


### PR DESCRIPTION
This is part of a [plan to simplify the web_socket_channel implementation](https://github.com/dart-lang/web_socket_channel/issues/340)

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
