### PR TITLE
Enable avoid_dynamic_calls lint

### DIFF
--- a/pkgs/fake_async/analysis_options.yaml
+++ b/pkgs/fake_async/analysis_options.yaml
@@ -15,7 +15,6 @@ linter:
     - join_return_with_assignment
     - literal_only_boolean_expressions
     - no_adjacent_strings_in_list
-    - package_api_docs
     - prefer_const_constructors
     - prefer_final_locals
     - test_types_in_equals

--- a/pkgs/matcher/CHANGELOG.md
+++ b/pkgs/matcher/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.12.18-wip
 
-* Remove some dynamic invocation.
+* Remove some dynamic invocations.
 
 ## 0.12.17
 

--- a/pkgs/matcher/CHANGELOG.md
+++ b/pkgs/matcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.18-wip
+
+* Remove some dynamic invocation.
+
 ## 0.12.17
 
 * Require Dart 3.4

--- a/pkgs/matcher/analysis_options.yaml
+++ b/pkgs/matcher/analysis_options.yaml
@@ -16,7 +16,6 @@ linter:
     - no_runtimeType_toString
     - omit_local_variable_types
     - only_throw_errors
-    - package_api_docs
     - prefer_const_constructors
     - prefer_relative_imports
     - prefer_single_quotes

--- a/pkgs/matcher/analysis_options.yaml
+++ b/pkgs/matcher/analysis_options.yaml
@@ -3,6 +3,7 @@ include: package:lints/recommended.yaml
 linter:
   rules:
     - always_declare_return_types
+    - avoid_dynamic_calls
     - avoid_private_typedef_functions
     - avoid_unused_constructor_parameters
     - cancel_subscriptions

