### PR TITLE
Set a debug name for test isolates

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -252,7 +252,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: pkgs/test_core
       - name: "pkgs/test_core; dart format --output=none --set-exit-if-changed ."
-        run: "dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=show --set-exit-if-changed ."
         if: "always() && steps.pkgs_test_core_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/test_core
       - name: "pkgs/test_core; dart analyze --fatal-infos"

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -252,7 +252,7 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: pkgs/test_core
       - name: "pkgs/test_core; dart format --output=none --set-exit-if-changed ."
-        run: "dart format --output=show --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
         if: "always() && steps.pkgs_test_core_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/test_core
       - name: "pkgs/test_core; dart analyze --fatal-infos"

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.26.1-wip
+
+* Set a debug name for test isolates.
+
 ## 1.26.0
 
 * `test()` and `group()` functions now take an optional `TestLocation` that will

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.26.0
+version: 1.26.1-wip
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test
@@ -37,7 +37,7 @@ dependencies:
 
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.7.5
-  test_core: 0.6.9
+  test_core: 0.6.10
 
   typed_data: ^1.3.0
   web_socket_channel: '>=2.0.0 <4.0.0'

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.7.5
-  test_core: 0.6.10
+  test_core: 0.6.10-wip
 
   typed_data: ^1.3.0
   web_socket_channel: '>=2.0.0 <4.0.0'

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,10 +1,13 @@
+## 0.6.10-wip
+
+* Set a debug name for test isolates.
+
 ## 0.6.9
 
 * Add support for native assets for `dart test` in pub workspaces.
 * `test()` and `group()` functions now take an optional `TestLocation` that will
   be used as the location of the test in JSON reporters instead of being parsed
   from the call stack.
-* Set a debug name for test isolates.
 
 ## 0.6.8
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -4,6 +4,7 @@
 * `test()` and `group()` functions now take an optional `TestLocation` that will
   be used as the location of the test in JSON reporters instead of being parsed
   from the call stack.
+* Set a debug name for test isolates.
 
 ## 0.6.8
 

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -111,7 +111,7 @@ class VMPlatform extends PlatformPlugin {
       if (platform.compiler == Compiler.exe) {
         throw UnsupportedError(
             'Unable to debug tests compiled to `exe` (tried to debug $path with '
-            'the `exe` compiler).');
+          'the `exe` compiler).');
       }
       var info =
           await Service.controlWebServer(enable: true, silenceOutput: true);
@@ -123,8 +123,7 @@ class VMPlatform extends PlatformPlugin {
       client = await vmServiceConnectUri(_wsUriFor(serverUri).toString());
       var isolateNumber = int.parse(isolateID.split('/').last);
       isolateRef = (await client.getVM())
-          .isolates!
-          .firstWhere((isolate) => isolate.number == isolateNumber.toString());
+          .isolates!.firstWhere((isolate) => isolate.number == isolateNumber.toString());
       await client.setName(isolateRef.id!, path);
       var libraryRef = (await client.getIsolate(isolateRef.id!))
           .libraries!
@@ -180,8 +179,8 @@ class VMPlatform extends PlatformPlugin {
   Future<String> _compileToNative(String path, Metadata suiteMetadata) async {
     var bootstrapPath = await _bootstrapNativeTestFile(
         path,
-        suiteMetadata.languageVersionComment ??
-            await rootPackageLanguageVersionComment);
+      suiteMetadata.languageVersionComment ??
+          await rootPackageLanguageVersionComment);
     var output = File(p.setExtension(bootstrapPath, '.exe'));
     var processResult = await Process.run(Platform.resolvedExecutable, [
       'compile',
@@ -221,8 +220,8 @@ stderr: ${processResult.stderr}''');
         Compiler.source => _spawnIsolateWithUri(
             await _bootstrapIsolateTestFile(
                 path,
-                suiteMetadata.languageVersionComment ??
-                    await rootPackageLanguageVersionComment),
+            suiteMetadata.languageVersionComment ??
+                await rootPackageLanguageVersionComment),
             message),
         _ => throw StateError(
             'Unsupported compiler $compiler for the VM platform'),
@@ -246,9 +245,14 @@ stderr: ${processResult.stderr}''');
 
   /// Runs [uri] in an isolate, passing [message].
   Future<Isolate> _spawnIsolateWithUri(Uri uri, SendPort message) async {
-    return await Isolate.spawnUri(uri, [], message,
-        packageConfig: await packageConfigUri, checked: true,
-        debugName: 'test_main');
+    return await Isolate.spawnUri(
+      uri,
+      [],
+      message,
+      packageConfig: await packageConfigUri,
+      checked: true,
+      debugName: 'test_main',
+    );
   }
 
   Future<Isolate> _spawnPrecompiledIsolate(String testPath, SendPort message,
@@ -285,9 +289,14 @@ stderr: ${processResult.stderr}''');
         packageConfig = null;
       }
     }
-    return await Isolate.spawnUri(testUri, [], message,
-        packageConfig: packageConfig?.uri, checked: true,
-        debugName: 'test_main');
+    return await Isolate.spawnUri(
+      testUri,
+      [],
+      message,
+      packageConfig: packageConfig?.uri,
+      checked: true,
+      debugName: 'test_main',
+    );
   }
 
   /// Bootstraps the test at [testPath] and writes its contents to a temporary
@@ -346,7 +355,7 @@ Uri _wsUriFor(Uri observatoryUrl) =>
 Uri _observatoryUrlFor(Uri base, String isolateId, String id) => base.replace(
     fragment: Uri(
         path: '/inspect',
-        queryParameters: {'isolateId': isolateId, 'objectId': id}).toString());
+    queryParameters: {'isolateId': isolateId, 'objectId': id}).toString());
 
 var _hasRegistered = false;
 void _setupPauseAfterTests() {

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -247,7 +247,8 @@ stderr: ${processResult.stderr}''');
   /// Runs [uri] in an isolate, passing [message].
   Future<Isolate> _spawnIsolateWithUri(Uri uri, SendPort message) async {
     return await Isolate.spawnUri(uri, [], message,
-        packageConfig: await packageConfigUri, checked: true);
+        packageConfig: await packageConfigUri, checked: true,
+        debugName: 'test_main');
   }
 
   Future<Isolate> _spawnPrecompiledIsolate(String testPath, SendPort message,
@@ -285,7 +286,8 @@ stderr: ${processResult.stderr}''');
       }
     }
     return await Isolate.spawnUri(testUri, [], message,
-        packageConfig: packageConfig?.uri, checked: true);
+        packageConfig: packageConfig?.uri, checked: true,
+        debugName: 'test_main');
   }
 
   /// Bootstraps the test at [testPath] and writes its contents to a temporary

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -252,7 +252,7 @@ stderr: ${processResult.stderr}''');
       message,
       packageConfig: await packageConfigUri,
       checked: true,
-      debugName: 'test_main',
+      debugName: 'test_suite:$uri',
     );
   }
 
