### PR TITLE
Always wrap Condition descriptions

### DIFF
--- a/pkgs/checks/CHANGELOG.md
+++ b/pkgs/checks/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.3.1-wip
 
-- Update min SDK constraint to 3.4.0.
+-   Update min SDK constraint to 3.4.0.
+-   Always wrap Condition descriptions in angle brackets.
 
 ## 0.3.0
 

--- a/pkgs/checks/lib/src/describe.dart
+++ b/pkgs/checks/lib/src/describe.dart
@@ -62,8 +62,7 @@ Iterable<String> _prettyPrint(
         .toList();
     return prefixFirst("'", postfixLast("'", escaped));
   } else if (object is Condition) {
-    final value = ['A value that:', ...describe(object)];
-    return isTopLevel ? prefixFirst('<', postfixLast('>', value)) : value;
+    return ['<A value that:', ...postfixLast('>', describe(object))];
   } else {
     final value = const LineSplitter().convert(object.toString());
     return isTopLevel ? prefixFirst('<', postfixLast('>', value)) : value;

--- a/pkgs/checks/test/extensions/iterable_test.dart
+++ b/pkgs/checks/test/extensions/iterable_test.dart
@@ -107,8 +107,8 @@ void main() {
           .description
           .deepEquals([
         '  contains, in order: [1,',
-        '  A value that:',
-        '    equals <2>]'
+        '  <A value that:',
+        '    equals <2>>]'
       ]);
     });
   });


### PR DESCRIPTION
These will break across lines and they read more easily when wrapped
with angle brackets, regardless of whether they are the top level of the
literal.