--- a/pkgs/matcher/lib/src/core_matchers.dart
+++ b/pkgs/matcher/lib/src/core_matchers.dart
@@ -148,7 +148,7 @@ class _ReturnsNormally extends FeatureMatcher<Function> {
   const _ReturnsNormally();
 
   @override
-  bool typedMatches(Function f, Map matchState) {
+  bool typedMatches(void Function() f, Map matchState) {
     try {
       f();
       return true;

--- a/pkgs/matcher/lib/src/core_matchers.dart
+++ b/pkgs/matcher/lib/src/core_matchers.dart
@@ -148,8 +148,9 @@ class _ReturnsNormally extends FeatureMatcher<Function> {
   const _ReturnsNormally();
 
   @override
-  bool typedMatches(Object f, Map matchState) {
+  bool typedMatches(Function f, Map matchState) {
     try {
+      // ignore: unnecessary_cast
       (f as Function)();
       return true;
     } catch (e, s) {

--- a/pkgs/matcher/lib/src/core_matchers.dart
+++ b/pkgs/matcher/lib/src/core_matchers.dart
@@ -144,7 +144,7 @@ class isInstanceOf<T> extends TypeMatcher<T> {
 /// a wrapper will have to be created.
 const Matcher returnsNormally = _ReturnsNormally();
 
-class _ReturnsNormally extends FeatureMatcher<Function> {
+class _ReturnsNormally extends FeatureMatcher<void Function()> {
   const _ReturnsNormally();
 
   @override

--- a/pkgs/matcher/lib/src/core_matchers.dart
+++ b/pkgs/matcher/lib/src/core_matchers.dart
@@ -144,13 +144,13 @@ class isInstanceOf<T> extends TypeMatcher<T> {
 /// a wrapper will have to be created.
 const Matcher returnsNormally = _ReturnsNormally();
 
-class _ReturnsNormally extends FeatureMatcher<void Function()> {
+class _ReturnsNormally extends FeatureMatcher<Function> {
   const _ReturnsNormally();
 
   @override
-  bool typedMatches(void Function() f, Map matchState) {
+  bool typedMatches(Object f, Map matchState) {
     try {
-      f();
+      (f as Function)();
       return true;
     } catch (e, s) {
       addStateInfo(matchState, {'exception': e, 'stack': s});

--- a/pkgs/matcher/lib/src/expect/throws_matcher.dart
+++ b/pkgs/matcher/lib/src/expect/throws_matcher.dart
@@ -82,8 +82,8 @@ class Throws extends AsyncMatcher {
     }
 
     try {
-      item as Function;
-      var value = (item as Function)();
+      item as Object? Function();
+      var value = item();
       if (value is Future) {
         return _matchFuture(value, 'returned a Future that emitted ');
       }

--- a/pkgs/matcher/lib/src/expect/throws_matcher.dart
+++ b/pkgs/matcher/lib/src/expect/throws_matcher.dart
@@ -82,8 +82,7 @@ class Throws extends AsyncMatcher {
     }
 
     try {
-      item as Object? Function();
-      var value = item();
+      var value = (item as Function)();
       if (value is Future) {
         return _matchFuture(value, 'returned a Future that emitted ');
       }

--- a/pkgs/matcher/lib/src/expect/throws_matcher.dart
+++ b/pkgs/matcher/lib/src/expect/throws_matcher.dart
@@ -83,7 +83,7 @@ class Throws extends AsyncMatcher {
 
     try {
       item as Function;
-      var value = item();
+      var value = (item as Function)();
       if (value is Future) {
         return _matchFuture(value, 'returned a Future that emitted ');
       }

--- a/pkgs/matcher/lib/src/iterable_matchers.dart
+++ b/pkgs/matcher/lib/src/iterable_matchers.dart
@@ -204,7 +204,7 @@ class _UnorderedMatches extends _IterableMatcher {
       .add(' unordered');
 
   @override
-  Description describeTypedMismatch(dynamic item,
+  Description describeTypedMismatch(Iterable item,
           Description mismatchDescription, Map matchState, bool verbose) =>
       mismatchDescription.add(_test(item.toList())!);
 

--- a/pkgs/matcher/lib/src/map_matchers.dart
+++ b/pkgs/matcher/lib/src/map_matchers.dart
@@ -15,6 +15,7 @@ class _ContainsValue extends Matcher {
 
   @override
   bool matches(Object? item, Map matchState) =>
+      // ignore: avoid_dynamic_calls
       (item as dynamic).containsValue(_value);
   @override
   Description describe(Description description) =>
@@ -34,8 +35,9 @@ class _ContainsMapping extends Matcher {
 
   @override
   bool matches(Object? item, Map matchState) =>
+      // ignore: avoid_dynamic_calls
       (item as dynamic).containsKey(_key) &&
-      _valueMatcher.matches(item[_key], matchState);
+      _valueMatcher.matches((item as dynamic)[_key], matchState);
 
   @override
   Description describe(Description description) {
@@ -49,7 +51,8 @@ class _ContainsMapping extends Matcher {
   @override
   Description describeMismatch(Object? item, Description mismatchDescription,
       Map matchState, bool verbose) {
-    if (!(item as dynamic).containsKey(_key)) {
+    // ignore: avoid_dynamic_calls
+    if (!((item as dynamic).containsKey(_key) as bool)) {
       return mismatchDescription
           .add(" doesn't contain key ")
           .addDescriptionOf(_key);
@@ -59,7 +62,7 @@ class _ContainsMapping extends Matcher {
           .addDescriptionOf(_key)
           .add(' but with value ');
       _valueMatcher.describeMismatch(
-          item[_key], mismatchDescription, matchState, verbose);
+          (item as dynamic)[_key], mismatchDescription, matchState, verbose);
       return mismatchDescription;
     }
   }

--- a/pkgs/matcher/lib/src/map_matchers.dart
+++ b/pkgs/matcher/lib/src/map_matchers.dart
@@ -2,21 +2,20 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'feature_matcher.dart';
 import 'interfaces.dart';
 import 'util.dart';
 
 /// Returns a matcher which matches maps containing the given [value].
 Matcher containsValue(Object? value) => _ContainsValue(value);
 
-class _ContainsValue extends Matcher {
+class _ContainsValue extends FeatureMatcher<Map> {
   final Object? _value;
 
   const _ContainsValue(this._value);
 
   @override
-  bool matches(Object? item, Map matchState) =>
-      // ignore: avoid_dynamic_calls
-      (item as dynamic).containsValue(_value);
+  bool typedMatches(Map item, Map matchState) => item.containsValue(_value);
   @override
   Description describe(Description description) =>
       description.add('contains value ').addDescriptionOf(_value);
@@ -27,17 +26,15 @@ class _ContainsValue extends Matcher {
 Matcher containsPair(Object? key, Object? valueOrMatcher) =>
     _ContainsMapping(key, wrapMatcher(valueOrMatcher));
 
-class _ContainsMapping extends Matcher {
+class _ContainsMapping extends FeatureMatcher<Map> {
   final Object? _key;
   final Matcher _valueMatcher;
 
   const _ContainsMapping(this._key, this._valueMatcher);
 
   @override
-  bool matches(Object? item, Map matchState) =>
-      // ignore: avoid_dynamic_calls
-      (item as dynamic).containsKey(_key) &&
-      _valueMatcher.matches((item as dynamic)[_key], matchState);
+  bool typedMatches(Map item, Map matchState) =>
+      item.containsKey(_key) && _valueMatcher.matches(item[_key], matchState);
 
   @override
   Description describe(Description description) {
@@ -49,10 +46,9 @@ class _ContainsMapping extends Matcher {
   }
 
   @override
-  Description describeMismatch(Object? item, Description mismatchDescription,
-      Map matchState, bool verbose) {
-    // ignore: avoid_dynamic_calls
-    if (!((item as dynamic).containsKey(_key) as bool)) {
+  Description describeTypedMismatch(
+      Map item, Description mismatchDescription, Map matchState, bool verbose) {
+    if (!item.containsKey(_key)) {
       return mismatchDescription
           .add(" doesn't contain key ")
           .addDescriptionOf(_key);
@@ -62,7 +58,7 @@ class _ContainsMapping extends Matcher {
           .addDescriptionOf(_key)
           .add(' but with value ');
       _valueMatcher.describeMismatch(
-          (item as dynamic)[_key], mismatchDescription, matchState, verbose);
+          item[_key], mismatchDescription, matchState, verbose);
       return mismatchDescription;
     }
   }

--- a/pkgs/matcher/lib/src/numeric_matchers.dart
+++ b/pkgs/matcher/lib/src/numeric_matchers.dart
@@ -32,8 +32,8 @@ class _IsCloseTo extends FeatureMatcher<num> {
       .addDescriptionOf(_value);
 
   @override
-  Description describeTypedMismatch(num item,
-      Description mismatchDescription, Map matchState, bool verbose) {
+  Description describeTypedMismatch(
+      num item, Description mismatchDescription, Map matchState, bool verbose) {
     var diff = item - _value;
     if (diff < 0) diff = -diff;
     return mismatchDescription.add(' differs by ').addDescriptionOf(diff);

--- a/pkgs/matcher/lib/src/numeric_matchers.dart
+++ b/pkgs/matcher/lib/src/numeric_matchers.dart
@@ -18,7 +18,7 @@ class _IsCloseTo extends FeatureMatcher<num> {
   const _IsCloseTo(this._value, this._delta);
 
   @override
-  bool typedMatches(dynamic item, Map matchState) {
+  bool typedMatches(num item, Map matchState) {
     var diff = item - _value;
     if (diff < 0) diff = -diff;
     return diff <= _delta;
@@ -32,7 +32,7 @@ class _IsCloseTo extends FeatureMatcher<num> {
       .addDescriptionOf(_value);
 
   @override
-  Description describeTypedMismatch(dynamic item,
+  Description describeTypedMismatch(num item,
       Description mismatchDescription, Map matchState, bool verbose) {
     var diff = item - _value;
     if (diff < 0) diff = -diff;
@@ -67,7 +67,7 @@ class _InRange extends FeatureMatcher<num> {
       this._low, this._high, this._lowMatchValue, this._highMatchValue);
 
   @override
-  bool typedMatches(dynamic value, Map matchState) {
+  bool typedMatches(num value, Map matchState) {
     if (value < _low || value > _high) {
       return false;
     }

--- a/pkgs/matcher/lib/src/operator_matchers.dart
+++ b/pkgs/matcher/lib/src/operator_matchers.dart
@@ -57,7 +57,7 @@ class _AllOf extends Matcher {
   @override
   Description describeMismatch(dynamic item, Description mismatchDescription,
       Map matchState, bool verbose) {
-    var matcher = matchState['matcher'];
+    var matcher = matchState['matcher'] as Matcher;
     matcher.describeMismatch(
         item, mismatchDescription, matchState['state'], verbose);
     return mismatchDescription;

--- a/pkgs/matcher/lib/src/order_matchers.dart
+++ b/pkgs/matcher/lib/src/order_matchers.dart
@@ -80,7 +80,7 @@ class _OrderingMatcher extends Matcher {
       return _equalValue;
     } else if ((item as dynamic) < _value) {
       return _lessThanValue;
-    } else if (item > _value) {
+    } else if ((item as dynamic) > _value) {
       return _greaterThanValue;
     } else {
       return false;

--- a/pkgs/matcher/lib/src/string_matchers.dart
+++ b/pkgs/matcher/lib/src/string_matchers.dart
@@ -80,7 +80,7 @@ class _StringStartsWith extends FeatureMatcher<String> {
   const _StringStartsWith(this._prefix);
 
   @override
-  bool typedMatches(dynamic item, Map matchState) => item.startsWith(_prefix);
+  bool typedMatches(String item, Map matchState) => item.startsWith(_prefix);
 
   @override
   Description describe(Description description) =>
@@ -97,7 +97,7 @@ class _StringEndsWith extends FeatureMatcher<String> {
   const _StringEndsWith(this._suffix);
 
   @override
-  bool typedMatches(dynamic item, Map matchState) => item.endsWith(_suffix);
+  bool typedMatches(String item, Map matchState) => item.endsWith(_suffix);
 
   @override
   Description describe(Description description) =>
@@ -119,7 +119,7 @@ class _StringContainsInOrder extends FeatureMatcher<String> {
   const _StringContainsInOrder(this._substrings);
 
   @override
-  bool typedMatches(dynamic item, Map matchState) {
+  bool typedMatches(String item, Map matchState) {
     var fromIndex = 0;
     for (var s in _substrings) {
       var index = item.indexOf(s, fromIndex);

--- a/pkgs/matcher/pubspec.yaml
+++ b/pkgs/matcher/pubspec.yaml
@@ -1,5 +1,5 @@
 name: matcher
-version: 0.12.17
+version: 0.12.18-wip
 description: >-
   Support for specifying test expectations via an extensible Matcher class.
   Also includes a number of built-in Matcher implementations for common cases.

--- a/pkgs/matcher/test/expect_async_test.dart
+++ b/pkgs/matcher/test/expect_async_test.dart
@@ -336,7 +336,7 @@ void main() {
     test('works with no arguments', () async {
       var callbackRun = false;
       var monitor = await TestCaseMonitor.run(() {
-        // ignore: deprecated_member_use_from_same_package
+        // ignore: deprecated_member_use_from_same_package, avoid_dynamic_calls
         expectAsync(() {
           callbackRun = true;
         })();
@@ -349,7 +349,7 @@ void main() {
     test('works with dynamic arguments', () async {
       var callbackRun = false;
       var monitor = await TestCaseMonitor.run(() {
-        // ignore: deprecated_member_use_from_same_package
+        // ignore: deprecated_member_use_from_same_package, avoid_dynamic_calls
         expectAsync((arg1, arg2) {
           callbackRun = true;
         })(1, 2);
@@ -362,7 +362,7 @@ void main() {
     test('works with non-nullable arguments', () async {
       var callbackRun = false;
       var monitor = await TestCaseMonitor.run(() {
-        // ignore: deprecated_member_use_from_same_package
+        // ignore: deprecated_member_use_from_same_package, avoid_dynamic_calls
         expectAsync((int arg1, int arg2) {
           callbackRun = true;
         })(1, 2);
@@ -375,7 +375,7 @@ void main() {
     test('works with 6 arguments', () async {
       var callbackRun = false;
       var monitor = await TestCaseMonitor.run(() {
-        // ignore: deprecated_member_use_from_same_package
+        // ignore: deprecated_member_use_from_same_package, avoid_dynamic_calls
         expectAsync((arg1, arg2, arg3, arg4, arg5, arg6) {
           callbackRun = true;
         })(1, 2, 3, 4, 5, 6);

--- a/pkgs/matcher/test/matcher/throws_type_test.dart
+++ b/pkgs/matcher/test/matcher/throws_type_test.dart
@@ -95,6 +95,7 @@ void main() {
   group('[throwsNoSuchMethodError]', () {
     test('passes when a NoSuchMethodError is thrown', () {
       expect(() {
+        // ignore: avoid_dynamic_calls
         (1 as dynamic).notAMethodOnInt();
       }, throwsNoSuchMethodError);
     });

--- a/pkgs/matcher/test/mirror_matchers_test.dart
+++ b/pkgs/matcher/test/mirror_matchers_test.dart
@@ -5,6 +5,7 @@
 // ignore_for_file: deprecated_member_use_from_same_package
 
 @TestOn('vm')
+library;
 
 import 'package:matcher/mirror_matchers.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION
Add argument types to `typedMatches` arguments which were unnecessarily
widening it back to `dynamic`. 

Add some missing `as dynamic` and `as Function` which is the pattern the
lint uses to allow intentional dynamic calls.

Ignore some dynamic calls in a test for a legacy API.

Ignore a couple false positives for calling methods (as opposed to
getters) on a cast expression. The false positive was fixed in
https://dart-review.googlesource.com/c/sdk/+/390640
but not yet published.

Remove the deprecated lint `package_api_docs`.

Replaces https://github.com/dart-lang/matcher/pull/205
