### PR TITLE
Shorten failure message for NaN/not NaN

### DIFF
--- a/pkgs/checks/lib/src/extensions/math.dart
+++ b/pkgs/checks/lib/src/extensions/math.dart
@@ -7,18 +7,18 @@ import '../../context.dart';
 extension NumChecks on Subject<num> {
   /// Expects that [num.isNaN] is true.
   void isNaN() {
-    context.expect(() => ['is not a number (NaN)'], (actual) {
-      if (actual.isNaN) return null;
-      return Rejection(which: ['is a number']);
-    });
+    context.expect(
+      () => ['is not a number (NaN)'],
+      (actual) => actual.isNaN ? null : Rejection(),
+    );
   }
 
   /// Expects that [num.isNaN] is false.
   void isNotNaN() {
-    context.expect(() => ['is a number (not NaN)'], (actual) {
-      if (!actual.isNaN) return null;
-      return Rejection(which: ['is not a number (NaN)']);
-    });
+    context.expect(
+      () => ['is a number (not NaN)'],
+      (actual) => actual.isNaN ? Rejection() : null,
+    );
   }
 
   /// Expects that [num.isNegative] is true.

--- a/pkgs/checks/test/extensions/math_test.dart
+++ b/pkgs/checks/test/extensions/math_test.dart
@@ -14,10 +14,10 @@ void main() {
         check(double.nan).isNaN();
       });
       test('fails for ints', () {
-        check(42).isRejectedBy((it) => it.isNaN(), which: ['is a number']);
+        check(42).isRejectedBy((it) => it.isNaN());
       });
       test('fails for numeric doubles', () {
-        check(42.1).isRejectedBy((it) => it.isNaN(), which: ['is a number']);
+        check(42.1).isRejectedBy((it) => it.isNaN());
       });
     });
 
@@ -29,9 +29,7 @@ void main() {
         check(42.1).isNotNaN();
       });
       test('fails for NaN', () {
-        check(
-          double.nan,
-        ).isRejectedBy((it) => it.isNotNaN(), which: ['is not a number (NaN)']);
+        check(double.nan).isRejectedBy((it) => it.isNotNaN());
       });
     });
     group('isNegative', () {


### PR DESCRIPTION
The "expected" and "actual" here already clearly express the "NaN"
concept and every time I see failure output with this `which` phrase in
practice it feels redundant.
