### PR TITLE
[native assets] Add support for pub workspaces

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.6.9-wip
 
+- Add support for native assets for `dart test` in pub workspaces.
+
 ## 0.6.8
 
 * Fix hang when running multiple precompiled browser tests.

--- a/pkgs/test_core/lib/src/runner/vm/test_compiler.dart
+++ b/pkgs/test_core/lib/src/runner/vm/test_compiler.dart
@@ -151,12 +151,22 @@ class _TestCompilerForLanguageVersion {
         p.relative(p.dirname(p.dirname(Platform.resolvedExecutable)));
     final packageConfigUriAwaited = await packageConfigUri;
 
-    // If we have native assets for the host os in JIT mode, they are here.
+    // If we have native assets for the host os in JIT mode, they are either
+    // in the `.dart_tool/` in the root package or in the pub workspace.
     Uri? nativeAssetsYaml;
     if (enabledExperiments.contains('native-assets')) {
-      nativeAssetsYaml = packageConfigUriAwaited.resolve('native_assets.yaml');
-      if (!await File.fromUri(nativeAssetsYaml).exists()) {
-        nativeAssetsYaml = null;
+      final nativeAssetsYamlRootPackage =
+          Directory.current.uri.resolve('.dart_tool/native_assets.yaml');
+      final nativeAssetsYamlWorkspace =
+          packageConfigUriAwaited.resolve('native_assets.yaml');
+      for (final potentialNativeAssetsUri in [
+        nativeAssetsYamlRootPackage,
+        nativeAssetsYamlWorkspace
+      ]) {
+        if (await File.fromUri(potentialNativeAssetsUri).exists()) {
+          nativeAssetsYaml = potentialNativeAssetsUri;
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
Closes: https://github.com/dart-lang/test/issues/2483

Tested in `dartdev`: https://dart-review.googlesource.com/c/sdk/+/422080

Packages must opt in to a new version of package test to adopt this fix. (`dartdev` uses the version of `package:test` that's in the users' pubspec, rather than the one that's rolled in the Dart SDK!)
In the test for `dartdev` I manually applied the edits to `third_party/pkg/test/pkgs/test_core` and overrode the dependencies.