### PR TITLE
Add package config URI into VM test entrypoints

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -308,6 +308,41 @@ jobs:
       - job_003
       - job_004
   job_007:
+    name: "unit_test; linux; Dart 3.4.0; PKG: pkgs/test_core; `dart test`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/test_core;commands:command_01"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/test_core
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
+        with:
+          sdk: "3.4.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
+      - id: pkgs_test_core_pub_upgrade
+        name: pkgs/test_core; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test_core
+      - name: pkgs/test_core; dart test
+        run: dart test
+        if: "always() && steps.pkgs_test_core_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test_core
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_008:
     name: "unit_test; linux; Dart 3.4.0; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
     runs-on: ubuntu-latest
     steps:
@@ -342,7 +377,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_008:
+  job_009:
     name: "unit_test; linux; Dart 3.4.0; PKG: integration_tests/wasm; `pushd /tmp && wget https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb && sudo dpkg -i google-chrome-beta_current_amd64.deb && popd && which google-chrome-beta`, `dart test --timeout=60s`"
     runs-on: ubuntu-latest
     steps:
@@ -381,7 +416,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_009:
+  job_010:
     name: "unit_test; linux; Dart 3.4.0; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: ubuntu-latest
     steps:
@@ -416,7 +451,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_010:
+  job_011:
     name: "unit_test; linux; Dart 3.4.0; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: ubuntu-latest
     steps:
@@ -451,7 +486,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_011:
+  job_012:
     name: "unit_test; linux; Dart 3.4.0; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: ubuntu-latest
     steps:
@@ -486,7 +521,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_012:
+  job_013:
     name: "unit_test; linux; Dart 3.4.0; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 3`"
     runs-on: ubuntu-latest
     steps:
@@ -521,7 +556,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_013:
+  job_014:
     name: "unit_test; linux; Dart 3.4.0; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 4`"
     runs-on: ubuntu-latest
     steps:
@@ -556,7 +591,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_014:
+  job_015:
     name: "unit_test; linux; Dart 3.4.0; PKG: pkgs/test_api; `dart test --preset travis -x browser`"
     runs-on: ubuntu-latest
     steps:
@@ -591,7 +626,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_015:
+  job_016:
     name: "unit_test; linux; Dart dev; PKG: integration_tests/regression; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -626,7 +661,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_016:
+  job_017:
     name: "unit_test; linux; Dart dev; PKG: pkgs/checks; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -661,7 +696,42 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_017:
+  job_018:
+    name: "unit_test; linux; Dart dev; PKG: pkgs/test_core; `dart test`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/test_core;commands:command_01"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/test_core
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
+      - id: pkgs_test_core_pub_upgrade
+        name: pkgs/test_core; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test_core
+      - name: pkgs/test_core; dart test
+        run: dart test
+        if: "always() && steps.pkgs_test_core_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test_core
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_019:
     name: "unit_test; linux; Dart dev; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
     runs-on: ubuntu-latest
     steps:
@@ -696,7 +766,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_018:
+  job_020:
     name: "unit_test; linux; Dart dev; PKG: integration_tests/wasm; `pushd /tmp && wget https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb && sudo dpkg -i google-chrome-beta_current_amd64.deb && popd && which google-chrome-beta`, `dart test --timeout=60s`"
     runs-on: ubuntu-latest
     steps:
@@ -735,7 +805,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_019:
+  job_021:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: ubuntu-latest
     steps:
@@ -770,7 +840,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_020:
+  job_022:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: ubuntu-latest
     steps:
@@ -805,7 +875,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_021:
+  job_023:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: ubuntu-latest
     steps:
@@ -840,7 +910,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_022:
+  job_024:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 3`"
     runs-on: ubuntu-latest
     steps:
@@ -875,7 +945,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_023:
+  job_025:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 4`"
     runs-on: ubuntu-latest
     steps:
@@ -910,7 +980,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_024:
+  job_026:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test_api; `dart test --preset travis -x browser`"
     runs-on: ubuntu-latest
     steps:
