### PR TITLE
Support dart2wasm in node.js tests

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v6.6.1
+# Created with package:mono_repo v6.6.2
 name: Dart CI
 on:
   push:
@@ -36,7 +36,7 @@ jobs:
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - name: mono_repo self validate
-        run: dart pub global activate mono_repo 6.6.1
+        run: dart pub global activate mono_repo 6.6.2
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
@@ -417,181 +417,6 @@ jobs:
       - job_003
       - job_004
   job_010:
-    name: "unit_test; linux; Dart 3.5.0-259.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 0`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:pkgs/test;commands:command_02"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:pkgs/test
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
-        with:
-          sdk: "3.5.0-259.0.dev"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-      - id: pkgs_test_pub_upgrade
-        name: pkgs/test; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test
-      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 0"
-        run: "xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 0"
-        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_011:
-    name: "unit_test; linux; Dart 3.5.0-259.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 1`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:pkgs/test;commands:command_03"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:pkgs/test
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
-        with:
-          sdk: "3.5.0-259.0.dev"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-      - id: pkgs_test_pub_upgrade
-        name: pkgs/test; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test
-      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 1"
-        run: "xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 1"
-        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_012:
-    name: "unit_test; linux; Dart 3.5.0-259.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 2`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:pkgs/test;commands:command_04"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:pkgs/test
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
-        with:
-          sdk: "3.5.0-259.0.dev"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-      - id: pkgs_test_pub_upgrade
-        name: pkgs/test; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test
-      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 2"
-        run: "xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 2"
-        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_013:
-    name: "unit_test; linux; Dart 3.5.0-259.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 3`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:pkgs/test;commands:command_05"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:pkgs/test
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
-        with:
-          sdk: "3.5.0-259.0.dev"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-      - id: pkgs_test_pub_upgrade
-        name: pkgs/test; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test
-      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 3"
-        run: "xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 3"
-        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_014:
-    name: "unit_test; linux; Dart 3.5.0-259.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 4`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:pkgs/test;commands:command_06"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:pkgs/test
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
-        with:
-          sdk: "3.5.0-259.0.dev"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-      - id: pkgs_test_pub_upgrade
-        name: pkgs/test; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test
-      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 4"
-        run: "xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 4"
-        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_015:
     name: "unit_test; linux; Dart 3.5.0-259.0.dev; PKG: pkgs/test_api; `dart test --preset travis -x browser`"
     runs-on: ubuntu-latest
     steps:
@@ -621,6 +446,181 @@ jobs:
         run: dart test --preset travis -x browser
         if: "always() && steps.pkgs_test_api_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/test_api
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_011:
+    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 0`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test;commands:command_02"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+        with:
+          sdk: "3.5.0-300.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - id: pkgs_test_pub_upgrade
+        name: pkgs/test; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 0"
+        run: "xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 0"
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_012:
+    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 1`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test;commands:command_03"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+        with:
+          sdk: "3.5.0-300.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - id: pkgs_test_pub_upgrade
+        name: pkgs/test; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 1"
+        run: "xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 1"
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_013:
+    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 2`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test;commands:command_04"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+        with:
+          sdk: "3.5.0-300.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - id: pkgs_test_pub_upgrade
+        name: pkgs/test; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 2"
+        run: "xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 2"
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_014:
+    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 3`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test;commands:command_05"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+        with:
+          sdk: "3.5.0-300.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - id: pkgs_test_pub_upgrade
+        name: pkgs/test; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 3"
+        run: "xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 3"
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_015:
+    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 4`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test;commands:command_06"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+        with:
+          sdk: "3.5.0-300.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - id: pkgs_test_pub_upgrade
+        name: pkgs/test; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+      - name: "pkgs/test; xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 4"
+        run: "xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 4"
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
     needs:
       - job_001
       - job_002
@@ -1041,13 +1041,13 @@ jobs:
       - job_003
       - job_004
   job_028:
-    name: "unit_test; windows; Dart 3.5.0-259.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 0`"
+    name: "unit_test; windows; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-259.0.dev"
+          sdk: "3.5.0-300.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1066,13 +1066,13 @@ jobs:
       - job_003
       - job_004
   job_029:
-    name: "unit_test; windows; Dart 3.5.0-259.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 1`"
+    name: "unit_test; windows; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-259.0.dev"
+          sdk: "3.5.0-300.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1091,13 +1091,13 @@ jobs:
       - job_003
       - job_004
   job_030:
-    name: "unit_test; windows; Dart 3.5.0-259.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 2`"
+    name: "unit_test; windows; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-259.0.dev"
+          sdk: "3.5.0-300.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1116,13 +1116,13 @@ jobs:
       - job_003
       - job_004
   job_031:
-    name: "unit_test; windows; Dart 3.5.0-259.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 3`"
+    name: "unit_test; windows; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 3`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-259.0.dev"
+          sdk: "3.5.0-300.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1141,13 +1141,13 @@ jobs:
       - job_003
       - job_004
   job_032:
-    name: "unit_test; windows; Dart 3.5.0-259.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 4`"
+    name: "unit_test; windows; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 4`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-259.0.dev"
+          sdk: "3.5.0-300.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -40,23 +40,23 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; linux; Dart 3.5.0-300.0.dev; PKGS: integration_tests/regression, integration_tests/wasm; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos`"
+    name: "analyze_and_format; linux; Dart 3.5.0-311.0.dev; PKGS: integration_tests/regression, integration_tests/wasm; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:integration_tests/regression-integration_tests/wasm;commands:format-analyze_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:integration_tests/regression-integration_tests/wasm;commands:format-analyze_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:integration_tests/regression-integration_tests/wasm
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:integration_tests/regression-integration_tests/wasm
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -87,23 +87,23 @@ jobs:
         if: "always() && steps.integration_tests_wasm_pub_upgrade.conclusion == 'success'"
         working-directory: integration_tests/wasm
   job_003:
