### PR TITLE
Expose the backend APIs used by flutter_test from test_api

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.31.2-wip
+
 ## 1.31.1
 
 * Ignore an error locating the SDK directory on platforms where the

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test
-version: 1.31.1
+version: 1.31.2-wip
 description: >-
   A full featured library for writing and running Dart tests across platforms.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test
@@ -35,8 +35,8 @@ dependencies:
   stream_channel: ^2.1.0
 
   # Use an exact version until the test_api and test_core package are stable.
-  test_api: 0.7.12
-  test_core: 0.6.18
+  test_api: 0.7.13-wip
+  test_core: 0.6.19-wip
 
   typed_data: ^1.3.0
   web_socket_channel: '>=2.0.0 <4.0.0'

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.13-wip
+
+* Expose several more backend APIs for use in `flutter_test`.
+
 ## 0.7.12
 
 * Allow `analyzer` major version 13.

--- a/pkgs/test_api/lib/backend.dart
+++ b/pkgs/test_api/lib/backend.dart
@@ -3,6 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 export 'src/backend/compiler.dart' show Compiler;
+export 'src/backend/declarer.dart' show Declarer;
+export 'src/backend/group.dart' show Group;
+export 'src/backend/group_entry.dart' show GroupEntry;
+export 'src/backend/invoker.dart' show Invoker;
+export 'src/backend/live_test.dart' show LiveTest;
+export 'src/backend/message.dart' show Message;
 export 'src/backend/metadata.dart' show Metadata;
 export 'src/backend/platform_selector.dart' show PlatformSelector;
 export 'src/backend/remote_exception.dart' show RemoteException;
@@ -10,5 +16,7 @@ export 'src/backend/remote_listener.dart' show RemoteListener;
 export 'src/backend/runtime.dart' show Runtime;
 export 'src/backend/stack_trace_formatter.dart' show StackTraceFormatter;
 export 'src/backend/stack_trace_mapper.dart' show StackTraceMapper;
+export 'src/backend/state.dart' show State;
 export 'src/backend/suite_platform.dart' show SuitePlatform;
+export 'src/backend/test.dart' show Test;
 export 'src/backend/test_location.dart' show TestLocation;

--- a/pkgs/test_api/pubspec.yaml
+++ b/pkgs/test_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_api
-version: 0.7.12
+version: 0.7.13-wip
 description: >-
   The user facing API for structuring Dart tests and checking expectations.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_api

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.6.19-wip
+
 ## 0.6.18
 
 * Ignore an error locating the SDK directory on platforms where the

--- a/pkgs/test_core/lib/src/direct_run.dart
+++ b/pkgs/test_core/lib/src/direct_run.dart
@@ -7,11 +7,6 @@ import 'dart:collection';
 
 import 'package:path/path.dart' as p;
 import 'package:test_api/backend.dart';
-import 'package:test_api/src/backend/declarer.dart'; //ignore: implementation_imports
-import 'package:test_api/src/backend/group.dart'; //ignore: implementation_imports
-import 'package:test_api/src/backend/group_entry.dart'; //ignore: implementation_imports
-import 'package:test_api/src/backend/invoker.dart'; // ignore: implementation_imports
-import 'package:test_api/src/backend/test.dart'; //ignore: implementation_imports
 
 import 'runner/configuration.dart';
 import 'runner/engine.dart';

--- a/pkgs/test_core/lib/src/scaffolding.dart
+++ b/pkgs/test_core/lib/src/scaffolding.dart
@@ -8,8 +8,6 @@ import 'package:meta/meta.dart' show doNotSubmit, isTest, isTestGroup;
 import 'package:path/path.dart' as p;
 import 'package:test_api/backend.dart';
 import 'package:test_api/scaffolding.dart' show Timeout, pumpEventQueue;
-import 'package:test_api/src/backend/declarer.dart'; // ignore: implementation_imports
-import 'package:test_api/src/backend/invoker.dart'; // ignore: implementation_imports
 
 import 'runner/engine.dart';
 import 'runner/plugin/environment.dart';

--- a/pkgs/test_core/pubspec.yaml
+++ b/pkgs/test_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_core
-version: 0.6.18
+version: 0.6.19-wip
 description: A basic library for writing tests and running them on the VM.
 repository: https://github.com/dart-lang/test/tree/master/pkgs/test_core
 issue_tracker: https://github.com/dart-lang/test/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Atest
@@ -28,7 +28,7 @@ dependencies:
   stack_trace: ^1.10.0
   stream_channel: ^2.1.0
   # Use an exact version until the test_api package is stable.
-  test_api: 0.7.12
+  test_api: 0.7.13-wip
   vm_service: '>=6.0.0 <16.0.0'
   yaml: ^3.0.0
 


### PR DESCRIPTION
This would allow `test_api` to be unpinned from the flutter SDK.

This does greatly expose the public surface area and also greatly increase the probability of breaking API changes, but we are already in this situation in reality (any breaking changes to these APIs would break flutter anyways).

Part of https://github.com/flutter/flutter/issues/185016