### PR TITLE
[matcher] Add type check in pairwiseCompare

### DIFF
--- a/pkgs/matcher/CHANGELOG.md
+++ b/pkgs/matcher/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.12.19-wip
 
 * Improve speed of pretty printing for large collections.
+* Improve output of pairwiseCompare with mismatched types.
 
 ## 0.12.18
 

--- a/pkgs/matcher/lib/src/iterable_matchers.dart
+++ b/pkgs/matcher/lib/src/iterable_matchers.dart
@@ -297,7 +297,8 @@ class _PairwiseCompare<S, T> extends _IterableMatcher {
     var i = 0;
     for (var e in _expected) {
       iterator.moveNext();
-      if (!_comparator(e, iterator.current as T)) {
+      var current = iterator.current;
+      if (current is! T || !_comparator(e, current)) {
         addStateInfo(matchState, {
           'index': i,
           'expected': e,

--- a/pkgs/matcher/test/iterable_matchers_test.dart
+++ b/pkgs/matcher/test/iterable_matchers_test.dart
@@ -422,6 +422,17 @@ void main() {
     );
   });
 
+  test('pairwiseCompare with mismatched types', () async {
+    final notInts = ['notInt'];
+    shouldFail(
+      notInts,
+      pairwiseCompare([1], (int e, int a) => a <= e, 'less than or equal'),
+      'Expected: pairwise less than or equal [1] '
+      "Actual: ['notInt'] "
+      "Which: has 'notInt' which is not less than or equal <1> at index 0",
+    );
+  });
+
   test('isEmpty', () {
     var d = SimpleIterable(0);
     var e = SimpleIterable(1);


### PR DESCRIPTION
Closes #2454

Currently a failure from the cast causes a failure output including:

     Which: has <null> which is not  <null> at index null

Fill in the missing info by adding an explicit type check instead of an
unchecked cast before passing to the comparison callback. Elements with
mismatched type are treated identically to those which fail the
comparison, but should be clear to a reader of the failure.