@@ -945,7 +1015,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_025:
+  job_027:
     name: "unit_test; windows; Dart 3.4.0; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
     runs-on: windows-latest
     steps:
@@ -970,7 +1040,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_026:
+  job_028:
     name: "unit_test; windows; Dart 3.4.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: windows-latest
     steps:
@@ -995,7 +1065,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_027:
+  job_029:
     name: "unit_test; windows; Dart 3.4.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: windows-latest
     steps:
@@ -1020,7 +1090,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_028:
+  job_030:
     name: "unit_test; windows; Dart 3.4.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: windows-latest
     steps:
@@ -1045,7 +1115,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_029:
+  job_031:
     name: "unit_test; windows; Dart 3.4.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 3`"
     runs-on: windows-latest
     steps:
@@ -1070,7 +1140,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_030:
+  job_032:
     name: "unit_test; windows; Dart 3.4.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 4`"
     runs-on: windows-latest
     steps:
@@ -1095,7 +1165,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_031:
+  job_033:
     name: "unit_test; windows; Dart dev; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
     runs-on: windows-latest
     steps:
@@ -1120,7 +1190,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_032:
+  job_034:
     name: Notify failure
     runs-on: ubuntu-latest
     if: "(github.event_name == 'push' || github.event_name == 'schedule') && failure()"
@@ -1163,3 +1233,5 @@ jobs:
       - job_029
       - job_030
       - job_031
+      - job_032
+      - job_033

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -299,10 +299,11 @@ stderr: ${processResult.stderr}''');
     if (!file.existsSync()) {
       file
         ..createSync(recursive: true)
-        ..writeAsStringSync(_bootstrapIsolateTestContents(
+        ..writeAsStringSync(testBootstrapContents(
           testUri: await absoluteUri(testPath),
           languageVersionComment: languageVersionComment,
           packageConfigUri: await Isolate.packageConfig,
+          bootstrapType: 'Vm',
         ));
     }
     return file.uri;
@@ -319,56 +320,16 @@ stderr: ${processResult.stderr}''');
     if (!file.existsSync()) {
       file
         ..createSync(recursive: true)
-        ..writeAsStringSync(_bootstrapNativeTestContents(
+        ..writeAsStringSync(testBootstrapContents(
           testUri: await absoluteUri(testPath),
           languageVersionComment: languageVersionComment,
           packageConfigUri: await Isolate.packageConfig,
+          bootstrapType: 'Native',
         ));
     }
     return file.path;
   }
 }
-
-/// Creates bootstrap file contents for running [testUri] in a VM isolate.
-String _bootstrapIsolateTestContents({
-  required Uri testUri,
-  required String languageVersionComment,
-  required Uri? packageConfigUri,
-}) =>
-    '''
-    $languageVersionComment
-
-    import 'dart:isolate';
-    import 'package:test_core/src/bootstrap/vm.dart';
-    import '$testUri' as test;
-
-    const packageConfigLocation = '$packageConfigUri';
-
-    void main(_, SendPort sendPort) {
-      internalBootstrapVmTest(() => test.main, sendPort);
-    }
-  ''';
-
-/// Creates bootstrap file contents for running [testUri] as a native
-/// executable.
-String _bootstrapNativeTestContents({
-  required Uri testUri,
-  required String languageVersionComment,
-  required Uri? packageConfigUri,
-}) =>
-    '''
-    $languageVersionComment
-
-    import 'dart:isolate';
-    import 'package:test_core/src/bootstrap/vm.dart';
-    import '$testUri' as test;
-
-    const packageConfigLocation = '$packageConfigUri';
-
-    void main(List<String> args) {
-      internalBootstrapNativeTest(() => test.main, args);
-    }
-  ''';
 
 Future<Map<String, dynamic>> _gatherCoverage(Environment environment) async {
   final isolateId = Uri.parse(environment.observatoryUrl!.fragment)

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -300,7 +300,10 @@ stderr: ${processResult.stderr}''');
       file
         ..createSync(recursive: true)
         ..writeAsStringSync(_bootstrapIsolateTestContents(
-            await absoluteUri(testPath), languageVersionComment));
+          testUri: await absoluteUri(testPath),
+          languageVersionComment: languageVersionComment,
+          packageConfigUri: await Isolate.packageConfig,
+        ));
     }
     return file.uri;
   }
@@ -317,20 +320,30 @@ stderr: ${processResult.stderr}''');
       file
         ..createSync(recursive: true)
         ..writeAsStringSync(_bootstrapNativeTestContents(
-            await absoluteUri(testPath), languageVersionComment));
+          testUri: await absoluteUri(testPath),
+          languageVersionComment: languageVersionComment,
+          packageConfigUri: await Isolate.packageConfig,
+        ));
     }
     return file.path;
   }
 }
 
 /// Creates bootstrap file contents for running [testUri] in a VM isolate.
