### PR TITLE
Supporting passing a filename that contains a list of arguments as the last argument

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.25.16-wip
 
+* Allow the final argument to be a filename prefixed with `@` that contains a
+  list of arguments as if they had been provided on the command line directly.
+
 ## 1.25.15
 
 * Allow the latest version of `package:shelf_web_socket`.

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 0.6.9-wip
 
-- Add support for native assets for `dart test` in pub workspaces.
+* Add support for native assets for `dart test` in pub workspaces.
+* Allow the final argument provided to the executable `main` method to be a
+  filename prefixed with `@` that contains a list of arguments as if they had
+  been provided on the command line directly.
 
 ## 0.6.8
 


### PR DESCRIPTION
Allows the final argument to be `@filename` where `filename` is a path (relative to `cwd`) to a file that contains arguments to replace it before parsing.

This allows arguments longer than Windows supports to be provided (see https://github.com/Dart-Code/Dart-Code/issues/5473).

cc @jakemac53 