### PR TITLE
Allow analyzer ^13.0.0, with breaking changes.

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Ignore an error locating the SDK directory on platforms where the
   `resolvedExecutable` is unexpectedly `null`.
 * Fix a bug where `-c exe` tests would hang on exit on windows.
-* Require `analyzer: ^13.0.0`
+* Allow `analyzer` version  `13.x.x`.
 
 ## 1.31.0
 

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Ignore an error locating the SDK directory on platforms where the
   `resolvedExecutable` is unexpectedly `null`.
 * Fix a bug where `-c exe` tests would hang on exit on windows.
+* Require `analyzer: ^13.0.0`
 
 ## 1.31.0
 

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   stream_channel: ^2.1.0
 
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.7.11
+  test_api: 0.7.12-wip
   test_core: 0.6.18-wip
 
   typed_data: ^1.3.0

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  analyzer: ^13.0.0
+  analyzer: '>=8.0.0 <14.0.0'
   async: ^2.5.0
   boolean_selector: ^2.1.0
   collection: ^1.15.0

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  analyzer: '>=8.0.0 <13.0.0'
+  analyzer: ^13.0.0
   async: ^2.5.0
   boolean_selector: ^2.1.0
   collection: ^1.15.0

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,10 +1,13 @@
+## 0.7.12-wip
+
+* Allow `analyzer` major version 13.
+
 ## 0.7.11
 
 * Add `vmAsan`, `vmMsan` and `vmTsan` runtimes.
 * Change return type on the `body` callback argument to `group` to `void` from
   `dynamic`. This may surface cases where the group callback was erroneously
   returning an ignored value.
-* Allow `analyzer` major version 13.
 
 ## 0.7.10
 

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Change return type on the `body` callback argument to `group` to `void` from
   `dynamic`. This may surface cases where the group callback was erroneously
   returning an ignored value.
-* Require `analyzer: '>=8.0.0 <13.0.0'`
+* Allow `analyzer` major version 13.
 
 ## 0.7.10
 

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   term_glyph: ^1.2.0
 
 dev_dependencies:
-  analyzer: ^13.0.0
+  analyzer: '>=8.0.0 <14.0.0'
   fake_async: ^1.2.0
   glob: ^2.0.0
   graphs: ^2.0.0

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   term_glyph: ^1.2.0
 
 dev_dependencies:
-  analyzer: '>=8.0.0 <13.0.0'
+  analyzer: ^13.0.0
   fake_async: ^1.2.0
   glob: ^2.0.0
   graphs: ^2.0.0

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.7.11
+version: 0.7.12-wip
 description: >-
   The user facing API for structuring Dart tests and checking expectations.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_api

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Respect `NO_COLOR`, `CLICOLOR`, `FORCE_COLOR`, `CLICOLOR_FORCE`, and `TERM=dumb`
   environment variables for color output detection.
 * Fix a bug where `-c exe` tests would hang on exit on windows.
+* Update `parse_metadata.dart` to be compatible with `analyzer >=8.0.0 <14.0.0`.
 
 ## 0.6.17
 

--- a/pkgs/test_core/lib/src/runner/parse_metadata.dart
+++ b/pkgs/test_core/lib/src/runner/parse_metadata.dart
@@ -622,7 +622,7 @@ extension type const CompatibleArgument(AstNode _node) {
     }
     // Old analyzer or positional in new analyzer.
     try {
-        var nameObj = (_node as dynamic).name;
+      var nameObj = (_node as dynamic).name;
       if (nameObj is Label) {
         return (nameObj as dynamic).label.name as String;
       }

--- a/pkgs/test_core/lib/src/runner/parse_metadata.dart
+++ b/pkgs/test_core/lib/src/runner/parse_metadata.dart
@@ -163,8 +163,9 @@ class _Parser {
   /// Parses a `@Retry` annotation.
   ///
   /// [annotation] is the annotation.
-  int _parseRetry(Annotation annotation) =>
-      _parseInt(annotation.arguments!.compatibleArguments.first.argumentExpression);
+  int _parseRetry(Annotation annotation) => _parseInt(
+    annotation.arguments!.compatibleArguments.first.argumentExpression,
+  );
 
   /// Parses a `@Timeout` annotation.
   ///
@@ -331,12 +332,12 @@ class _Parser {
     );
   }
 
-  Map<String, Expression> _parseNamedArguments(Iterable<CompatibleArgument> arguments) =>
-      {
-        for (var argument in arguments)
-          if (argument.name case String name)
-            name: argument.argumentExpression,
-      };
+  Map<String, Expression> _parseNamedArguments(
+    Iterable<CompatibleArgument> arguments,
+  ) => {
+    for (var argument in arguments)
+      if (argument.name case String name) name: argument.argumentExpression,
+  };
 
   /// Asserts that [existing] is null.
   ///
@@ -602,7 +603,6 @@ class _Parser {
       throw SourceSpanFormatException(error.message, span);
     }
   }
