### PR TITLE
Fix hang on windows with multiple exe tests

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -715,7 +715,7 @@ jobs:
       - job_005
       - job_006
   job_018:
-    name: "unit_test; linux; Dart 3.7.0; PKG: pkgs/test_api; `dart test --preset travis -x browser`"
+    name: "unit_test; linux; Dart 3.7.0; PKG: pkgs/test_api; `dart test --preset travis -x browser -c kernel,exe`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -740,8 +740,8 @@ jobs:
         run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: pkgs/test_api
-      - name: "pkgs/test_api; dart test --preset travis -x browser"
-        run: dart test --preset travis -x browser
+      - name: "pkgs/test_api; dart test --preset travis -x browser -c kernel,exe"
+        run: "dart test --preset travis -x browser -c kernel,exe"
         if: "always() && steps.pkgs_test_api_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/test_api
     needs:
@@ -1159,7 +1159,7 @@ jobs:
       - job_005
       - job_006
   job_030:
-    name: "unit_test; linux; Dart dev; PKG: pkgs/test_api; `dart test --preset travis -x browser`"
+    name: "unit_test; linux; Dart dev; PKG: pkgs/test_api; `dart test --preset travis -x browser -c kernel,exe`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
@@ -1184,8 +1184,8 @@ jobs:
         run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: pkgs/test_api
-      - name: "pkgs/test_api; dart test --preset travis -x browser"
-        run: dart test --preset travis -x browser
+      - name: "pkgs/test_api; dart test --preset travis -x browser -c kernel,exe"
+        run: "dart test --preset travis -x browser -c kernel,exe"
         if: "always() && steps.pkgs_test_api_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/test_api
     needs:

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Ignore an error locating the SDK directory on platforms where the
   `resolvedExecutable` is unexpectedly `null`.
+* Fix a bug where `-c exe` tests would hang on exit on windows.
 
 ## 1.31.0
 

--- a/pkgs/test_api/mono_pkg.yaml
+++ b/pkgs/test_api/mono_pkg.yaml
@@ -13,7 +13,7 @@ stages:
     - dev
 - unit_test:
   - group:
-    - command: dart test --preset travis -x browser
+    - command: dart test --preset travis -x browser -c kernel,exe
       os:
       - linux
       - windows

--- a/pkgs/test_api/test/import_restrictions_test.dart
+++ b/pkgs/test_api/test/import_restrictions_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn('!exe')
+library;
+
 import 'dart:async';
 import 'dart:io';
 import 'dart:isolate';

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -4,6 +4,7 @@
   `resolvedExecutable` is unexpectedly `null`.
 * Respect `NO_COLOR`, `CLICOLOR`, `FORCE_COLOR`, `CLICOLOR_FORCE`, and `TERM=dumb`
   environment variables for color output detection.
+* Fix a bug where `-c exe` tests would hang on exit on windows.
 
 ## 0.6.17
 

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -75,8 +75,8 @@ class VMPlatform extends PlatformPlugin {
       var socket = await serverSocket.first;
       outerChannel = MultiChannel<Object?>(jsonSocketStreamChannel(socket));
       cleanupCallbacks
-        ..add(serverSocket.close)
         ..add(socket.destroy)
+        ..add(serverSocket.close)
         ..add(process.kill);
     } else {
       var receivePort = ReceivePort();

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -116,8 +116,8 @@ for PKG in ${PKGS}; do
         dart test --preset travis --total-shards 5 --shard-index 4 || EXIT_CODE=$?
         ;;
       command_11)
-        echo 'dart test --preset travis -x browser'
-        dart test --preset travis -x browser || EXIT_CODE=$?
+        echo 'dart test --preset travis -x browser -c kernel,exe'
+        dart test --preset travis -x browser -c kernel,exe || EXIT_CODE=$?
         ;;
       format)
         echo 'dart format --output=none --set-exit-if-changed .'


### PR DESCRIPTION
Fixes https://github.com/dart-lang/test/issues/2617

Not sure exactly what is happening here, but re-ordering the `socket.destroy` and `serverSocket.close` calls appears to resolve the issue.

Also enabled `-c exe` tests for test_api to help get better coverage of these kinds of tests.