### PR TITLE
Allow exceptions from operator ==

### DIFF
--- a/pkgs/matcher/CHANGELOG.md
+++ b/pkgs/matcher/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Add `isSorted` and related matchers for iterables.
 * Consider `NaN` to be equal to itself in `equals`.
+* Allow exceptions from `operator ==` to bubble up and fail the test instead of
+  treating them as unequal objects.
 * Remove some dynamic invocations.
 * Add explicit casts from `dynamic` values.
 * Require Dart 3.7

--- a/pkgs/matcher/lib/src/equals_matcher.dart
+++ b/pkgs/matcher/lib/src/equals_matcher.dart
@@ -210,22 +210,12 @@ class _DeepMatcher extends Matcher {
       });
     } else {
       // Otherwise, test for equality, or both values NaN
-      try {
-        if (expected == actual ||
-            (expected is num &&
-                expected.isNaN &&
-                actual is num &&
-                actual.isNaN)) {
-          return null;
-        }
-      } catch (e) {
-        // TODO(gram): Add a test for this case.
-        return _Mismatch(
-          location,
-          actual,
-          (description, verbose) =>
-              description.add('== threw ').addDescriptionOf(e),
-        );
+      if (expected == actual ||
+          (expected is num &&
+              expected.isNaN &&
+              actual is num &&
+              actual.isNaN)) {
+        return null;
       }
     }
 


### PR DESCRIPTION
It's confusing to treat an object that throws from `operator ==`
identically to one that returns `false` normally. Intentional exceptions
in `operator ==` are very unlikely, so this change is not likely to
cause spurious failures.