-
 }
 
 extension ArgumentListExt on ArgumentList {
@@ -622,7 +622,7 @@ extension type const CompatibleArgument(AstNode _node) {
     }
     // Old analyzer or positional in new analyzer.
     try {
-      var nameObj = (_node as dynamic).name;
+        var nameObj = (_node as dynamic).name;
       if (nameObj is Label) {
         return (nameObj as dynamic).label.name as String;
       }

--- a/pkgs/test_core/lib/src/runner/parse_metadata.dart
+++ b/pkgs/test_core/lib/src/runner/parse_metadata.dart
@@ -145,7 +145,7 @@ class _Parser {
   /// [annotation] is the annotation.
   PlatformSelector _parseTestOn(Annotation annotation) =>
       _parsePlatformSelector(
-        annotation.arguments!.arguments.first.argumentExpression,
+        annotation.arguments!.compatibleArguments.first.argumentExpression,
       );
 
   /// Parses an [expression] that should contain a string representing a
@@ -164,7 +164,7 @@ class _Parser {
   ///
   /// [annotation] is the annotation.
   int _parseRetry(Annotation annotation) =>
-      _parseInt(annotation.arguments!.arguments.first.argumentExpression);
+      _parseInt(annotation.arguments!.compatibleArguments.first.argumentExpression);
 
   /// Parses a `@Timeout` annotation.
   ///
@@ -175,7 +175,7 @@ class _Parser {
       return Timeout.none;
     }
 
-    var args = annotation.arguments!.arguments;
+    var args = annotation.arguments!.compatibleArguments;
     if (constructorName == null) {
       return Timeout(_parseDuration(args.first.argumentExpression));
     }
@@ -201,7 +201,7 @@ class _Parser {
   ///
   /// Returns either `true` or a reason string.
   dynamic _parseSkip(Annotation annotation) {
-    var args = annotation.arguments!.arguments;
+    var args = annotation.arguments!.compatibleArguments;
     return args.isEmpty
         ? true
         : _parseString(args.first.argumentExpression).stringValue;
@@ -223,7 +223,7 @@ class _Parser {
   /// [annotation] is the annotation.
   Set<String> _parseTags(Annotation annotation) {
     return _parseList(
-      annotation.arguments!.arguments.first.argumentExpression,
+      annotation.arguments!.compatibleArguments.first.argumentExpression,
     ).map((tagExpression) {
       var name = _parseString(tagExpression).stringValue!;
       if (name.contains(anchoredHyphenatedIdentifier)) return name;
@@ -241,7 +241,7 @@ class _Parser {
   /// [annotation] is the annotation.
   Map<PlatformSelector, Metadata> _parseOnPlatform(Annotation annotation) {
     return _parseMap(
-      annotation.arguments!.arguments.first.argumentExpression,
+      annotation.arguments!.compatibleArguments.first.argumentExpression,
       key: _parsePlatformSelector,
       value: (value) {
         var expressions = <AstNode>[];
@@ -331,10 +331,11 @@ class _Parser {
     );
   }
 
-  Map<String, Expression> _parseNamedArguments(NodeList<Argument> arguments) =>
+  Map<String, Expression> _parseNamedArguments(Iterable<CompatibleArgument> arguments) =>
       {
-        for (var a in arguments.whereType<NamedArgument>())
-          a.name.lexeme: a.argumentExpression,
+        for (var argument in arguments)
+          if (argument.name case String name)
+            name: argument.argumentExpression,
       };
 
   /// Asserts that [existing] is null.
@@ -349,12 +350,12 @@ class _Parser {
     );
   }
 
-  NodeList<Argument> _parseArguments(Expression expression) {
+  Iterable<CompatibleArgument> _parseArguments(Expression expression) {
     if (expression is InstanceCreationExpression) {
-      return expression.argumentList.arguments;
+      return expression.argumentList.compatibleArguments;
     }
     if (expression is MethodInvocation) {
-      return expression.argumentList.arguments;
+      return expression.argumentList.compatibleArguments;
     }
     throw SourceSpanFormatException(
       'Expected an instantiation',
@@ -599,6 +600,47 @@ class _Parser {
       var span = contextualizeSpan(error.span!, literal, file);
       if (span == null) rethrow;
       throw SourceSpanFormatException(error.message, span);
+    }
+  }
+
+}
+
+extension ArgumentListExt on ArgumentList {
+  Iterable<CompatibleArgument> get compatibleArguments =>
+      arguments.map(CompatibleArgument.new);
+}
+
+/// A zero-cost wrapper to provide a compatible interface for arguments
+/// across different analyzer versions.
+/// TODO(scheglov): Simplify to `Argument` when ready for `analyzer 13`.
+extension type const CompatibleArgument(AstNode _node) {
+  /// Returns the name of the named argument, or null if not a named argument.
+  String? get name {
+    if (_node is! Expression) {
+      // New analyzer: `NamedArgument.name` is a Token.
+      return (_node as dynamic).name.lexeme as String;
+    }
+    // Old analyzer or positional in new analyzer.
+    try {
+      var nameObj = (_node as dynamic).name;
+      if (nameObj is Label) {
+        return (nameObj as dynamic).label.name as String;
+      }
+    } catch (_) {
+      // Ignore
+    }
+    return null;
+  }
+
+  /// Returns the evaluation value of the argument.
+  Expression get argumentExpression {
+    if (_node is Expression) {
+      if (name != null) {
+        return (_node as dynamic).expression as Expression;
+      }
+      return _node;
+    } else {
+      return (_node as dynamic).argumentExpression as Expression;
     }
   }
 }

--- a/pkgs/test_core/lib/src/runner/parse_metadata.dart
+++ b/pkgs/test_core/lib/src/runner/parse_metadata.dart
@@ -144,7 +144,9 @@ class _Parser {
   ///
   /// [annotation] is the annotation.
   PlatformSelector _parseTestOn(Annotation annotation) =>
-      _parsePlatformSelector(annotation.arguments!.arguments.first);
+      _parsePlatformSelector(
+        annotation.arguments!.arguments.first.argumentExpression,
+      );
 
   /// Parses an [expression] that should contain a string representing a
   /// [PlatformSelector].
@@ -162,7 +164,7 @@ class _Parser {
   ///
   /// [annotation] is the annotation.
   int _parseRetry(Annotation annotation) =>
-      _parseInt(annotation.arguments!.arguments.first);
+      _parseInt(annotation.arguments!.arguments.first.argumentExpression);
 
   /// Parses a `@Timeout` annotation.
   ///
@@ -174,16 +176,22 @@ class _Parser {
     }
 
     var args = annotation.arguments!.arguments;
-    if (constructorName == null) return Timeout(_parseDuration(args.first));
-    return Timeout.factor(_parseNum(args.first));
+    if (constructorName == null) {
+      return Timeout(_parseDuration(args.first.argumentExpression));
+    }
+    return Timeout.factor(_parseNum(args.first.argumentExpression));
   }
 
   /// Parses a `Timeout` constructor.
   Timeout _parseTimeoutConstructor(Expression constructor) {
     var name = _findConstructorName(constructor, 'Timeout');
     var arguments = _parseArguments(constructor);
-    if (name == null) return Timeout(_parseDuration(arguments.first));
-    if (name == 'factor') return Timeout.factor(_parseNum(arguments.first));
+    if (name == null) {
+      return Timeout(_parseDuration(arguments.first.argumentExpression));
+    }
+    if (name == 'factor') {
+      return Timeout.factor(_parseNum(arguments.first.argumentExpression));
+    }
     throw SourceSpanFormatException('Invalid timeout', _spanFor(constructor));
   }
 
@@ -194,7 +202,9 @@ class _Parser {
   /// Returns either `true` or a reason string.
   dynamic _parseSkip(Annotation annotation) {
     var args = annotation.arguments!.arguments;
-    return args.isEmpty ? true : _parseString(args.first).stringValue;
+    return args.isEmpty
+        ? true
+        : _parseString(args.first.argumentExpression).stringValue;
   }
 
   /// Parses a `Skip` constructor.
@@ -203,16 +213,18 @@ class _Parser {
   dynamic _parseSkipConstructor(Expression constructor) {
     _findConstructorName(constructor, 'Skip');
     var arguments = _parseArguments(constructor);
-    return arguments.isEmpty ? true : _parseString(arguments.first).stringValue;
+    return arguments.isEmpty
+        ? true
+        : _parseString(arguments.first.argumentExpression).stringValue;
   }
 
   /// Parses a `@Tags` annotation.
   ///
   /// [annotation] is the annotation.
   Set<String> _parseTags(Annotation annotation) {
-    return _parseList(annotation.arguments!.arguments.first).map((
-      tagExpression,
-    ) {
+    return _parseList(
+      annotation.arguments!.arguments.first.argumentExpression,
+    ).map((tagExpression) {
       var name = _parseString(tagExpression).stringValue!;
       if (name.contains(anchoredHyphenatedIdentifier)) return name;
 
@@ -229,7 +241,7 @@ class _Parser {
   /// [annotation] is the annotation.
   Map<PlatformSelector, Metadata> _parseOnPlatform(Annotation annotation) {
     return _parseMap(
-      annotation.arguments!.arguments.first,
+      annotation.arguments!.arguments.first.argumentExpression,
       key: _parsePlatformSelector,
       value: (value) {
         var expressions = <AstNode>[];
@@ -319,12 +331,11 @@ class _Parser {
     );
   }
 
-  Map<String, Expression> _parseNamedArguments(
-    NodeList<Expression> arguments,
-  ) => {
-    for (var a in arguments.whereType<NamedExpression>())
-      a.name.label.name: a.expression,
-  };
+  Map<String, Expression> _parseNamedArguments(NodeList<Argument> arguments) =>
+      {
+        for (var a in arguments.whereType<NamedArgument>())
+          a.name.lexeme: a.argumentExpression,
+      };
 
   /// Asserts that [existing] is null.
   ///
@@ -338,7 +349,7 @@ class _Parser {
     );
   }
 
-  NodeList<Expression> _parseArguments(Expression expression) {
+  NodeList<Argument> _parseArguments(Expression expression) {
     if (expression is InstanceCreationExpression) {
       return expression.argumentList.arguments;
     }

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   stack_trace: ^1.10.0
   stream_channel: ^2.1.0
   # Use an exact version until the test_api package is stable.
-  test_api: 0.7.11
+  test_api: 0.7.12-wip
   vm_service: '>=6.0.0 <16.0.0'
   yaml: ^3.0.0
 

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  analyzer: ^13.0.0
+  analyzer: '>=8.0.0 <14.0.0'
   args: ^2.0.0
   async: ^2.5.0
   boolean_selector: ^2.1.0

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  analyzer: '>=8.0.0 <13.0.0'
+  analyzer: ^13.0.0
   args: ^2.0.0
   async: ^2.5.0
   boolean_selector: ^2.1.0


### PR DESCRIPTION
This change refers to not yet published `analyzer 13.0.0`, because I cannot land corresponding [analyzer CL](https://dart-review.googlesource.com/c/sdk/+/488624) (and then publish) without pulling a compatible version of `package:test` into the Dart SDK. So, I want to land this PR with a version of `test` that is compatible with `analyzer 13.0.0` (to be), and the pull this git commit into [the CL](https://dart-review.googlesource.com/c/sdk/+/488624).

I tested it locally with
```yaml
dependency_overrides:
  _fe_analyzer_shared:
    path: /Users/scheglov/Source/Dart/sdk.git/sdk/pkg/_fe_analyzer_shared
  analyzer:
    path: /Users/scheglov/Source/Dart/sdk.git/sdk/pkg/analyzer
```
Obviously, GitHub bots will be red until `analyzer 13.0.0` is published.