### PR TITLE
use pub workspaces

### DIFF
--- a/integration_tests/regression/pubspec.yaml
+++ b/integration_tests/regression/pubspec.yaml
@@ -1,15 +1,7 @@
 name: regression_tests
 publish_to: none
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
+resolution: workspace
 dependencies:
   test: any
-dev_dependencies:
-  dart_flutter_team_lints: ^3.0.0
-dependency_overrides:
-  test:
-    path: ../../pkgs/test
-  test_api:
-    path: ../../pkgs/test_api
-  test_core:
-    path: ../../pkgs/test_core

--- a/integration_tests/spawn_hybrid/pubspec.yaml
+++ b/integration_tests/spawn_hybrid/pubspec.yaml
@@ -1,20 +1,13 @@
 name: spawn_hybrid
 publish_to: none
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
+resolution: workspace
 dependencies:
   async: ^2.9.0
   path: ^1.8.2
   stream_channel: ^2.1.0
 dev_dependencies:
-  dart_flutter_team_lints: ^3.0.0
   other_package:
     path: other_package/
   test: any
-dependency_overrides:
-  test:
-    path: ../../pkgs/test
-  test_api:
-    path: ../../pkgs/test_api
-  test_core:
-    path: ../../pkgs/test_core

--- a/integration_tests/wasm/pubspec.yaml
+++ b/integration_tests/wasm/pubspec.yaml
@@ -1,14 +1,7 @@
 name: wasm_tests
 publish_to: none
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
+resolution: workspace
 dev_dependencies:
-  dart_flutter_team_lints: ^3.0.0
   test: any
-dependency_overrides:
-  test:
-    path: ../../pkgs/test
-  test_api:
-    path: ../../pkgs/test_api
-  test_core:
-    path: ../../pkgs/test_core

--- a/pkgs/checks/pubspec.yaml
+++ b/pkgs/checks/pubspec.yaml
@@ -1,12 +1,12 @@
 name: checks
-version: 0.3.1-wip
 description: >-
   A framework for checking values against expectations and building custom
   expectations.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/checks
+resolution: workspace
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 dependencies:
   async: ^2.8.0
@@ -14,5 +14,4 @@ dependencies:
   test_api: ">=0.5.0 <0.8.0"
 
 dev_dependencies:
-  dart_flutter_team_lints: ^3.0.0
   test: ^1.21.3

--- a/pkgs/checks/pubspec_overrides.yaml
+++ b/pkgs/checks/pubspec_overrides.yaml
@@ -1,7 +1,0 @@
-dependency_overrides:
-  test_api:
-    path: ../test_api
-  test_core:
-    path: ../test_core
-  test:
-    path: ../test

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -3,9 +3,10 @@ version: 1.25.8-wip
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test
+resolution: workspace
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 dependencies:
   analyzer: '>=5.12.0 <7.0.0'
@@ -34,8 +35,8 @@ dependencies:
   stream_channel: ^2.1.0
 
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.7.3
-  test_core: 0.6.5
+  test_api: '>=0.7.3-wip <0.7.4'
+  test_core: '>=0.6.5-wip <0.6.6'
 
   typed_data: ^1.3.0
   web_socket_channel: '>=2.0.0 <4.0.0'
@@ -43,7 +44,6 @@ dependencies:
   yaml: ^3.0.0
 
 dev_dependencies:
-  dart_flutter_team_lints: ^3.0.0
   fake_async: ^1.0.0
   glob: ^2.0.0
   test_descriptor: ^2.0.0

--- a/pkgs/test/pubspec_overrides.yaml
+++ b/pkgs/test/pubspec_overrides.yaml
@@ -1,5 +1,0 @@
-dependency_overrides:
-  test_core:
-    path: ../test_core
-  test_api:
-    path: ../test_api

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -3,9 +3,10 @@ version: 0.7.3-wip
 description: >-
   The user facing API for structuring Dart tests and checking expectations.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_api
+resolution: workspace
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 dependencies:
   async: ^2.5.0
@@ -20,7 +21,6 @@ dependencies:
 
 dev_dependencies:
   analyzer: '>=2.1.0 <7.0.0'
-  dart_flutter_team_lints: ^3.0.0
   fake_async: ^1.2.0
   glob: ^2.0.0
   graphs: ^2.0.0

--- a/pkgs/test_api/pubspec_overrides.yaml
+++ b/pkgs/test_api/pubspec_overrides.yaml
@@ -1,6 +1,0 @@
-dependency_overrides:
-  test:
-    path: ../test
-  test_core:
-    path: ../test_core
-  matcher: 0.12.16

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -2,9 +2,10 @@ name: test_core
 version: 0.6.5-wip
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
+resolution: workspace
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 dependencies:
   analyzer: '>=3.3.0 <7.0.0'
@@ -26,10 +27,9 @@ dependencies:
   stack_trace: ^1.10.0
   stream_channel: ^2.1.0
   # Use an exact version until the test_api package is stable.
-  test_api: 0.7.3
+  test_api: '>=0.7.3-wip <0.7.4'
   vm_service: ">=6.0.0 <15.0.0"
   yaml: ^3.0.0
 
 dev_dependencies:
-  dart_flutter_team_lints: ^3.0.0
   test: any

--- a/pkgs/test_core/pubspec_overrides.yaml
+++ b/pkgs/test_core/pubspec_overrides.yaml
@@ -1,5 +1,0 @@
-dependency_overrides:
-  test_api:
-    path: ../test_api
-  test:
-    path: ../test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,14 @@
+name: test_workspace
+publish_to: none
+environment:
+  sdk: ^3.5.0-259.0.dev   # Must be ^3.5.0 or later for workspace to be allowed
+workspace:
+  - integration_tests/regression
+  - integration_tests/spawn_hybrid
+  - integration_tests/wasm
+  - pkgs/checks
+  - pkgs/test
+  - pkgs/test_api
+  - pkgs/test_core
+dev_dependencies:
+  dart_flutter_team_lints: ^3.1.0


### PR DESCRIPTION
There is one weird quirk here - our usual way of pinning package versions doesn't work, because we are pinning a version which doesn't yet exist, using the non-wip number. I resolved that by adding version constraints like this instead `>=x.x.x-wip <x.x.(x+1)`. But, it is a bit weird. When creating a release, we can change these to exact versions, because they will then match the version in the repo. But, we might not remember to. WDYT @natebosch ?

Also cc @sigurdm and @jonasfj in case they have a different solution to suggest.