### PR TITLE
widen the dep in package:shelf_web_socket

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.25.11
+
+* Update the `package:shelf_web_socket` constraint to allow version `3.x`.
+
 ## 1.25.10
 
 * Update the `package:vm_service` constraint to allow version `15.x`.

--- a/pkgs/test/README.md
+++ b/pkgs/test/README.md
@@ -798,7 +798,7 @@ import 'package:stream_channel/stream_channel.dart';
 // returned spawnHybridCode().
 hybridMain(StreamChannel channel) async {
   // Start a WebSocket server that just sends "hello!" to its clients.
-  var server = await io.serve(webSocketHandler((webSocket) {
+  var server = await io.serve(webSocketHandler((webSocket, _) {
     webSocket.sink.add('hello!');
   }), 'localhost', 0);
 

--- a/pkgs/test/lib/src/runner/browser/compilers/dart2js.dart
+++ b/pkgs/test/lib/src/runner/browser/compilers/dart2js.dart
@@ -174,7 +174,10 @@ class Dart2JsSupport extends CompilerSupport with JsHtmlWrapper {
   @override
   (Uri, Future<WebSocketChannel>) get webSocket {
     var completer = Completer<WebSocketChannel>.sync();
-    var path = _webSocketHandler.create(webSocketHandler(completer.complete));
+    var path =
+        _webSocketHandler.create(webSocketHandler((WebSocketChannel ws, _) {
+      completer.complete(ws);
+    }));
     var webSocketUrl = serverUrl.replace(scheme: 'ws').resolve(path);
     return (webSocketUrl, completer.future);
   }

--- a/pkgs/test/lib/src/runner/browser/compilers/dart2wasm.dart
+++ b/pkgs/test/lib/src/runner/browser/compilers/dart2wasm.dart
@@ -180,7 +180,10 @@ class Dart2WasmSupport extends CompilerSupport with WasmHtmlWrapper {
   @override
   (Uri, Future<WebSocketChannel>) get webSocket {
     var completer = Completer<WebSocketChannel>.sync();
-    var path = _webSocketHandler.create(webSocketHandler(completer.complete));
+    var path =
+        _webSocketHandler.create(webSocketHandler((WebSocketChannel ws, _) {
+      completer.complete(ws);
+    }));
     var webSocketUrl = serverUrl.replace(scheme: 'ws').resolve(path);
     return (webSocketUrl, completer.future);
   }

--- a/pkgs/test/lib/src/runner/browser/compilers/precompiled.dart
+++ b/pkgs/test/lib/src/runner/browser/compilers/precompiled.dart
@@ -137,7 +137,10 @@ abstract class PrecompiledSupport extends CompilerSupport {
   @override
   (Uri, Future<WebSocketChannel>) get webSocket {
     var completer = Completer<WebSocketChannel>.sync();
-    var path = _webSocketHandler.create(webSocketHandler(completer.complete));
+    var path =
+        _webSocketHandler.create(webSocketHandler((WebSocketChannel ws, _) {
+      completer.complete(ws);
+    }));
     var webSocketUrl = serverUrl.replace(scheme: 'ws').resolve(path);
     return (webSocketUrl, completer.future);
   }

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.25.10
+version: 1.25.11
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test
@@ -29,7 +29,7 @@ dependencies:
   shelf: ^1.0.0
   shelf_packages_handler: ^3.0.0
   shelf_static: ^1.0.0
-  shelf_web_socket: '>=1.0.0 <3.0.0'
+  shelf_web_socket: '>=1.0.0 <4.0.0'
   source_span: ^1.8.0
   stack_trace: ^1.10.0
   stream_channel: ^2.1.0

--- a/pkgs/test/test/runner/browser/code_server.dart
+++ b/pkgs/test/test/runner/browser/code_server.dart
@@ -59,7 +59,9 @@ class CodeServer {
   /// future that will complete to the WebSocket.
   Future<WebSocketChannel> handleWebSocket() {
     var completer = Completer<WebSocketChannel>();
-    _handler.expect('GET', '/', webSocketHandler(completer.complete));
+    _handler.expect('GET', '/', webSocketHandler((WebSocketChannel ws, _) {
+      completer.complete(ws);
+    }));
     return completer.future;
   }
 }


### PR DESCRIPTION
- add a 2nd argument to the closure passed into package:shelf_web_socket's `webSocketHandler` method
- widen the dep on package:shelf_web_socket

This will allow us to add more type info to the closure that `webSocketHandler` expects; it's currently an untyped Function. See also https://github.com/dart-lang/shelf/issues/457 and https://github.com/dart-lang/shelf/pull/463.

This forward declares compatibility with `3.0` of `package:shelf_web_socket`; I _think_ this is necessary - as `dart test` uses both package:test and package:shelf_web_socket - but happy to hear otherwise.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