-String _bootstrapIsolateTestContents(
-        Uri testUri, String languageVersionComment) =>
+String _bootstrapIsolateTestContents({
+  required Uri testUri,
+  required String languageVersionComment,
+  required Uri? packageConfigUri,
+}) =>
     '''
     $languageVersionComment
-    import "dart:isolate";
-    import "package:test_core/src/bootstrap/vm.dart";
-    import "$testUri" as test;
+
+    import 'dart:isolate';
+    import 'package:test_core/src/bootstrap/vm.dart';
+    import '$testUri' as test;
+
+    const packageConfigLocation = '$packageConfigUri';
+
     void main(_, SendPort sendPort) {
       internalBootstrapVmTest(() => test.main, sendPort);
     }
@@ -338,13 +351,20 @@ String _bootstrapIsolateTestContents(
 
 /// Creates bootstrap file contents for running [testUri] as a native
 /// executable.
-String _bootstrapNativeTestContents(
-        Uri testUri, String languageVersionComment) =>
+String _bootstrapNativeTestContents({
+  required Uri testUri,
+  required String languageVersionComment,
+  required Uri? packageConfigUri,
+}) =>
     '''
     $languageVersionComment
-    import "dart:isolate";
-    import "package:test_core/src/bootstrap/vm.dart";
-    import "$testUri" as test;
+
+    import 'dart:isolate';
+    import 'package:test_core/src/bootstrap/vm.dart';
+    import '$testUri' as test;
+
+    const packageConfigLocation = '$packageConfigUri';
+
     void main(List<String> args) {
       internalBootstrapNativeTest(() => test.main, args);
     }

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -303,7 +303,7 @@ stderr: ${processResult.stderr}''');
           testUri: await absoluteUri(testPath),
           languageVersionComment: languageVersionComment,
           packageConfigUri: await Isolate.packageConfig,
-          bootstrapType: 'Vm',
+          testType: VmTestType.isolate,
         ));
     }
     return file.uri;
@@ -324,7 +324,7 @@ stderr: ${processResult.stderr}''');
           testUri: await absoluteUri(testPath),
           languageVersionComment: languageVersionComment,
           packageConfigUri: await Isolate.packageConfig,
-          bootstrapType: 'Native',
+          testType: VmTestType.process,
         ));
     }
     return file.path;

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -302,7 +302,7 @@ stderr: ${processResult.stderr}''');
         ..writeAsStringSync(testBootstrapContents(
           testUri: await absoluteUri(testPath),
           languageVersionComment: languageVersionComment,
-          packageConfigUri: await Isolate.packageConfig,
+          packageConfigUri: await packageConfigUri,
           testType: VmTestType.isolate,
         ));
     }
@@ -323,7 +323,7 @@ stderr: ${processResult.stderr}''');
         ..writeAsStringSync(testBootstrapContents(
           testUri: await absoluteUri(testPath),
           languageVersionComment: languageVersionComment,
-          packageConfigUri: await Isolate.packageConfig,
+          packageConfigUri: await packageConfigUri,
           testType: VmTestType.process,
         ));
     }

