### PR TITLE
test: allow latest pkg:matcher

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.25.13
+
+* Allow the latest version of `package:matcher`.
+
 ## 1.25.12
 
 * Fix hang when running multiple precompiled browser tests.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.25.12
+version: 1.25.13
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test
@@ -20,7 +20,7 @@ dependencies:
 
   # Use a tight version constraint to ensure that a constraint on matcher
   # properly constrains all features it provides.
-  matcher: '>=0.12.16 <0.12.17'
+  matcher: '>=0.12.16 <0.12.18'
 
   node_preamble: ^2.0.0
   package_config: ^2.0.0


### PR DESCRIPTION
Eliminates the noisy outdated dep warning for anyone using pkg:test