@@ -296,7 +296,7 @@ stderr: ${processResult.stderr}''');
       message,
       packageConfig: packageConfig?.uri,
       checked: true,
-      debugName: 'test_main',
+      debugName: 'test_suite:$testUri',
     );
   }
 

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -111,7 +111,7 @@ class VMPlatform extends PlatformPlugin {
       if (platform.compiler == Compiler.exe) {
         throw UnsupportedError(
             'Unable to debug tests compiled to `exe` (tried to debug $path with '
-          'the `exe` compiler).');
+            'the `exe` compiler).');
       }
       var info =
           await Service.controlWebServer(enable: true, silenceOutput: true);
@@ -123,7 +123,8 @@ class VMPlatform extends PlatformPlugin {
       client = await vmServiceConnectUri(_wsUriFor(serverUri).toString());
       var isolateNumber = int.parse(isolateID.split('/').last);
       isolateRef = (await client.getVM())
-          .isolates!.firstWhere((isolate) => isolate.number == isolateNumber.toString());
+          .isolates!
+          .firstWhere((isolate) => isolate.number == isolateNumber.toString());
       await client.setName(isolateRef.id!, path);
       var libraryRef = (await client.getIsolate(isolateRef.id!))
           .libraries!
@@ -179,8 +180,8 @@ class VMPlatform extends PlatformPlugin {
   Future<String> _compileToNative(String path, Metadata suiteMetadata) async {
     var bootstrapPath = await _bootstrapNativeTestFile(
         path,
-      suiteMetadata.languageVersionComment ??
-          await rootPackageLanguageVersionComment);
+        suiteMetadata.languageVersionComment ??
+            await rootPackageLanguageVersionComment);
     var output = File(p.setExtension(bootstrapPath, '.exe'));
     var processResult = await Process.run(Platform.resolvedExecutable, [
       'compile',
@@ -220,8 +221,8 @@ stderr: ${processResult.stderr}''');
         Compiler.source => _spawnIsolateWithUri(
             await _bootstrapIsolateTestFile(
                 path,
-            suiteMetadata.languageVersionComment ??
-                await rootPackageLanguageVersionComment),
+                suiteMetadata.languageVersionComment ??
+                    await rootPackageLanguageVersionComment),
             message),
         _ => throw StateError(
             'Unsupported compiler $compiler for the VM platform'),
@@ -355,7 +356,7 @@ Uri _wsUriFor(Uri observatoryUrl) =>
 Uri _observatoryUrlFor(Uri base, String isolateId, String id) => base.replace(
     fragment: Uri(
         path: '/inspect',
-    queryParameters: {'isolateId': isolateId, 'objectId': id}).toString());
+        queryParameters: {'isolateId': isolateId, 'objectId': id}).toString());
 
 var _hasRegistered = false;
 void _setupPauseAfterTests() {

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.6.9
+version: 0.6.10-wip
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 issue_tracker: https://github.com/dart-lang/test/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Atest


### PR DESCRIPTION
The Dart VM treats the main isolate specially. When the main isolate shuts down, the entire VM shuts down, even if there are other isolates still running.

package:coverage needs to collect coverage for all isolates. To do this, the VM is run with `--pause-isolates-on-exit`, and package:coverage waits for each isolate to pause, collects the coverage, then resumes the isolate and allows it to exit. But since the main isolate exiting would cause all isolates to exit, some of which may not have been collected yet, package:coverage needs to treat the main isolate specially, and avoid resuming it until every other isolate is collected.

Unfortunately there's no reliable way of determining which isolate is the main isolate using the VM service API. So package:coverage uses a heuristic: the first isolate is sees with a debug name of "main" is the main isolate. 99% of the time this works. But package:test spawns a new isolate for each test file, and doesn't set a debug name, so the name defaults to "main". If one of those test isolates is seen by package:coverage before the true main isolate, the system breaks. This causes about a 1% flakiness for test coverage in g3.

We're [working](https://dart-review.googlesource.com/c/sdk/+/427062) on extending the VM service API to tell us which isolate is the main one, but it's turning out to be non-trivial. In the meantime, a quick fix for the g3 flakiness is just to set some other debug name on the isolates that package:test spawns.

I've manually tested that this works, but let me know if I missed any isolate spawns that could be hit during `dart test`. Also, do you think this needs a test?

See also: https://github.com/dart-lang/sdk/issues/56732