### PR TITLE
Update dart2wasm module runner

### DIFF
--- a/pkgs/test/lib/src/runner/browser/static/run_wasm_chrome.js
+++ b/pkgs/test/lib/src/runner/browser/static/run_wasm_chrome.js
@@ -26,6 +26,6 @@
     // Old, deprecated API.
     let modulePromise = WebAssembly.compileStreaming(fetch(data.wasmurl));
     let dartInstance = await dart2wasmJsRuntime.instantiate(modulePromise, {});
-    await dart2wasm.invoke(dartInstance);
+    await dart2wasmJsRuntime.invoke(dartInstance);
   }
 })();

--- a/pkgs/test/lib/src/runner/browser/static/run_wasm_chrome.js
+++ b/pkgs/test/lib/src/runner/browser/static/run_wasm_chrome.js
@@ -35,8 +35,8 @@
       instantiatedModule.invokeMain();
     } else {
       // Version (2).
-      let dartInstance = await dart2wasm.instantiate(compiledModule, {});
-      await dart2wasm.invoke(dartInstance);
+      let dartInstance = await dart2wasmJsRuntime.instantiate(compiledModule, {});
+      await dart2wasmJsRuntime.invoke(dartInstance);
     }
   } else {
     // Version (1).

--- a/pkgs/test/lib/src/runner/browser/static/run_wasm_chrome.js
+++ b/pkgs/test/lib/src/runner/browser/static/run_wasm_chrome.js
@@ -11,11 +11,21 @@
 
   // Instantiate the Dart module, importing from the global scope.
   let dart2wasmJsRuntime = await import('./' + data.jsruntimeurl);
-  let compiledModule = await dart2wasmJsRuntime.compileStreaming(fetch(data.wasmurl));
-  let instantiatedModule = await compiledModule.instantiate()
 
-  // Call `main`. If tasks are placed into the event loop (by scheduling tasks
-  // explicitly or awaiting Futures), these will automatically keep the script
-  // alive even after `main` returns.
-  await instantiatedModule.invokeMain();
+  // Check whether the JS shim has the new instantiation API.
+  if (dart2wasmJsRuntime.CompiledApp !== undefined) {
+    // New API.
+    let compiledModule = await dart2wasmJsRuntime.compileStreaming(fetch(data.wasmurl));
+    let instantiatedModule = await compiledModule.instantiate()
+
+    // Call `main`. If tasks are placed into the event loop (by scheduling tasks
+    // explicitly or awaiting Futures), these will automatically keep the script
+    // alive even after `main` returns.
+    await instantiatedModule.invokeMain();
+  } else {
+    // Old, deprecated API.
+    let modulePromise = WebAssembly.compileStreaming(fetch(data.wasmurl));
+    let dartInstance = await dart2wasmJsRuntime.instantiate(modulePromise, {});
+    await dart2wasmJsRuntime.invoke(dartInstance);
+  }
 })();

--- a/pkgs/test/lib/src/runner/browser/static/run_wasm_chrome.js
+++ b/pkgs/test/lib/src/runner/browser/static/run_wasm_chrome.js
@@ -11,21 +11,11 @@
 
   // Instantiate the Dart module, importing from the global scope.
   let dart2wasmJsRuntime = await import('./' + data.jsruntimeurl);
+  let compiledModule = await dart2wasmJsRuntime.compileStreaming(fetch(data.wasmurl));
+  let instantiatedModule = await compiledModule.instantiate()
 
-  // Check whether the JS shim has the new instantiation API.
-  if (dart2wasmJsRuntime.CompiledApp !== undefined) {
-    // New API.
-    let compiledModule = await dart2wasmJsRuntime.compileStreaming(fetch(data.wasmurl));
-    let instantiatedModule = await compiledModule.instantiate()
-
-    // Call `main`. If tasks are placed into the event loop (by scheduling tasks
-    // explicitly or awaiting Futures), these will automatically keep the script
-    // alive even after `main` returns.
-    await instantiatedModule.invokeMain();
-  } else {
-    // Old, deprecated API.
-    let modulePromise = WebAssembly.compileStreaming(fetch(data.wasmurl));
-    let dartInstance = await dart2wasmJsRuntime.instantiate(modulePromise, {});
-    await dart2wasmJsRuntime.invoke(dartInstance);
-  }
+  // Call `main`. If tasks are placed into the event loop (by scheduling tasks
+  // explicitly or awaiting Futures), these will automatically keep the script
+  // alive even after `main` returns.
+  await instantiatedModule.invokeMain();
 })();

--- a/pkgs/test/lib/src/runner/browser/static/run_wasm_chrome.js
+++ b/pkgs/test/lib/src/runner/browser/static/run_wasm_chrome.js
@@ -8,14 +8,14 @@
 (async () => {
   // Fetch and compile Wasm binary.
   let data = document.getElementById('WasmBootstrapInfo').dataset;
-  let modulePromise = WebAssembly.compileStreaming(fetch(data.wasmurl));
 
   // Instantiate the Dart module, importing from the global scope.
-  let dart2wasm = await import('./' + data.jsruntimeurl);
-  let dartInstance = await dart2wasm.instantiate(modulePromise, {});
+  let dart2wasmJsRuntime = await import('./' + data.jsruntimeurl);
+  let compiledModule = await dart2wasmJsRuntime.compileStreaming(fetch(data.wasmurl));
+  let instantiatedModule = await compiledModule.instantiate()
 
   // Call `main`. If tasks are placed into the event loop (by scheduling tasks
   // explicitly or awaiting Futures), these will automatically keep the script
   // alive even after `main` returns.
-  await dart2wasm.invoke(dartInstance);
+  await instantiatedModule.invokeMain();
 })();


### PR DESCRIPTION
Update dart2wasm module instantiation, compilation, and invoking `main` to support all the ways dart2wasm implemented.