### PR TITLE
Use dart_flutter_team_lints for matcher

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -70,36 +70,6 @@ jobs:
         if: "always() && steps.pkgs_fake_async_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/fake_async
   job_003:
-    name: "analyze_and_format; linux; Dart 3.4.0; PKG: pkgs/matcher; `dart analyze`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/matcher;commands:analyze_1"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/matcher
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@e630b99d28a3b71860378cafdc2a067c71107f94
-        with:
-          sdk: "3.4.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - id: pkgs_matcher_pub_upgrade
-        name: pkgs/matcher; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/matcher
-      - name: pkgs/matcher; dart analyze
-        run: dart analyze
-        if: "always() && steps.pkgs_matcher_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/matcher
-  job_004:
     name: "analyze_and_format; linux; Dart 3.5.0; PKGS: integration_tests/regression, integration_tests/wasm; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos`"
     runs-on: ubuntu-latest
     steps:
@@ -146,17 +116,17 @@ jobs:
         run: dart analyze --fatal-infos
         if: "always() && steps.integration_tests_wasm_pub_upgrade.conclusion == 'success'"
         working-directory: integration_tests/wasm
-  job_005:
-    name: "analyze_and_format; linux; Dart 3.5.0; PKGS: pkgs/checks, pkgs/test_core; `dart analyze`"
+  job_004:
+    name: "analyze_and_format; linux; Dart 3.5.0; PKGS: pkgs/checks, pkgs/matcher, pkgs/test_core; `dart analyze`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:pkgs/checks-pkgs/test_core;commands:analyze_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:pkgs/checks-pkgs/matcher-pkgs/test_core;commands:analyze_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:pkgs/checks-pkgs/test_core
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:pkgs/checks-pkgs/matcher-pkgs/test_core
             os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -176,6 +146,15 @@ jobs:
         run: dart analyze
         if: "always() && steps.pkgs_checks_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/checks
+      - id: pkgs_matcher_pub_upgrade
+        name: pkgs/matcher; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/matcher
+      - name: pkgs/matcher; dart analyze
+        run: dart analyze
+        if: "always() && steps.pkgs_matcher_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/matcher
       - id: pkgs_test_core_pub_upgrade
         name: pkgs/test_core; dart pub upgrade
         run: dart pub upgrade
@@ -185,7 +164,7 @@ jobs:
         run: dart analyze
         if: "always() && steps.pkgs_test_core_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/test_core
-  job_006:
+  job_005:
     name: "analyze_and_format; linux; Dart dev; PKGS: integration_tests/regression, integration_tests/spawn_hybrid, integration_tests/wasm, pkgs/checks, pkgs/fake_async, pkgs/matcher, pkgs/test, pkgs/test_api, pkgs/test_core; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos`"
     runs-on: ubuntu-latest
     steps:
@@ -323,7 +302,7 @@ jobs:
         run: dart analyze --fatal-infos
         if: "always() && steps.pkgs_test_core_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/test_core
-  job_007:
+  job_006:
     name: "analyze_and_format; windows; Dart 3.5.0; PKG: integration_tests/wasm; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos`"
     runs-on: windows-latest
     steps:
@@ -347,7 +326,7 @@ jobs:
         run: dart analyze --fatal-infos
         if: "always() && steps.integration_tests_wasm_pub_upgrade.conclusion == 'success'"
         working-directory: integration_tests/wasm
-  job_008:
+  job_007:
     name: "analyze_and_format; windows; Dart dev; PKG: integration_tests/wasm; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos`"
     runs-on: windows-latest
     steps:
@@ -371,7 +350,7 @@ jobs:
         run: dart analyze --fatal-infos
         if: "always() && steps.integration_tests_wasm_pub_upgrade.conclusion == 'success'"
         working-directory: integration_tests/wasm
-  job_009:
+  job_008:
     name: "unit_test; linux; Dart 3.3.0; PKG: pkgs/fake_async; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -409,47 +388,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_010:
-    name: "unit_test; linux; Dart 3.4.0; PKG: pkgs/matcher; `dart test`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/matcher;commands:command_00"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:pkgs/matcher
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@e630b99d28a3b71860378cafdc2a067c71107f94
-        with:
-          sdk: "3.4.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - id: pkgs_matcher_pub_upgrade
-        name: pkgs/matcher; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/matcher
-      - name: pkgs/matcher; dart test
-        run: dart test
-        if: "always() && steps.pkgs_matcher_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/matcher
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-      - job_005
-      - job_006
-      - job_007
-      - job_008
-  job_011:
+  job_009:
     name: "unit_test; linux; Dart 3.5.0; PKG: integration_tests/regression; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -487,8 +426,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_012:
+  job_010:
     name: "unit_test; linux; Dart 3.5.0; PKG: pkgs/checks; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -526,8 +464,45 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_013:
+  job_011:
+    name: "unit_test; linux; Dart 3.5.0; PKG: pkgs/matcher; `dart test`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:pkgs/matcher;commands:command_00"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:pkgs/matcher
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@e630b99d28a3b71860378cafdc2a067c71107f94
+        with:
+          sdk: "3.5.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - id: pkgs_matcher_pub_upgrade
+        name: pkgs/matcher; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/matcher
+      - name: pkgs/matcher; dart test
+        run: dart test
+        if: "always() && steps.pkgs_matcher_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/matcher
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+  job_012:
     name: "unit_test; linux; Dart 3.5.0; PKG: pkgs/test_core; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -565,8 +540,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_014:
+  job_013:
     name: "unit_test; linux; Dart 3.5.0; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
     runs-on: ubuntu-latest
     steps:
@@ -604,8 +578,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_015:
+  job_014:
     name: "unit_test; linux; Dart 3.5.0; PKG: integration_tests/wasm; `dart test --timeout=60s`"
     runs-on: ubuntu-latest
     steps:
@@ -643,8 +616,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_016:
+  job_015:
     name: "unit_test; linux; Dart 3.5.0; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: ubuntu-latest
     steps:
@@ -682,8 +654,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_017:
+  job_016:
     name: "unit_test; linux; Dart 3.5.0; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: ubuntu-latest
     steps:
@@ -721,8 +692,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_018:
+  job_017:
     name: "unit_test; linux; Dart 3.5.0; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: ubuntu-latest
     steps:
@@ -760,8 +730,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_019:
+  job_018:
     name: "unit_test; linux; Dart 3.5.0; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 3`"
     runs-on: ubuntu-latest
     steps:
@@ -799,8 +768,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_020:
+  job_019:
     name: "unit_test; linux; Dart 3.5.0; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 4`"
     runs-on: ubuntu-latest
     steps:
@@ -838,8 +806,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_021:
+  job_020:
     name: "unit_test; linux; Dart 3.5.0; PKG: pkgs/test_api; `dart test --preset travis -x browser`"
     runs-on: ubuntu-latest
     steps:
@@ -877,8 +844,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_022:
+  job_021:
     name: "unit_test; linux; Dart dev; PKG: integration_tests/regression; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -916,8 +882,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_023:
+  job_022:
     name: "unit_test; linux; Dart dev; PKG: pkgs/checks; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -955,8 +920,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_024:
+  job_023:
     name: "unit_test; linux; Dart dev; PKG: pkgs/fake_async; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -994,8 +958,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_025:
+  job_024:
     name: "unit_test; linux; Dart dev; PKG: pkgs/matcher; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -1033,8 +996,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_026:
+  job_025:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test_core; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -1072,8 +1034,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_027:
+  job_026:
     name: "unit_test; linux; Dart dev; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
     runs-on: ubuntu-latest
     steps:
@@ -1111,8 +1072,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_028:
+  job_027:
     name: "unit_test; linux; Dart dev; PKG: integration_tests/wasm; `dart test --timeout=60s`"
     runs-on: ubuntu-latest
     steps:
@@ -1150,8 +1110,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_029:
+  job_028:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: ubuntu-latest
     steps:
@@ -1189,8 +1148,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_030:
+  job_029:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: ubuntu-latest
     steps:
@@ -1228,8 +1186,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_031:
+  job_030:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: ubuntu-latest
     steps:
@@ -1267,8 +1224,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_032:
+  job_031:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 3`"
     runs-on: ubuntu-latest
     steps:
@@ -1306,8 +1262,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_033:
+  job_032:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 4`"
     runs-on: ubuntu-latest
     steps:
@@ -1345,8 +1300,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_034:
+  job_033:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test_api; `dart test --preset travis -x browser`"
     runs-on: ubuntu-latest
     steps:
@@ -1384,8 +1338,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_035:
+  job_034:
     name: "unit_test; osx; Dart 3.5.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: macos-latest
     steps:
@@ -1423,8 +1376,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_036:
+  job_035:
     name: "unit_test; osx; Dart 3.5.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: macos-latest
     steps:
@@ -1462,8 +1414,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_037:
+  job_036:
     name: "unit_test; osx; Dart 3.5.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: macos-latest
     steps:
@@ -1501,8 +1452,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_038:
+  job_037:
     name: "unit_test; osx; Dart 3.5.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 3`"
     runs-on: macos-latest
     steps:
@@ -1540,8 +1490,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_039:
+  job_038:
     name: "unit_test; osx; Dart 3.5.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 4`"
     runs-on: macos-latest
     steps:
@@ -1579,8 +1528,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_040:
+  job_039:
     name: "unit_test; windows; Dart 3.5.0; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
     runs-on: windows-latest
     steps:
@@ -1608,8 +1556,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_041:
+  job_040:
     name: "unit_test; windows; Dart 3.5.0; PKG: integration_tests/wasm; `dart test --timeout=60s`"
     runs-on: windows-latest
     steps:
@@ -1637,8 +1584,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_042:
+  job_041:
     name: "unit_test; windows; Dart 3.5.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: windows-latest
     steps:
@@ -1666,8 +1612,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_043:
+  job_042:
     name: "unit_test; windows; Dart 3.5.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: windows-latest
     steps:
@@ -1695,8 +1640,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_044:
+  job_043:
     name: "unit_test; windows; Dart 3.5.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: windows-latest
     steps:
@@ -1724,8 +1668,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_045:
+  job_044:
     name: "unit_test; windows; Dart 3.5.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 3`"
     runs-on: windows-latest
     steps:
@@ -1753,8 +1696,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_046:
+  job_045:
     name: "unit_test; windows; Dart 3.5.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 4`"
     runs-on: windows-latest
     steps:
@@ -1782,8 +1724,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_047:
+  job_046:
     name: "unit_test; windows; Dart dev; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
     runs-on: windows-latest
     steps:
@@ -1811,8 +1752,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_048:
+  job_047:
     name: "unit_test; windows; Dart dev; PKG: integration_tests/wasm; `dart test --timeout=60s`"
     runs-on: windows-latest
     steps:
@@ -1840,8 +1780,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-      - job_008
-  job_049:
+  job_048:
     name: Notify failure
     runs-on: ubuntu-latest
     if: "(github.event_name == 'push' || github.event_name == 'schedule') && failure()"
@@ -1900,4 +1839,3 @@ jobs:
       - job_045
       - job_046
       - job_047
-      - job_048

--- a/pkgs/matcher/CHANGELOG.md
+++ b/pkgs/matcher/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Remove some dynamic invocations.
 * Add explicit casts from `dynamic` values.
+* Require Dart 3.5
 
 ## 0.12.17
 

--- a/pkgs/matcher/CHANGELOG.md
+++ b/pkgs/matcher/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.12.18-wip
 
 * Remove some dynamic invocations.
+* Add explicit casts from `dynamic` values.
 
 ## 0.12.17
 

--- a/pkgs/matcher/analysis_options.yaml
+++ b/pkgs/matcher/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:lints/recommended.yaml
+include: package:dart_flutter_team_lints/analysis_options.yaml
 
 linter:
   rules:

--- a/pkgs/matcher/lib/expect.dart
+++ b/pkgs/matcher/lib/expect.dart
@@ -38,14 +38,14 @@ export 'src/expect/prints_matcher.dart' show prints;
 export 'src/expect/stream_matcher.dart' show StreamMatcher;
 export 'src/expect/stream_matchers.dart'
     show
-        emitsDone,
         emits,
-        emitsError,
-        mayEmit,
         emitsAnyOf,
-        emitsInOrder,
+        emitsDone,
+        emitsError,
         emitsInAnyOrder,
+        emitsInOrder,
         emitsThrough,
+        mayEmit,
         mayEmitMultiple,
         neverEmits;
 export 'src/expect/throws_matcher.dart' show Throws, throws, throwsA;

