### PR TITLE
Remove executable argument forwarding in tests

### DIFF
--- a/pkgs/test/test/io.dart
+++ b/pkgs/test/test/io.dart
@@ -142,10 +142,6 @@ Future<TestProcess> runDart(
   String? packageConfig,
 }) async {
   var allArgs = <String>[
-    ...Platform.executableArguments.where(
-      (arg) =>
-          !arg.startsWith('--package-root=') && !arg.startsWith('--packages='),
-    ),
     '--packages=${packageConfig ?? await Isolate.packageConfig}',
     ...args,
   ];


### PR DESCRIPTION
Similar to #2528

This case of argument forwarding existed since the test runner was first
written. It's not clear exactly why it was necessary, and it should be safe
to remove.

The existing argument forwarding breaks some tests on CI where an
unexpected argument is passed to some dart invocations.
