### PR TITLE
Fix stdout color support check

### DIFF
--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Restrict to latest version of analyzer package.
 * Require Dart 3.7
 * Add `--coverage-path` and `--branch-coverage` options to `dart test`.
+* Don't generate ANSI color codes when stdout is redirected or piped.
 
 ## 0.6.12
 

--- a/pkgs/test_core/lib/src/scaffolding.dart
+++ b/pkgs/test_core/lib/src/scaffolding.dart
@@ -11,6 +11,7 @@ import 'package:test_api/scaffolding.dart' show Timeout, pumpEventQueue;
 import 'package:test_api/src/backend/declarer.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/invoker.dart'; // ignore: implementation_imports
 
+import 'runner/configuration.dart';
 import 'runner/engine.dart';
 import 'runner/plugin/environment.dart';
 import 'runner/reporter/expanded.dart';
@@ -63,7 +64,7 @@ Declarer get _declarer {
     ExpandedReporter.watch(
       engine,
       PrintSink(),
-      color: true,
+      color: Configuration.empty.color,
       printPath: false,
       printPlatform: false,
     );

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -95,11 +95,19 @@ final _tempDir =
         ? Platform.environment['_UNITTEST_TEMP_DIR']!
         : Directory.systemTemp.path;
 
-/// Whether or not the current terminal supports ansi escape codes.
+/// Whether or not [stdout] supports ANSI escape codes.
 ///
 /// Otherwise only printable ASCII characters should be used.
+///
+/// We assume that most terminals support color codes and just check that
+/// [stdout] is a tty.
+///
+/// We can't use [supportsAnsiEscapes] as it's broken:
+/// https://github.com/dart-lang/sdk/issues/31606
 bool get canUseSpecialChars =>
-    (!Platform.isWindows || stdout.supportsAnsiEscapes) && !inTestTests;
+    !Platform.isWindows &&
+    stdioType(stdout) == StdioType.terminal &&
+    !inTestTests;
 
 /// Detect whether we're running in a Github Actions context.
 ///


### PR DESCRIPTION
Currently `canUseSpecialChars` returns `true` when not in Windows and not in tests of the package itself.

This causes color codes to be printed when stdout is redirected or piped.

Fix it by checking if stdout is a tty. If it is, then we assume that most terminals today support colors and return `true`.

(We can't use the standard library `supportsAnsiEscapes` as it only returns `true` when `$TERM` is `xterm`, see
https://github.com/dart-lang/sdk/issues/31606.)

Also fix the extended reporter's color support flag initialization, which was hard-coded as `true`.

Fixes #19.