### PR TITLE
fix: improve error reporting on GitHub

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Ignore an error locating the SDK directory on platforms where the
   `resolvedExecutable` is unexpectedly `null`.
 * Fix a bug where `-c exe` tests would hang on exit on windows.
+* In `GithubReporter`, group contiguous passing tests into a collapsible group 
+  to reduce log noise in GitHub Actions.
 
 ## 1.31.0
 

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -3,8 +3,10 @@
 * Ignore an error locating the SDK directory on platforms where the
   `resolvedExecutable` is unexpectedly `null`.
 * Fix a bug where `-c exe` tests would hang on exit on windows.
-* In `GithubReporter`, group contiguous passing tests into a collapsible group 
-  to reduce log noise in GitHub Actions.
+* `GithubReporter`:
+    * Group contiguous passing and skipped tests into collapsible groups to
+      reduce log noise in GitHub Actions.
+    * Updated skipped icon to ⚠️.
 
 ## 1.31.0
 

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -7,7 +7,7 @@
 * `GithubReporter`:
     * Group contiguous passing and skipped tests into collapsible groups to
       reduce log noise in GitHub Actions.
-    * Updated skipped icon to ⚠️.
+    * Updated skipped icon to ⏭️.
 
 ## 1.31.0
 

--- a/pkgs/test/test/runner/github_reporter_test.dart
+++ b/pkgs/test/test/runner/github_reporter_test.dart
@@ -260,10 +260,10 @@ void main() {
           test('skip 2', () {}, skip: true);
           test('skip 3', () {}, skip: true);''',
         '''
-          ::group::⚠️ Skipped tests
-          ⚠️ skip 1 (skipped)
-          ⚠️ skip 2 (skipped)
-          ⚠️ skip 3 (skipped)
+          ::group::⏭️ Skipped tests
+          ⏭️ skip 1 (skipped)
+          ⏭️ skip 2 (skipped)
+          ⏭️ skip 3 (skipped)
           ::endgroup::
           🎉 0 tests passed, 3 skipped.''',
       );
@@ -278,10 +278,10 @@ void main() {
             test('test 3', () {});
           }, skip: true);''',
         '''
-          ::group::⚠️ Skipped tests
-          ⚠️ skip test 1 (skipped)
-          ⚠️ skip test 2 (skipped)
-          ⚠️ skip test 3 (skipped)
+          ::group::⏭️ Skipped tests
+          ⏭️ skip test 1 (skipped)
+          ⏭️ skip test 2 (skipped)
+          ⏭️ skip test 3 (skipped)
           ::endgroup::
           🎉 0 tests passed, 3 skipped.''',
       );