-    name: "analyze_and_format; linux; Dart 3.5.0-300.0.dev; PKGS: pkgs/checks, pkgs/test_core; `dart analyze`"
+    name: "analyze_and_format; linux; Dart 3.5.0-311.0.dev; PKGS: pkgs/checks, pkgs/test_core; `dart analyze`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/checks-pkgs/test_core;commands:analyze_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/checks-pkgs/test_core;commands:analyze_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/checks-pkgs/test_core
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/checks-pkgs/test_core
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -238,13 +238,13 @@ jobs:
         if: "always() && steps.pkgs_test_core_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/test_core
   job_005:
-    name: "analyze_and_format; windows; Dart 3.5.0-300.0.dev; PKG: integration_tests/wasm; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos`"
+    name: "analyze_and_format; windows; Dart 3.5.0-311.0.dev; PKG: integration_tests/wasm; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -286,23 +286,23 @@ jobs:
         if: "always() && steps.integration_tests_wasm_pub_upgrade.conclusion == 'success'"
         working-directory: integration_tests/wasm
   job_007:
-    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: integration_tests/regression; `dart test`"
+    name: "unit_test; linux; Dart 3.5.0-311.0.dev; PKG: integration_tests/regression; `dart test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:integration_tests/regression;commands:command_00"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:integration_tests/regression;commands:command_00"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:integration_tests/regression
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:integration_tests/regression
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -323,23 +323,23 @@ jobs:
       - job_005
       - job_006
   job_008:
-    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/checks; `dart test`"
+    name: "unit_test; linux; Dart 3.5.0-311.0.dev; PKG: pkgs/checks; `dart test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/checks;commands:command_00"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/checks;commands:command_00"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/checks
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/checks
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -360,23 +360,23 @@ jobs:
       - job_005
       - job_006
   job_009:
-    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/test_core; `dart test`"
+    name: "unit_test; linux; Dart 3.5.0-311.0.dev; PKG: pkgs/test_core; `dart test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test_core;commands:command_00"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test_core;commands:command_00"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test_core
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test_core
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -397,23 +397,23 @@ jobs:
       - job_005
       - job_006
   job_010:
-    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
+    name: "unit_test; linux; Dart 3.5.0-311.0.dev; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:integration_tests/spawn_hybrid;commands:test_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:integration_tests/spawn_hybrid;commands:test_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:integration_tests/spawn_hybrid
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:integration_tests/spawn_hybrid
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -434,23 +434,23 @@ jobs:
       - job_005
       - job_006
   job_011:
-    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: integration_tests/wasm; `dart test --timeout=60s`"
+    name: "unit_test; linux; Dart 3.5.0-311.0.dev; PKG: integration_tests/wasm; `dart test --timeout=60s`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:integration_tests/wasm;commands:test_2"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:integration_tests/wasm;commands:test_2"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:integration_tests/wasm
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:integration_tests/wasm
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -471,23 +471,23 @@ jobs:
       - job_005
       - job_006
   job_012:
-    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 0`"
+    name: "unit_test; linux; Dart 3.5.0-311.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test;commands:command_01"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test;commands:command_01"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -508,23 +508,23 @@ jobs:
       - job_005
       - job_006
   job_013:
-    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 1`"
+    name: "unit_test; linux; Dart 3.5.0-311.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test;commands:command_02"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test;commands:command_02"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -545,23 +545,23 @@ jobs:
       - job_005
       - job_006
   job_014:
-    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 2`"
+    name: "unit_test; linux; Dart 3.5.0-311.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test;commands:command_03"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test;commands:command_03"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -582,23 +582,23 @@ jobs:
       - job_005
       - job_006
   job_015:
-    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 3`"
+    name: "unit_test; linux; Dart 3.5.0-311.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 3`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test;commands:command_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test;commands:command_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -619,23 +619,23 @@ jobs:
       - job_005
       - job_006
   job_016:
-    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 4`"
+    name: "unit_test; linux; Dart 3.5.0-311.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 4`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test;commands:command_05"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test;commands:command_05"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -656,23 +656,23 @@ jobs:
       - job_005
       - job_006
   job_017:
-    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/test_api; `dart test --preset travis -x browser`"
+    name: "unit_test; linux; Dart 3.5.0-311.0.dev; PKG: pkgs/test_api; `dart test --preset travis -x browser`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test_api;commands:command_11"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test_api;commands:command_11"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test_api
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test_api
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1100,13 +1100,13 @@ jobs:
       - job_005
       - job_006
   job_029:
-    name: "unit_test; windows; Dart 3.5.0-300.0.dev; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
+    name: "unit_test; windows; Dart 3.5.0-311.0.dev; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1127,13 +1127,13 @@ jobs:
       - job_005
       - job_006
   job_030:
-    name: "unit_test; windows; Dart 3.5.0-300.0.dev; PKG: integration_tests/wasm; `dart test --timeout=60s`"
+    name: "unit_test; windows; Dart 3.5.0-311.0.dev; PKG: integration_tests/wasm; `dart test --timeout=60s`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1154,13 +1154,13 @@ jobs:
       - job_005
       - job_006
   job_031:
