### PR TITLE
Sort reporter options

### DIFF
--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.7.4
-  test_core: 0.6.8
+  test_core: 0.6.9
 
   typed_data: ^1.3.0
   web_socket_channel: '>=2.0.0 <4.0.0'

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.7.4
-  test_core: 0.6.9
+  test_core: 0.6.9-wip
 
   typed_data: ^1.3.0
   web_socket_channel: '>=2.0.0 <4.0.0'

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.6.9-wip
+
 ## 0.6.8
 
 * Fix hang when running multiple precompiled browser tests.

--- a/pkgs/test_core/lib/src/runner/configuration/reporters.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/reporters.dart
@@ -31,17 +31,17 @@ final UnmodifiableMapView<String, ReporterDetails> allReporters =
     UnmodifiableMapView<String, ReporterDetails>(_allReporters);
 
 final _allReporters = <String, ReporterDetails>{
-  'expanded': ReporterDetails(
-      'A separate line for each update.',
-      (config, engine, sink) => ExpandedReporter.watch(engine, sink,
+  'compact': ReporterDetails(
+      'A single line, updated continuously.',
+      (config, engine, sink) => CompactReporter.watch(engine, sink,
           color: config.color,
           printPath: config.testSelections.length > 1 ||
               Directory(config.testSelections.keys.single).existsSync(),
           printPlatform: config.suiteDefaults.runtimes.length > 1 ||
               config.suiteDefaults.compilerSelections != null)),
-  'compact': ReporterDetails(
-      'A single line, updated continuously.',
-      (config, engine, sink) => CompactReporter.watch(engine, sink,
+  'expanded': ReporterDetails(
+      'A separate line for each update.',
+      (config, engine, sink) => ExpandedReporter.watch(engine, sink,
           color: config.color,
           printPath: config.testSelections.length > 1 ||
               Directory(config.testSelections.keys.single).existsSync(),

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.6.8
+version: 0.6.9-wip
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 issue_tracker: https://github.com/dart-lang/test/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Atest


### PR DESCRIPTION
Previous versions of `package:args` alphabetically sorted the
`allowedHelp` entries for help output. The latest release removes the
sorting and breaks the change-detection tests for the help output.

https://github.com/dart-lang/core/pull/852

Manually sort the keys of the reporters map to match the alpha sort of
the old output.
