### PR TITLE
require approval from core-package-admins for anything under /pkgs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/pkgs/ @dart-lang/core-package-admins


### PR DESCRIPTION
Trying out the CODEOWNERS workflows, we can remove this if it is annoying.

Any dart-lang admin can edit that group so we can always get something landed if needed that way, but it will require some explicit steps from an admin.