@@ -295,14 +295,14 @@ void main() {
           test('skip 2', () {}, skip: true);
           test('success 2', () {});''',
         '''
-          ::group::⚠️ Skipped tests
-          ⚠️ skip 1 (skipped)
+          ::group::⏭️ Skipped tests
+          ⏭️ skip 1 (skipped)
           ::endgroup::
           ::group::✅ Passing tests
           ✅ success 1
           ::endgroup::
-          ::group::⚠️ Skipped tests
-          ⚠️ skip 2 (skipped)
+          ::group::⏭️ Skipped tests
+          ⏭️ skip 2 (skipped)
           ::endgroup::
           ::group::✅ Passing tests
           ✅ success 2
@@ -325,8 +325,8 @@ void main() {
           oh no
           test.dart 6:35  main.<fn>
           ::endgroup::
-          ::group::⚠️ Skipped tests
-          ⚠️ skip 1 (skipped)
+          ::group::⏭️ Skipped tests
+          ⏭️ skip 1 (skipped)
           ::endgroup::
           ::group::✅ Passing tests
           ✅ success 1
@@ -335,8 +335,8 @@ void main() {
           oh no
           test.dart 9:35  main.<fn>
           ::endgroup::
-          ::group::⚠️ Skipped tests
-          ⚠️ skip 2 (skipped)
+          ::group::⏭️ Skipped tests
+          ⏭️ skip 2 (skipped)
           ::endgroup::
           ::group::✅ Passing tests
           ✅ success 2
@@ -351,10 +351,10 @@ void main() {
           test('skip 1', () {}, skip: 'some reason');
           test('skip 2', () {}, skip: 'or another');''',
         '''
-          ::group::⚠️ Skipped tests
-          ⚠️ skip 1 (skipped)
+          ::group::⏭️ Skipped tests
+          ⏭️ skip 1 (skipped)
           Skip: some reason
-          ⚠️ skip 2 (skipped)
+          ⏭️ skip 2 (skipped)
           Skip: or another
           ::endgroup::
           🎉 0 tests passed, 2 skipped.''',

--- a/pkgs/test/test/runner/github_reporter_test.dart
+++ b/pkgs/test/test/runner/github_reporter_test.dart
@@ -30,9 +30,11 @@ void main() {
         test('success 2', () {});
         test('success 3', () {});''',
       '''
+        ::group::✅ Passing tests
         ✅ success 1
         ✅ success 2
         ✅ success 3
+        ::endgroup::
         🎉 3 tests passed.''',
     );
   });
@@ -42,8 +44,10 @@ void main() {
       '''
         test('success 1', () {});''',
       [
+        '::group::✅ Passing tests',
         '✅ [VM, Kernel] success 1',
         '✅ [Chrome, Dart2Js] success 1',
+        '::endgroup::',
         '🎉 2 tests passed.',
       ],
       args: ['-p', 'vm,chrome'],
@@ -104,12 +108,16 @@ void main() {
         oh no
         test.dart 6:33  main.<fn>
         ::endgroup::
+        ::group::✅ Passing tests
         ✅ success 1
+        ::endgroup::
         ::group::❌ failure 2 (failed)
         oh no
         test.dart 8:33  main.<fn>
         ::endgroup::
+        ::group::✅ Passing tests
         ✅ success 2
+        ::endgroup::
         ::error::2 tests passed, 2 failed.''',
     );
   });
@@ -148,7 +156,9 @@ void main() {
         third error
         test.dart 12:34  main.<fn>.<fn>
         ::endgroup::
+        ::group::✅ Passing tests
         ✅ wait
+        ::endgroup::
         ::error::1 test passed, 1 failed.''',
     );
   });
@@ -164,7 +174,9 @@ void main() {
 
       test('second test so that the first failure is reported', () {});''',
       '''
+        ::group::✅ Passing tests
         ✅ fail after completion
+        ::endgroup::
         ::group::❌ fail after completion (failed after test completion)
         foo
         test.dart 8:62  main.<fn>.<fn>
@@ -175,7 +187,9 @@ void main() {
         of pending async work.
         test.dart 8:62  main.<fn>.<fn>
         ::endgroup::
+        ::group::✅ Passing tests
         ✅ second test so that the first failure is reported
+        ::endgroup::
         ::error::1 test passed, 1 failed.''',
     );
   });
@@ -223,12 +237,16 @@ void main() {
           return testDone.future;
         });''',
         '''
+        ::group::✅ Passing tests
         ✅ test
+        ::endgroup::
         one
         two
         three
         four
+        ::group::✅ Passing tests
         ✅ wait
+        ::endgroup::
         🎉 2 tests passed.''',
       );
     });
@@ -242,9 +260,11 @@ void main() {
           test('skip 2', () {}, skip: true);
           test('skip 3', () {}, skip: true);''',
         '''
+          ::group::✅ Passing tests
           ❎ skip 1 (skipped)
           ❎ skip 2 (skipped)
           ❎ skip 3 (skipped)
+          ::endgroup::
           🎉 0 tests passed, 3 skipped.''',
       );
     });
@@ -258,9 +278,11 @@ void main() {
             test('test 3', () {});
           }, skip: true);''',
         '''
+          ::group::✅ Passing tests
           ❎ skip test 1 (skipped)
           ❎ skip test 2 (skipped)
           ❎ skip test 3 (skipped)
+          ::endgroup::
           🎉 0 tests passed, 3 skipped.''',
       );
     });