-    name: "unit_test; windows; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 0`"
+    name: "unit_test; windows; Dart 3.5.0-311.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1181,13 +1181,13 @@ jobs:
       - job_005
       - job_006
   job_032:
-    name: "unit_test; windows; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 1`"
+    name: "unit_test; windows; Dart 3.5.0-311.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1208,13 +1208,13 @@ jobs:
       - job_005
       - job_006
   job_033:
-    name: "unit_test; windows; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 2`"
+    name: "unit_test; windows; Dart 3.5.0-311.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1235,13 +1235,13 @@ jobs:
       - job_005
       - job_006
   job_034:
-    name: "unit_test; windows; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 3`"
+    name: "unit_test; windows; Dart 3.5.0-311.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 3`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1262,13 +1262,13 @@ jobs:
       - job_005
       - job_006
   job_035:
-    name: "unit_test; windows; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 4`"
+    name: "unit_test; windows; Dart 3.5.0-311.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 4`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-300.0.dev"
+          sdk: "3.5.0-311.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -40,23 +40,23 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; linux; Dart 3.5.0-259.0.dev; PKGS: integration_tests/regression, integration_tests/wasm; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos`"
+    name: "analyze_and_format; linux; Dart 3.5.0-300.0.dev; PKGS: integration_tests/regression, integration_tests/wasm; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:integration_tests/regression-integration_tests/wasm;commands:format-analyze_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:integration_tests/regression-integration_tests/wasm;commands:format-analyze_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:integration_tests/regression-integration_tests/wasm
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:integration_tests/regression-integration_tests/wasm
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-259.0.dev"
+          sdk: "3.5.0-300.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -87,23 +87,23 @@ jobs:
         if: "always() && steps.integration_tests_wasm_pub_upgrade.conclusion == 'success'"
         working-directory: integration_tests/wasm
   job_003:
-    name: "analyze_and_format; linux; Dart 3.5.0-259.0.dev; PKGS: pkgs/checks, pkgs/test_core; `dart analyze`"
+    name: "analyze_and_format; linux; Dart 3.5.0-300.0.dev; PKGS: pkgs/checks, pkgs/test_core; `dart analyze`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:pkgs/checks-pkgs/test_core;commands:analyze_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/checks-pkgs/test_core;commands:analyze_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:pkgs/checks-pkgs/test_core
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/checks-pkgs/test_core
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-259.0.dev"
+          sdk: "3.5.0-300.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -238,13 +238,13 @@ jobs:
         if: "always() && steps.pkgs_test_core_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/test_core
   job_005:
-    name: "analyze_and_format; windows; Dart 3.5.0-259.0.dev; PKG: integration_tests/wasm; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos`"
+    name: "analyze_and_format; windows; Dart 3.5.0-300.0.dev; PKG: integration_tests/wasm; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-259.0.dev"
+          sdk: "3.5.0-300.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -286,23 +286,23 @@ jobs:
         if: "always() && steps.integration_tests_wasm_pub_upgrade.conclusion == 'success'"
         working-directory: integration_tests/wasm
   job_007:
-    name: "unit_test; linux; Dart 3.5.0-259.0.dev; PKG: integration_tests/regression; `dart test`"
+    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: integration_tests/regression; `dart test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:integration_tests/regression;commands:command_00"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:integration_tests/regression;commands:command_00"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:integration_tests/regression
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:integration_tests/regression
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-259.0.dev"
+          sdk: "3.5.0-300.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -323,23 +323,23 @@ jobs:
       - job_005
       - job_006
   job_008:
-    name: "unit_test; linux; Dart 3.5.0-259.0.dev; PKG: pkgs/checks; `dart test`"
+    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/checks; `dart test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:pkgs/checks;commands:command_00"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/checks;commands:command_00"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:pkgs/checks
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/checks
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-259.0.dev"
+          sdk: "3.5.0-300.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -360,23 +360,23 @@ jobs:
       - job_005
       - job_006
   job_009:
-    name: "unit_test; linux; Dart 3.5.0-259.0.dev; PKG: pkgs/test_core; `dart test`"
+    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/test_core; `dart test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:pkgs/test_core;commands:command_00"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test_core;commands:command_00"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:pkgs/test_core
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test_core
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-259.0.dev"
+          sdk: "3.5.0-300.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -397,23 +397,23 @@ jobs:
       - job_005
       - job_006
   job_010:
-    name: "unit_test; linux; Dart 3.5.0-259.0.dev; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
+    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:integration_tests/spawn_hybrid;commands:test_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:integration_tests/spawn_hybrid;commands:test_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:integration_tests/spawn_hybrid
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:integration_tests/spawn_hybrid
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-259.0.dev"
+          sdk: "3.5.0-300.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -434,23 +434,23 @@ jobs:
       - job_005
       - job_006
   job_011:
-    name: "unit_test; linux; Dart 3.5.0-259.0.dev; PKG: integration_tests/wasm; `dart test --timeout=60s`"
+    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: integration_tests/wasm; `dart test --timeout=60s`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:integration_tests/wasm;commands:test_2"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:integration_tests/wasm;commands:test_2"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:integration_tests/wasm
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:integration_tests/wasm
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-259.0.dev"
+          sdk: "3.5.0-300.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -471,43 +471,6 @@ jobs:
       - job_005
       - job_006
   job_012:
-    name: "unit_test; linux; Dart 3.5.0-259.0.dev; PKG: pkgs/test_api; `dart test --preset travis -x browser`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:pkgs/test_api;commands:command_11"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:pkgs/test_api
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
-        with:
-          sdk: "3.5.0-259.0.dev"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-      - id: pkgs_test_api_pub_upgrade
-        name: pkgs/test_api; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/test_api
-      - name: "pkgs/test_api; dart test --preset travis -x browser"
-        run: dart test --preset travis -x browser
-        if: "always() && steps.pkgs_test_api_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/test_api
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-      - job_005
-      - job_006
-  job_013:
     name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: ubuntu-latest
     steps:
@@ -544,7 +507,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-  job_014:
+  job_013:
     name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: ubuntu-latest
     steps:
@@ -581,7 +544,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-  job_015:
+  job_014:
     name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: ubuntu-latest
     steps:
@@ -618,7 +581,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-  job_016:
+  job_015:
     name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 3`"
     runs-on: ubuntu-latest
     steps:
@@ -655,7 +618,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-  job_017:
+  job_016:
     name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 4`"
     runs-on: ubuntu-latest
     steps:
@@ -685,6 +648,43 @@ jobs:
         run: "xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 4"
         if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/test
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+  job_017:
+    name: "unit_test; linux; Dart 3.5.0-300.0.dev; PKG: pkgs/test_api; `dart test --preset travis -x browser`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test_api;commands:command_11"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev;packages:pkgs/test_api
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-300.0.dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+        with:
+          sdk: "3.5.0-300.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - id: pkgs_test_api_pub_upgrade
+        name: pkgs/test_api; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test_api
+      - name: "pkgs/test_api; dart test --preset travis -x browser"
+        run: dart test --preset travis -x browser
+        if: "always() && steps.pkgs_test_api_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test_api
     needs:
       - job_001
       - job_002
@@ -1100,13 +1100,13 @@ jobs:
       - job_005
       - job_006
   job_029:
-    name: "unit_test; windows; Dart 3.5.0-259.0.dev; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
+    name: "unit_test; windows; Dart 3.5.0-300.0.dev; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-259.0.dev"
+          sdk: "3.5.0-300.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1127,13 +1127,13 @@ jobs:
       - job_005
       - job_006
   job_030:
-    name: "unit_test; windows; Dart 3.5.0-259.0.dev; PKG: integration_tests/wasm; `dart test --timeout=60s`"
+    name: "unit_test; windows; Dart 3.5.0-300.0.dev; PKG: integration_tests/wasm; `dart test --timeout=60s`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.5.0-259.0.dev"
+          sdk: "3.5.0-300.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332

--- a/integration_tests/regression/pubspec.yaml
+++ b/integration_tests/regression/pubspec.yaml
@@ -1,7 +1,7 @@
 name: regression_tests
 publish_to: none
 environment:
-  sdk: ^3.5.0-259.0.dev
+  sdk: ^3.5.0-300.0.dev
 resolution: workspace
 dependencies:
   test: any

--- a/integration_tests/regression/pubspec.yaml
+++ b/integration_tests/regression/pubspec.yaml
@@ -1,7 +1,7 @@
 name: regression_tests
 publish_to: none
 environment:
-  sdk: ^3.5.0-300.0.dev
+  sdk: ^3.5.0-311.0.dev
 resolution: workspace
 dependencies:
   test: any

--- a/integration_tests/spawn_hybrid/pubspec.yaml
+++ b/integration_tests/spawn_hybrid/pubspec.yaml
@@ -1,7 +1,7 @@
 name: spawn_hybrid
 publish_to: none
 environment:
-  sdk: ^3.5.0-300.0.dev
+  sdk: ^3.5.0-311.0.dev
 resolution: workspace
 dependencies:
   async: ^2.9.0

--- a/integration_tests/spawn_hybrid/pubspec.yaml
+++ b/integration_tests/spawn_hybrid/pubspec.yaml
@@ -1,7 +1,7 @@
 name: spawn_hybrid
 publish_to: none
 environment:
-  sdk: ^3.5.0-259.0.dev
+  sdk: ^3.5.0-300.0.dev
 resolution: workspace
 dependencies:
   async: ^2.9.0

--- a/integration_tests/wasm/dart_test.yaml
+++ b/integration_tests/wasm/dart_test.yaml
@@ -1,2 +1,5 @@
-platforms: [chrome, firefox, node]
+platforms: [chrome, firefox]
+# Node doesn't work because the version available in the current Ubuntu GitHub runners is too
+# old to support WASM+GC, which would be required to run Dart tests.
+#platforms: [chrome, firefox, node]
 compilers: [dart2wasm]

--- a/integration_tests/wasm/dart_test.yaml
+++ b/integration_tests/wasm/dart_test.yaml
@@ -1,2 +1,2 @@
-platforms: [chrome, firefox]
+platforms: [chrome, firefox, node]
 compilers: [dart2wasm]

--- a/integration_tests/wasm/pubspec.yaml
+++ b/integration_tests/wasm/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wasm_tests
 publish_to: none
 environment:
-  sdk: ^3.5.0-300.0.dev
+  sdk: ^3.5.0-311.0.dev
 resolution: workspace
 dev_dependencies:
   test: any

--- a/integration_tests/wasm/pubspec.yaml
+++ b/integration_tests/wasm/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wasm_tests
 publish_to: none
 environment:
-  sdk: ^3.5.0-259.0.dev
+  sdk: ^3.5.0-300.0.dev
 resolution: workspace
 dev_dependencies:
   test: any

--- a/pkgs/checks/pubspec.yaml
+++ b/pkgs/checks/pubspec.yaml
@@ -7,7 +7,7 @@ repository: https://github.com/dart-lang/test/tree/master/pkgs/checks
 resolution: workspace
 
 environment:
-  sdk: ^3.5.0-300.0.dev
+  sdk: ^3.5.0-311.0.dev
 
 dependencies:
   async: ^2.8.0

--- a/pkgs/checks/pubspec.yaml
+++ b/pkgs/checks/pubspec.yaml
@@ -7,7 +7,7 @@ repository: https://github.com/dart-lang/test/tree/master/pkgs/checks
 resolution: workspace
 
 environment:
-  sdk: ^3.5.0-259.0.dev
+  sdk: ^3.5.0-300.0.dev
 
 dependencies:
   async: ^2.8.0

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.25.9-wip
 
 * Increase SDK constraint to ^3.5.0-259.0.dev.
+* Support running Node.js tests compiled with dart2wasm.
 
 ## 1.25.8
 

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.25.9-wip
 
 * Fix dart2wasm tests on windows.
-* Increase SDK constraint to ^3.5.0-259.0.dev.
+* Increase SDK constraint to ^3.5.0-300.0.dev.
 * Support running Node.js tests compiled with dart2wasm.
 
 ## 1.25.8

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.25.9-wip
 
 * Fix dart2wasm tests on windows.
-* Increase SDK constraint to ^3.5.0-300.0.dev.
+* Increase SDK constraint to ^3.5.0-311.0.dev.
 * Support running Node.js tests compiled with dart2wasm.
 
 ## 1.25.8

--- a/pkgs/test/lib/src/bootstrap/node.dart
+++ b/pkgs/test/lib/src/bootstrap/node.dart
@@ -14,5 +14,5 @@ void internalBootstrapNodeTest(Function Function() getMain) {
     if (serialized is! Map) return;
     setStackTraceMapper(JSStackTraceMapper.deserialize(serialized)!);
   });
-  socketChannel().pipe(channel);
+  socketChannel().then((socket) => socket.pipe(channel));
 }

--- a/pkgs/test/lib/src/runner/node/platform.dart
+++ b/pkgs/test/lib/src/runner/node/platform.dart
@@ -23,10 +23,10 @@ import 'package:test_core/src/runner/plugin/environment.dart'; // ignore: implem
 import 'package:test_core/src/runner/plugin/platform_helpers.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/runner_suite.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/suite.dart'; // ignore: implementation_imports
+import 'package:test_core/src/runner/wasm_compiler_pool.dart'; // ignore: implementation_imports
 import 'package:test_core/src/util/errors.dart'; // ignore: implementation_imports
 import 'package:test_core/src/util/io.dart'; // ignore: implementation_imports
 import 'package:test_core/src/util/package_config.dart'; // ignore: implementation_imports
-import 'package:test_core/src/util/pair.dart'; // ignore: implementation_imports
 import 'package:test_core/src/util/stack_trace_mapper.dart'; // ignore: implementation_imports
 import 'package:yaml/yaml.dart';
 
@@ -40,7 +40,8 @@ class NodePlatform extends PlatformPlugin
   final Configuration _config;
 
   /// The [Dart2JsCompilerPool] managing active instances of `dart2js`.
-  final _compilers = Dart2JsCompilerPool(['-Dnode=true', '--server-mode']);
+  final _jsCompilers = Dart2JsCompilerPool(['-Dnode=true', '--server-mode']);
+  final _wasmCompilers = WasmCompilerPool(['-Dnode=true']);
 
   /// The temporary directory in which compiled JS is emitted.
   final _compiledDir = createTempDir();
@@ -75,15 +76,17 @@ class NodePlatform extends PlatformPlugin
   @override
   Future<RunnerSuite> load(String path, SuitePlatform platform,
       SuiteConfiguration suiteConfig, Map<String, Object?> message) async {
-    if (platform.compiler != Compiler.dart2js) {
+    if (platform.compiler != Compiler.dart2js &&
+        platform.compiler != Compiler.dart2wasm) {
       throw StateError(
           'Unsupported compiler for the Node platform ${platform.compiler}.');
     }
-    var pair = await _loadChannel(path, platform, suiteConfig);
+    var (channel, stackMapper) =
+        await _loadChannel(path, platform, suiteConfig);
     var controller = deserializeSuite(path, platform, suiteConfig,
-        const PluginEnvironment(), pair.first, message);
+        const PluginEnvironment(), channel, message);
 
-    controller.channel('test.node.mapper').sink.add(pair.last?.serialize());
+    controller.channel('test.node.mapper').sink.add(stackMapper?.serialize());
 
     return await controller.suite;
   }
@@ -92,16 +95,13 @@ class NodePlatform extends PlatformPlugin
   ///
   /// Returns that channel along with a [StackTraceMapper] representing the
   /// source map for the compiled suite.
-  Future<Pair<StreamChannel<Object?>, StackTraceMapper?>> _loadChannel(
-      String path,
-      SuitePlatform platform,
-      SuiteConfiguration suiteConfig) async {
+  Future<(StreamChannel<Object?>, StackTraceMapper?)> _loadChannel(String path,
+      SuitePlatform platform, SuiteConfiguration suiteConfig) async {
     final servers = await _loopback();
 
     try {
-      var pair = await _spawnProcess(
-          path, platform.runtime, suiteConfig, servers.first.port);
-      var process = pair.first;
+      var (process, stackMapper) =
+          await _spawnProcess(path, platform, suiteConfig, servers.first.port);
 
       // Forward Node's standard IO to the print handler so it's associated with
       // the load test.
@@ -120,7 +120,7 @@ class NodePlatform extends PlatformPlugin
         sink.close();
       }));
 
-      return Pair(channel, pair.last);
+      return (channel, stackMapper);
     } finally {
       unawaited(Future.wait<void>(servers.map((s) =>
           s.close().then<ServerSocket?>((v) => v).onError((_, __) => null))));
@@ -131,23 +131,28 @@ class NodePlatform extends PlatformPlugin
   ///
   /// Returns that channel along with a [StackTraceMapper] representing the
   /// source map for the compiled suite.
-  Future<Pair<Process, StackTraceMapper?>> _spawnProcess(String path,
-      Runtime runtime, SuiteConfiguration suiteConfig, int socketPort) async {
+  Future<(Process, StackTraceMapper?)> _spawnProcess(
+      String path,
+      SuitePlatform platform,
+      SuiteConfiguration suiteConfig,
+      int socketPort) async {
     if (_config.suiteDefaults.precompiledPath != null) {
-      return _spawnPrecompiledProcess(path, runtime, suiteConfig, socketPort,
-          _config.suiteDefaults.precompiledPath!);
+      return _spawnPrecompiledProcess(path, platform.runtime, suiteConfig,
+          socketPort, _config.suiteDefaults.precompiledPath!);
     } else {
-      return _spawnNormalProcess(path, runtime, suiteConfig, socketPort);
+      return switch (platform.compiler) {
+        Compiler.dart2js => _spawnNormalJsProcess(
+            path, platform.runtime, suiteConfig, socketPort),
+        Compiler.dart2wasm => _spawnNormalWasmProcess(
+            path, platform.runtime, suiteConfig, socketPort),
+        _ => throw StateError('Unsupported compiler ${platform.compiler}'),
+      };
     }
   }
 
-  /// Compiles [testPath] with dart2js, adds the node preamble, and then spawns
-  /// a Node.js process that loads that Dart test suite.
-  Future<Pair<Process, StackTraceMapper?>> _spawnNormalProcess(String testPath,
-      Runtime runtime, SuiteConfiguration suiteConfig, int socketPort) async {
-    var dir = Directory(_compiledDir).createTempSync('test_').path;
-    var jsPath = p.join(dir, '${p.basename(testPath)}.node_test.dart.js');
-    await _compilers.compile('''
+  Future<String> _entrypointScriptForTest(
+      String testPath, SuiteConfiguration suiteConfig) async {
+    return '''
         ${suiteConfig.metadata.languageVersionComment ?? await rootPackageLanguageVersionComment}
         import "package:test/src/bootstrap/node.dart";
 
@@ -156,7 +161,20 @@ class NodePlatform extends PlatformPlugin
         void main() {
           internalBootstrapNodeTest(() => test.main);
         }
-      ''', jsPath, suiteConfig);
+      ''';
+  }
+
+  /// Compiles [testPath] with dart2js, adds the node preamble, and then spawns
+  /// a Node.js process that loads that Dart test suite.
+  Future<(Process, StackTraceMapper?)> _spawnNormalJsProcess(String testPath,
+      Runtime runtime, SuiteConfiguration suiteConfig, int socketPort) async {
+    var dir = Directory(_compiledDir).createTempSync('test_').path;
+    var jsPath = p.join(dir, '${p.basename(testPath)}.node_test.dart.js');
+    await _jsCompilers.compile(
+      await _entrypointScriptForTest(testPath, suiteConfig),
+      jsPath,
+      suiteConfig,
+    );
 
     // Add the Node.js preamble to ensure that the dart2js output is
     // compatible. Use the minified version so the source map remains valid.
@@ -173,12 +191,63 @@ class NodePlatform extends PlatformPlugin
           packageMap: (await currentPackageConfig).toPackageMap());
     }
 
-    return Pair(await _startProcess(runtime, jsPath, socketPort), mapper);
+    return (await _startProcess(runtime, jsPath, socketPort), mapper);
+  }
+
+  /// Compiles [testPath] with dart2wasm, adds a JS entrypoint and then spawns
+  /// a Node.js process loading the compiled test suite.
+  Future<(Process, StackTraceMapper?)> _spawnNormalWasmProcess(String testPath,
+      Runtime runtime, SuiteConfiguration suiteConfig, int socketPort) async {
+    var dir = Directory(_compiledDir).createTempSync('test_').path;
+    // dart2wasm will emit a .wasm file and a .mjs file responsible for loading
+    // that file.
+    var wasmPath = p.join(dir, '${p.basename(testPath)}.node_test.dart.wasm');
+    var loader = '${p.basename(testPath)}.node_test.dart.wasm.mjs';
+
+    // We need to create an additional entrypoint file loading the wasm module.
+    var jsPath = p.join(dir, '${p.basename(testPath)}.node_test.dart.js');
+
+    await _wasmCompilers.compile(
+      await _entrypointScriptForTest(testPath, suiteConfig),
+      wasmPath,
+      suiteConfig,
+    );
+
+    await File(jsPath).writeAsString('''
+const { createReadStream } = require('fs');
+const { once } = require('events');
+const { PassThrough } = require('stream');
+
+const main = async () => {
+  const { instantiate, invoke } = await import("./$loader");
+
+  const wasmContents = createReadStream("$wasmPath.wasm");
+  const stream = new PassThrough();
+  wasmContents.pipe(stream);
+
+  await once(wasmContents, 'open');
+  const response = new Response(
+    stream,
+    {
+      headers: {
+        "Content-Type": "application/wasm"
+      }
+    }
+  );
+  const instancePromise = WebAssembly.compileStreaming(response);
+  const module = await instantiate(instancePromise, {});
+  invoke(module);
+};
+
+main();
+''');
+
+    return (await _startProcess(runtime, jsPath, socketPort), null);
   }
 
   /// Spawns a Node.js process that loads the Dart test suite at [testPath]
   /// under [precompiledPath].
-  Future<Pair<Process, StackTraceMapper?>> _spawnPrecompiledProcess(
+  Future<(Process, StackTraceMapper?)> _spawnPrecompiledProcess(
       String testPath,
       Runtime runtime,
       SuiteConfiguration suiteConfig,
@@ -195,7 +264,7 @@ class NodePlatform extends PlatformPlugin
               .toPackageMap());
     }
 
-    return Pair(await _startProcess(runtime, jsPath, socketPort), mapper);
+    return (await _startProcess(runtime, jsPath, socketPort), mapper);
   }
 
   /// Starts the Node.js process for [runtime] with [jsPath].
@@ -224,7 +293,8 @@ class NodePlatform extends PlatformPlugin
 
   @override
   Future<void> close() => _closeMemo.runOnce(() async {
-        await _compilers.close();
+        await _jsCompilers.close();
+        await _wasmCompilers.close();
         await Directory(_compiledDir).deleteWithRetry();
       });
   final _closeMemo = AsyncMemoizer<void>();

--- a/pkgs/test/lib/src/runner/node/socket_channel.dart
+++ b/pkgs/test/lib/src/runner/node/socket_channel.dart
@@ -1,46 +1,41 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-
-@JS()
-library;
-
 import 'dart:async';
 import 'dart:convert';
+import 'dart:js_interop';
 
-import 'package:js/js.dart';
 import 'package:stream_channel/stream_channel.dart';
 
-@JS('require')
-external _Net _require(String module);
-
 @JS('process.argv')
-external List<String> get _args;
+external JSArray<JSString> get _args;
 
-@JS()
-class _Net {
+extension type _Net._(JSObject _) {
   external _Socket connect(int port);
 }
 
-@JS()
-class _Socket {
-  external void setEncoding(String encoding);
-  external void on(String event, void Function(String chunk) callback);
-  external void write(String data);
+extension type _Socket._(JSObject _) {
+  external void setEncoding(JSString encoding);
+  external void on(JSString event, JSFunction callback);
+  external void write(JSString data);
 }
 
 /// Returns a [StreamChannel] of JSON-encodable objects that communicates over a
 /// socket whose port is given by `process.argv[2]`.
-StreamChannel<Object?> socketChannel() {
-  var net = _require('net');
-  var socket = net.connect(int.parse(_args[2]));
-  socket.setEncoding('utf8');
+Future<StreamChannel<Object?>> socketChannel() async {
+  final net = (await importModule('node:net'.toJS).toDart) as _Net;
+
+  var socket = net.connect(int.parse(_args.toDart[2].toDart));
+  socket.setEncoding('utf8'.toJS);
 
   var socketSink = StreamController<Object?>(sync: true)
-    ..stream.listen((event) => socket.write('${jsonEncode(event)}\n'));
+    ..stream.listen((event) => socket.write('${jsonEncode(event)}\n'.toJS));
 
   var socketStream = StreamController<String>(sync: true);
-  socket.on('data', allowInterop(socketStream.add));
+  socket.on(
+    'data'.toJS,
+    ((JSString chunk) => socketStream.add(chunk.toDart)).toJS,
+  );
 
   return StreamChannel.withCloseGuarantee(
       socketStream.stream.transform(const LineSplitter()).map(jsonDecode),

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/test/tree/master/pkgs/test
 resolution: workspace
 
 environment:
-  sdk: ^3.5.0-259.0.dev
+  sdk: ^3.5.0-300.0.dev
 
 dependencies:
   analyzer: '>=5.12.0 <7.0.0'

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/test/tree/master/pkgs/test
 resolution: workspace
 
 environment:
-  sdk: ^3.5.0-300.0.dev
+  sdk: ^3.5.0-311.0.dev
 
 dependencies:
   analyzer: '>=5.12.0 <7.0.0'

--- a/pkgs/test/test/runner/node/runner_test.dart
+++ b/pkgs/test/test/runner/node/runner_test.dart
@@ -116,6 +116,15 @@ void main() {
       expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
       await test.shouldExit(0);
     });
+
+    test('compiled with dart2wasm', () async {
+      await d.file('test.dart', _success).create();
+      var test =
+          await runTest(['-p', 'node', '--compiler', 'dart2wasm', 'test.dart']);
+
+      expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
+      await test.shouldExit(0);
+    });
   });
 
   test('defines a node environment constant', () async {
@@ -148,8 +157,18 @@ void main() {
         }
       ''').create();
 
-    var test = await runTest(['-p', 'node', '-p', 'vm', 'test.dart']);
-    expect(test.stdout, emitsThrough(contains('+1 -1: Some tests failed.')));
+    var test = await runTest([
+      '-p',
+      'node',
+      '-p',
+      'vm',
+      '-c',
+      'dart2js',
+      '-c',
+      'dart2wasm',
+      'test.dart'
+    ]);
+    expect(test.stdout, emitsThrough(contains('+1 -2: Some tests failed.')));
     await test.shouldExit(1);
   });
 

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -131,7 +131,7 @@ final _runtimeCompilers = [
   '[firefox]: dart2js (default), dart2wasm',
   if (Platform.isMacOS) '[safari]: dart2js (default)',
   '[edge]: dart2js (default)',
-  '[node]: dart2js (default)',
+  '[node]: dart2js (default), dart2wasm',
 ].map((str) => '                                      $str').join('\n');
 
 void main() {

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.7.4-wip
 
 * Increase SDK constraint to ^3.5.0-259.0.dev.
+* Support running Node.js tests compiled with dart2wasm.
 
 ## 0.7.3
 

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.7.4-wip
 
-* Increase SDK constraint to ^3.5.0-300.0.dev.
+* Increase SDK constraint to ^3.5.0-311.0.dev.
 * Support running Node.js tests compiled with dart2wasm.
 
 ## 0.7.3

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.7.4-wip
 
-* Increase SDK constraint to ^3.5.0-259.0.dev.
+* Increase SDK constraint to ^3.5.0-300.0.dev.
 * Support running Node.js tests compiled with dart2wasm.
 
 ## 0.7.3

--- a/pkgs/test_api/lib/src/backend/runtime.dart
+++ b/pkgs/test_api/lib/src/backend/runtime.dart
@@ -41,8 +41,8 @@ final class Runtime {
       isBrowser: true, isBlink: true);
 
   /// The command-line Node.js VM.
-  static const Runtime nodeJS =
-      Runtime('Node.js', 'node', Compiler.dart2js, [Compiler.dart2js]);
+  static const Runtime nodeJS = Runtime('Node.js', 'node', Compiler.dart2js,
+      [Compiler.dart2js, Compiler.dart2wasm]);
 
   /// The platforms that are supported by the test runner by default.
   static const List<Runtime> builtIn = [

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/test/tree/master/pkgs/test_api
 resolution: workspace
 
 environment:
-  sdk: ^3.5.0-259.0.dev
+  sdk: ^3.5.0-300.0.dev
 
 dependencies:
   async: ^2.5.0

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/test/tree/master/pkgs/test_api
 resolution: workspace
 
 environment:
-  sdk: ^3.5.0-300.0.dev
+  sdk: ^3.5.0-311.0.dev
 
 dependencies:
   async: ^2.5.0

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.6.6-wip
 
 * Fix dart2wasm tests on windows.
-* Increase SDK constraint to ^3.5.0-300.0.dev.
+* Increase SDK constraint to ^3.5.0-311.0.dev.
 * Allow passing additional arguments to `dart compile wasm`.
 
 ## 0.6.5

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.6.6-wip
 
 * Increase SDK constraint to ^3.5.0-259.0.dev.
+* Allow passing additional arguments to `dart compile wasm`.
 
 ## 0.6.5
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.6.6-wip
 
 * Fix dart2wasm tests on windows.
-* Increase SDK constraint to ^3.5.0-259.0.dev.
+* Increase SDK constraint to ^3.5.0-300.0.dev.
 * Allow passing additional arguments to `dart compile wasm`.
 
 ## 0.6.5

--- a/pkgs/test_core/lib/src/runner/wasm_compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/wasm_compiler_pool.dart
@@ -17,8 +17,13 @@ import 'suite.dart';
 ///
 /// This limits the number of compiler instances running concurrently.
 class WasmCompilerPool extends CompilerPool {
+  /// Extra arguments to pass to `dart compile js`.
+  final List<String> _extraArgs;
+
   /// The currently-active dart2wasm processes.
   final _processes = <Process>{};
+
+  WasmCompilerPool([this._extraArgs = const []]);
 
   /// Compiles [code] to [path].
   ///
@@ -41,6 +46,7 @@ class WasmCompilerPool extends CompilerPool {
         for (var experiment in enabledExperiments)
           '--enable-experiment=$experiment',
         '-O0',
+        ..._extraArgs,
         '-o',
         outWasmPath,
         wrapperPath,

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 resolution: workspace
 
 environment:
-  sdk: ^3.5.0-300.0.dev
+  sdk: ^3.5.0-311.0.dev
 
 dependencies:
   analyzer: '>=3.3.0 <7.0.0'

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 resolution: workspace
 
 environment:
-  sdk: ^3.5.0-259.0.dev
+  sdk: ^3.5.0-300.0.dev
 
 dependencies:
   analyzer: '>=3.3.0 <7.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: test_workspace
 publish_to: none
 environment:
-  sdk: ^3.5.0-259.0.dev   # Must be ^3.5.0 or later for workspace to be allowed
+  sdk: ^3.5.0-300.0.dev   # Must be ^3.5.0 or later for workspace to be allowed
 workspace:
   - integration_tests/regression
   - integration_tests/spawn_hybrid

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: test_workspace
 publish_to: none
 environment:
-  sdk: ^3.5.0-300.0.dev   # Must be ^3.5.0 or later for workspace to be allowed
+  sdk: ^3.5.0-311.0.dev   # Must be ^3.5.0 or later for workspace to be allowed
 workspace:
   - integration_tests/regression
   - integration_tests/spawn_hybrid

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v6.6.1
+# Created with package:mono_repo v6.6.2
 
 # Support built in commands on windows out of the box.
 


### PR DESCRIPTION
Support `dart2wasm` as a compiler for tests running in Node.js. `dart2wasm` emits a `.mjs` file exporting definitions to load generated wasm modules, the only additional thing we have to do is wrap that in a simple entrypoint file compiling the wasm module and invoking the startup wrapper.

There's no support for stack trace maps yet. We also don't support precompiled node wasm tests yet (`dart2wasm` is also not currently supported by `build_web_compilers`, so we're blocked on that either way).

In the test runtime, I had to migrate off `require` as that function is not in the global context for `.mjs` files. It looks like we can use `await import` instead though. If we need to support ancient Node versions that lack `import` support, I can adapt that to still use `require` when compiled with `dart2js` for compatibility.
