### PR TITLE
Fix typos in json_reporter documentation

### DIFF
--- a/pkgs/test/doc/json_reporter.md
+++ b/pkgs/test/doc/json_reporter.md
@@ -362,7 +362,7 @@ class Test {
   // Will only be present if `root_url` is different from `url`.
   int? root_line;
 
-  // The (1-based) line on in the original test suite from which the test
+  // The (1-based) line in the original test suite from which the test
   // originated.
   //
   // Will only be present if `root_url` is different from `url`.

--- a/pkgs/test/doc/json_reporter.md
+++ b/pkgs/test/doc/json_reporter.md
@@ -319,7 +319,7 @@ class DoneEvent extends Event {
 
   // Whether all tests succeeded (or were skipped).
   //
-  // Will be `null` if the test runner was close before all tests completed
+  // Will be `null` if the test runner was closed before all tests completed
   // running.
   bool? success;
 }
@@ -395,7 +395,7 @@ and may be a `package:` URL.
 
 ```
 class Suite {
-  // An opaque ID for the group.
+  // An opaque ID for the suite.
   int id;
 
   // The platform on which the suite is running.


### PR DESCRIPTION
Fix two minor typos in the documentation for the `json_reporter`.

Several tools parse this documentation and therefore use the incorrect comments.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