@@ -273,10 +295,12 @@ void main() {
           test('skip 2', () {}, skip: true);
           test('success 2', () {});''',
         '''
+          ::group::✅ Passing tests
           ❎ skip 1 (skipped)
           ✅ success 1
           ❎ skip 2 (skipped)
           ✅ success 2
+          ::endgroup::
           🎉 2 tests passed, 2 skipped.''',
       );
     });
@@ -295,14 +319,18 @@ void main() {
           oh no
           test.dart 6:35  main.<fn>
           ::endgroup::
+          ::group::✅ Passing tests
           ❎ skip 1 (skipped)
           ✅ success 1
+          ::endgroup::
           ::group::❌ failure 2 (failed)
           oh no
           test.dart 9:35  main.<fn>
           ::endgroup::
+          ::group::✅ Passing tests
           ❎ skip 2 (skipped)
           ✅ success 2
+          ::endgroup::
           ::error::2 tests passed, 2 failed, 2 skipped.''',
       );
     });
@@ -333,7 +361,9 @@ void main() {
             test('test 1', () {});
           });''',
       '''
+          ::group::✅ Passing tests
           ✅ one test 1
+          ::endgroup::
           🎉 1 test passed.''',
     );
   });
@@ -350,7 +380,9 @@ void main() {
           ::group::✅ one (setUpAll)
           one
           ::endgroup::
+          ::group::✅ Passing tests
           ✅ one test 1
+          ::endgroup::
           ::group::✅ one (tearDownAll)
           two
           ::endgroup::

--- a/pkgs/test/test/runner/github_reporter_test.dart
+++ b/pkgs/test/test/runner/github_reporter_test.dart
@@ -260,10 +260,10 @@ void main() {
           test('skip 2', () {}, skip: true);
           test('skip 3', () {}, skip: true);''',
         '''
-          ::group::✅ Passing tests
-          ❎ skip 1 (skipped)
-          ❎ skip 2 (skipped)
-          ❎ skip 3 (skipped)
+          ::group::⚠️ Skipped tests
+          ⚠️ skip 1 (skipped)
+          ⚠️ skip 2 (skipped)
+          ⚠️ skip 3 (skipped)
           ::endgroup::
           🎉 0 tests passed, 3 skipped.''',
       );
@@ -278,10 +278,10 @@ void main() {
             test('test 3', () {});
           }, skip: true);''',
         '''
-          ::group::✅ Passing tests
-          ❎ skip test 1 (skipped)
-          ❎ skip test 2 (skipped)
-          ❎ skip test 3 (skipped)
+          ::group::⚠️ Skipped tests
+          ⚠️ skip test 1 (skipped)
+          ⚠️ skip test 2 (skipped)
+          ⚠️ skip test 3 (skipped)
           ::endgroup::
           🎉 0 tests passed, 3 skipped.''',
       );
@@ -295,10 +295,16 @@ void main() {
           test('skip 2', () {}, skip: true);
           test('success 2', () {});''',
         '''
+          ::group::⚠️ Skipped tests
+          ⚠️ skip 1 (skipped)
+          ::endgroup::
           ::group::✅ Passing tests
-          ❎ skip 1 (skipped)
           ✅ success 1
-          ❎ skip 2 (skipped)
+          ::endgroup::
+          ::group::⚠️ Skipped tests
+          ⚠️ skip 2 (skipped)
+          ::endgroup::
+          ::group::✅ Passing tests
           ✅ success 2
           ::endgroup::
           🎉 2 tests passed, 2 skipped.''',
