### PR TITLE
Add the platform level channel to zone values

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.26.3-WIP
+
 ## 1.26.2
 
 * Graduate native assets from experiment to preview.

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.26.2
+version: 1.26.3-WIP
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test
@@ -36,8 +36,8 @@ dependencies:
   stream_channel: ^2.1.0
 
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.7.6
-  test_core: 0.6.11
+  test_api: 0.7.7
+  test_core: 0.6.12
 
   typed_data: ^1.3.0
   web_socket_channel: '>=2.0.0 <4.0.0'

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.7.7-WIP
+
 ## 0.7.6
 
 * Fix an assertion failure when using `setUpAll` or `tearDownAll` and running

--- a/pkgs/test_api/lib/src/backend/declarer.dart
+++ b/pkgs/test_api/lib/src/backend/declarer.dart
@@ -191,8 +191,8 @@ class Declarer {
   /// Runs [body] with this declarer as [Declarer.current].
   ///
   /// Returns the return value of [body].
-  T declare<T>(T Function() body) =>
-      runZoned(body, zoneValues: {#test.declarer: this});
+  T declare<T>(T Function() body, {Map<Object?, Object?>? zoneValues}) =>
+      runZoned(body, zoneValues: {#test.declarer: this, ...?zoneValues});
 
   /// Defines a test case with the given name and body.
   void test(String name, dynamic Function() body,

--- a/pkgs/test_api/lib/src/backend/remote_listener.dart
+++ b/pkgs/test_api/lib/src/backend/remote_listener.dart
@@ -117,7 +117,8 @@ final class RemoteListener {
           await beforeLoad(suiteChannelManager.connectOut);
         }
 
-        await declarer.declare(main);
+        await declarer.declare(main,
+            zoneValues: {#test.platformChannel: controller.foreign});
 
         var suite = Suite(
           declarer.build(),

--- a/pkgs/test_api/lib/src/scaffolding/spawn_hybrid.dart
+++ b/pkgs/test_api/lib/src/scaffolding/spawn_hybrid.dart
@@ -170,7 +170,7 @@ StreamChannel _spawn(String uri, Object? message, {bool stayAlive = false}) {
   });
 
   if (!stayAlive) {
-    var disconnector = Disconnector<void>();
+    var disconnector = Disconnector();
     addTearDown(() => disconnector.disconnect());
     isolateChannel = isolateChannel.transform(disconnector);
   }

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.7.6
+version: 0.7.7-WIP
 description: >-
   The user facing API for structuring Dart tests and checking expectations.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_api

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.6.12-WIP
+
 ## 0.6.11
 
 * Graduate native assets from experiment to preview.

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.6.11
+version: 0.6.12-WIP
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 issue_tracker: https://github.com/dart-lang/test/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Atest
@@ -28,7 +28,7 @@ dependencies:
   stack_trace: ^1.10.0
   stream_channel: ^2.1.0
   # Use an exact version until the test_api package is stable.
-  test_api: 0.7.6
+  test_api: 0.7.7
   vm_service: '>=6.0.0 <16.0.0'
   yaml: ^3.0.0
 


### PR DESCRIPTION
We make a test channel available in the zones running tests to enable
features like spawning VM isolates but it's not available in the zone
that runs `main`. Add a new zone variable that holds the test channel.
