### PR TITLE
Fix output for multiline clauses in failures

### DIFF
--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -850,7 +850,9 @@ final class _TestContext<T> implements Context<T>, _ClauseDescription {
     if (_clauses.isEmpty) {
       expected.addAll(_label());
     } else {
-      expected.addAll(postfixLast(' that:', _label()));
+      final label = postfixLast(' that:', _label());
+      expected.addAll(label);
+      final labelLines = label.length;
       for (var clause in _clauses) {
         final details = clause.detail(failingContext);
         expected.addAll(indent(details.expected));
@@ -858,7 +860,7 @@ final class _TestContext<T> implements Context<T>, _ClauseDescription {
           assert(foundDepth == -1);
           assert(foundOverlap == -1);
           foundDepth = details.depth + 1;
-          foundOverlap = details._actualOverlap + successfulOverlap + 1;
+          foundOverlap = details._actualOverlap + successfulOverlap + labelLines;
         } else {
           if (foundDepth == -1) {
             successfulOverlap += details.expected.length;

--- a/pkgs/checks/lib/src/checks.dart
+++ b/pkgs/checks/lib/src/checks.dart
@@ -860,7 +860,8 @@ final class _TestContext<T> implements Context<T>, _ClauseDescription {
           assert(foundDepth == -1);
           assert(foundOverlap == -1);
           foundDepth = details.depth + 1;
-          foundOverlap = details._actualOverlap + successfulOverlap + labelLines;
+          foundOverlap =
+              details._actualOverlap + successfulOverlap + labelLines;
         } else {
           if (foundDepth == -1) {
             successfulOverlap += details.expected.length;

--- a/pkgs/checks/test/failure_message_test.dart
+++ b/pkgs/checks/test/failure_message_test.dart
@@ -27,6 +27,70 @@ Actual: a List<dynamic> that:
   Which: are not equal''');
     });
 
+    test('includes matching portions of actual when label is multiline', () {
+      final largeKey = Iterable.generate(30, (i) => i).toList();
+      check(() {
+        check({largeKey: [1]})[largeKey].first.identicalTo(2);
+      }).throwsFailure().equals('''
+Expected: a Map<List<int>, List<int>> that:
+  contains a value for [0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+  16,
+  17,
+  18,
+  19,
+  20,
+  21,
+  22,
+  23,
+  ...] that:
+    has first element that:
+      is identical to <2>
+Actual: a Map<List<int>, List<int>> that:
+  contains a value for [0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+  16,
+  17,
+  18,
+  19,
+  20,
+  21,
+  22,
+  23,
+  ...] that:
+    has first element that:
+    Actual: <1>
+    Which: is not identical''');
+    });
+
     test('include a reason when provided', () {
       check(() {
         check(because: 'Some reason', 1).isGreaterThan(2);

--- a/pkgs/checks/test/failure_message_test.dart
+++ b/pkgs/checks/test/failure_message_test.dart
@@ -28,69 +28,23 @@ Actual: a List<dynamic> that:
     });
 
     test('includes matching portions of actual when label is multiline', () {
-      final largeKey = Iterable.generate(30, (i) => i).toList();
       check(() {
         check({
-          largeKey: [1],
-        })[largeKey].first.identicalTo(2);
+          'foo\nbar': [10],
+        })['foo\nbar'].first..isGreaterThan(0)..isLessThan(10);
       }).throwsFailure().equals('''
-Expected: a Map<List<int>, List<int>> that:
-  contains a value for [0,
-  1,
-  2,
-  3,
-  4,
-  5,
-  6,
-  7,
-  8,
-  9,
-  10,
-  11,
-  12,
-  13,
-  14,
-  15,
-  16,
-  17,
-  18,
-  19,
-  20,
-  21,
-  22,
-  23,
-  ...] that:
+Expected: a Map<String, List<int>> that:
+  contains a value for 'foo
+  bar' that:
     has first element that:
-      is identical to <2>
-Actual: a Map<List<int>, List<int>> that:
-  contains a value for [0,
-  1,
-  2,
-  3,
-  4,
-  5,
-  6,
-  7,
-  8,
-  9,
-  10,
-  11,
-  12,
-  13,
-  14,
-  15,
-  16,
-  17,
-  18,
-  19,
-  20,
-  21,
-  22,
-  23,
-  ...] that:
+      is greater than <0>
+      is less than <10>
+Actual: a Map<String, List<int>> that:
+  contains a value for 'foo
+  bar' that:
     has first element that:
-    Actual: <1>
-    Which: is not identical''');
+    Actual: <10>
+    Which: is not less than <10>''');
     });
 
     test('include a reason when provided', () {

--- a/pkgs/checks/test/failure_message_test.dart
+++ b/pkgs/checks/test/failure_message_test.dart
@@ -30,7 +30,9 @@ Actual: a List<dynamic> that:
     test('includes matching portions of actual when label is multiline', () {
       final largeKey = Iterable.generate(30, (i) => i).toList();
       check(() {
-        check({largeKey: [1]})[largeKey].first.identicalTo(2);
+        check({
+          largeKey: [1],
+        })[largeKey].first.identicalTo(2);
       }).throwsFailure().equals('''
 Expected: a Map<List<int>, List<int>> that:
   contains a value for [0,

--- a/pkgs/checks/test/failure_message_test.dart
+++ b/pkgs/checks/test/failure_message_test.dart
@@ -30,8 +30,10 @@ Actual: a List<dynamic> that:
     test('includes matching portions of actual when label is multiline', () {
       check(() {
         check({
-          'foo\nbar': [10],
-        })['foo\nbar'].first..isGreaterThan(0)..isLessThan(10);
+            'foo\nbar': [10],
+          })['foo\nbar'].first
+          ..isGreaterThan(0)
+          ..isLessThan(10);
       }).throwsFailure().equals('''
 Expected: a Map<String, List<int>> that:
   contains a value for 'foo


### PR DESCRIPTION
In a failure message the parts of the expectation which were checked and
satisfied are represented in both the "Expected" and "Actual" portions.
This is handled by tracking how many lines of the text overlaps.
Previously this tracked the depth of nesting and assumed each level
contributed only a single line, but this assumption is violated by some
expectations which print with multiple lines. Correct the overlap
accounting to include the actual number of lines added by a label.
