### PR TITLE
Make all package:coverage imports conditional

### DIFF
--- a/pkgs/test_core/lib/src/runner/coverage.dart
+++ b/pkgs/test_core/lib/src/runner/coverage.dart
@@ -12,7 +12,7 @@ import '../util/package_config.dart';
 import 'live_suite_controller.dart';
 
 /// Collects coverage and outputs to the [coveragePath] path.
-Future<Map<String, HitMap>> writeCoverage(
+Future<Coverage> writeCoverage(
   String? coveragePath,
   LiveSuiteController controller,
 ) async {
@@ -35,7 +35,7 @@ Future<Map<String, HitMap>> writeCoverage(
 
 Future<void> writeCoverageLcov(
   String coverageLcov,
-  Map<String, HitMap> allCoverageData,
+  Coverage allCoverageData,
 ) async {
   final resolver = await Resolver.create(
     packagePath: (await currentPackage).root.toFilePath(),
@@ -50,4 +50,10 @@ Future<void> writeCoverageLcov(
   out.write(lcovData);
   await out.flush();
   await out.close();
+}
+
+typedef Coverage = Map<String, HitMap>;
+
+extension Merge on Coverage {
+  void merge(Coverage other) => FileHitMaps(this).merge(other);
 }

--- a/pkgs/test_core/lib/src/runner/coverage_stub.dart
+++ b/pkgs/test_core/lib/src/runner/coverage_stub.dart
@@ -2,11 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:coverage/coverage.dart';
-
 import 'live_suite_controller.dart';
 
-Future<Map<String, HitMap>> writeCoverage(
+Future<Coverage> writeCoverage(
   String? coveragePath,
   LiveSuiteController controller,
 ) =>
@@ -14,10 +12,16 @@ Future<Map<String, HitMap>> writeCoverage(
       'Coverage is only supported through the test runner.',
     );
 
-Future<void> writeCoverageLcov(
-  String coverageLcov,
-  Map<String, HitMap> allCoverageData,
-) =>
+Future<void> writeCoverageLcov(String coverageLcov, Coverage allCoverageData) =>
     throw UnsupportedError(
       'Coverage is only supported through the test runner.',
     );
+
+typedef Coverage = Map<String, void>;
+
+extension Merge on Coverage {
+  void merge(Coverage other) =>
+      throw UnsupportedError(
+        'Coverage is only supported through the test runner.',
+      );
+}

--- a/pkgs/test_core/lib/src/runner/engine.dart
+++ b/pkgs/test_core/lib/src/runner/engine.dart
@@ -7,7 +7,6 @@ import 'dart:math';
 
 import 'package:async/async.dart' hide Result;
 import 'package:collection/collection.dart';
-import 'package:coverage/coverage.dart';
 import 'package:pool/pool.dart';
 import 'package:test_api/src/backend/group.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/invoker.dart'; // ignore: implementation_imports
@@ -68,7 +67,7 @@ class Engine {
   final String? _coverageLcov;
 
   /// The merged coverage data from all tests.
-  final Map<String, HitMap> _allCoverageData = {};
+  final Coverage _allCoverageData = {};
 
   /// The seed used to generate randomness for test case shuffling.
   ///


### PR DESCRIPTION
The `package:coverage` library imports `dart:io` directly and cannot be
a dependency of apps compiled to platforms without `dart:io`. All
imports and uses of `package:coverage` must be through platform specific
imports. Add extra indirection in the `coverage.dart` and
`coverage_stub.dart` libraries so that `engine.dart` does not need to
import `package:coverage` or refer to the `HitMap` type it exports. Add
a forwarding implementation of the `merge` extension.
