### PR TITLE
Serve dart2wasm source map files

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Restrict to latest version of analyzer package.
 * Require Dart 3.7
 * Add `--coverage-path` and `--branch-coverage` options to `dart test`.
+* Serve dart2wasm source map files.
 
 ## 1.26.3
 

--- a/pkgs/test/lib/src/runner/browser/compilers/dart2wasm.dart
+++ b/pkgs/test/lib/src/runner/browser/compilers/dart2wasm.dart
@@ -125,21 +125,21 @@ class Dart2WasmSupport extends CompilerSupport with WasmHtmlWrapper {
     SuitePlatform platform,
   ) {
     return _compileFutures.putIfAbsent(dartPath, () async {
-      final dir = Directory(_compiledDir).createTempSync('test_').path;
+      var dir = Directory(_compiledDir).createTempSync('test_').path;
 
-      final baseCompiledPath = p.join(
+      var baseCompiledPath = p.join(
         dir,
         '${p.basename(dartPath)}.browser_test.dart',
       );
-      final baseUrl =
+      var baseUrl =
           '${p.toUri(p.relative(dartPath, from: _root)).path}.browser_test.dart';
-      final wasmUrl = '$baseUrl.wasm';
-      final sourceMapUrl = '$wasmUrl.map';
-      final jsRuntimeWrapperUrl = '$baseUrl.js';
-      final jsRuntimeUrl = '$baseUrl.mjs';
-      final htmlUrl = '$baseUrl.html';
+      var wasmUrl = '$baseUrl.wasm';
+      var sourceMapUrl = '$wasmUrl.map';
+      var jsRuntimeWrapperUrl = '$baseUrl.js';
+      var jsRuntimeUrl = '$baseUrl.mjs';
+      var htmlUrl = '$baseUrl.html';
 
-      final bootstrapContent = '''
+      var bootstrapContent = '''
         ${suiteConfig.metadata.languageVersionComment ?? await rootPackageLanguageVersionComment}
         import 'package:test/src/bootstrap/browser.dart';
 
@@ -157,7 +157,7 @@ class Dart2WasmSupport extends CompilerSupport with WasmHtmlWrapper {
       );
       if (_closed) return;
 
-      final wasmPath = '$baseCompiledPath.wasm';
+      var wasmPath = '$baseCompiledPath.wasm';
       _pathHandler.add(wasmUrl, (request) {
         return shelf.Response.ok(
           File(wasmPath).readAsBytesSync(),
@@ -172,7 +172,7 @@ class Dart2WasmSupport extends CompilerSupport with WasmHtmlWrapper {
         );
       });
 
-      final jsRuntimePath = '$baseCompiledPath.mjs';
+      var jsRuntimePath = '$baseCompiledPath.mjs';
       _pathHandler.add(jsRuntimeUrl, (request) {
         return shelf.Response.ok(
           File(jsRuntimePath).readAsBytesSync(),
@@ -180,7 +180,7 @@ class Dart2WasmSupport extends CompilerSupport with WasmHtmlWrapper {
         );
       });
 
-      final htmlPath = '$baseCompiledPath.html';
+      var htmlPath = '$baseCompiledPath.html';
       _pathHandler.add(htmlUrl, (request) {
         return shelf.Response.ok(
           File(htmlPath).readAsBytesSync(),
@@ -188,7 +188,7 @@ class Dart2WasmSupport extends CompilerSupport with WasmHtmlWrapper {
         );
       });
 
-      final sourceMapPath = '$wasmPath.map';
+      var sourceMapPath = '$wasmPath.map';
       _pathHandler.add(sourceMapUrl, (request) {
         return shelf.Response.ok(
           File(sourceMapPath).readAsBytesSync(),

--- a/pkgs/test/lib/src/runner/browser/compilers/dart2wasm.dart
+++ b/pkgs/test/lib/src/runner/browser/compilers/dart2wasm.dart
@@ -125,20 +125,21 @@ class Dart2WasmSupport extends CompilerSupport with WasmHtmlWrapper {
     SuitePlatform platform,
   ) {
     return _compileFutures.putIfAbsent(dartPath, () async {
-      var dir = Directory(_compiledDir).createTempSync('test_').path;
+      final dir = Directory(_compiledDir).createTempSync('test_').path;
 
-      var baseCompiledPath = p.join(
+      final baseCompiledPath = p.join(
         dir,
         '${p.basename(dartPath)}.browser_test.dart',
       );
-      var baseUrl =
+      final baseUrl =
           '${p.toUri(p.relative(dartPath, from: _root)).path}.browser_test.dart';
-      var wasmUrl = '$baseUrl.wasm';
-      var jsRuntimeWrapperUrl = '$baseUrl.js';
-      var jsRuntimeUrl = '$baseUrl.mjs';
-      var htmlUrl = '$baseUrl.html';
+      final wasmUrl = '$baseUrl.wasm';
+      final sourceMapUrl = '$wasmUrl.map';
+      final jsRuntimeWrapperUrl = '$baseUrl.js';
+      final jsRuntimeUrl = '$baseUrl.mjs';
+      final htmlUrl = '$baseUrl.html';
 
-      var bootstrapContent = '''
+      final bootstrapContent = '''
         ${suiteConfig.metadata.languageVersionComment ?? await rootPackageLanguageVersionComment}
         import 'package:test/src/bootstrap/browser.dart';
 
@@ -156,7 +157,7 @@ class Dart2WasmSupport extends CompilerSupport with WasmHtmlWrapper {
       );
       if (_closed) return;
 
-      var wasmPath = '$baseCompiledPath.wasm';
+      final wasmPath = '$baseCompiledPath.wasm';
       _pathHandler.add(wasmUrl, (request) {
         return shelf.Response.ok(
           File(wasmPath).readAsBytesSync(),
@@ -171,7 +172,7 @@ class Dart2WasmSupport extends CompilerSupport with WasmHtmlWrapper {
         );
       });
 
-      var jsRuntimePath = '$baseCompiledPath.mjs';
+      final jsRuntimePath = '$baseCompiledPath.mjs';
       _pathHandler.add(jsRuntimeUrl, (request) {
         return shelf.Response.ok(
           File(jsRuntimePath).readAsBytesSync(),
@@ -179,11 +180,19 @@ class Dart2WasmSupport extends CompilerSupport with WasmHtmlWrapper {
         );
       });
 
-      var htmlPath = '$baseCompiledPath.html';
+      final htmlPath = '$baseCompiledPath.html';
       _pathHandler.add(htmlUrl, (request) {
         return shelf.Response.ok(
           File(htmlPath).readAsBytesSync(),
           headers: {'Content-Type': 'text/html'},
+        );
+      });
+
+      final sourceMapPath = '$wasmPath.map';
+      _pathHandler.add(sourceMapUrl, (request) {
+        return shelf.Response.ok(
+          File(sourceMapPath).readAsBytesSync(),
+          headers: {'Content-Type': 'application/json'},
         );
       });
     });


### PR DESCRIPTION
dart2wasm generates a source map file at the same location with the .wasm file. Serve it to help with debugging in the browser with `--pause-after-load`.

Note: somehow the source map file is not requested by the browser when testing with just `test -p chrome -c dart2wasm` (without `--pause-after-load` and manually adding breakpoints). I'm investigating why the source map isn't requested by default. When I run the same failing test with `-c dart2js` the source map is used.