--- a/pkgs/test_core/lib/src/runner/vm/test_compiler.dart
+++ b/pkgs/test_core/lib/src/runner/vm/test_compiler.dart
@@ -98,7 +98,7 @@ class _TestCompilerForLanguageVersion {
         testUri: mainUri,
         packageConfigUri: await Isolate.packageConfig,
         languageVersionComment: _languageVersionComment,
-        bootstrapType: 'Vm',
+        testType: VmTestType.isolate,
       ));
     final testCache = File(_dillCachePath);
 
@@ -211,9 +211,13 @@ String testBootstrapContents({
   required Uri testUri,
   required String languageVersionComment,
   required Uri? packageConfigUri,
-  required String bootstrapType,
-}) =>
-    '''
+  required VmTestType testType,
+}) {
+  final (argType, argName, bootstrapType) = switch (testType) {
+    VmTestType.isolate => ('_, SendPort', 'sendPort', 'Vm'),
+    VmTestType.process => ('List<String>', 'args', 'Native'),
+  };
+  return '''
     $languageVersionComment
 
     import 'dart:isolate';
@@ -224,7 +228,10 @@ String testBootstrapContents({
 
     const packageConfigLocation = '$packageConfigUri';
 
-    void main(_, SendPort sendPort) {
-      internalBootstrap${bootstrapType}Test(() => test.main, sendPort);
+    void main($argType $argName) {
+      internalBootstrap${bootstrapType}Test(() => test.main, $argName);
     }
   ''';
+}
+
+enum VmTestType { isolate, process }

--- a/pkgs/test_core/lib/src/runner/vm/test_compiler.dart
+++ b/pkgs/test_core/lib/src/runner/vm/test_compiler.dart
@@ -203,7 +203,10 @@ String _dillCacheSuffix(
   return base64.encode(utf8.encode(identifierString.toString()));
 }
 
-/// Creates bootstrap file contents for running [testUri] in a VM isolate.
+/// Creates bootstrap file contents for running [testUri].
+///
+/// The [bootstrapType] argument should be either 'Vm' or 'Native' depending on
+/// which `internalBootstrap*Test` function should be used.
 String testBootstrapContents({
   required Uri testUri,
   required String languageVersionComment,

--- a/pkgs/test_core/mono_pkg.yaml
+++ b/pkgs/test_core/mono_pkg.yaml
@@ -11,3 +11,7 @@ stages:
   - group:
     - analyze
     sdk: pubspec
+- unit_test:
+  - group:
+    - command: dart test
+    sdk: [dev, pubspec]

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -32,3 +32,4 @@ dependencies:
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0
+  test: any

--- a/pkgs/test_core/pubspec_overrides.yaml
+++ b/pkgs/test_core/pubspec_overrides.yaml
@@ -1,3 +1,5 @@
 dependency_overrides:
   test_api:
     path: ../test_api
+  test:
+    path: ../test

--- a/pkgs/test_core/test/runner/vm/test_compiler_test.dart
+++ b/pkgs/test_core/test/runner/vm/test_compiler_test.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:test/test.dart';
+import 'package:test_core/src/runner/vm/test_compiler.dart';
+
+void main() {
+  group('VM test templates', () {
+    test('include package config URI variable', () async {
+      // This variable is read through the VM service and should not be removed.
+      final template = testBootstrapContents(
+        testUri: Uri.file('foo.dart'),
+        languageVersionComment: '// version comment',
+        packageConfigUri: Uri.file('package_config.json'),
+        testType: VmTestType.isolate,
+      );
+      final lines = LineSplitter.split(template).map((line) => line.trim());
+      expect(lines,
+          contains("const packageConfigLocation = 'package_config.json';"));
+    });
+  });
+}


### PR DESCRIPTION
Towards #2246 

This will allow a client of the VM service to evaluate the top level
variable and locate the package config used by the test runner.

Add a public `testBootstapContents` function in `test_compiler.dart`
which centralizes the bootstrap templates. Add an argument for the
package config URI and a `VmTestType` which is either "Vm" or
"Native".

Add the first test case in `test_core`. Add the pub dependency and
override for `package:test`, as well as the mono_repo configuration to
run unit tests. Other tests for `test_core` code is under the `test`
package but should be moved eventually.

