### PR TITLE
Fix exception for missing resolved executable

### DIFF
--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -38,8 +38,14 @@ final int lineLength = () {
   }
 }();
 
-/// The root directory of the Dart SDK.
-final String sdkDir = p.dirname(p.dirname(Platform.resolvedExecutable));
+/// The root directory of the Dart SDK if it can be located.
+final String? sdkDir = () {
+  try {
+    return p.dirname(p.dirname(Platform.resolvedExecutable));
+  } on Exception {
+    return null;
+  }
+}();
 
 /// The current operating system.
 final currentOS = OperatingSystem.findByIoName(Platform.operatingSystem);


### PR DESCRIPTION
In some executions of the test runner internally the
`Platform.resolvedExectuble` may be unexpectedly `null`. Catch
exceptions trying to read the field and allow a `null` return. The usage
for this variable currently prepends it to file paths, and it's safe to
search the "wrong" full path and not find the file.
