### PR TITLE
Consider NaN a match for itself

### DIFF
--- a/pkgs/matcher/CHANGELOG.md
+++ b/pkgs/matcher/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## 0.12.18-wip
 
+* Add `isSorted` and related matchers for iterables.
+* Consider `NaN` to be equal to itself in `equals`.
 * Remove some dynamic invocations.
 * Add explicit casts from `dynamic` values.
 * Require Dart 3.7
-* Add `isSorted` and related matchers for iterables.
 
 ## 0.12.17
 

--- a/pkgs/matcher/lib/src/equals_matcher.dart
+++ b/pkgs/matcher/lib/src/equals_matcher.dart
@@ -209,9 +209,15 @@ class _DeepMatcher extends Matcher {
         }
       });
     } else {
-      // Otherwise, test for equality.
+      // Otherwise, test for equality, or both values NaN
       try {
-        if (expected == actual) return null;
+        if (expected == actual ||
+            (expected is num &&
+                expected.isNaN &&
+                actual is num &&
+                actual.isNaN)) {
+          return null;
+        }
       } catch (e) {
         // TODO(gram): Add a test for this case.
         return _Mismatch(

--- a/pkgs/matcher/test/core_matchers_test.dart
+++ b/pkgs/matcher/test/core_matchers_test.dart
@@ -95,6 +95,32 @@ void main() {
     );
   });
 
+  test('equals with NaN', () {
+    final a = double.nan;
+    final b = 0;
+    shouldPass(a, equals(a));
+    shouldFail(a, equals(b), 'Expected: <0> Actual: <NaN>');
+    shouldFail(b, equals(a), 'Expected: <NaN> Actual: <0>');
+  });
+
+  test('equals with NaN in a collection', () {
+    final a = {double.nan};
+    final b = {0};
+    shouldPass(a, equals(a));
+    shouldFail(
+      a,
+      equals(b),
+      'Expected: Set:[0] Actual: Set:[NaN] '
+      'Which: does not contain <0>',
+    );
+    shouldFail(
+      b,
+      equals(a),
+      'Expected: Set:[NaN] Actual: Set:[0] '
+      'Which: does not contain <NaN>',
+    );
+  });
+
   test('anything', () {
     var a = <Object?, Object?>{};
     shouldPass(0, anything);


### PR DESCRIPTION
Closes #2520

A `double.nan` is not equal to itself with the `==` operator, but for
the purposes of testing it's easier to consider a `NaN` correct where a
`NaN` was expected. This matches behavior in several other testing
frameworks in other languages. This is unlikely to cause existing tests
to fail or change semantics since a test is unlikely to use non-equality
as a positive indication of a `NaN` result.
