### PR TITLE
Fix documentation rendering issues

### DIFF
--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -956,7 +956,7 @@ final class FailureDetail {
   ///
   ///   a List that:
   ///     has length that:
-  ///       equals <3>
+  ///       equals &lt;3&gt;
   ///
   /// If the actual value had an incorrect length, the [depth] will be `1` to
   /// indicate that the failure occurred checking one of the expectations

--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -918,7 +918,7 @@ final class FailureDetail {
   ///
   ///   a List that:
   ///     has length that:
-  ///       equals <3>
+  ///       equals &lt;3&gt;
   final Iterable<String> expected;
 
   /// A description of the conditions the checked value satisfied.

--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -908,11 +908,11 @@ final class CheckFailure {
 final class FailureDetail {
   /// A description of all the conditions the subject was expected to satisfy.
   ///
-  /// Each subject has a label. At the root the label is typically "a <Type>"
-  /// and nested subjects get a label based on the condition which extracted a
-  /// property for further checks. Each level of nesting is described as
-  /// "<label> that:" followed by an indented list of the expectations for that
-  /// property.
+  /// Each subject has a label. At the root the label is typically "a
+  /// &lt;Type&gt;" and nested subjects get a label based on the condition
+  /// which extracted a property for further checks. Each level of nesting is
+  /// described as "&lt;label&gt; that:" followed by an indented list of the
+  /// expectations for that property.
   ///
   /// For example:
   ///

--- a/pkgs/test_core/lib/src/runner/hack_register_platform.dart
+++ b/pkgs/test_core/lib/src/runner/hack_register_platform.dart
@@ -24,7 +24,7 @@ final _platformCallbacks = <Runtime, FutureOr<PlatformPlugin> Function()>{};
 /// This globally registers a plugin for all [Loader]s. When the runner first
 /// requests that a suite be loaded for one of the given runtimes, this will
 /// call [plugin] to load the platform plugin. It may return either a
-/// [PlatformPlugin] or a [Future<PlatformPlugin>]. That plugin is then
+/// [PlatformPlugin] or a `Future<PlatformPlugin>`. That plugin is then
 /// preserved and used to load all suites for all matching runtimes.
 ///
 /// This overwrites the default plugins for those runtimes.


### PR DESCRIPTION
Replace `<` and `>` in documentation comments with `&lt` and `&gt` so
that they won't be interpreted as HTML tags and will render as expected.

In one place where we show Dart code with angle bracket I've replaced
the wrapping `[` and `]` with backticks.

Fixes CI.