--- a/pkgs/matcher/lib/mirror_matchers.dart
+++ b/pkgs/matcher/lib/mirror_matchers.dart
@@ -73,7 +73,7 @@ class _HasProperty extends Matcher {
           .add('has property "$_name" with value ')
           .addDescriptionOf(matchState['value']);
       var innerDescription = StringDescription();
-      matchState['state'] ??= {};
+      matchState['state'] ??= <Object?, Object?>{};
       _matcher?.describeMismatch(matchState['value'], innerDescription,
           matchState['state'] as Map, verbose);
       if (innerDescription.length > 0) {

--- a/pkgs/matcher/lib/src/core_matchers.dart
+++ b/pkgs/matcher/lib/src/core_matchers.dart
@@ -14,7 +14,8 @@ class _Empty extends Matcher {
   const _Empty();
 
   @override
-  bool matches(Object? item, Map matchState) => (item as dynamic).isEmpty;
+  bool matches(Object? item, Map matchState) =>
+      (item as dynamic).isEmpty as bool;
 
   @override
   Description describe(Description description) => description.add('empty');
@@ -27,7 +28,8 @@ class _NotEmpty extends Matcher {
   const _NotEmpty();
 
   @override
-  bool matches(Object? item, Map matchState) => (item as dynamic).isNotEmpty;
+  bool matches(Object? item, Map matchState) =>
+      (item as dynamic).isNotEmpty as bool;
 
   @override
   Description describe(Description description) => description.add('non-empty');

--- a/pkgs/matcher/lib/src/equals_matcher.dart
+++ b/pkgs/matcher/lib/src/equals_matcher.dart
@@ -167,7 +167,7 @@ class _DeepMatcher extends Matcher {
       Object? expected, Object? actual, String location, int depth) {
     // If the expected value is a matcher, try to match it.
     if (expected is Matcher) {
-      var matchState = {};
+      var matchState = <Object?, Object?>{};
       if (expected.matches(actual, matchState)) return null;
       return _Mismatch(location, actual, (description, verbose) {
         var oldLength = description.length;

--- a/pkgs/matcher/lib/src/expect/expect.dart
+++ b/pkgs/matcher/lib/src/expect/expect.dart
@@ -74,7 +74,10 @@ Future expectLater(dynamic actual, dynamic matcher,
 
 /// The implementation of [expect] and [expectLater].
 Future _expect(Object? actual, Object? matcher,
-    {String? reason, skip, bool verbose = false, ErrorFormatter? formatter}) {
+    {String? reason,
+    Object? skip,
+    bool verbose = false,
+    ErrorFormatter? formatter}) {
   final test = TestHandle.current;
   formatter ??= (actual, matcher, reason, matchState, verbose) {
     var mismatchDescription = StringDescription();
@@ -133,7 +136,7 @@ Future _expect(Object? actual, Object? matcher,
     return Future.sync(() {});
   }
 
-  var matchState = {};
+  var matchState = <Object?, Object?>{};
   try {
     if ((matcher as Matcher).matches(actual, matchState)) {
       return Future.sync(() {});

--- a/pkgs/matcher/lib/src/expect/expect_async.dart
+++ b/pkgs/matcher/lib/src/expect/expect_async.dart
@@ -124,15 +124,17 @@ class _ExpectedFunction<T> {
   /// Returns a function that has the same number of positional arguments as the
   /// wrapped function (up to a total of 6).
   Function get func {
-    if (_callback is Function(Never, Never, Never, Never, Never, Never)) {
+    if (_callback is void Function(Never, Never, Never, Never, Never, Never)) {
       return max6;
     }
-    if (_callback is Function(Never, Never, Never, Never, Never)) return max5;
-    if (_callback is Function(Never, Never, Never, Never)) return max4;
-    if (_callback is Function(Never, Never, Never)) return max3;
-    if (_callback is Function(Never, Never)) return max2;
-    if (_callback is Function(Never)) return max1;
-    if (_callback is Function()) return max0;
+    if (_callback is void Function(Never, Never, Never, Never, Never)) {
+      return max5;
+    }
+    if (_callback is void Function(Never, Never, Never, Never)) return max4;
+    if (_callback is void Function(Never, Never, Never)) return max3;
+    if (_callback is void Function(Never, Never)) return max2;
+    if (_callback is void Function(Never)) return max1;
+    if (_callback is void Function()) return max0;
 
     _outstandingWork?.complete();
     throw ArgumentError(
@@ -219,7 +221,8 @@ class _ExpectedFunction<T> {
 @Deprecated('Will be removed in 0.13.0')
 Function expectAsync(Function callback,
         {int count = 1, int max = 0, String? id, String? reason}) =>
-    _ExpectedFunction(callback, count, max, id: id, reason: reason).func;
+    _ExpectedFunction<Object?>(callback, count, max, id: id, reason: reason)
+        .func;
 
 /// Informs the framework that the given [callback] of arity 0 is expected to be
 /// called [count] number of times (by default 1).
@@ -415,7 +418,8 @@ Func6<T, A, B, C, D, E, F> expectAsync6<T, A, B, C, D, E, F>(
 @Deprecated('Will be removed in 0.13.0')
 Function expectAsyncUntil(Function callback, bool Function() isDone,
         {String? id, String? reason}) =>
-    _ExpectedFunction(callback, 0, -1, id: id, reason: reason, isDone: isDone)
+    _ExpectedFunction<Object?>(callback, 0, -1,
+            id: id, reason: reason, isDone: isDone)
         .func;
 
 /// Informs the framework that the given [callback] of arity 0 is expected to be

--- a/pkgs/matcher/lib/src/expect/future_matchers.dart
+++ b/pkgs/matcher/lib/src/expect/future_matchers.dart
@@ -58,7 +58,7 @@ class _Completes extends AsyncMatcher {
         result = await _matcher.matchAsync(value) as String?;
         if (result == null) return null;
       } else {
-        var matchState = {};
+        var matchState = <Object?, Object?>{};
         if (_matcher.matches(value, matchState)) return null;
         result = _matcher
             .describeMismatch(value, StringDescription(), matchState, false)

--- a/pkgs/matcher/lib/src/expect/prints_matcher.dart
+++ b/pkgs/matcher/lib/src/expect/prints_matcher.dart
@@ -33,7 +33,7 @@ class _Prints extends AsyncMatcher {
   // synchronous.
   @override
   dynamic /*FutureOr<String>*/ matchAsync(Object? item) {
-    if (item is! Function()) return 'was not a unary Function';
+    if (item is! Object? Function()) return 'was not a unary Function';
 
     var buffer = StringBuffer();
     var result = runZoned(item,
@@ -53,7 +53,7 @@ class _Prints extends AsyncMatcher {
   /// Verifies that [actual] matches [_matcher] and returns a [String]
   /// description of the failure if it doesn't.
   String? _check(String actual) {
-    var matchState = {};
+    var matchState = <Object?, Object?>{};
     if (_matcher.matches(actual, matchState)) return null;
 
     var result = _matcher

--- a/pkgs/matcher/lib/src/expect/stream_matcher.dart
+++ b/pkgs/matcher/lib/src/expect/stream_matcher.dart
@@ -155,7 +155,7 @@ class _StreamMatcher extends AsyncMatcher implements StreamMatcher {
           .listen(events.add, onDone: () => events.add(null));
 
       // Wait on a timer tick so all buffered events are emitted.
-      await Future.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
       _unawaited(subscription.cancel());
 
       var eventsString = events.map((event) {

--- a/pkgs/matcher/lib/src/expect/stream_matchers.dart
+++ b/pkgs/matcher/lib/src/expect/stream_matchers.dart
@@ -34,7 +34,7 @@ StreamMatcher emits(Object? matcher) {
   return StreamMatcher((queue) async {
     if (!await queue.hasNext) return '';
 
-    var matchState = {};
+    var matchState = <Object?, Object?>{};
     var actual = await queue.next;
     if (wrapped.matches(actual, matchState)) return null;
 
@@ -138,7 +138,7 @@ StreamMatcher emitsAnyOf(Iterable matchers) {
     if (consumedMost == null) {
       transaction.reject();
       if (firstError != null) {
-        await Future.error(firstError!, firstStackTrace);
+        await Future<Never>.error(firstError!, firstStackTrace);
       }
 
       var failureMessages = <String>[];
@@ -368,7 +368,9 @@ Future<bool> _tryInAnyOrder(
 
   if (consumedMost == null) {
     transaction.reject();
-    if (firstError != null) await Future.error(firstError!, firstStackTrace);
+    if (firstError != null) {
+      await Future<Never>.error(firstError!, firstStackTrace);
+    }
     return false;
   } else {
     transaction.commit(consumedMost!);

--- a/pkgs/matcher/lib/src/expect/throws_matcher.dart
+++ b/pkgs/matcher/lib/src/expect/throws_matcher.dart
@@ -116,10 +116,10 @@ class Throws extends AsyncMatcher {
 
   /// Verifies that [error] matches [_matcher] and returns a [String]
   /// description of the failure if it doesn't.
-  String? _check(error, StackTrace? trace) {
+  String? _check(Object error, StackTrace? trace) {
     if (_matcher == null) return null;
 
-    var matchState = {};
+    var matchState = <Object?, Object?>{};
     if (_matcher.matches(error, matchState)) return null;
 
     var result = _matcher

--- a/pkgs/matcher/lib/src/map_matchers.dart
+++ b/pkgs/matcher/lib/src/map_matchers.dart
@@ -16,7 +16,7 @@ class _ContainsValue extends Matcher {
   @override
   bool matches(Object? item, Map matchState) =>
       // ignore: avoid_dynamic_calls
-      (item as dynamic).containsValue(_value);
+      (item as dynamic).containsValue(_value) as bool;
   @override
   Description describe(Description description) =>
       description.add('contains value ').addDescriptionOf(_value);
@@ -36,7 +36,7 @@ class _ContainsMapping extends Matcher {
   @override
   bool matches(Object? item, Map matchState) =>
       // ignore: avoid_dynamic_calls
-      (item as dynamic).containsKey(_key) &&
+      ((item as dynamic).containsKey(_key) as bool) &&
       _valueMatcher.matches((item as dynamic)[_key], matchState);
 
   @override

--- a/pkgs/matcher/lib/src/operator_matchers.dart
+++ b/pkgs/matcher/lib/src/operator_matchers.dart
@@ -59,7 +59,7 @@ class _AllOf extends Matcher {
       Map matchState, bool verbose) {
     var matcher = matchState['matcher'] as Matcher;
     matcher.describeMismatch(
-        item, mismatchDescription, matchState['state'], verbose);
+        item, mismatchDescription, matchState['state'] as Map, verbose);
     return mismatchDescription;
   }
 

--- a/pkgs/matcher/lib/src/order_matchers.dart
+++ b/pkgs/matcher/lib/src/order_matchers.dart
@@ -78,9 +78,9 @@ class _OrderingMatcher extends Matcher {
   bool matches(Object? item, Map matchState) {
     if (item == _value) {
       return _equalValue;
-    } else if ((item as dynamic) < _value) {
+    } else if ((item as dynamic) < _value as bool) {
       return _lessThanValue;
-    } else if ((item as dynamic) > _value) {
+    } else if ((item as dynamic) > _value as bool) {
       return _greaterThanValue;
     } else {
       return false;

--- a/pkgs/matcher/lib/src/string_matchers.dart
+++ b/pkgs/matcher/lib/src/string_matchers.dart
@@ -61,7 +61,7 @@ class _IsEqualIgnoringWhitespace extends FeatureMatcher<String> {
       description.addDescriptionOf(_matchValue).add(' ignoring whitespace');
 
   @override
-  Description describeTypedMismatch(dynamic item,
+  Description describeTypedMismatch(String item,
       Description mismatchDescription, Map matchState, bool verbose) {
     return mismatchDescription
         .add('is ')
@@ -152,7 +152,7 @@ class _MatchesRegExp extends FeatureMatcher<String> {
                 : throw ArgumentError('matches requires a regexp or string');
 
   @override
-  bool typedMatches(dynamic item, Map matchState) => _regexp.hasMatch(item);
+  bool typedMatches(String item, Map matchState) => _regexp.hasMatch(item);
 
   @override
   Description describe(Description description) =>

--- a/pkgs/matcher/lib/src/util.dart
+++ b/pkgs/matcher/lib/src/util.dart
@@ -43,8 +43,7 @@ Matcher wrapMatcher(Object? valueOrMatcher) {
   } else if (valueOrMatcher is bool Function(Never)) {
     // unary predicate, but expects a specific type
     // so wrap it.
-    // ignore: unnecessary_lambdas
-    return predicate((a) => (valueOrMatcher as dynamic)(a));
+    return predicate((a) => (valueOrMatcher as dynamic)(a) as bool);
   } else {
     return equals(valueOrMatcher);
   }

--- a/pkgs/matcher/pubspec.yaml
+++ b/pkgs/matcher/pubspec.yaml
@@ -16,8 +16,8 @@ dependencies:
   test_api: ">=0.5.0 <0.8.0"
 
 dev_dependencies:
+  dart_flutter_team_lints: ^3.2.0
   fake_async: ^1.3.0
-  lints: ^3.0.0
   test: ^1.23.0
 
 dependency_overrides:

--- a/pkgs/matcher/pubspec.yaml
+++ b/pkgs/matcher/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
 repository: https://github.com/dart-lang/test/tree/master/pkgs/matcher
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0
 
 dependencies:
   async: ^2.10.0

--- a/pkgs/matcher/test/core_matchers_test.dart
+++ b/pkgs/matcher/test/core_matchers_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:matcher/matcher.dart';
-import 'package:test/test.dart' show test, group;
+import 'package:test/test.dart' show group, test;
 
 import 'test_utils.dart';
 
@@ -42,22 +42,22 @@ void main() {
   });
 
   test('same', () {
-    var a = {};
-    var b = {};
+    var a = <Object?, Object?>{};
+    var b = <Object?, Object?>{};
     shouldPass(a, same(a));
     shouldFail(b, same(a), 'Expected: same instance as {} Actual: {}');
   });
 
   test('equals', () {
-    var a = {};
-    var b = {};
+    var a = <Object?, Object?>{};
+    var b = <Object?, Object?>{};
     shouldPass(a, equals(a));
     shouldPass(a, equals(b));
   });
 
   test('equals with null', () {
     Object? a; // null
-    var b = {};
+    var b = <Object?, Object?>{};
     shouldPass(a, equals(a));
     shouldFail(
         a, equals(b), 'Expected: {} Actual: <null> Which: expected a map');
@@ -87,7 +87,7 @@ void main() {
   });
 
   test('anything', () {
-    var a = {};
+    var a = <Object?, Object?>{};
     shouldPass(0, anything);
     shouldPass(null, anything);
     shouldPass(a, anything);
@@ -107,8 +107,8 @@ void main() {
   });
 
   test('hasLength', () {
-    var a = {};
-    var b = [];
+    var a = <Object?, Object?>{};
+    var b = <Object?>[];
     shouldPass(a, hasLength(0));
     shouldPass(b, hasLength(0));
     shouldPass('a', hasLength(1));
@@ -173,13 +173,13 @@ void main() {
       ['foo', 'bar'],
       ['foo'],
       3,
-      []
+      <Object?>[]
     ];
     var expected1 = [
       ['foo', 'bar'],
       ['foo'],
       4,
-      []
+      <Object?>[]
     ];
     var reason1 = "Expected: [['foo', 'bar'], ['foo'], 4, []] "
         "Actual: [['foo', 'bar'], ['foo'], 3, []] "
@@ -189,13 +189,13 @@ void main() {
       ['foo', 'barry'],
       ['foo'],
       4,
-      []
+      <Object?>[]
     ];
     var expected2 = [
       ['foo', 'bar'],
       ['foo'],
       4,
-      []
+      <Object?>[]
     ];
     var reason2 = "Expected: [['foo', 'bar'], ['foo'], 4, []] "
         "Actual: [['foo', 'barry'], ['foo'], 4, []] "

--- a/pkgs/matcher/test/expect_test.dart
+++ b/pkgs/matcher/test/expect_test.dart
@@ -18,7 +18,7 @@ void main() {
     });
 
     test('contains an async error', () {
-      expect(expectLater(Future.error('oh no'), completion(isFalse)),
+      expect(expectLater(Future<Never>.error('oh no'), completion(isFalse)),
           throwsA('oh no'));
     });
   });

--- a/pkgs/matcher/test/having_test.dart
+++ b/pkgs/matcher/test/having_test.dart
@@ -5,7 +5,7 @@
 // ignore_for_file: lines_longer_than_80_chars
 
 import 'package:matcher/matcher.dart';
-import 'package:test/test.dart' show test, expect, throwsA, group;
+import 'package:test/test.dart' show expect, group, test, throwsA;
 
 import 'test_utils.dart';
 

--- a/pkgs/matcher/test/iterable_matchers_test.dart
+++ b/pkgs/matcher/test/iterable_matchers_test.dart
@@ -83,13 +83,13 @@ void main() {
     var d = [
       ['foo', 'bar'],
       ['foo'],
-      []
+      <Object?>[]
     ];
     var e = [
       ['foo', 'bar'],
       ['foo'],
       3,
-      []
+      <Object?>[]
     ];
     shouldPass(d, everyElement(anyOf(isEmpty, contains('foo'))));
     shouldFail(
@@ -196,7 +196,7 @@ void main() {
           equals(2), // 2
           allOf([lessThan(3), isNot(0)]), // 1
           equals(0), // 0
-          predicate((int v) => v % 2 == 1), // 3
+          predicate((int v) => v.isOdd), // 3
           equals(5), // 5
         ]));
     shouldFail(

--- a/pkgs/matcher/test/map_matchers_test.dart
+++ b/pkgs/matcher/test/map_matchers_test.dart
@@ -1,5 +1,5 @@
 import 'package:matcher/matcher.dart'
-    show contains, containsValue, containsPair;
+    show contains, containsPair, containsValue;
 import 'package:test/test.dart' show test;
 
 import 'test_utils.dart';

--- a/pkgs/matcher/test/matcher/completion_test.dart
+++ b/pkgs/matcher/test/matcher/completion_test.dart
@@ -20,13 +20,13 @@ void main() {
     });
 
     test('succeeds when a future does not complete', () {
-      var completer = Completer();
+      var completer = Completer<Never>();
       expect(completer.future, doesNotComplete);
     });
 
     test('fails when a future does complete', () async {
       var monitor = await TestCaseMonitor.run(() {
-        var completer = Completer();
+        var completer = Completer<void>();
         completer.complete(null);
         expect(completer.future, doesNotComplete);
       });
@@ -39,7 +39,7 @@ void main() {
 
     test('fails when a future completes after the expect', () async {
       var monitor = await TestCaseMonitor.run(() {
-        var completer = Completer();
+        var completer = Completer<void>();
         expect(completer.future, doesNotComplete);
         completer.complete(null);
       });
@@ -52,7 +52,7 @@ void main() {
 
     test('fails when a future eventually completes', () async {
       var monitor = await TestCaseMonitor.run(() {
-        var completer = Completer();
+        var completer = Completer<void>();
         expect(completer.future, doesNotComplete);
         Future(() async {
           await pumpEventQueue(times: 10);
@@ -80,7 +80,7 @@ void main() {
 
     test('with an error', () async {
       var monitor = await TestCaseMonitor.run(() {
-        expect(Future.error('X'), completes);
+        expect(Future<Never>.error('X'), completes);
       });
 
       expect(monitor.state, equals(State.failed));
@@ -89,7 +89,7 @@ void main() {
 
     test('with a failure', () async {
       var monitor = await TestCaseMonitor.run(() {
-        expect(Future.error(TestFailure('oh no')), completes);
+        expect(Future<Never>.error(TestFailure('oh no')), completes);
       });
 
       expectTestFailed(monitor, 'oh no');
@@ -127,7 +127,7 @@ void main() {
 
     test('with an error', () async {
       var monitor = await TestCaseMonitor.run(() {
-        expect(Future.error('X'), completion(isNull));
+        expect(Future<Never>.error('X'), completion(isNull));
       });
 
       expect(monitor.state, equals(State.failed));
@@ -136,7 +136,7 @@ void main() {
 
     test('with a failure', () async {
       var monitor = await TestCaseMonitor.run(() {
-        expect(Future.error(TestFailure('oh no')), completion(isNull));
+        expect(Future<Never>.error(TestFailure('oh no')), completion(isNull));
       });
 
       expectTestFailed(monitor, 'oh no');
@@ -175,7 +175,7 @@ void main() {
     });
 
     test("blocks expectLater's Future", () async {
-      var completer = Completer();
+      var completer = Completer<int>();
       var fired = false;
       unawaited(expectLater(completer.future, completion(equals(1))).then((_) {
         fired = true;

--- a/pkgs/matcher/test/matcher/prints_test.dart
+++ b/pkgs/matcher/test/matcher/prints_test.dart
@@ -158,7 +158,7 @@ void main() {
     });
 
     test('describes a failure with no text nicely', () async {
-      void local() => Future.value();
+      void local() => Future<void>.value();
       var monitor = await TestCaseMonitor.run(() {
         expect(local, prints(contains('Goodbye')));
       });
@@ -186,7 +186,7 @@ void main() {
     });
 
     test("blocks expectLater's Future", () async {
-      var completer = Completer();
+      var completer = Completer<void>();
       var fired = false;
 
       unawaited(expectLater(() {

--- a/pkgs/matcher/test/matcher/throws_test.dart
+++ b/pkgs/matcher/test/matcher/throws_test.dart
@@ -115,13 +115,13 @@ void main() {
     group('[throws]', () {
       test('with a Future that throws an error', () {
         // ignore: deprecated_member_use_from_same_package
-        expect(Future.error('oh no'), throws);
+        expect(Future<Never>.error('oh no'), throws);
       });
 
       test("with a Future that doesn't throw", () async {
         var monitor = await TestCaseMonitor.run(() {
           // ignore: deprecated_member_use_from_same_package
-          expect(Future.value(), throws);
+          expect(Future<void>.value(), throws);
         });
 
         expectTestFailed(
@@ -136,7 +136,7 @@ void main() {
 
       test('with a closure that returns a Future that throws an error', () {
         // ignore: deprecated_member_use_from_same_package
-        expect(() => Future.error('oh no'), throws);
+        expect(() => Future<Never>.error('oh no'), throws);
       });
 
       test("with a closure that returns a Future that doesn't throw", () async {
@@ -173,17 +173,17 @@ void main() {
 
     group('[throwsA]', () {
       test('with a Future that throws an identical error', () {
-        expect(Future.error('oh no'), throwsA('oh no'));
+        expect(Future<Never>.error('oh no'), throwsA('oh no'));
       });
 
       test('with a Future that throws a matching error', () {
-        expect(Future.error(const FormatException('bad')),
+        expect(Future<Never>.error(const FormatException('bad')),
             throwsA(isFormatException));
       });
 
       test("with a Future that doesn't throw", () async {
         var monitor = await TestCaseMonitor.run(() {
-          expect(Future.value(), throwsA('oh no'));
+          expect(Future<void>.value(), throwsA('oh no'));
         });
 
         expectTestFailed(
@@ -198,7 +198,7 @@ void main() {
 
       test('with a Future that throws the wrong error', () async {
         var monitor = await TestCaseMonitor.run(() {
-          expect(Future.error('aw dang'), throwsA('oh no'));
+          expect(Future<Never>.error('aw dang'), throwsA('oh no'));
         });
 
         expectTestFailed(
@@ -213,7 +213,7 @@ void main() {
 
       test('with a closure that returns a Future that throws a matching error',
           () {
-        expect(() => Future.error(const FormatException('bad')),
+        expect(() => Future<Never>.error(const FormatException('bad')),
             throwsA(isFormatException));
       });
 
@@ -235,7 +235,7 @@ void main() {
       test('with closure that returns a Future that throws the wrong error',
           () async {
         var monitor = await TestCaseMonitor.run(() {
-          expect(() => Future.error('aw dang'), throwsA('oh no'));
+          expect(() => Future<Never>.error('aw dang'), throwsA('oh no'));
         });
 
         expectTestFailed(
@@ -264,7 +264,7 @@ void main() {
       });
 
       test("blocks expectLater's Future", () async {
-        var completer = Completer();
+        var completer = Completer<Never>();
         var fired = false;
         unawaited(expectLater(completer.future, throwsArgumentError).then((_) {
           fired = true;

--- a/pkgs/matcher/test/mirror_matchers_test.dart
+++ b/pkgs/matcher/test/mirror_matchers_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // ignore_for_file: deprecated_member_use_from_same_package
+// ignore_for_file: unreachable_from_main
 
 @TestOn('vm')
 library;

--- a/pkgs/matcher/test/never_called_test.dart
+++ b/pkgs/matcher/test/never_called_test.dart
@@ -15,7 +15,7 @@ void main() {
 
   test("doesn't throw if it isn't called", () async {
     var monitor = await TestCaseMonitor.run(() {
-      const Stream.empty().listen(neverCalled);
+      const Stream<Never>.empty().listen(neverCalled);
     });
 
     expectTestPassed(monitor);

--- a/pkgs/matcher/test/operator_matchers_test.dart
+++ b/pkgs/matcher/test/operator_matchers_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:matcher/matcher.dart';
-import 'package:test/test.dart' show test, expect, throwsArgumentError;
+import 'package:test/test.dart' show expect, test, throwsArgumentError;
 
 import 'test_utils.dart';
 

--- a/pkgs/matcher/test/pretty_print_test.dart
+++ b/pkgs/matcher/test/pretty_print_test.dart
@@ -6,7 +6,7 @@ import 'dart:collection';
 
 import 'package:matcher/matcher.dart';
 import 'package:matcher/src/pretty_print.dart';
-import 'package:test/test.dart' show group, test, expect;
+import 'package:test/test.dart' show expect, group, test;
 
 class DefaultToString {}
 

--- a/pkgs/matcher/test/stream_matcher_test.dart
+++ b/pkgs/matcher/test/stream_matcher_test.dart
@@ -71,7 +71,7 @@ void main() {
 
     test('rejects an empty stream', () {
       expect(
-          expectLater(const Stream.empty(), emits(1)),
+          expectLater(const Stream<Never>.empty(), emits(1)),
           throwsTestFailure(allOf([
             startsWith('Expected: should emit an event that <1>\n'),
             endsWith('   Which: emitted x Stream closed.\n')
@@ -96,7 +96,7 @@ void main() {
 
   group('emitsDone', () {
     test('succeeds for an empty stream', () {
-      expect(const Stream.empty(), emitsDone);
+      expect(const Stream<Never>.empty(), emitsDone);
     });
 
     test('fails for a stream with events', () {

--- a/pkgs/matcher/test/string_matchers_test.dart
+++ b/pkgs/matcher/test/string_matchers_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:matcher/matcher.dart';
-import 'package:test/test.dart' show test, expect;
+import 'package:test/test.dart' show expect, test;
 
 import 'test_utils.dart';
 

--- a/pkgs/matcher/test/type_matcher_test.dart
+++ b/pkgs/matcher/test/type_matcher_test.dart
@@ -4,13 +4,13 @@
 
 // ignore_for_file: deprecated_member_use_from_same_package
 import 'package:matcher/matcher.dart';
-import 'package:test/test.dart' show test, group;
+import 'package:test/test.dart' show group, test;
 
 import 'test_utils.dart';
 
 void main() {
-  _test(isMap, {}, name: 'Map');
-  _test(isList, [], name: 'List');
+  _test(isMap, <Object?, Object?>{}, name: 'Map');
+  _test(isList, <Object?>[], name: 'List');
   _test(isArgumentError, ArgumentError());
   _test(isCastError, TypeError());
   _test<Exception>(isException, const FormatException());


### PR DESCRIPTION
Change the dependency and analysis options include to the stricter team
configuration.

Fix newly surfaced diagnostics. Most code changes are related to the
strict modes that are enabled by the team config.
Fix most implicit casts with explicit casts, but fix some arguments in
`typedMatches` implementation so they don't unnecessarily widen the type
back to `dynamic` before using the value.
