### PR TITLE
[test] Add compiler `dart test -c cli` to run hooks

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.31.2-wip
 
+* Add support for running tests as native CLI bundles (vm platform only).
+  * You can run tests this way with `--compiler cli`.
 * **Impacts Configuration** Support using the OS platform selector to configure
   browser tests.
   Previously tests loaded for the browser would have an operating system of

--- a/pkgs/test/lib/src/runner/browser/compilers/precompiled.dart
+++ b/pkgs/test/lib/src/runner/browser/compilers/precompiled.dart
@@ -112,6 +112,7 @@ abstract class PrecompiledSupport extends CompilerSupport {
         faviconPath,
       ),
       Compiler.exe ||
+      Compiler.cli ||
       Compiler.kernel ||
       Compiler.source => throw UnsupportedError(
         'The browser platform does not support $compiler',

--- a/pkgs/test/pubspec.yaml
+++ b/pkgs/test/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
 dev_dependencies:
   fake_async: ^1.0.0
   glob: ^2.0.0
+  pub_semver: ^2.0.0
   test_descriptor: ^2.0.0
   test_process: ^2.0.0
 

--- a/pkgs/test/test/io.dart
+++ b/pkgs/test/test/io.dart
@@ -28,7 +28,7 @@ final String sdkDir = p.dirname(p.dirname(Platform.resolvedExecutable));
 
 final bool supportsCliCompiler = () {
   var current = Version.parse(Platform.version.split(' ').first);
-  return current > Version.parse('3.13.0-139.0.dev');
+  return current > Version.parse('3.13.0-155.0.dev');
 }();
 
 /// The platform-specific message emitted when a nonexistent file is loaded.

--- a/pkgs/test/test/io.dart
+++ b/pkgs/test/test/io.dart
@@ -28,7 +28,7 @@ final String sdkDir = p.dirname(p.dirname(Platform.resolvedExecutable));
 
 final bool supportsCliCompiler = () {
   var current = Version.parse(Platform.version.split(' ').first);
-  return current > Version.parse('3.13.0-155.0.dev');
+  return current > Version.parse('3.13.0-159.0.dev');
 }();
 
 /// The platform-specific message emitted when a nonexistent file is loaded.

--- a/pkgs/test/test/io.dart
+++ b/pkgs/test/test/io.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
@@ -24,6 +25,11 @@ final Future<String> packageDir =
 
 /// The root directory of the Dart SDK.
 final String sdkDir = p.dirname(p.dirname(Platform.resolvedExecutable));
+
+final bool supportsCliCompiler = () {
+  var current = Version.parse(Platform.version.split(' ').first);
+  return current > Version.parse('3.13.0-139.0.dev');
+}();
 
 /// The platform-specific message emitted when a nonexistent file is loaded.
 final String noSuchFileMessage = Platform.isWindows

--- a/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
+++ b/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
@@ -26,34 +26,8 @@ final bool supportsCliCompiler = () {
 }();
 
 void main() {
-  late String testPath;
-  late String testCorePath;
-  late String testApiPath;
-
   setUpAll(() async {
     await precompileTestExecutable();
-
-    testPath = await packageDir;
-    final testPathParts = p.split(testPath);
-    testCorePath = p.joinAll(
-      testPathParts.take(testPathParts.length - 1).followedBy(['test_core']),
-    );
-    testApiPath = p.joinAll(
-      testPathParts.take(testPathParts.length - 1).followedBy(['test_api']),
-    );
-  });
-
-  // The test sandbox must be set up as a valid Dart package (with its own
-  // pubspec.yaml, running `pub get` to generate a valid package_config.json,
-  // and putting the entrypoint under the correct package root). This is required
-  // for the `cli` compiler (`dart build cli`), which requires the entrypoint
-  // target to reside inside a package defined in the package config.
-  setUp(() async {
-    await d
-        .file('pubspec.yaml', _pubspec(testPath, testCorePath, testApiPath))
-        .create();
-
-    await (await runPub(['get'], workingDirectory: d.sandbox)).shouldExit(0);
   });
 
   for (var runtime in Runtime.builtIn) {
@@ -93,7 +67,7 @@ void main() {
         skip: skipReason,
         () {
           final testArgs = [
-            'test/test.dart',
+            'test.dart',
             '-p',
             runtime.identifier,
             '-c',
@@ -101,15 +75,8 @@ void main() {
           ];
 
           test('can run passing tests', () async {
-            await d.dir('test', [d.file('test.dart', _goodTest)]).create();
-            var test = await runTest(
-              testArgs,
-              packageConfig: p.join(
-                d.sandbox,
-                '.dart_tool/package_config.json',
-              ),
-              workingDirectory: d.sandbox,
-            );
+            await d.file('test.dart', _goodTest).create();
+            var test = await runTest(testArgs);
 
             expect(
               test.stdout,
@@ -119,17 +86,8 @@ void main() {
           });
 
           test('fails gracefully for invalid code', () async {
-            await d.dir('test', [
-              d.file('test.dart', _compileErrorTest),
-            ]).create();
-            var test = await runTest(
-              testArgs,
-              packageConfig: p.join(
-                d.sandbox,
-                '.dart_tool/package_config.json',
-              ),
-              workingDirectory: d.sandbox,
-            );
+            await d.file('test.dart', _compileErrorTest).create();
+            var test = await runTest(testArgs);
 
             expect(
               test.stdout,
@@ -143,22 +101,15 @@ void main() {
           });
 
           test('fails gracefully for test failures', () async {
-            await d.dir('test', [d.file('test.dart', _failingTest)]).create();
-            var test = await runTest(
-              testArgs,
-              packageConfig: p.join(
-                d.sandbox,
-                '.dart_tool/package_config.json',
-              ),
-              workingDirectory: d.sandbox,
-            );
+            await d.file('test.dart', _failingTest).create();
+            var test = await runTest(testArgs);
 
             expect(
               test.stdout,
               containsInOrder([
                 'Expected: <2>',
                 'Actual: <1>',
-                '${p.join('test', 'test.dart')} 5',
+                'test.dart 5',
                 '+0 -1: Some tests failed.',
               ]),
             );
@@ -167,37 +118,21 @@ void main() {
           });
 
           test('fails gracefully if a test file throws in main', () async {
-            await d.dir('test', [d.file('test.dart', _throwingTest)]).create();
-            var test = await runTest(
-              testArgs,
-              packageConfig: p.join(
-                d.sandbox,
-                '.dart_tool/package_config.json',
-              ),
-              workingDirectory: d.sandbox,
-            );
+            await d.file('test.dart', _throwingTest).create();
+            var test = await runTest(testArgs);
             expect(
               test.stdout,
               containsInOrder([
-                '-1: [${runtime.name}, ${compiler.name}] loading test/test.dart [E]',
-                'Failed to load "test/test.dart": oh no',
+                '-1: [${runtime.name}, ${compiler.name}] loading test.dart [E]',
+                'Failed to load "test.dart": oh no',
               ]),
             );
             await test.shouldExit(1);
           });
 
           test('captures prints', () async {
-            await d.dir('test', [
-              d.file('test.dart', _testWithPrints),
-            ]).create();
-            var test = await runTest(
-              [...testArgs, '-r', 'json'],
-              packageConfig: p.join(
-                d.sandbox,
-                '.dart_tool/package_config.json',
-              ),
-              workingDirectory: d.sandbox,
-            );
+            await d.file('test.dart', _testWithPrints).create();
+            var test = await runTest([...testArgs, '-r', 'json']);
 
             expect(
               test.stdout,
@@ -213,18 +148,8 @@ void main() {
             test(
               'forwards stdout/stderr',
               () async {
-                await d.dir('test', [
-                  d.file('test.dart', _testWithStdOutAndErr),
-                ]).create();
-                var test = await runTest(
-                  testArgs,
-                  reporter: 'silent',
-                  packageConfig: p.join(
-                    d.sandbox,
-                    '.dart_tool/package_config.json',
-                  ),
-                  workingDirectory: d.sandbox,
-                );
+                await d.file('test.dart', _testWithStdOutAndErr).create();
+                var test = await runTest(testArgs, reporter: 'silent');
 
                 expect(test.stdout, emitsThrough('hello'));
                 expect(test.stderr, emits('world'));
@@ -285,20 +210,3 @@ void main() async {
   stderr.writeln('world');
   test('success', () {});
 }''';
-
-String _pubspec(String testPath, String testCorePath, String testApiPath) =>
-    '''
-name: mypackage
-version: 1.0.0
-environment:
-  sdk: ^3.5.0
-dev_dependencies:
-  test: any
-dependency_overrides:
-  test:
-    path: $testPath
-  test_core:
-    path: $testCorePath
-  test_api:
-    path: $testApiPath
-''';

--- a/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
+++ b/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
@@ -8,15 +8,50 @@ library;
 
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 import 'package:test_api/backend.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
 import '../io.dart';
 
+final bool supportsCliCompiler = () {
+  try {
+    var current = Version.parse(Platform.version.split(' ').first);
+    return current > Version.parse('3.13.0-139.0.dev');
+  } catch (_) {
+    return false;
+  }
+}();
+
 void main() {
+  late String testPath;
+  late String testCorePath;
+  late String testApiPath;
+
   setUpAll(() async {
     await precompileTestExecutable();
+
+    testPath = await packageDir;
+    final testPathParts = p.split(testPath);
+    testCorePath = p.joinAll(
+      testPathParts.take(testPathParts.length - 1).followedBy(['test_core']),
+    );
+    testApiPath = p.joinAll(
+      testPathParts.take(testPathParts.length - 1).followedBy(['test_api']),
+    );
+  });
+
+  // The test sandbox must be set up as a valid Dart package (with its own
+  // pubspec.yaml, running `pub get` to generate a valid package_config.json,
+  // and putting the entrypoint under the correct package root). This is required
+  // for the `cli` compiler (`dart build cli`), which requires the entrypoint
+  // target to reside inside a package defined in the package config.
+  setUp(() async {
+    await d.file('pubspec.yaml', _pubspec(testPath, testCorePath, testApiPath)).create();
+
+    await (await runPub(['get'], workingDirectory: d.sandbox)).shouldExit(0);
   });
 
   for (var runtime in Runtime.builtIn) {
@@ -48,13 +83,15 @@ void main() {
       } else if (runtime == Runtime.vmTsan &&
           !File('$sdkDir/bin/dartaotruntime_tsan').existsSync()) {
         skipReason = 'SDK too old';
+      } else if (compiler == Compiler.cli && !supportsCliCompiler) {
+        skipReason = 'SDK too old';
       }
       group(
         '--runtime ${runtime.identifier} --compiler ${compiler.identifier}',
         skip: skipReason,
         () {
           final testArgs = [
-            'test.dart',
+            'test/test.dart',
             '-p',
             runtime.identifier,
             '-c',
@@ -62,8 +99,15 @@ void main() {
           ];
 
           test('can run passing tests', () async {
-            await d.file('test.dart', _goodTest).create();
-            var test = await runTest(testArgs);
+            await d.dir('test', [d.file('test.dart', _goodTest)]).create();
+            var test = await runTest(
+              testArgs,
+              packageConfig: p.join(
+                d.sandbox,
+                '.dart_tool/package_config.json',
+              ),
+              workingDirectory: d.sandbox,
+            );
 
             expect(
               test.stdout,
@@ -73,8 +117,17 @@ void main() {
           });
 
           test('fails gracefully for invalid code', () async {
-            await d.file('test.dart', _compileErrorTest).create();
-            var test = await runTest(testArgs);
+            await d.dir('test', [
+              d.file('test.dart', _compileErrorTest),
+            ]).create();
+            var test = await runTest(
+              testArgs,
+              packageConfig: p.join(
+                d.sandbox,
+                '.dart_tool/package_config.json',
+              ),
+              workingDirectory: d.sandbox,
+            );
 
             expect(
               test.stdout,
@@ -88,15 +141,22 @@ void main() {
           });
 
           test('fails gracefully for test failures', () async {
-            await d.file('test.dart', _failingTest).create();
-            var test = await runTest(testArgs);
+            await d.dir('test', [d.file('test.dart', _failingTest)]).create();
+            var test = await runTest(
+              testArgs,
+              packageConfig: p.join(
+                d.sandbox,
+                '.dart_tool/package_config.json',
+              ),
+              workingDirectory: d.sandbox,
+            );
 
             expect(
               test.stdout,
               containsInOrder([
                 'Expected: <2>',
                 'Actual: <1>',
-                'test.dart 5',
+                '${p.join('test', 'test.dart')} 5',
                 '+0 -1: Some tests failed.',
               ]),
             );
@@ -105,21 +165,37 @@ void main() {
           });
 
           test('fails gracefully if a test file throws in main', () async {
-            await d.file('test.dart', _throwingTest).create();
-            var test = await runTest(testArgs);
+            await d.dir('test', [d.file('test.dart', _throwingTest)]).create();
+            var test = await runTest(
+              testArgs,
+              packageConfig: p.join(
+                d.sandbox,
+                '.dart_tool/package_config.json',
+              ),
+              workingDirectory: d.sandbox,
+            );
             expect(
               test.stdout,
               containsInOrder([
-                '-1: [${runtime.name}, ${compiler.name}] loading test.dart [E]',
-                'Failed to load "test.dart": oh no',
+                '-1: [${runtime.name}, ${compiler.name}] loading ${p.join('test', 'test.dart')} [E]',
+                'Failed to load "${p.join('test', 'test.dart')}": oh no',
               ]),
             );
             await test.shouldExit(1);
           });
 
           test('captures prints', () async {
-            await d.file('test.dart', _testWithPrints).create();
-            var test = await runTest([...testArgs, '-r', 'json']);
+            await d.dir('test', [
+              d.file('test.dart', _testWithPrints),
+            ]).create();
+            var test = await runTest(
+              [...testArgs, '-r', 'json'],
+              packageConfig: p.join(
+                d.sandbox,
+                '.dart_tool/package_config.json',
+              ),
+              workingDirectory: d.sandbox,
+            );
 
             expect(
               test.stdout,
@@ -135,8 +211,18 @@ void main() {
             test(
               'forwards stdout/stderr',
               () async {
-                await d.file('test.dart', _testWithStdOutAndErr).create();
-                var test = await runTest(testArgs, reporter: 'silent');
+                await d.dir('test', [
+                  d.file('test.dart', _testWithStdOutAndErr),
+                ]).create();
+                var test = await runTest(
+                  testArgs,
+                  reporter: 'silent',
+                  packageConfig: p.join(
+                    d.sandbox,
+                    '.dart_tool/package_config.json',
+                  ),
+                  workingDirectory: d.sandbox,
+                );
 
                 expect(test.stdout, emitsThrough('hello'));
                 expect(test.stderr, emits('world'));
@@ -197,3 +283,19 @@ void main() async {
   stderr.writeln('world');
   test('success', () {});
 }''';
+
+String _pubspec(String testPath, String testCorePath, String testApiPath) => '''
+name: mypackage
+version: 1.0.0
+environment:
+  sdk: ^3.5.0
+dev_dependencies:
+  test: any
+dependency_overrides:
+  test:
+    path: $testPath
+  test_core:
+    path: $testCorePath
+  test_api:
+    path: $testApiPath
+''';

--- a/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
+++ b/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
@@ -49,7 +49,9 @@ void main() {
   // for the `cli` compiler (`dart build cli`), which requires the entrypoint
   // target to reside inside a package defined in the package config.
   setUp(() async {
-    await d.file('pubspec.yaml', _pubspec(testPath, testCorePath, testApiPath)).create();
+    await d
+        .file('pubspec.yaml', _pubspec(testPath, testCorePath, testApiPath))
+        .create();
 
     await (await runPub(['get'], workingDirectory: d.sandbox)).shouldExit(0);
   });
@@ -284,7 +286,8 @@ void main() async {
   test('success', () {});
 }''';
 
-String _pubspec(String testPath, String testCorePath, String testApiPath) => '''
+String _pubspec(String testPath, String testCorePath, String testApiPath) =>
+    '''
 name: mypackage
 version: 1.0.0
 environment:

--- a/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
+++ b/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
@@ -8,22 +8,11 @@ library;
 
 import 'dart:io';
 
-import 'package:path/path.dart' as p;
-import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 import 'package:test_api/backend.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
 import '../io.dart';
-
-final bool supportsCliCompiler = () {
-  try {
-    var current = Version.parse(Platform.version.split(' ').first);
-    return current > Version.parse('3.13.0-139.0.dev');
-  } catch (_) {
-    return false;
-  }
-}();
 
 void main() {
   setUpAll(() async {

--- a/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
+++ b/pkgs/test/test/runner/compiler_runtime_matrix_test.dart
@@ -179,8 +179,8 @@ void main() {
             expect(
               test.stdout,
               containsInOrder([
-                '-1: [${runtime.name}, ${compiler.name}] loading ${p.join('test', 'test.dart')} [E]',
-                'Failed to load "${p.join('test', 'test.dart')}": oh no',
+                '-1: [${runtime.name}, ${compiler.name}] loading test/test.dart [E]',
+                'Failed to load "test/test.dart": oh no',
               ]),
             );
             await test.shouldExit(1);

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -75,7 +75,7 @@ Running Tests:
                                       $_runtimes.
                                       Each platform supports the following compilers:
 $_runtimeCompilers
--c, --compiler                        The compiler(s) to use to run tests, supported compilers are [dart2js, dart2wasm, exe, kernel, source].
+-c, --compiler                        The compiler(s) to use to run tests, supported compilers are [dart2js, dart2wasm, exe, cli, kernel, source].
                                       Each platform has a default compiler but may support other compilers.
                                       You can target a compiler to a specific platform using arguments of the following form [<platform-selector>:]<compiler>.
                                       If a platform is specified but no given compiler is supported for that platform, then it will use its default compiler.
@@ -137,7 +137,7 @@ final _runtimes =
     ', edge, node]';
 
 final _runtimeCompilers = [
-  '[vm]: kernel (default), source, exe',
+  '[vm]: kernel (default), source, exe, cli',
   '[vm-asan]: exe (default)',
   '[vm-msan]: exe (default)',
   '[vm-tsan]: exe (default)',

--- a/pkgs/test/test/runner/subprocess_crash_test.dart
+++ b/pkgs/test/test/runner/subprocess_crash_test.dart
@@ -5,22 +5,10 @@
 @TestOn('vm')
 library;
 
-import 'dart:io';
-import 'package:path/path.dart' as p;
-import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
 import '../io.dart';
-
-final bool supportsCliCompiler = () {
-  try {
-    var current = Version.parse(Platform.version.split(' ').first);
-    return current > Version.parse('3.13.0-139.0.dev');
-  } catch (_) {
-    return false;
-  }
-}();
 
 void main() {
   setUpAll(precompileTestExecutable);

--- a/pkgs/test/test/runner/subprocess_crash_test.dart
+++ b/pkgs/test/test/runner/subprocess_crash_test.dart
@@ -5,35 +5,102 @@
 @TestOn('vm')
 library;
 
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
 import '../io.dart';
 
+final bool supportsCliCompiler = () {
+  try {
+    var current = Version.parse(Platform.version.split(' ').first);
+    return current > Version.parse('3.13.0-139.0.dev');
+  } catch (_) {
+    return false;
+  }
+}();
+
 void main() {
-  setUpAll(precompileTestExecutable);
+  late String testPath;
+  late String testCorePath;
+  late String testApiPath;
 
-  test('gracefully handles an early test suite exit', () async {
-    await d.file('test.dart', '''
-      import 'dart:io';
+  setUpAll(() async {
+    await precompileTestExecutable();
 
-      import 'package:test/test.dart';
-
-      void main() {
-        test('runs', () {});
-        test('exits', () {
-          exit(0);
-        });
-      }''').create();
-
-    var test = await runTest(['--compiler', 'exe', 'test.dart']);
-    expect(
-      test.stdout,
-      containsInOrder([
-        '+1: [VM, Exe] exits - did not complete [E]',
-        '+1: Some tests failed.',
-      ]),
+    testPath = await packageDir;
+    final testPathParts = p.split(testPath);
+    testCorePath = p.joinAll(
+      testPathParts.take(testPathParts.length - 1).followedBy(['test_core']),
     );
-    await test.shouldExit(1);
+    testApiPath = p.joinAll(
+      testPathParts.take(testPathParts.length - 1).followedBy(['test_api']),
+    );
   });
+
+  // The test sandbox must be set up as a valid Dart package (with its own
+  // pubspec.yaml, running `pub get` to generate a valid package_config.json,
+  // and putting the entrypoint under the correct package root). This is required
+  // for the `cli` compiler (`dart build cli`), which requires the entrypoint
+  // target to reside inside a package defined in the package config.
+  setUp(() async {
+    await d.file('pubspec.yaml', _pubspec(testPath, testCorePath, testApiPath)).create();
+
+    await (await runPub(['get'], workingDirectory: d.sandbox)).shouldExit(0);
+  });
+
+  for (var compiler in ['exe', 'cli']) {
+    test(
+        'gracefully handles an early test suite exit with the $compiler compiler',
+        () async {
+      await d.dir('test', [
+        d.file('test.dart', '''
+        import 'dart:io';
+
+        import 'package:test/test.dart';
+
+        void main() {
+          test('runs', () {});
+          test('exits', () {
+            exit(0);
+          });
+        }''')
+      ]).create();
+
+      var test = await runTest(
+        ['--compiler', compiler, 'test/test.dart'],
+        packageConfig: p.join(d.sandbox, '.dart_tool/package_config.json'),
+        workingDirectory: d.sandbox,
+      );
+      expect(
+        test.stdout,
+        containsInOrder([
+          '+1: [VM, ${compiler == 'exe' ? 'Exe' : 'Cli'}] exits - did not complete [E]',
+          '+1: Some tests failed.',
+        ]),
+      );
+      await test.shouldExit(1);
+    },
+        skip: compiler == 'cli' && !supportsCliCompiler
+            ? 'Dart version does not support build cli'
+            : null);
+  }
 }
+
+String _pubspec(String testPath, String testCorePath, String testApiPath) => '''
+name: mypackage
+version: 1.0.0
+environment:
+  sdk: ^3.5.0
+dev_dependencies:
+  test: any
+dependency_overrides:
+  test:
+    path: $testPath
+  test_core:
+    path: $testCorePath
+  test_api:
+    path: $testApiPath
+''';

--- a/pkgs/test/test/runner/subprocess_crash_test.dart
+++ b/pkgs/test/test/runner/subprocess_crash_test.dart
@@ -46,17 +46,19 @@ void main() {
   // for the `cli` compiler (`dart build cli`), which requires the entrypoint
   // target to reside inside a package defined in the package config.
   setUp(() async {
-    await d.file('pubspec.yaml', _pubspec(testPath, testCorePath, testApiPath)).create();
+    await d
+        .file('pubspec.yaml', _pubspec(testPath, testCorePath, testApiPath))
+        .create();
 
     await (await runPub(['get'], workingDirectory: d.sandbox)).shouldExit(0);
   });
 
   for (var compiler in ['exe', 'cli']) {
     test(
-        'gracefully handles an early test suite exit with the $compiler compiler',
-        () async {
-      await d.dir('test', [
-        d.file('test.dart', '''
+      'gracefully handles an early test suite exit with the $compiler compiler',
+      () async {
+        await d.dir('test', [
+          d.file('test.dart', '''
         import 'dart:io';
 
         import 'package:test/test.dart';
@@ -66,30 +68,32 @@ void main() {
           test('exits', () {
             exit(0);
           });
-        }''')
-      ]).create();
+        }'''),
+        ]).create();
 
-      var test = await runTest(
-        ['--compiler', compiler, 'test/test.dart'],
-        packageConfig: p.join(d.sandbox, '.dart_tool/package_config.json'),
-        workingDirectory: d.sandbox,
-      );
-      expect(
-        test.stdout,
-        containsInOrder([
-          '+1: [VM, ${compiler == 'exe' ? 'Exe' : 'Cli'}] exits - did not complete [E]',
-          '+1: Some tests failed.',
-        ]),
-      );
-      await test.shouldExit(1);
-    },
-        skip: compiler == 'cli' && !supportsCliCompiler
-            ? 'Dart version does not support build cli'
-            : null);
+        var test = await runTest(
+          ['--compiler', compiler, 'test/test.dart'],
+          packageConfig: p.join(d.sandbox, '.dart_tool/package_config.json'),
+          workingDirectory: d.sandbox,
+        );
+        expect(
+          test.stdout,
+          containsInOrder([
+            '+1: [VM, ${compiler == 'exe' ? 'Exe' : 'Cli'}] exits - did not complete [E]',
+            '+1: Some tests failed.',
+          ]),
+        );
+        await test.shouldExit(1);
+      },
+      skip: compiler == 'cli' && !supportsCliCompiler
+          ? 'Dart version does not support build cli'
+          : null,
+    );
   }
 }
 
-String _pubspec(String testPath, String testCorePath, String testApiPath) => '''
+String _pubspec(String testPath, String testCorePath, String testApiPath) =>
+    '''
 name: mypackage
 version: 1.0.0
 environment:

--- a/pkgs/test/test/runner/subprocess_crash_test.dart
+++ b/pkgs/test/test/runner/subprocess_crash_test.dart
@@ -23,42 +23,13 @@ final bool supportsCliCompiler = () {
 }();
 
 void main() {
-  late String testPath;
-  late String testCorePath;
-  late String testApiPath;
-
-  setUpAll(() async {
-    await precompileTestExecutable();
-
-    testPath = await packageDir;
-    final testPathParts = p.split(testPath);
-    testCorePath = p.joinAll(
-      testPathParts.take(testPathParts.length - 1).followedBy(['test_core']),
-    );
-    testApiPath = p.joinAll(
-      testPathParts.take(testPathParts.length - 1).followedBy(['test_api']),
-    );
-  });
-
-  // The test sandbox must be set up as a valid Dart package (with its own
-  // pubspec.yaml, running `pub get` to generate a valid package_config.json,
-  // and putting the entrypoint under the correct package root). This is required
-  // for the `cli` compiler (`dart build cli`), which requires the entrypoint
-  // target to reside inside a package defined in the package config.
-  setUp(() async {
-    await d
-        .file('pubspec.yaml', _pubspec(testPath, testCorePath, testApiPath))
-        .create();
-
-    await (await runPub(['get'], workingDirectory: d.sandbox)).shouldExit(0);
-  });
+  setUpAll(precompileTestExecutable);
 
   for (var compiler in ['exe', 'cli']) {
     test(
       'gracefully handles an early test suite exit with the $compiler compiler',
       () async {
-        await d.dir('test', [
-          d.file('test.dart', '''
+        await d.file('test.dart', '''
         import 'dart:io';
 
         import 'package:test/test.dart';
@@ -68,14 +39,9 @@ void main() {
           test('exits', () {
             exit(0);
           });
-        }'''),
-        ]).create();
+        }''').create();
 
-        var test = await runTest(
-          ['--compiler', compiler, 'test/test.dart'],
-          packageConfig: p.join(d.sandbox, '.dart_tool/package_config.json'),
-          workingDirectory: d.sandbox,
-        );
+        var test = await runTest(['--compiler', compiler, 'test.dart']);
         expect(
           test.stdout,
           containsInOrder([
@@ -91,20 +57,3 @@ void main() {
     );
   }
 }
-
-String _pubspec(String testPath, String testCorePath, String testApiPath) =>
-    '''
-name: mypackage
-version: 1.0.0
-environment:
-  sdk: ^3.5.0
-dev_dependencies:
-  test: any
-dependency_overrides:
-  test:
-    path: $testPath
-  test_core:
-    path: $testCorePath
-  test_api:
-    path: $testApiPath
-''';

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.7.13-wip
 
+* Add `Compiler.cli` (the native CLI compiler).
 * Expose several more backend APIs for use in `flutter_test`.
 * Allow using browser platforms with a specified OS.
 

--- a/pkgs/test_api/lib/src/backend/compiler.dart
+++ b/pkgs/test_api/lib/src/backend/compiler.dart
@@ -10,8 +10,13 @@ enum Compiler {
   /// Experimental Dart to Wasm compiler.
   dart2wasm('Dart2Wasm', 'dart2wasm'),
 
-  /// Compiles dart code to a native executable.
+  /// Compiles dart code to a native executable. This compiler does not
+  /// support code assets from build and link hooks.
   exe('Exe', 'exe'),
+
+  /// Compiles dart code to a native CLI bundle. This compiler supports
+  /// code assets from build and link hooks.
+  cli('Cli', 'cli'),
 
   /// The standard compiler for vm tests, compiles tests to kernel before
   /// running them on the VM.
@@ -25,6 +30,7 @@ enum Compiler {
     Compiler.dart2js,
     Compiler.dart2wasm,
     Compiler.exe,
+    Compiler.cli,
     Compiler.kernel,
     Compiler.source,
   ];

--- a/pkgs/test_api/lib/src/backend/runtime.dart
+++ b/pkgs/test_api/lib/src/backend/runtime.dart
@@ -14,6 +14,7 @@ final class Runtime {
     Compiler.kernel,
     Compiler.source,
     Compiler.exe,
+    Compiler.cli,
   ], isDartVM: true);
   static const Runtime vmAsan = Runtime(
     'VM with Address Sanitizer',

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.6.19-wip
 
+* Add support for `-c cli` (the native CLI compiler) to the vm platform.
 * Support using the OS platform selector to configure browser tests.
 * Use a DevTools URL instead of a defunct observatory URL.
 

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -41,20 +41,7 @@ class VMPlatform extends PlatformPlugin {
     p.join(p.current, '.dart_tool', 'test', 'incremental_kernel'),
   );
   final _closeMemo = AsyncMemoizer<void>();
-  // The temporary directory must be located within the package workspace
-  // under `.dart_tool` (and thus inside the active package root). This is
-  // because the bootstrapped/wrapper test file (e.g. `.bootstrap.native.dart`
-  // created by [_bootstrapNativeTestFile]) is written to this directory and
-  // passed as the `--target` entrypoint to `dart build cli`. If this wrapper
-  // entrypoint resides outside of a mapped package root (such as in the system
-  // temp directory), `dart build cli` will fail to compile.
-  final _tempDir = () {
-    var tempRoot = Directory(p.join(p.current, '.dart_tool', 'test', 'temp'));
-    if (!tempRoot.existsSync()) {
-      tempRoot.createSync(recursive: true);
-    }
-    return tempRoot.createTempSync('dart_test.vm.');
-  }();
+  final _tempDir = Directory.systemTemp.createTempSync('dart_test.vm.');
 
   @override
   Future<RunnerSuite?> load(
@@ -302,6 +289,8 @@ class VMPlatform extends PlatformPlugin {
       outputDir,
       '--packages',
       (await packageConfigUri).toFilePath(),
+      '--root-package',
+      (await currentPackage).name,
       if (platform.runtime == Runtime.vmAsan) '--target-sanitizer=asan',
       if (platform.runtime == Runtime.vmMsan) '--target-sanitizer=msan',
       if (platform.runtime == Runtime.vmTsan) '--target-sanitizer=tsan',

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -257,14 +257,16 @@ class VMPlatform extends PlatformPlugin {
     switch (platform.compiler) {
       case Compiler.cli:
         var executable = await _compileToCli(platform, path, suiteMetadata);
-        return await Process.start(
-          executable,
-          [socket.address.host, socket.port.toString()],
-          mode: ProcessStartMode.inheritStdio,
-        );
+        return await Process.start(executable, [
+          socket.address.host,
+          socket.port.toString(),
+        ], mode: ProcessStartMode.inheritStdio);
       case Compiler.exe:
-        var sharedLibrary =
-            await _compileToNative(platform, path, suiteMetadata);
+        var sharedLibrary = await _compileToNative(
+          platform,
+          path,
+          suiteMetadata,
+        );
         return await Process.start(
           _aotRuntimeFor(platform),
           [sharedLibrary, socket.address.host, socket.port.toString()],
@@ -318,7 +320,9 @@ stderr: ${processResult.stderr}''');
     );
     if (!await File(executablePath).exists()) {
       throw LoadException(
-          path, 'Compiled executable not found at $executablePath');
+        path,
+        'Compiled executable not found at $executablePath',
+      );
     }
     return executablePath;
   }

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -41,7 +41,17 @@ class VMPlatform extends PlatformPlugin {
     p.join(p.current, '.dart_tool', 'test', 'incremental_kernel'),
   );
   final _closeMemo = AsyncMemoizer<void>();
-  final _tempDir = Directory.systemTemp.createTempSync('dart_test.vm.');
+  // The temporary directory must be located within the package workspace
+  // under `.dart_tool` so that the bootstrapped target file resides inside a
+  // package root, which is required for `dart build cli` to find and run
+  // build/link hooks.
+  final _tempDir = () {
+    var tempRoot = Directory(p.join(p.current, '.dart_tool', 'test', 'temp'));
+    if (!tempRoot.existsSync()) {
+      tempRoot.createSync(recursive: true);
+    }
+    return tempRoot.createTempSync('dart_test.vm.');
+  }();
 
   @override
   Future<RunnerSuite?> load(
@@ -57,7 +67,8 @@ class VMPlatform extends PlatformPlugin {
     MultiChannel outerChannel;
     var cleanupCallbacks = <void Function()>[];
     Isolate? isolate;
-    if (platform.compiler == Compiler.exe) {
+    if (platform.compiler == Compiler.exe ||
+        platform.compiler == Compiler.cli) {
       var serverSocket = await ServerSocket.bind('localhost', 0);
       Process process;
       try {
@@ -131,10 +142,11 @@ class VMPlatform extends PlatformPlugin {
     String? isolateID;
     Uri? serverUri;
     if (_config.debug) {
-      if (platform.compiler == Compiler.exe) {
+      if (platform.compiler == Compiler.exe ||
+          platform.compiler == Compiler.cli) {
         throw UnsupportedError(
-          'Unable to debug tests compiled to `exe` (tried to debug $path with '
-          'the `exe` compiler).',
+          'Unable to debug tests compiled to `${platform.compiler.identifier}` '
+          '(tried to debug $path with the `${platform.compiler.identifier}` compiler).',
         );
       }
       var info = await Service.controlWebServer(
@@ -239,13 +251,73 @@ class VMPlatform extends PlatformPlugin {
       );
     }
 
-    var sharedLibrary = await _compileToNative(platform, path, suiteMetadata);
-    return await Process.start(
-      _aotRuntimeFor(platform),
-      [sharedLibrary, socket.address.host, socket.port.toString()],
-      environment: _environmentFor(platform),
-      mode: ProcessStartMode.inheritStdio,
+    switch (platform.compiler) {
+      case Compiler.cli:
+        var executable = await _compileToCli(platform, path, suiteMetadata);
+        return await Process.start(
+          executable,
+          [socket.address.host, socket.port.toString()],
+          mode: ProcessStartMode.inheritStdio,
+        );
+      case Compiler.exe:
+        var sharedLibrary =
+            await _compileToNative(platform, path, suiteMetadata);
+        return await Process.start(
+          _aotRuntimeFor(platform),
+          [sharedLibrary, socket.address.host, socket.port.toString()],
+          environment: _environmentFor(platform),
+          mode: ProcessStartMode.inheritStdio,
+        );
+      default:
+        throw StateError(
+          'Unsupported compiler ${platform.compiler} for spawning an executable',
+        );
+    }
+  }
+
+  /// Compiles [path] to a native CLI bundle using `dart build cli`.
+  Future<String> _compileToCli(
+    SuitePlatform platform,
+    String path,
+    Metadata suiteMetadata,
+  ) async {
+    var bootstrapPath = await _bootstrapNativeTestFile(
+      path,
+      suiteMetadata.languageVersionComment ??
+          await rootPackageLanguageVersionComment,
     );
+
+    var outputDir = p.join(_tempDir.path, 'cli_build');
+    var processResult = await Process.run(Platform.resolvedExecutable, [
+      'build',
+      'cli',
+      '--target',
+      bootstrapPath,
+      '--output',
+      outputDir,
+      '--packages',
+      (await packageConfigUri).toFilePath(),
+      if (platform.runtime == Runtime.vmAsan) '--target-sanitizer=asan',
+      if (platform.runtime == Runtime.vmMsan) '--target-sanitizer=msan',
+      if (platform.runtime == Runtime.vmTsan) '--target-sanitizer=tsan',
+    ]);
+    if (processResult.exitCode != 0) {
+      throw LoadException(path, '''
+exitCode: ${processResult.exitCode}
+stdout: ${processResult.stdout}
+stderr: ${processResult.stderr}''');
+    }
+    var executablePath = p.join(
+      outputDir,
+      'bundle',
+      'bin',
+      p.basenameWithoutExtension(bootstrapPath),
+    );
+    if (!await File(executablePath).exists()) {
+      throw LoadException(
+          path, 'Compiled executable not found at $executablePath');
+    }
+    return executablePath;
   }
 
   /// Compiles [path] to a native shared library using

--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -42,9 +42,12 @@ class VMPlatform extends PlatformPlugin {
   );
   final _closeMemo = AsyncMemoizer<void>();
   // The temporary directory must be located within the package workspace
-  // under `.dart_tool` so that the bootstrapped target file resides inside a
-  // package root, which is required for `dart build cli` to find and run
-  // build/link hooks.
+  // under `.dart_tool` (and thus inside the active package root). This is
+  // because the bootstrapped/wrapper test file (e.g. `.bootstrap.native.dart`
+  // created by [_bootstrapNativeTestFile]) is written to this directory and
+  // passed as the `--target` entrypoint to `dart build cli`. If this wrapper
+  // entrypoint resides outside of a mapped package root (such as in the system
+  // temp directory), `dart build cli` will fail to compile.
   final _tempDir = () {
     var tempRoot = Directory(p.join(p.current, '.dart_tool', 'test', 'temp'));
     if (!tempRoot.existsSync()) {


### PR DESCRIPTION
Bug:

* https://github.com/dart-lang/sdk/issues/63372

This PR uses `dart build cli` under the `-c cli` flag.

Implementation:

* The wrapper Dart script around the test that package test creates is the new entry-point and **must** be within the package root to run the correct hooks.
  * So, this PR updates the temp dir to be in `.dart_tool/test/temp/<...>` rather than in the system temp.
* Gates the implementation on the next dev release after https://dart-review.googlesource.com/c/sdk/+/506242.

Testing:

* The integration tests run with the `cli` compiler
* The integration tests must run on a valid package with a valid pubspec and package_config.json (otherwise the hooks-runner cannot determine which hooks to run).
* The integration tests do _not_ actually run a hook and include c code. `dart build cli` bundles are already properly tested in the dartdev tests for `dart build cli` in the SDK. If you feel we should add an integration test running native code here, I'm happy to add one.
* Skips the tests before the next dev release.
  * **TODO**: Rerun tests on Tuesday after new dev release has come out.