### PR TITLE
Run package:test tests on mac

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1100,6 +1100,191 @@ jobs:
       - job_005
       - job_006
   job_029:
+    name: "unit_test; osx; Dart 3.5.0-311.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 0`"
+    runs-on: macos-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:macos-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test;commands:command_06"
+          restore-keys: |
+            os:macos-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test
+            os:macos-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev
+            os:macos-latest;pub-cache-hosted
+            os:macos-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+        with:
+          sdk: "3.5.0-311.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - id: pkgs_test_pub_upgrade
+        name: pkgs/test; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+      - name: "pkgs/test; dart test --preset travis --total-shards 5 --shard-index 0"
+        run: dart test --preset travis --total-shards 5 --shard-index 0
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+  job_030:
+    name: "unit_test; osx; Dart 3.5.0-311.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 1`"
+    runs-on: macos-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:macos-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test;commands:command_07"
+          restore-keys: |
+            os:macos-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test
+            os:macos-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev
+            os:macos-latest;pub-cache-hosted
+            os:macos-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+        with:
+          sdk: "3.5.0-311.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - id: pkgs_test_pub_upgrade
+        name: pkgs/test; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+      - name: "pkgs/test; dart test --preset travis --total-shards 5 --shard-index 1"
+        run: dart test --preset travis --total-shards 5 --shard-index 1
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+  job_031:
+    name: "unit_test; osx; Dart 3.5.0-311.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 2`"
+    runs-on: macos-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:macos-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test;commands:command_08"
+          restore-keys: |
+            os:macos-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test
+            os:macos-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev
+            os:macos-latest;pub-cache-hosted
+            os:macos-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+        with:
+          sdk: "3.5.0-311.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - id: pkgs_test_pub_upgrade
+        name: pkgs/test; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+      - name: "pkgs/test; dart test --preset travis --total-shards 5 --shard-index 2"
+        run: dart test --preset travis --total-shards 5 --shard-index 2
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+  job_032:
+    name: "unit_test; osx; Dart 3.5.0-311.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 3`"
+    runs-on: macos-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:macos-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test;commands:command_09"
+          restore-keys: |
+            os:macos-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test
+            os:macos-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev
+            os:macos-latest;pub-cache-hosted
+            os:macos-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+        with:
+          sdk: "3.5.0-311.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - id: pkgs_test_pub_upgrade
+        name: pkgs/test; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+      - name: "pkgs/test; dart test --preset travis --total-shards 5 --shard-index 3"
+        run: dart test --preset travis --total-shards 5 --shard-index 3
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+  job_033:
+    name: "unit_test; osx; Dart 3.5.0-311.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 4`"
+    runs-on: macos-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:macos-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test;commands:command_10"
+          restore-keys: |
+            os:macos-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev;packages:pkgs/test
+            os:macos-latest;pub-cache-hosted;sdk:3.5.0-311.0.dev
+            os:macos-latest;pub-cache-hosted
+            os:macos-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+        with:
+          sdk: "3.5.0-311.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - id: pkgs_test_pub_upgrade
+        name: pkgs/test; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/test
+      - name: "pkgs/test; dart test --preset travis --total-shards 5 --shard-index 4"
+        run: dart test --preset travis --total-shards 5 --shard-index 4
+        if: "always() && steps.pkgs_test_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/test
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+  job_034:
     name: "unit_test; windows; Dart 3.5.0-311.0.dev; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
     runs-on: windows-latest
     steps:
@@ -1126,7 +1311,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-  job_030:
+  job_035:
     name: "unit_test; windows; Dart 3.5.0-311.0.dev; PKG: integration_tests/wasm; `dart test --timeout=60s`"
     runs-on: windows-latest
     steps:
@@ -1153,7 +1338,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-  job_031:
+  job_036:
     name: "unit_test; windows; Dart 3.5.0-311.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: windows-latest
     steps:
@@ -1180,7 +1365,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-  job_032:
+  job_037:
     name: "unit_test; windows; Dart 3.5.0-311.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: windows-latest
     steps:
@@ -1207,7 +1392,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-  job_033:
+  job_038:
     name: "unit_test; windows; Dart 3.5.0-311.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: windows-latest
     steps:
@@ -1234,7 +1419,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-  job_034:
+  job_039:
     name: "unit_test; windows; Dart 3.5.0-311.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 3`"
     runs-on: windows-latest
     steps:
@@ -1261,7 +1446,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-  job_035:
+  job_040:
     name: "unit_test; windows; Dart 3.5.0-311.0.dev; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 4`"
     runs-on: windows-latest
     steps:
@@ -1288,7 +1473,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-  job_036:
+  job_041:
     name: "unit_test; windows; Dart dev; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
     runs-on: windows-latest
     steps:
