### PR TITLE
Fix an issue with failed assertions using setUpAll/tearDownAll

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.26.1-wip
 
 * Set a debug name for test isolates.
+* Use version `0.7.6` of `packge:test_api` to fix an assertion failure when
+  using `setUpAll` or `tearDownAll` and running with asserts enabled.
 
 ## 1.26.0
 

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 1.26.1-wip
+## 1.26.1
 
 * Set a debug name for test isolates.
-* Use version `0.7.6` of `packge:test_api` to fix an assertion failure when
-  using `setUpAll` or `tearDownAll` and running with asserts enabled.
+* Fix an assertion failure when using `setUpAll` or `tearDownAll` and running
+  with asserts enabled.
 
 ## 1.26.0
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.26.1-wip
+version: 1.26.1
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test
@@ -37,7 +37,7 @@ dependencies:
 
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.7.6
-  test_core: 0.6.10-wip
+  test_core: 0.6.10
 
   typed_data: ^1.3.0
   web_socket_channel: '>=2.0.0 <4.0.0'

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   stream_channel: ^2.1.0
 
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.7.5
+  test_api: 0.7.6
   test_core: 0.6.10-wip
 
   typed_data: ^1.3.0

--- a/pkgs/test/test/runner/set_up_all_test.dart
+++ b/pkgs/test/test/runner/set_up_all_test.dart
@@ -95,4 +95,19 @@ void main() {
     expect(test.stdout, neverEmits(contains('(setUpAll)')));
     await test.shouldExit(0);
   });
+
+  test('does not fail with asserts enabled - issue #2498', () async {
+    await d.file('test.dart', r'''
+        import 'package:test/test.dart';
+
+        void main() {
+          setUpAll(() {});
+
+          test("test", () {});
+        }
+        ''').create();
+
+    var test = await runTest(['test.dart'], vmArgs: ['--enable-asserts']);
+    await test.shouldExit(0);
+  });
 }

--- a/pkgs/test/test/runner/tear_down_all_test.dart
+++ b/pkgs/test/test/runner/tear_down_all_test.dart
@@ -95,4 +95,19 @@ void main() {
     expect(test.stdout, neverEmits(contains('(tearDownAll)')));
     await test.shouldExit(0);
   });
+
+  test('does not fail with asserts enabled - issue #2498', () async {
+    await d.file('test.dart', r'''
+        import 'package:test/test.dart';
+
+        void main() {
+          tearDownAll(() {});
+
+          test("test", () {});
+        }
+        ''').create();
+
+    var test = await runTest(['test.dart'], vmArgs: ['--enable-asserts']);
+    await test.shouldExit(0);
+  });
 }

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.6
+
+* Fix an assertion failure when using `setUpAll` or `tearDownAll` and running
+  with asserts enabled.
+
 ## 0.7.5
 
 * `test()` and `group()` functions now take an optional `TestLocation` that will

--- a/pkgs/test_api/lib/src/backend/group.dart
+++ b/pkgs/test_api/lib/src/backend/group.dart
@@ -97,8 +97,20 @@ class Group implements GroupEntry {
         trace: trace,
         location: location,
         // Always clone these because they are being re-parented.
-        setUpAll: setUpAll?.filter((_) => true),
-        tearDownAll: tearDownAll?.filter((_) => true));
+        setUpAll: setUpAll?.clone(),
+        tearDownAll: tearDownAll?.clone());
+  }
+
+  @override
+  Group? clone() {
+    var entries = _map((entry) => entry.clone());
+    return Group(name, entries,
+        metadata: metadata,
+        trace: trace,
+        location: location,
+        // Always clone these because they are being re-parented.
+        setUpAll: setUpAll?.clone(),
+        tearDownAll: tearDownAll?.clone());
   }
 
   /// Returns the entries of this group mapped using [callback].

