### PR TITLE
Point README links to the test library

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.25.5-wip
+
 ## 1.25.4
 
 * Add `@doNotSubmit` to more declarations of the `solo` parameter.

--- a/pkgs/test/README.md
+++ b/pkgs/test/README.md
@@ -37,7 +37,7 @@
 Tests are specified using the top-level [`test()`] function.
 Test asserts can be made using [`expect` from `package:matcher`][expect]
 
-[`test()`]: https://pub.dev/documentation/test_core/latest/test_core.scaffolding/test.html
+[`test()`]: https://pub.dev/documentation/test/latest/test/test.html
 
 [expect]: https://pub.dev/documentation/matcher/latest/expect/expect.html
 
@@ -60,7 +60,7 @@ void main() {
 Tests can be grouped together using the [`group()`] function. Each group's
 description is added to the beginning of its test's descriptions.
 
-[`group()`]: https://pub.dev/documentation/test_core/latest/test_core.scaffolding/group.html
+[`group()`]: https://pub.dev/documentation/test/latest/test/group.html
 
 ```dart
 import 'package:test/test.dart';
@@ -116,9 +116,9 @@ void main() {
 }
 ```
 
-[`setUp()`]: https://pub.dev/documentation/test_core/latest/test_core.scaffolding/setUp.html
+[`setUp()`]: https://pub.dev/documentation/test/latest/test/setUp.html
 
-[`tearDown()`]: https://pub.dev/documentation/test_core/latest/test_core.scaffolding/tearDown.html
+[`tearDown()`]: https://pub.dev/documentation/test/latest/test/tearDown.html
 
 ## Running Tests
 
@@ -317,7 +317,7 @@ void main() {
 }
 ```
 
-[`@TestOn`]: https://pub.dev/documentation/test_api/latest/test_api.scaffolding/TestOn-class.html
+[`@TestOn`]: https://pub.dev/documentation/test/latest/test/TestOn-class.html
 
 The string you pass to `@TestOn` is what's called a "platform selector", and it
 specifies exactly which platforms a test can run on. It can be as simple as the
@@ -776,9 +776,9 @@ The only difference is where the code from the isolate comes from:
 `spawnHybridUri()` takes a URL. They both return a [`StreamChannel`] that
 communicates with the hybrid isolate. For example:
 
-[`spawnHybridCode()`]: https://pub.dev/documentation/test_api/latest/test_api.scaffolding/spawnHybridCode.html
+[`spawnHybridCode()`]: https://pub.dev/documentation/test/latest/test/spawnHybridCode.html
 
-[`spawnHybridUri()`]: https://pub.dev/documentation/test_api/latest/test_api.scaffolding/spawnHybridUri.html
+[`spawnHybridUri()`]: https://pub.dev/documentation/test/latest/test/spawnHybridUri.html
 
 [dart:isolate]: https://api.dart.dev/stable/dart-isolate/dart-isolate-library.html
 

--- a/pkgs/test/doc/architecture.md
+++ b/pkgs/test/doc/architecture.md
@@ -29,14 +29,14 @@ thought of as frontend functions as well.
 
 The frontend communicates with the backend using zone-scoped getters.
 [`Invoker.current`][Invoker] provides access to the current test case to
-built-in matchers like [`completion()`][completion], for example to control when
+matchers like [`completion()`][completion], for example to control when
 it completes. Structural functions use [`Declarer.current`][Declarer] to
 gradually build up an in-memory representation of a test suite. The runner is in
 charge of setting up these variables, but the frontend never communicates with
 the runner directly.
 
 [Invoker]: https://github.com/dart-lang/test/blob/master/lib/src/backend/invoker.dart
-[completion]: https://pub.dev/documentation/test_api/latest/test_api/completion.html
+[completion]: https://pub.dev/documentation/matcher/latest/expect/completion.html
 [Declarer]: https://github.com/dart-lang/test/blob/master/lib/src/backend/declarer.dart
 
 ### Backend

--- a/pkgs/test/doc/configuration.md
+++ b/pkgs/test/doc/configuration.md
@@ -149,7 +149,7 @@ This field controls whether or not tests are skipped. It's usually applied to
 `skip` parameter for [`test()`][test], it can either be a boolean indicating
 whether the tests are skipped or a string indicating the reason they're skipped.
 
-[test]: https://pub.dev/documentation/test_api/latest/test_api/test.html
+[test]: https://pub.dev/documentation/test/latest/test/test.html
 
 ```yaml
 tags:

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.25.4
+version: 1.25.5-wip
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test


### PR DESCRIPTION
Closes #2218

These links were to the defining library, which can change without a
user visible breaking change or major version bump. Link instead to the
`package:test/test.dart` library docs for all APIs. The export makes the
dartdoc links work, and these are more stable since they are user facing
and will only change in a major version release.
