### PR TITLE
Remove an unnecessary `dynamic`

### DIFF
--- a/pkgs/test_core/lib/src/runner/console.dart
+++ b/pkgs/test_core/lib/src/runner/console.dart
@@ -47,9 +47,9 @@ class Console {
   ///
   /// The [description] should be a one-line description of the command to print
   /// in the help output. The [body] callback will be called when the user types
-  /// the command, and may return a [Future].
+  /// the command.
   void registerCommand(
-      String name, String description, dynamic Function() body) {
+      String name, String description, FutureOr<void> Function() body) {
     if (_commands.containsKey(name)) {
       throw ArgumentError('The console already has a command named "$name".');
     }
@@ -111,7 +111,7 @@ class _Command {
   final String description;
 
   /// The callback to run when the command is invoked.
-  final Function body;
+  final FutureOr<void> Function() body;
 
   _Command(this.name, this.description, this.body);
 }

--- a/pkgs/test_core/lib/src/runner/console.dart
+++ b/pkgs/test_core/lib/src/runner/console.dart
@@ -13,7 +13,8 @@ import '../util/io.dart';
 /// An interactive console for taking user commands.
 class Console {
   /// The registered commands.
-  final _commands = <String, _Command>{};
+  final _commands = <String,
+      ({String name, String description, FutureOr<void> Function() body})>{};
 
   /// The pending next line of standard input, if we're waiting on one.
   CancelableOperation? _nextLine;
@@ -54,7 +55,7 @@ class Console {
       throw ArgumentError('The console already has a command named "$name".');
     }
 
-    _commands[name] = _Command(name, description, body);
+    _commands[name] = (name: name, description: description, body: body);
   }
 
   /// Starts running the console.
@@ -100,18 +101,4 @@ class Console {
       print('$_bold$name$_noColor${command.description}');
     }
   }
-}
-
-/// An individual console command.
-class _Command {
-  /// The name of the command.
-  final String name;
-
-  /// The single-line description of the command.
-  final String description;
-
-  /// The callback to run when the command is invoked.
-  final FutureOr<void> Function() body;
-
-  _Command(this.name, this.description, this.body);
 }

--- a/pkgs/test_core/lib/src/runner/console.dart
+++ b/pkgs/test_core/lib/src/runner/console.dart
@@ -13,8 +13,7 @@ import '../util/io.dart';
 /// An interactive console for taking user commands.
 class Console {
   /// The registered commands.
-  final _commands = <String,
-      ({String name, String description, FutureOr<void> Function() body})>{};
+  final _commands = <String, _Command>{};
 
   /// The pending next line of standard input, if we're waiting on one.
   CancelableOperation? _nextLine;
@@ -102,3 +101,9 @@ class Console {
     }
   }
 }
+
+typedef _Command = ({
+  String name,
+  String description,
+  FutureOr<void> Function() body,
+});


### PR DESCRIPTION
The `dynamic` was used to satisfy the purpose that is more directly
expressed with `FutureOr`.

Replace the private `_Command` class with a typedef record with named fields.
