### PR TITLE
fix: use `toFilePath` in package config Uri

### DIFF
--- a/pkgs/test_core/lib/src/runner/wasm_compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/wasm_compiler_pool.dart
@@ -37,7 +37,7 @@ class WasmCompilerPool extends CompilerPool {
         'compile',
         'wasm',
         '--enable-asserts',
-        '--packages=${(await packageConfigUri).path}',
+        '--packages=${(await packageConfigUri).toFilePath()}',
         for (var experiment in enabledExperiments)
           '--enable-experiment=$experiment',
         '-O0',


### PR DESCRIPTION
fixes #2231

Thanks to @d-markey https://github.com/dart-lang/test/issues/2231#issuecomment-2282283629 for figuring it out.

This fix uses the same technique as in precompiled tests:

https://github.com/dart-lang/test/blob/9fbbfdbee18a686e3f84a386a01960ea0543ba01/pkgs/test/test/runner/precompiled_test.dart#L54

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
