### PR TITLE
Add isSorted and related matchers

### DIFF
--- a/pkgs/matcher/CHANGELOG.md
+++ b/pkgs/matcher/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Remove some dynamic invocations.
 * Add explicit casts from `dynamic` values.
 * Require Dart 3.5
+* Add `isSorted` and related matchers for iterables.
 
 ## 0.12.17
 

--- a/pkgs/matcher/lib/src/iterable_matchers.dart
+++ b/pkgs/matcher/lib/src/iterable_matchers.dart
@@ -132,7 +132,7 @@ class _UnorderedEquals extends _UnorderedMatches {
 
 /// Iterable matchers match against [Iterable]s. We add this intermediate
 /// class to give better mismatch error messages than the base Matcher class.
-abstract class _IterableMatcher extends FeatureMatcher<Iterable> {
+abstract class _IterableMatcher<T> extends FeatureMatcher<Iterable<T>> {
   const _IterableMatcher();
 }
 
@@ -416,32 +416,37 @@ class _ContainsOnce extends _IterableMatcher {
 }
 
 // Matches [Iterable]s which are sorted.
-Matcher isSorted() => _IsSorted();
+Matcher isSorted<T>(Comparator<T> comparator) =>
+    _IsSorted<T, T>((t) => t, comparator);
 
 // Matches [Iterable]s which are sorted by the given key.
-Matcher isSortedBy(Function keyOf) => _IsSorted(keyOf);
+Matcher isSortedBy<T, K extends Comparable<K>>(K Function(T) keyOf) =>
+    _IsSorted<T, K>(keyOf, (a, b) => a.compareTo(b));
 
 // Matches [Iterable]s which are sorted by the given key, using the given
 // comparator.
-Matcher isSortedByCompare(Function keyOf, Comparator comparator) =>
+Matcher isSortedByCompare<T, K>(
+        K Function(T) keyOf, Comparator<K> comparator) =>
     _IsSorted(keyOf, comparator);
 
-class _IsSorted extends _IterableMatcher {
-  final Function? _keyOf;
-  final Comparator? _comparator;
+class _IsSorted<T, K> extends _IterableMatcher<T> {
+  final K Function(T) _keyOf;
+  final Comparator<K> _comparator;
 
-  _IsSorted([this._keyOf, this._comparator]);
+  _IsSorted(K Function(T) keyOf, Comparator<K> comparator)
+      : _keyOf = keyOf,
+        _comparator = comparator;
 
-  String? _test(Iterable item, Map matchState) {
+  String? _test(Iterable<T> item, Map matchState) {
     if (item.length < 2) {
       return null;
     }
 
-    dynamic prevElem = item.first;
-    dynamic prevKey = _key(prevElem);
+    var prevElem = item.first;
+    var prevKey = _keyOf(prevElem);
     for (final elem in item.skip(1)) {
-      var key = _key(elem);
-      if (_compare(prevKey, key)! > 0) {
+      var key = _keyOf(elem);
+      if (_comparator(prevKey, key) > 0) {
         return StringDescription()
             .add('found elements out of order ')
             .add(prevElem.toString())
@@ -455,25 +460,15 @@ class _IsSorted extends _IterableMatcher {
     return null;
   }
 
-  Object? _key(elem) => _keyOf != null ? _keyOf(elem) : elem;
-
-  int? _compare(elem1, elem2) => _comparator != null
-      ? _comparator(elem1, elem2)
-      :
-      // Order null before non-null
-      (elem1 == null
-          ? (elem2 == null ? 0 : -1)
-          : (elem2 == null ? 1 : elem1.compareTo(elem2)));
-
   @override
-  bool typedMatches(Iterable item, Map matchState) =>
+  bool typedMatches(Iterable<T> item, Map matchState) =>
       _test(item, matchState) == null;
 
   @override
   Description describe(Description description) => description.add('is sorted');
 
   @override
-  Description describeTypedMismatch(Iterable item,
+  Description describeTypedMismatch(Iterable<T> item,
           Description mismatchDescription, Map matchState, bool verbose) =>
       mismatchDescription.add(_test(item, matchState)!);
 }

--- a/pkgs/matcher/lib/src/iterable_matchers.dart
+++ b/pkgs/matcher/lib/src/iterable_matchers.dart
@@ -436,29 +436,24 @@ class _IsSorted<T, K> extends _IterableMatcher<T> {
       : _keyOf = keyOf,
         _compare = compare;
 
-  String? _test(Iterable<T> item, Map matchState) {
+  @override
+  bool typedMatches(Iterable<T> item, Map matchState) {
     var iterator = item.iterator;
-    if (!iterator.moveNext()) return null;
+    if (!iterator.moveNext()) return true;
     var previousElement = iterator.current;
     var previousKey = _keyOf(previousElement);
     while (iterator.moveNext()) {
       var element = iterator.current;
       var key = _keyOf(element);
       if (_compare(previousKey, key) > 0) {
-        return StringDescription(
-                'found elements out of order: <$previousElement> and '
-                '<$element>')
-            .toString();
+        addStateInfo(matchState, {'first': previousElement, 'second': element});
+        return false;
       }
       previousElement = element;
       previousKey = key;
     }
-    return null;
+    return true;
   }
-
-  @override
-  bool typedMatches(Iterable<T> item, Map matchState) =>
-      _test(item, matchState) == null;
 
   @override
   Description describe(Description description) => description.add('is sorted');
@@ -466,5 +461,9 @@ class _IsSorted<T, K> extends _IterableMatcher<T> {
   @override
   Description describeTypedMismatch(Iterable<T> item,
           Description mismatchDescription, Map matchState, bool verbose) =>
-      mismatchDescription.add(_test(item, matchState)!);
+      mismatchDescription
+          .add('found elements out of order: ')
+          .addDescriptionOf(matchState['first'])
+          .add(' and ')
+          .addDescriptionOf(matchState['second']);
 }

--- a/pkgs/matcher/lib/src/iterable_matchers.dart
+++ b/pkgs/matcher/lib/src/iterable_matchers.dart
@@ -445,15 +445,18 @@ class _IsSorted<T, K> extends _IterableMatcher<T> {
     if (!iterator.moveNext()) return true;
     var previousElement = iterator.current;
     var previousKey = _keyOf(previousElement);
+    var index = 0;
     while (iterator.moveNext()) {
       var element = iterator.current;
       var key = _keyOf(element);
       if (_compare(previousKey, key) > 0) {
-        addStateInfo(matchState, {'first': previousElement, 'second': element});
+        addStateInfo(matchState,
+            {'index': index, 'first': previousElement, 'second': element});
         return false;
       }
       previousElement = element;
       previousKey = key;
+      index++;
     }
     return true;
   }
@@ -465,7 +468,9 @@ class _IsSorted<T, K> extends _IterableMatcher<T> {
   Description describeTypedMismatch(Iterable<T> item,
           Description mismatchDescription, Map matchState, bool verbose) =>
       mismatchDescription
-          .add('found elements out of order: ')
+          .add('found elements out of order at ')
+          .addDescriptionOf(matchState['index'])
+          .add(': ')
           .addDescriptionOf(matchState['first'])
           .add(' and ')
           .addDescriptionOf(matchState['second']);

--- a/pkgs/matcher/lib/src/iterable_matchers.dart
+++ b/pkgs/matcher/lib/src/iterable_matchers.dart
@@ -447,11 +447,8 @@ class _IsSorted<T, K> extends _IterableMatcher<T> {
     for (final elem in item.skip(1)) {
       var key = _keyOf(elem);
       if (_comparator(prevKey, key) > 0) {
-        return StringDescription()
-            .add('found elements out of order ')
-            .add(prevElem.toString())
-            .add(' and ')
-            .add(elem.toString())
+        return StringDescription(
+                'found elements out of order: <$prevElem> and <$elem>')
             .toString();
       }
       prevElem = elem;

--- a/pkgs/matcher/lib/src/iterable_matchers.dart
+++ b/pkgs/matcher/lib/src/iterable_matchers.dart
@@ -419,16 +419,15 @@ class _ContainsOnce extends _IterableMatcher {
 Matcher isSorted<T extends Comparable<T>>() =>
     _IsSorted<T, T>((t) => t, (a, b) => a.compareTo(b));
 
-/// Matches [Iterable]s which are sorted using the given comparator.
+/// Matches [Iterable]s which are [compare]-sorted.
 Matcher isSortedUsing<T>(Comparator<T> compare) =>
     _IsSorted<T, T>((t) => t, compare);
 
-/// Matches [Iterable]s which are sorted by the given key.
+/// Matches [Iterable]s which are sorted by the [keyOf] property.
 Matcher isSortedBy<T, K extends Comparable<K>>(K Function(T) keyOf) =>
     _IsSorted<T, K>(keyOf, (a, b) => a.compareTo(b));
 
-/// Matches [Iterable]s which are sorted by the given key, using the given
-/// comparator.
+/// Matches [Iterable]s which are [compare]-sorted by their [keyOf] property.
 Matcher isSortedByCompare<T, K>(K Function(T) keyOf, Comparator<K> compare) =>
     _IsSorted(keyOf, compare);
 

--- a/pkgs/matcher/lib/src/iterable_matchers.dart
+++ b/pkgs/matcher/lib/src/iterable_matchers.dart
@@ -416,7 +416,11 @@ class _ContainsOnce extends _IterableMatcher {
 }
 
 /// Matches [Iterable]s which are sorted.
-Matcher isSorted<T>(Comparator<T> compare) =>
+Matcher isSorted<T extends Comparable<T>>() =>
+    _IsSorted<T, T>((t) => t, (a, b) => a.compareTo(b));
+
+/// Matches [Iterable]s which are sorted using the given comparator.
+Matcher isSortedUsing<T>(Comparator<T> compare) =>
     _IsSorted<T, T>((t) => t, compare);
 
 /// Matches [Iterable]s which are sorted by the given key.

--- a/pkgs/matcher/lib/src/iterable_matchers.dart
+++ b/pkgs/matcher/lib/src/iterable_matchers.dart
@@ -416,8 +416,8 @@ class _ContainsOnce extends _IterableMatcher {
 }
 
 // Matches [Iterable]s which are sorted.
-Matcher isSorted<T>(Comparator<T> comparator) =>
-    _IsSorted<T, T>((t) => t, comparator);
+Matcher isSorted<T>(Comparator<T> compare) =>
+    _IsSorted<T, T>((t) => t, compare);
 
 // Matches [Iterable]s which are sorted by the given key.
 Matcher isSortedBy<T, K extends Comparable<K>>(K Function(T) keyOf) =>
@@ -425,34 +425,33 @@ Matcher isSortedBy<T, K extends Comparable<K>>(K Function(T) keyOf) =>
 
 // Matches [Iterable]s which are sorted by the given key, using the given
 // comparator.
-Matcher isSortedByCompare<T, K>(
-        K Function(T) keyOf, Comparator<K> comparator) =>
-    _IsSorted(keyOf, comparator);
+Matcher isSortedByCompare<T, K>(K Function(T) keyOf, Comparator<K> compare) =>
+    _IsSorted(keyOf, compare);
 
 class _IsSorted<T, K> extends _IterableMatcher<T> {
   final K Function(T) _keyOf;
-  final Comparator<K> _comparator;
+  final Comparator<K> _compare;
 
-  _IsSorted(K Function(T) keyOf, Comparator<K> comparator)
+  _IsSorted(K Function(T) keyOf, Comparator<K> compare)
       : _keyOf = keyOf,
-        _comparator = comparator;
+        _compare = compare;
 
   String? _test(Iterable<T> item, Map matchState) {
-    if (item.length < 2) {
-      return null;
-    }
-
-    var prevElem = item.first;
-    var prevKey = _keyOf(prevElem);
-    for (final elem in item.skip(1)) {
-      var key = _keyOf(elem);
-      if (_comparator(prevKey, key) > 0) {
+    var iterator = item.iterator;
+    if (!iterator.moveNext()) return null;
+    var previousElement = iterator.current;
+    var previousKey = _keyOf(previousElement);
+    while (iterator.moveNext()) {
+      var element = iterator.current;
+      var key = _keyOf(element);
+      if (_compare(previousKey, key) > 0) {
         return StringDescription(
-                'found elements out of order: <$prevElem> and <$elem>')
+                'found elements out of order: <$previousElement> and '
+                '<$element>')
             .toString();
       }
-      prevElem = elem;
-      prevKey = key;
+      previousElement = element;
+      previousKey = key;
     }
     return null;
   }

--- a/pkgs/matcher/lib/src/iterable_matchers.dart
+++ b/pkgs/matcher/lib/src/iterable_matchers.dart
@@ -415,16 +415,16 @@ class _ContainsOnce extends _IterableMatcher {
       mismatchDescription.add(_test(item, matchState)!);
 }
 
-// Matches [Iterable]s which are sorted.
+/// Matches [Iterable]s which are sorted.
 Matcher isSorted<T>(Comparator<T> compare) =>
     _IsSorted<T, T>((t) => t, compare);
 
-// Matches [Iterable]s which are sorted by the given key.
+/// Matches [Iterable]s which are sorted by the given key.
 Matcher isSortedBy<T, K extends Comparable<K>>(K Function(T) keyOf) =>
     _IsSorted<T, K>(keyOf, (a, b) => a.compareTo(b));
 
-// Matches [Iterable]s which are sorted by the given key, using the given
-// comparator.
+/// Matches [Iterable]s which are sorted by the given key, using the given
+/// comparator.
 Matcher isSortedByCompare<T, K>(K Function(T) keyOf, Comparator<K> compare) =>
     _IsSorted(keyOf, compare);
 

--- a/pkgs/matcher/test/iterable_matchers_test.dart
+++ b/pkgs/matcher/test/iterable_matchers_test.dart
@@ -396,33 +396,24 @@ void main() {
   test('isSorted', () {
     var a = [1, 2, 3];
     var b = [1, 3, 2];
-    var c = [null, 2, 5];
-    var d = [2, null, 5];
 
-    shouldPass(a, isSorted());
+    shouldPass(a, isSorted((int x, int y) => x - y));
     shouldFail(
         b,
-        isSorted(),
+        isSorted((int x, int y) => x - y),
         'Expected: is sorted '
         'Actual: [1, 3, 2] '
         'Which: found elements out of order 3 and 2');
-    shouldPass(c, isSorted());
-    shouldFail(
-        d,
-        isSorted(),
-        'Expected: is sorted '
-        'Actual: [2, null, 5] '
-        'Which: found elements out of order 2 and null');
   });
 
   test('isSortedBy', () {
     var a = ['y', 'zz', 'bbbb', 'aaaa'];
     var b = ['y', 'bbbb', 'aaaa', 'zz'];
 
-    shouldPass(a, isSortedBy((String s) => s.length));
+    shouldPass(a, isSortedBy<String, num>((String s) => s.length));
     shouldFail(
         b,
-        isSortedBy((String s) => s.length),
+        isSortedBy<String, num>((String s) => s.length),
         'Expected: is sorted '
         'Actual: [\'y\', \'bbbb\', \'aaaa\', \'zz\'] '
         'Which: found elements out of order aaaa and zz');

--- a/pkgs/matcher/test/iterable_matchers_test.dart
+++ b/pkgs/matcher/test/iterable_matchers_test.dart
@@ -403,7 +403,7 @@ void main() {
         isSorted((int x, int y) => x - y),
         'Expected: is sorted '
         'Actual: [1, 3, 2] '
-        'Which: found elements out of order 3 and 2');
+        'Which: found elements out of order: <3> and <2>');
   });
 
   test('isSortedBy', () {
@@ -416,7 +416,7 @@ void main() {
         isSortedBy<String, num>((String s) => s.length),
         'Expected: is sorted '
         'Actual: [\'y\', \'bbbb\', \'aaaa\', \'zz\'] '
-        'Which: found elements out of order aaaa and zz');
+        'Which: found elements out of order: <aaaa> and <zz>');
   });
 
   test('isSortedByCompare', () {
@@ -430,6 +430,6 @@ void main() {
         isSortedByCompare((String s) => s.length, (a, b) => b.compareTo(a)),
         'Expected: is sorted '
         'Actual: [\'y\', \'bbbb\', \'aaaa\', \'zz\'] '
-        'Which: found elements out of order y and bbbb');
+        'Which: found elements out of order: <y> and <bbbb>');
   });
 }

--- a/pkgs/matcher/test/iterable_matchers_test.dart
+++ b/pkgs/matcher/test/iterable_matchers_test.dart
@@ -392,4 +392,53 @@ void main() {
         'Actual: SimpleIterable:[3, 2, 1] '
         'Which: does not contain <5>');
   });
+
+  test('isSorted', () {
+    var a = [1, 2, 3];
+    var b = [1, 3, 2];
+    var c = [null, 2, 5];
+    var d = [2, null, 5];
+
+    shouldPass(a, isSorted());
+    shouldFail(
+        b,
+        isSorted(),
+        'Expected: is sorted '
+        'Actual: [1, 3, 2] '
+        'Which: found elements out of order 3 and 2');
+    shouldPass(c, isSorted());
+    shouldFail(
+        d,
+        isSorted(),
+        'Expected: is sorted '
+        'Actual: [2, null, 5] '
+        'Which: found elements out of order 2 and null');
+  });
+
+  test('isSortedBy', () {
+    var a = ['y', 'zz', 'bbbb', 'aaaa'];
+    var b = ['y', 'bbbb', 'aaaa', 'zz'];
+
+    shouldPass(a, isSortedBy((String s) => s.length));
+    shouldFail(
+        b,
+        isSortedBy((String s) => s.length),
+        'Expected: is sorted '
+        'Actual: [\'y\', \'bbbb\', \'aaaa\', \'zz\'] '
+        'Which: found elements out of order aaaa and zz');
+  });
+
+  test('isSortedByCompare', () {
+    var a = ['aaaa', 'bbbb', 'zz', 'y'];
+    var b = ['y', 'bbbb', 'aaaa', 'zz'];
+
+    shouldPass(
+        a, isSortedByCompare((String s) => s.length, (a, b) => b.compareTo(a)));
+    shouldFail(
+        b,
+        isSortedByCompare((String s) => s.length, (a, b) => b.compareTo(a)),
+        'Expected: is sorted '
+        'Actual: [\'y\', \'bbbb\', \'aaaa\', \'zz\'] '
+        'Which: found elements out of order y and bbbb');
+  });
 }

--- a/pkgs/matcher/test/iterable_matchers_test.dart
+++ b/pkgs/matcher/test/iterable_matchers_test.dart
@@ -416,7 +416,7 @@ void main() {
         isSortedBy<String, num>((String s) => s.length),
         'Expected: is sorted '
         'Actual: [\'y\', \'bbbb\', \'aaaa\', \'zz\'] '
-        'Which: found elements out of order: <aaaa> and <zz>');
+        'Which: found elements out of order: \'aaaa\' and \'zz\'');
   });
 
   test('isSortedByCompare', () {
@@ -430,6 +430,6 @@ void main() {
         isSortedByCompare((String s) => s.length, (a, b) => b.compareTo(a)),
         'Expected: is sorted '
         'Actual: [\'y\', \'bbbb\', \'aaaa\', \'zz\'] '
-        'Which: found elements out of order: <y> and <bbbb>');
+        'Which: found elements out of order: \'y\' and \'bbbb\'');
   });
 }

--- a/pkgs/matcher/test/iterable_matchers_test.dart
+++ b/pkgs/matcher/test/iterable_matchers_test.dart
@@ -394,54 +394,105 @@ void main() {
   });
 
   test('isSorted', () {
-    var a = [1, 2, 3];
-    var b = [1, 3, 2];
+    final sorted = [4, 8, 15, 16, 23, 42];
+    final mismatchAtStart = [8, 4, 15, 16, 23, 42];
+    final mismatchInMiddle = [4, 8, 16, 15, 23, 42];
+    final mismatchAtEnd = [4, 8, 15, 16, 42, 23];
+    final singleElement = [42];
+    final twoElementsSorted = [42, 143];
+    final twoElementsUnsorted = [143, 42];
 
-    shouldPass(a, isSorted<num>());
+    shouldPass(sorted, isSorted<num>());
     shouldFail(
-        b,
+        mismatchAtStart,
         isSorted<num>(),
         'Expected: is sorted '
-        'Actual: [1, 3, 2] '
-        'Which: found elements out of order at <1>: <3> and <2>');
+        'Actual: [8, 4, 15, 16, 23, 42] '
+        'Which: found elements out of order at <0>: <8> and <4>');
+    shouldFail(
+        mismatchInMiddle,
+        isSorted<num>(),
+        'Expected: is sorted '
+        'Actual: [4, 8, 16, 15, 23, 42] '
+        'Which: found elements out of order at <2>: <16> and <15>');
+    shouldFail(
+        mismatchAtEnd,
+        isSorted<num>(),
+        'Expected: is sorted '
+        'Actual: [4, 8, 15, 16, 42, 23] '
+        'Which: found elements out of order at <4>: <42> and <23>');
+    shouldPass(singleElement, isSorted<num>());
+    shouldPass(twoElementsSorted, isSorted<num>());
+    shouldFail(
+        twoElementsUnsorted,
+        isSorted<num>(),
+        'Expected: is sorted '
+        'Actual: [143, 42] '
+        'Which: found elements out of order at <0>: <143> and <42>');
   });
 
   test('isSortedUsing', () {
-    var a = [1, 2, 3];
-    var b = [1, 3, 2];
-    var c = [3, 2, 1];
+    final sorted = [1, 2, 3];
+    final unsorted = [1, 3, 2];
+    final reverseSorted = [3, 2, 1];
 
-    shouldPass(a, isSortedUsing((int x, int y) => x - y));
+    int alwaysEqualCompare(int x, int y) => 0;
+    int throwingCompare(int x, int y) => throw Error();
+
+    shouldPass(sorted, isSortedUsing((int x, int y) => x - y));
     shouldFail(
-        b,
+        unsorted,
         isSortedUsing((int x, int y) => x - y),
         'Expected: is sorted '
         'Actual: [1, 3, 2] '
         'Which: found elements out of order at <1>: <3> and <2>');
-    shouldPass(c, isSortedUsing((int x, int y) => y - x));
+    shouldPass(reverseSorted, isSortedUsing((int x, int y) => y - x));
+
+    shouldPass(unsorted, isSortedUsing(alwaysEqualCompare));
+
+    shouldFail(
+        sorted,
+        isSortedUsing(throwingCompare),
+        'Expected: is sorted '
+        'Actual: [1, 2, 3] '
+        'Which: got error <Instance of \'Error\'> at <0> '
+        'when comparing <1> and <2>');
   });
 
   test('isSortedBy', () {
-    var a = ['y', 'zz', 'bbbb', 'aaaa'];
-    var b = ['y', 'bbbb', 'aaaa', 'zz'];
+    final sorted = ['y', 'zz', 'bbbb', 'aaaa'];
+    final unsorted = ['y', 'bbbb', 'aaaa', 'zz'];
+    final sortedDueToSameKey = ['zzz', 'abc', 'def', 'aaa'];
 
-    shouldPass(a, isSortedBy<String, num>((String s) => s.length));
+    num throwingKey(String s) => throw Error();
+
+    shouldPass(sorted, isSortedBy<String, num>((String s) => s.length));
     shouldFail(
-        b,
+        unsorted,
         isSortedBy<String, num>((String s) => s.length),
         'Expected: is sorted '
         'Actual: [\'y\', \'bbbb\', \'aaaa\', \'zz\'] '
         'Which: found elements out of order at <2>: \'aaaa\' and \'zz\'');
+    shouldPass(
+        sortedDueToSameKey, isSortedBy<String, num>((String s) => s.length));
+
+    shouldFail(
+        sorted,
+        isSortedBy(throwingKey),
+        'Expected: is sorted '
+        'Actual: [\'y\', \'zz\', \'bbbb\', \'aaaa\'] '
+        'Which: got error <Instance of \'Error\'> at <0> '
+        'when getting key of \'y\'');
   });
 
   test('isSortedByCompare', () {
-    var a = ['aaaa', 'bbbb', 'zz', 'y'];
-    var b = ['y', 'bbbb', 'aaaa', 'zz'];
+    final sorted = ['aaaa', 'bbbb', 'zz', 'y'];
+    final unsorted = ['y', 'bbbb', 'aaaa', 'zz'];
 
-    shouldPass(
-        a, isSortedByCompare((String s) => s.length, (a, b) => b.compareTo(a)));
+    shouldPass(sorted,
+        isSortedByCompare((String s) => s.length, (a, b) => b.compareTo(a)));
     shouldFail(
-        b,
+        unsorted,
         isSortedByCompare((String s) => s.length, (a, b) => b.compareTo(a)),
         'Expected: is sorted '
         'Actual: [\'y\', \'bbbb\', \'aaaa\', \'zz\'] '

--- a/pkgs/matcher/test/iterable_matchers_test.dart
+++ b/pkgs/matcher/test/iterable_matchers_test.dart
@@ -397,13 +397,28 @@ void main() {
     var a = [1, 2, 3];
     var b = [1, 3, 2];
 
-    shouldPass(a, isSorted((int x, int y) => x - y));
+    shouldPass(a, isSorted<num>());
     shouldFail(
         b,
-        isSorted((int x, int y) => x - y),
+        isSorted<num>(),
         'Expected: is sorted '
         'Actual: [1, 3, 2] '
         'Which: found elements out of order: <3> and <2>');
+  });
+
+  test('isSortedUsing', () {
+    var a = [1, 2, 3];
+    var b = [1, 3, 2];
+    var c = [3, 2, 1];
+
+    shouldPass(a, isSortedUsing((int x, int y) => x - y));
+    shouldFail(
+        b,
+        isSortedUsing((int x, int y) => x - y),
+        'Expected: is sorted '
+        'Actual: [1, 3, 2] '
+        'Which: found elements out of order: <3> and <2>');
+    shouldPass(c, isSortedUsing((int x, int y) => y - x));
   });
 
   test('isSortedBy', () {

--- a/pkgs/matcher/test/iterable_matchers_test.dart
+++ b/pkgs/matcher/test/iterable_matchers_test.dart
@@ -403,7 +403,7 @@ void main() {
         isSorted<num>(),
         'Expected: is sorted '
         'Actual: [1, 3, 2] '
-        'Which: found elements out of order: <3> and <2>');
+        'Which: found elements out of order at <1>: <3> and <2>');
   });
 
   test('isSortedUsing', () {
@@ -417,7 +417,7 @@ void main() {
         isSortedUsing((int x, int y) => x - y),
         'Expected: is sorted '
         'Actual: [1, 3, 2] '
-        'Which: found elements out of order: <3> and <2>');
+        'Which: found elements out of order at <1>: <3> and <2>');
     shouldPass(c, isSortedUsing((int x, int y) => y - x));
   });
 
@@ -431,7 +431,7 @@ void main() {
         isSortedBy<String, num>((String s) => s.length),
         'Expected: is sorted '
         'Actual: [\'y\', \'bbbb\', \'aaaa\', \'zz\'] '
-        'Which: found elements out of order: \'aaaa\' and \'zz\'');
+        'Which: found elements out of order at <2>: \'aaaa\' and \'zz\'');
   });
 
   test('isSortedByCompare', () {
@@ -445,6 +445,6 @@ void main() {
         isSortedByCompare((String s) => s.length, (a, b) => b.compareTo(a)),
         'Expected: is sorted '
         'Actual: [\'y\', \'bbbb\', \'aaaa\', \'zz\'] '
-        'Which: found elements out of order: \'y\' and \'bbbb\'');
+        'Which: found elements out of order at <0>: \'y\' and \'bbbb\'');
   });
 }


### PR DESCRIPTION
Add sorting related matchers for iterables.
* isSorted
* isSortedUsing
* isSortedBy
* isSortedByCompare

These match the functions available in https://github.com/dart-lang/core/blob/main/pkgs/collection/lib/src/iterable_extensions.dart

---

- [✅ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
