### PR TITLE
Ignore test pid on windows

### DIFF
--- a/pkgs/test/test/runner/json_file_reporter_test.dart
+++ b/pkgs/test/test/runner/json_file_reporter_test.dart
@@ -180,7 +180,7 @@ $tests
   ).readAsLinesSync();
   await expectJsonReport(
     fileOutputLines,
-    test.pid,
+    Platform.isWindows ? anything : equals(test.pid),
     jsonFileExpected,
     jsonFileDone,
   );

--- a/pkgs/test/test/runner/json_reporter_test.dart
+++ b/pkgs/test/test/runner/json_reporter_test.dart
@@ -6,6 +6,7 @@
 library;
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -908,5 +909,10 @@ import 'package:test/test.dart';
   await test.shouldExit();
 
   var stdoutLines = await test.stdoutStream().toList();
-  return expectJsonReport(stdoutLines, test.pid, expected, done);
+  return expectJsonReport(
+    stdoutLines,
+    Platform.isWindows ? anything : equals(test.pid),
+    expected,
+    done,
+  );
 }

--- a/pkgs/test/test/runner/json_reporter_utils.dart
+++ b/pkgs/test/test/runner/json_reporter_utils.dart
@@ -15,7 +15,7 @@ import 'package:test_descriptor/test_descriptor.dart' as d;
 /// includes the [testPid] from the test process, and ends with [done].
 Future<void> expectJsonReport(
   List<String> outputLines,
-  int testPid,
+  Matcher testPid,
   List<List<Object /*Map|Matcher*/>> expected,
   Map<Object, Object> done,
 ) async {


### PR DESCRIPTION
The tests are flaky or always failing due to inconsistencies with PID
behavior on windows. Change the PID expectation argument to take a
matcher and use `anything` on windows.
