### PR TITLE
Fix hang after multiple precompiled browser tests

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.25.12
+
+* Fix hang when running multiple precompiled browser tests.
+
 ## 1.25.11
 
 * Update to be forward compatible with `package:shelf_web_socket` version `3.x`.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.25.11
+version: 1.25.12
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test
@@ -36,7 +36,7 @@ dependencies:
 
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.7.4
-  test_core: 0.6.7
+  test_core: 0.6.8
 
   typed_data: ^1.3.0
   web_socket_channel: '>=2.0.0 <4.0.0'

--- a/pkgs/test/test/runner/precompiled_test.dart
+++ b/pkgs/test/test/runner/precompiled_test.dart
@@ -42,7 +42,7 @@ void main() {
 
     test('run two precompiled tests', () async {
       await _precompileBrowserTest('test_2.dart');
-      var test = await runTest([
+      var test = await runTest(concurrency: 2, [
         '-p',
         'chrome',
         '--precompiled=precompiled/',

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.8
+
+* Fix hang when running multiple precompiled browser tests.
+
 ## 0.6.7
 
 * Update the `package:vm_service` constraint to allow version `15.x`.

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.6.7
+version: 0.6.8
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 resolution: workspace


### PR DESCRIPTION
Fixes #2294

Avoid creating extra unexpected BrowserManager instances by caching the
future in the `_browserManagers` map without any async delay. Previously
it was possible for two managers to be created if the second suite is
loaded before the first suite's `compilerSupport` was resolved. This was
not a problem for tests that get compiled by the test runner because the
compilation would delay the second suite load until after the first
suite's `compilerSupport` has resolved. It is not a problem when running
without concurrency because that delays the second suite load.

Add a concurrency argument to the regression test, otherwise the default
is to run with concurrency 1 which works around the bug.
