### PR TITLE
update the fake_async version to -wip following this repos standar processes

### DIFF
--- a/pkgs/fake_async/CHANGELOG.md
+++ b/pkgs/fake_async/CHANGELOG.md
@@ -1,11 +1,10 @@
-## 1.3.2
+## 1.3.2-wip
 
 * Require Dart 3.3
 * Fix bug where a `flushTimers` or `elapse` call from within
   the callback of a periodic timer would immediately invoke
   the same timer.
 * Move to `dart-lang/test` monorepo.
-* Require Dart 3.5.
 
 ## 1.3.1
 
@@ -99,4 +98,3 @@ of the `fake_async` package.
 ## 0.1.2
 
 * Integrate with the clock package.
-

--- a/pkgs/fake_async/pubspec.yaml
+++ b/pkgs/fake_async/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fake_async
-version: 1.3.2
+version: 1.3.2-wip
 description: >-
   Fake asynchronous events such as timers and microtasks for deterministic
   testing.


### PR DESCRIPTION
As we merge these repos in, we should update the versions as well to follow our standard procedure (otherwise, firehose is going to keep saying we have ready to publish versions).

It is probably best done in a follow-up PR like this though, or in the source repo prior to merging.