--- a/pkgs/test_api/lib/src/backend/group.dart
+++ b/pkgs/test_api/lib/src/backend/group.dart
@@ -96,8 +96,9 @@ class Group implements GroupEntry {
         metadata: metadata,
         trace: trace,
         location: location,
-        setUpAll: setUpAll,
-        tearDownAll: tearDownAll);
+        // Always clone these because they are being re-parented.
+        setUpAll: setUpAll?.filter((_) => true),
+        tearDownAll: tearDownAll?.filter((_) => true));
   }
 
   /// Returns the entries of this group mapped using [callback].

--- a/pkgs/test_api/lib/src/backend/group_entry.dart
+++ b/pkgs/test_api/lib/src/backend/group_entry.dart
@@ -51,4 +51,8 @@ abstract class GroupEntry {
   /// Returns `null` if this is a test that doesn't match [callback] or a group
   /// where no child tests match [callback].
   GroupEntry? filter(bool Function(Test) callback);
+
+  /// Returns a clone of this object without the internal `parent` reference
+  /// set so that it may be attached to a new tree.
+  GroupEntry? clone();
 }

--- a/pkgs/test_api/lib/src/backend/invoker.dart
+++ b/pkgs/test_api/lib/src/backend/invoker.dart
@@ -79,11 +79,16 @@ class LocalTest extends Test {
     if (callback(this)) {
       // filter() always returns new copies because they need to be attached
       // to their new parents.
-      return LocalTest._(
-          name, metadata, _body, trace, location, _guarded, isScaffoldAll);
+      return clone();
     }
 
     return null;
+  }
+
+  @override
+  Test clone() {
+    return LocalTest._(
+        name, metadata, _body, trace, location, _guarded, isScaffoldAll);
   }
 }
 

--- a/pkgs/test_api/lib/src/backend/test.dart
+++ b/pkgs/test_api/lib/src/backend/test.dart
@@ -42,4 +42,7 @@ abstract class Test implements GroupEntry {
 
   @override
   Test? filter(bool Function(Test) callback);
+
+  @override
+  Test? clone();
 }

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.7.5
+version: 0.7.6
 description: >-
   The user facing API for structuring Dart tests and checking expectations.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_api

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 0.6.10-wip
+## 0.6.10
 
 * Set a debug name for test isolates.
-* Use version `0.7.6` of `packge:test_api` to fix an assertion failure when
-  using `setUpAll` or `tearDownAll` and running with asserts enabled.
+* Fix an assertion failure when using `setUpAll` or `tearDownAll` and running
+  with asserts enabled.
 
 ## 0.6.9
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.6.10-wip
 
 * Set a debug name for test isolates.
+* Use version `0.7.6` of `packge:test_api` to fix an assertion failure when
+  using `setUpAll` or `tearDownAll` and running with asserts enabled.
 
 ## 0.6.9
 

--- a/pkgs/test_core/lib/src/runner/runner_test.dart
+++ b/pkgs/test_core/lib/src/runner/runner_test.dart
@@ -115,9 +115,14 @@ class RunnerTest extends Test {
     if (callback(this)) {
       // filter() always returns new copies because they need to be attached
       // to their new parents.
-      return RunnerTest(name, metadata, trace, location, _channel);
+      return clone();
     }
 
     return null;
+  }
+
+  @override
+  Test clone() {
+    return RunnerTest(name, metadata, trace, location, _channel);
   }
 }

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.6.10-wip
+version: 0.6.10
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 issue_tracker: https://github.com/dart-lang/test/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Atest

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   stack_trace: ^1.10.0
   stream_channel: ^2.1.0
   # Use an exact version until the test_api package is stable.
-  test_api: 0.7.5
+  test_api: 0.7.6
   vm_service: ">=6.0.0 <16.0.0"
   yaml: ^3.0.0
 


### PR DESCRIPTION
When groups are filtered using `filter()` and not `onPlatform`, we would clone the group and tests without also cloning `setUpAll`/`tearDownAll`, which led to an assertion failure when trying to set the parents.

This change ensures we clone tests in `filter()` like we do in `forPlatform()`.

Fixes https://github.com/dart-lang/test/issues/2498

