### PR TITLE
Fix URI to file path conversion when invoking dart2wasm

### DIFF
--- a/pkgs/test_core/lib/src/runner/wasm_compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/wasm_compiler_pool.dart
@@ -37,7 +37,7 @@ class WasmCompilerPool extends CompilerPool {
         'compile',
         'wasm',
         '--enable-asserts',
-        '--packages=${(await packageConfigUri).path}',
+        '--packages=${(await packageConfigUri).toFilePath()}',
         for (var experiment in enabledExperiments)
           '--enable-experiment=$experiment',
         '-O0',


### PR DESCRIPTION
Fixes #2231.