### PR TITLE
Add a missed / in a doc comment

### DIFF
--- a/pkgs/checks/lib/src/extensions/async.dart
+++ b/pkgs/checks/lib/src/extensions/async.dart
@@ -233,7 +233,7 @@ extension StreamChecks<T> on Subject<StreamQueue<T>> {
   /// await check(someStream).withQueue.inOrder([
   ///   (s) => s.emits((e) => e.equals(0)),
   ///   (s) => s.emits((e) => e.equals(1)),
-  //  ]);
+  ///  ]);
   /// ```
   ///
   /// If this expectation fails, the source queue will be left in its original

--- a/pkgs/checks/lib/src/extensions/async.dart
+++ b/pkgs/checks/lib/src/extensions/async.dart
@@ -233,7 +233,7 @@ extension StreamChecks<T> on Subject<StreamQueue<T>> {
   /// await check(someStream).withQueue.inOrder([
   ///   (s) => s.emits((e) => e.equals(0)),
   ///   (s) => s.emits((e) => e.equals(1)),
-  ///  ]);
+  /// ]);
   /// ```
   ///
   /// If this expectation fails, the source queue will be left in its original


### PR DESCRIPTION
Resolves rendering issues with this doc on the hosted doc site.
