### PR TITLE
Catch Errors reading resolved executable

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.31.1-wip
+
+* Ignore an error locating the SDK directory on platforms where the
+  `resolvedExecutable` is unexpectedly null.
+
 ## 1.31.0
 
 * Print a summary of failed tests at the end of the expanded reporter output.

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.31.1-wip
 
 * Ignore an error locating the SDK directory on platforms where the
-  `resolvedExecutable` is unexpectedly null.
+  `resolvedExecutable` is unexpectedly `null`.
 
 ## 1.31.0
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.31.0
+version: 1.31.1-wip
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test
@@ -36,7 +36,7 @@ dependencies:
 
   # Use an exact version until the test_api and test_core package are stable.
   test_api: 0.7.11
-  test_core: 0.6.17
+  test_core: 0.6.18-wip
 
   typed_data: ^1.3.0
   web_socket_channel: '>=2.0.0 <4.0.0'

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.6.18-wip
 
 * Ignore an error locating the SDK directory on platforms where the
-  `resolvedExecutable` is unexpectedly null.
+  `resolvedExecutable` is unexpectedly `null`.
 
 ## 0.6.17
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.18-wip
+
+* Ignore an error locating the SDK directory on platforms where the
+  `resolvedExecutable` is unexpectedly null.
+
 ## 0.6.17
 
 * Print a summary of failed tests at the end of the expanded reporter output.

--- a/pkgs/test_core/lib/src/util/io.dart
+++ b/pkgs/test_core/lib/src/util/io.dart
@@ -42,7 +42,7 @@ final int lineLength = () {
 final String? sdkDir = () {
   try {
     return p.dirname(p.dirname(Platform.resolvedExecutable));
-  } on Exception {
+  } catch (_) {
     return null;
   }
 }();

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.6.17
+version: 0.6.18-wip
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 issue_tracker: https://github.com/dart-lang/test/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Atest


### PR DESCRIPTION
In some internal platform implementation the `resolvedExecutable` is
unexpectedly `null` and causes a `TypeError`. Generalize the catch to
ignore all errors, not just exceptions.