@@ -1315,7 +1500,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-  job_037:
+  job_042:
     name: "unit_test; windows; Dart dev; PKG: integration_tests/wasm; `dart test --timeout=60s`"
     runs-on: windows-latest
     steps:
@@ -1342,7 +1527,7 @@ jobs:
       - job_004
       - job_005
       - job_006
-  job_038:
+  job_043:
     name: Notify failure
     runs-on: ubuntu-latest
     if: "(github.event_name == 'push' || github.event_name == 'schedule') && failure()"
@@ -1391,3 +1576,8 @@ jobs:
       - job_035
       - job_036
       - job_037
+      - job_038
+      - job_039
+      - job_040
+      - job_041
+      - job_042

--- a/pkgs/test/mono_pkg.yaml
+++ b/pkgs/test/mono_pkg.yaml
@@ -22,25 +22,30 @@ stages:
   - command: dart test --preset travis --total-shards 5 --shard-index 0
     os:
     - windows
+    - osx
     sdk:
     - pubspec
   - command: dart test --preset travis --total-shards 5 --shard-index 1
     os:
     - windows
+    - osx
     sdk:
     - pubspec
   - command: dart test --preset travis --total-shards 5 --shard-index 2
     os:
     - windows
+    - osx
     sdk:
     - pubspec
   - command: dart test --preset travis --total-shards 5 --shard-index 3
     os:
     - windows
+    - osx
     sdk:
     - pubspec
   - command: dart test --preset travis --total-shards 5 --shard-index 4
     os:
     - windows
+    - osx
     sdk:
     - pubspec

--- a/pkgs/test/test/runner/browser/safari_test.dart
+++ b/pkgs/test/test/runner/browser/safari_test.dart
@@ -18,7 +18,8 @@ import 'code_server.dart';
 void main() {
   setUpAll(precompileTestExecutable);
 
-  test('starts Safari with the given URL', () async {
+  test('starts Safari with the given URL',
+      skip: 'https://github.com/dart-lang/test/issues/1253', () async {
     var server = await CodeServer.start();
 
     server.handleJavaScript('''

--- a/pkgs/test/test/runner/browser/safari_test.dart
+++ b/pkgs/test/test/runner/browser/safari_test.dart
@@ -55,7 +55,8 @@ webSocket.addEventListener("open", function() {
             startsWith('Failed to run Safari: $noSuchFileMessage'))));
   });
 
-  test('can run successful tests', () async {
+  test('can run successful tests',
+      skip: 'https://github.com/dart-lang/test/issues/1253', () async {
     await d.file('test.dart', '''
 import 'package:test/test.dart';
 

--- a/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
+++ b/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
@@ -34,6 +34,8 @@ void main() {
       } else if ([Runtime.firefox, Runtime.nodeJS].contains(runtime) &&
           Platform.isWindows) {
         skipReason = 'https://github.com/dart-lang/test/issues/1942';
+      } else if (runtime == Runtime.firefox && Platform.isMacOS) {
+        skipReason = 'https://github.com/dart-lang/test/pull/2276';
       }
       group('--runtime ${runtime.identifier} --compiler ${compiler.identifier}',
           skip: skipReason, () {

--- a/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
+++ b/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
@@ -26,8 +26,17 @@ void main() {
           (runtime == Runtime.safari && !Platform.isMacOS)) {
         continue;
       }
+      String? skipReason;
+      if (runtime == Runtime.safari) {
+        skipReason = 'https://github.com/dart-lang/test/issues/1253';
+      } else if (compiler == Compiler.dart2wasm) {
+        skipReason = 'Wasm tests are experimental and require special setup';
+      } else if ([Runtime.firefox, Runtime.nodeJS].contains(runtime) &&
+          Platform.isWindows) {
+        skipReason = 'https://github.com/dart-lang/test/issues/1942';
+      }
       group('--runtime ${runtime.identifier} --compiler ${compiler.identifier}',
-          () {
+          skip: skipReason, () {
         final testArgs = [
           'test.dart',
           '-p',
@@ -112,13 +121,7 @@ void main() {
                   ? 'https://github.com/dart-lang/test/issues/2150'
                   : null);
         }
-      },
-          skip: compiler == Compiler.dart2wasm
-              ? 'Wasm tests are experimental and require special setup'
-              : [Runtime.firefox, Runtime.nodeJS].contains(runtime) &&
-                      Platform.isWindows
-                  ? 'https://github.com/dart-lang/test/issues/1942'
-                  : null);
+      });
     }
   }
 }


### PR DESCRIPTION
This will exercise things like launching browsers (where they are
currently working on CI).

Add `osx` to the sharded `package:test` tests alongside `windows`. These
exercise the majority of OS specific behavior.

Skip existing safari tests due to a bug running tests in non-interactive
environments. (#1253)

Skip existing firefox tests due to a changed executable path. (Planned
fix in #2276)

Refactor a ternary chain to an if/else chain to add the extra
conditions for firefox and safari.