### PR TITLE
Allow connecting to the runner from test suite

### DIFF
--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## 0.7.8-wip
 
+* Add a zone function available from the test suite `main` that allows creating
+  channels to the test runner.
 * Restrict to latest version of analyzer package.
-- Require Dart 3.7
+* Require Dart 3.7
 
 ## 0.7.7
 

--- a/pkgs/test_api/lib/src/backend/declarer.dart
+++ b/pkgs/test_api/lib/src/backend/declarer.dart
@@ -191,8 +191,8 @@ class Declarer {
   /// Runs [body] with this declarer as [Declarer.current].
   ///
   /// Returns the return value of [body].
-  T declare<T>(T Function() body) =>
-      runZoned(body, zoneValues: {#test.declarer: this});
+  T declare<T>(T Function() body, {Map<Symbol, Object?>? zoneValues}) =>
+      runZoned(body, zoneValues: {#test.declarer: this, ...?zoneValues});
 
   /// Defines a test case with the given name and body.
   void test(

--- a/pkgs/test_api/lib/src/backend/remote_listener.dart
+++ b/pkgs/test_api/lib/src/backend/remote_listener.dart
@@ -133,7 +133,12 @@ final class RemoteListener {
             await beforeLoad(suiteChannelManager.connectOut);
           }
 
-          await declarer.declare(main);
+          await declarer.declare(
+            main,
+            zoneValues: {
+              #test.openChannelCallback: suiteChannelManager.connectOut,
+            },
+          );
 
           var suite = Suite(
             declarer.build(),


### PR DESCRIPTION
Closes #2497

Add a zone variable when the declarer runs `main` from the test suite
which gives access to the `connectOut` callback which creates a channel
back to the runner with a provided name.

Add an optional argument allowing a map of zone values to the `declare`
method and use it from the remote listener.
