### PR TITLE
Limit which health checks run

### DIFF
--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -6,5 +6,7 @@ on:
 jobs:
   health:
     uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
+    with:
+      checks: "version,changelog,do-not-submit"
     permissions:
       pull-requests: write


### PR DESCRIPTION
The `breaking` and `leaking` health checks are not currently compatible
with repos using pub workspaces.

The `coverage` health check is too slow to be worth using in this repo.

Run only `version`, `changelog`, and `do-not-submit` checks.
