### PR TITLE
Drop executable arguments forwarding

### DIFF
--- a/pkgs/test/test/runner/precompiled_test.dart
+++ b/pkgs/test/test/runner/precompiled_test.dart
@@ -272,7 +272,6 @@ Future<void> _precompileBrowserTest(String testPath) async {
   var dart2js = await TestProcess.start(Platform.resolvedExecutable, [
     'compile',
     'js',
-    ...Platform.executableArguments,
     '--packages=${(await Isolate.packageConfig)!.toFilePath()}',
     file.path,
     '--out=precompiled/$testPath.browser_test.dart.js',


### PR DESCRIPTION
Closes #2527

During the null safety migration there were `dart` level flags that
needed to be kept in sync for precompiled JS tests so the platform
executable arguments were forwarded direclty. This is currently causing
a test failure, and there are no null safety related `dart` level flags
so drop the forwarding.
