### PR TITLE
Simplify dart2wasm loading in run_wasm_chrome.js

### DIFF
--- a/pkgs/test/lib/src/runner/browser/static/run_wasm_chrome.js
+++ b/pkgs/test/lib/src/runner/browser/static/run_wasm_chrome.js
@@ -22,36 +22,12 @@
   // Instantiate the Dart module, importing from the global scope.
   let dart2wasmJsRuntime = await import(jsRuntimeUrl);
 
-  // Support three versions of dart2wasm:
-  //
-  // (1) Versions before 3.6.0-167.0.dev require the user to compile using the
-  // browser's `WebAssembly` API, the compiled module needs to be instantiated
-  // using the JS runtime.
-  //
-  // (2) Versions starting with 3.6.0-167.0.dev added helpers for compiling and
-  // instantiating.
-  //
-  // (3) Versions starting with 3.6.0-212.0.dev made compilation functions
-  // return a new type that comes with instantiation and invoke methods.
-
-  if (dart2wasmJsRuntime.compileStreaming !== undefined) {
-    // Version (2) or (3).
-    let compiledModule = await dart2wasmJsRuntime.compileStreaming(
-      fetch(wasmUrl),
-    );
-    if (compiledModule.instantiate !== undefined) {
-      // Version (3).
-      let instantiatedModule = await compiledModule.instantiate();
-      instantiatedModule.invokeMain();
-    } else {
-      // Version (2).
-      let dartInstance = await dart2wasmJsRuntime.instantiate(compiledModule, {});
-      await dart2wasmJsRuntime.invoke(dartInstance);
-    }
-  } else {
-    // Version (1).
-    let modulePromise = WebAssembly.compileStreaming(fetch(wasmUrl));
-    let dartInstance = await dart2wasmJsRuntime.instantiate(modulePromise, {});
-    await dart2wasmJsRuntime.invoke(dartInstance);
-  }
+  // dart2wasm versions starting with 3.6.0-212.0.dev return a new type that
+  // comes with instantiation and invoke methods. Since the min SDK is 3.7,
+  // we only need to support this version.
+  let compiledModule = await dart2wasmJsRuntime.compileStreaming(
+    fetch(wasmUrl),
+  );
+  let instantiatedModule = await compiledModule.instantiate();
+  instantiatedModule.invokeMain();
 })();


### PR DESCRIPTION
Since the minimum SDK of this package is now Dart 3.7, we can remove support for older dart2wasm versions (before 3.6.0-212.0.dev) which required fallbacks for compilation and instantiation.