@@ -319,16 +325,20 @@ void main() {
           oh no
           test.dart 6:35  main.<fn>
           ::endgroup::
+          ::group::⚠️ Skipped tests
+          ⚠️ skip 1 (skipped)
+          ::endgroup::
           ::group::✅ Passing tests
-          ❎ skip 1 (skipped)
           ✅ success 1
           ::endgroup::
           ::group::❌ failure 2 (failed)
           oh no
           test.dart 9:35  main.<fn>
           ::endgroup::
+          ::group::⚠️ Skipped tests
+          ⚠️ skip 2 (skipped)
+          ::endgroup::
           ::group::✅ Passing tests
-          ❎ skip 2 (skipped)
           ✅ success 2
           ::endgroup::
           ::error::2 tests passed, 2 failed, 2 skipped.''',
@@ -341,10 +351,10 @@ void main() {
           test('skip 1', () {}, skip: 'some reason');
           test('skip 2', () {}, skip: 'or another');''',
         '''
-          ::group::❎ skip 1 (skipped)
+          ::group::⚠️ Skipped tests
+          ⚠️ skip 1 (skipped)
           Skip: some reason
-          ::endgroup::
-          ::group::❎ skip 2 (skipped)
+          ⚠️ skip 2 (skipped)
           Skip: or another
           ::endgroup::
           🎉 0 tests passed, 2 skipped.''',

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Respect `NO_COLOR`, `CLICOLOR`, `FORCE_COLOR`, `CLICOLOR_FORCE`, and `TERM=dumb`
   environment variables for color output detection.
 * Fix a bug where `-c exe` tests would hang on exit on windows.
+* In `GithubReporter`, group contiguous passing tests into a collapsible group 
+  to reduce log noise in GitHub Actions.
 
 ## 0.6.17
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -9,7 +9,7 @@
 * `GithubReporter`:
     * Group contiguous passing and skipped tests into collapsible groups to
       reduce log noise in GitHub Actions.
-    * Updated skipped icon to ⚠️.
+    * Updated skipped icon to ⏭️.
 
 ## 0.6.17
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -5,8 +5,10 @@
 * Respect `NO_COLOR`, `CLICOLOR`, `FORCE_COLOR`, `CLICOLOR_FORCE`, and `TERM=dumb`
   environment variables for color output detection.
 * Fix a bug where `-c exe` tests would hang on exit on windows.
-* In `GithubReporter`, group contiguous passing tests into a collapsible group 
-  to reduce log noise in GitHub Actions.
+* `GithubReporter`:
+    * Group contiguous passing and skipped tests into collapsible groups to
+      reduce log noise in GitHub Actions.
+    * Updated skipped icon to ⚠️.
 
 ## 0.6.17
 

--- a/pkgs/test_core/lib/src/runner/reporter/github.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/github.dart
@@ -188,7 +188,7 @@ class GithubReporter implements Reporter {
         _inPassingGroup = false;
       }
       if (!_inSkippedGroup) {
-        _sink.writeln(_GithubMarkup.startGroup('⚠️ Skipped tests'));
+        _sink.writeln(_GithubMarkup.startGroup('⏭️ Skipped tests'));
         _inSkippedGroup = true;
       }
       _sink.writeln('$prefix $name$statusSuffix');
@@ -298,7 +298,7 @@ class GithubReporter implements Reporter {
 abstract class _GithubMarkup {
   // Char sets avilable at https://www.compart.com/en/unicode/.
   static const String passed = '✅';
-  static const String skipped = '⚠️';
+  static const String skipped = '⏭️';
   static const String failed = '❌';
   // The 'synthetic' icon is currently not used but is something to consider in
   // order to draw a distinction between user tests and test-like supporting

--- a/pkgs/test_core/lib/src/runner/reporter/github.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/github.dart
@@ -44,6 +44,9 @@ class GithubReporter implements Reporter {
 
   final Set<LiveTest> _completedTests = {};
 
+  /// Whether the reporter is currently inside a group of passing tests.
+  var _inPassingGroup = false;
+
   /// Watches the tests run by [engine] and prints their results as JSON.
   static GithubReporter watch(
     Engine engine,
@@ -112,6 +115,10 @@ class GithubReporter implements Reporter {
         if (_completedTests.contains(liveTest)) {
           // The test has already completed and it's previous messages were
           // written out; ensure this post-completion output is not lost.
+          if (_inPassingGroup) {
+            _sink.writeln(_GithubMarkup.endGroup);
+            _inPassingGroup = false;
+          }
           _sink.writeln(message.text);
         } else {
           _testMessages.putIfAbsent(liveTest, () => []).add(message);
@@ -169,8 +176,16 @@ class GithubReporter implements Reporter {
           '${test.suite.platform.compiler.name}] $name';
     }
     if (messages.isEmpty && errors.isEmpty) {
+      if (!_inPassingGroup) {
+        _sink.writeln(_GithubMarkup.startGroup('✅ Passing tests'));
+        _inPassingGroup = true;
+      }
       _sink.writeln('$prefix $name$statusSuffix');
     } else {
+      if (_inPassingGroup) {
+        _sink.writeln(_GithubMarkup.endGroup);
+        _inPassingGroup = false;
+      }
       _sink.writeln(_GithubMarkup.startGroup('$prefix $name$statusSuffix'));
       for (var message in messages) {
         _sink.writeln(message.text);
@@ -203,6 +218,10 @@ class GithubReporter implements Reporter {
             '${test.suite.platform.compiler.name}] $name';
       }
 
+      if (_inPassingGroup) {
+        _sink.writeln(_GithubMarkup.endGroup);
+        _inPassingGroup = false;
+      }
       _sink.writeln(_GithubMarkup.startGroup('$prefix $name$statusSuffix'));
       _sink.writeln('$error');
       _sink.writeln(stackTrace.toString().trimRight());
@@ -212,6 +231,11 @@ class GithubReporter implements Reporter {
 
   void _onDone(bool? success) {
     _cancel();
+
+    if (_inPassingGroup) {
+      _sink.writeln(_GithubMarkup.endGroup);
+      _inPassingGroup = false;
+    }
 
     _sink.writeln();
 

--- a/pkgs/test_core/lib/src/runner/reporter/github.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/github.dart
@@ -47,6 +47,9 @@ class GithubReporter implements Reporter {
   /// Whether the reporter is currently inside a group of passing tests.
   var _inPassingGroup = false;
 
+  /// Whether the reporter is currently inside a group of skipped tests.
+  var _inSkippedGroup = false;
+
   /// Watches the tests run by [engine] and prints their results as JSON.
   static GithubReporter watch(
     Engine engine,
@@ -119,6 +122,10 @@ class GithubReporter implements Reporter {
             _sink.writeln(_GithubMarkup.endGroup);
             _inPassingGroup = false;
           }
+          if (_inSkippedGroup) {
+            _sink.writeln(_GithubMarkup.endGroup);
+            _inSkippedGroup = false;
+          }
           _sink.writeln(message.text);
         } else {
           _testMessages.putIfAbsent(liveTest, () => []).add(message);
@@ -175,7 +182,24 @@ class GithubReporter implements Reporter {
           '[${test.suite.platform.runtime.name}, '
           '${test.suite.platform.compiler.name}] $name';
     }
-    if (messages.isEmpty && errors.isEmpty) {
+    if (skipped) {
+      if (_inPassingGroup) {
+        _sink.writeln(_GithubMarkup.endGroup);
+        _inPassingGroup = false;
+      }
+      if (!_inSkippedGroup) {
+        _sink.writeln(_GithubMarkup.startGroup('⚠️ Skipped tests'));
+        _inSkippedGroup = true;
+      }
+      _sink.writeln('$prefix $name$statusSuffix');
+      for (var message in messages) {
+        _sink.writeln(message.text);
+      }
+    } else if (messages.isEmpty && errors.isEmpty) {
+      if (_inSkippedGroup) {
+        _sink.writeln(_GithubMarkup.endGroup);
+        _inSkippedGroup = false;
+      }
       if (!_inPassingGroup) {
         _sink.writeln(_GithubMarkup.startGroup('✅ Passing tests'));
         _inPassingGroup = true;
@@ -185,6 +209,10 @@ class GithubReporter implements Reporter {
       if (_inPassingGroup) {
         _sink.writeln(_GithubMarkup.endGroup);
         _inPassingGroup = false;
+      }
+      if (_inSkippedGroup) {
+        _sink.writeln(_GithubMarkup.endGroup);
+        _inSkippedGroup = false;
       }
       _sink.writeln(_GithubMarkup.startGroup('$prefix $name$statusSuffix'));
       for (var message in messages) {
@@ -222,6 +250,10 @@ class GithubReporter implements Reporter {
         _sink.writeln(_GithubMarkup.endGroup);
         _inPassingGroup = false;
       }
+      if (_inSkippedGroup) {
+        _sink.writeln(_GithubMarkup.endGroup);
+        _inSkippedGroup = false;
+      }
       _sink.writeln(_GithubMarkup.startGroup('$prefix $name$statusSuffix'));
       _sink.writeln('$error');
       _sink.writeln(stackTrace.toString().trimRight());
@@ -235,6 +267,10 @@ class GithubReporter implements Reporter {
     if (_inPassingGroup) {
       _sink.writeln(_GithubMarkup.endGroup);
       _inPassingGroup = false;
+    }
+    if (_inSkippedGroup) {
+      _sink.writeln(_GithubMarkup.endGroup);
+      _inSkippedGroup = false;
     }
 
     _sink.writeln();
@@ -262,7 +298,7 @@ class GithubReporter implements Reporter {
 abstract class _GithubMarkup {
   // Char sets avilable at https://www.compart.com/en/unicode/.
   static const String passed = '✅';
-  static const String skipped = '❎';
+  static const String skipped = '⚠️';
   static const String failed = '❌';
   // The 'synthetic' icon is currently not used but is something to consider in
   // order to draw a distinction between user tests and test-like supporting

--- a/pkgs/test_core/lib/src/runner/reporter/github.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/github.dart
@@ -47,7 +47,6 @@ class GithubReporter implements Reporter {
   /// The github markdown `::group::` that is currently open.
   var _activeGroup = _ReportGroup.ungrouped;
 
-
   /// Watches the tests run by [engine] and prints their results as JSON.
   static GithubReporter watch(
     Engine engine,

--- a/pkgs/test_core/lib/src/runner/reporter/github.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/github.dart
@@ -44,11 +44,9 @@ class GithubReporter implements Reporter {
 
   final Set<LiveTest> _completedTests = {};
 
-  /// Whether the reporter is currently inside a group of passing tests.
-  var _inPassingGroup = false;
+  /// The github markdown `::group::` that is currently open.
+  var _activeGroup = _ReportGroup.ungrouped;
 
-  /// Whether the reporter is currently inside a group of skipped tests.
-  var _inSkippedGroup = false;
 
   /// Watches the tests run by [engine] and prints their results as JSON.
   static GithubReporter watch(
@@ -118,13 +116,9 @@ class GithubReporter implements Reporter {
         if (_completedTests.contains(liveTest)) {
           // The test has already completed and it's previous messages were
           // written out; ensure this post-completion output is not lost.
-          if (_inPassingGroup) {
+          if (!_activeGroup.isUngrouped) {
             _sink.writeln(_GithubMarkup.endGroup);
-            _inPassingGroup = false;
-          }
-          if (_inSkippedGroup) {
-            _sink.writeln(_GithubMarkup.endGroup);
-            _inSkippedGroup = false;
+            _activeGroup = _ReportGroup.ungrouped;
           }
           _sink.writeln(message.text);
         } else {
@@ -181,36 +175,30 @@ class GithubReporter implements Reporter {
           '${test.suite.platform.compiler.name}] $name';
     }
     if (skipped) {
-      if (_inPassingGroup) {
+      if (_activeGroup.isPassing) {
         _sink.writeln(_GithubMarkup.endGroup);
-        _inPassingGroup = false;
       }
-      if (!_inSkippedGroup) {
+      if (!_activeGroup.isSkipped) {
         _sink.writeln(_GithubMarkup.startGroup('⏭️ Skipped tests'));
-        _inSkippedGroup = true;
+        _activeGroup = _ReportGroup.skipped;
       }
       _sink.writeln('$prefix $name$statusSuffix');
       for (var message in messages) {
         _sink.writeln(message.text);
       }
     } else if (messages.isEmpty && errors.isEmpty) {
-      if (_inSkippedGroup) {
+      if (_activeGroup.isSkipped) {
         _sink.writeln(_GithubMarkup.endGroup);
-        _inSkippedGroup = false;
       }
-      if (!_inPassingGroup) {
+      if (!_activeGroup.isPassing) {
         _sink.writeln(_GithubMarkup.startGroup('✅ Passing tests'));
-        _inPassingGroup = true;
+        _activeGroup = _ReportGroup.passing;
       }
       _sink.writeln('$prefix $name$statusSuffix');
     } else {
-      if (_inPassingGroup) {
+      if (!_activeGroup.isUngrouped) {
         _sink.writeln(_GithubMarkup.endGroup);
-        _inPassingGroup = false;
-      }
-      if (_inSkippedGroup) {
-        _sink.writeln(_GithubMarkup.endGroup);
-        _inSkippedGroup = false;
+        _activeGroup = _ReportGroup.ungrouped;
       }
       _sink.writeln(_GithubMarkup.startGroup('$prefix $name$statusSuffix'));
       for (var message in messages) {
@@ -244,13 +232,9 @@ class GithubReporter implements Reporter {
             '${test.suite.platform.compiler.name}] $name';
       }
 
-      if (_inPassingGroup) {
+      if (!_activeGroup.isUngrouped) {
         _sink.writeln(_GithubMarkup.endGroup);
-        _inPassingGroup = false;
-      }
-      if (_inSkippedGroup) {
-        _sink.writeln(_GithubMarkup.endGroup);
-        _inSkippedGroup = false;
+        _activeGroup = _ReportGroup.ungrouped;
       }
       _sink.writeln(_GithubMarkup.startGroup('$prefix $name$statusSuffix'));
       _sink.writeln('$error');
@@ -262,13 +246,9 @@ class GithubReporter implements Reporter {
   void _onDone(bool? success) {
     _cancel();
 
-    if (_inPassingGroup) {
+    if (!_activeGroup.isUngrouped) {
       _sink.writeln(_GithubMarkup.endGroup);
-      _inPassingGroup = false;
-    }
-    if (_inSkippedGroup) {
-      _sink.writeln(_GithubMarkup.endGroup);
-      _inSkippedGroup = false;
+      _activeGroup = _ReportGroup.ungrouped;
     }
 
     _sink.writeln();
@@ -310,4 +290,14 @@ abstract class _GithubMarkup {
   static final String endGroup = '::endgroup::';
 
   static String error(String message) => '::error::$message';
+}
+
+enum _ReportGroup {
+  passing,
+  skipped,
+  ungrouped;
+
+  bool get isPassing => this == _ReportGroup.passing;
+  bool get isSkipped => this == _ReportGroup.skipped;
+  bool get isUngrouped => this == _ReportGroup.ungrouped;
 }


### PR DESCRIPTION
Group success and skip so it's easy to see the failures!
Update skip icon to ⚠️ so they are easier to scan

Fixes https://github.com/dart-lang/test/issues/2628
