### PR TITLE
Throw when an async matcher is used with isNot

### DIFF
--- a/pkgs/matcher/CHANGELOG.md
+++ b/pkgs/matcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.21-wip
+
+* Throw an `ArgumentError` when `isNot` or `anyOf` is used with an `AsyncMatcher`.
+
 ## 0.12.20
 
 * Allow exceptions from `operator ==` to bubble up and fail the test instead of

--- a/pkgs/matcher/lib/src/operator_matchers.dart
+++ b/pkgs/matcher/lib/src/operator_matchers.dart
@@ -2,11 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'expect/async_matcher.dart';
 import 'interfaces.dart';
 import 'util.dart';
 
 /// Returns a matcher that inverts [valueOrMatcher] to its logical negation.
-Matcher isNot(Object? valueOrMatcher) => _IsNot(wrapMatcher(valueOrMatcher));
+Matcher isNot(Object? valueOrMatcher) {
+  final matcher = wrapMatcher(valueOrMatcher);
+  if (matcher is AsyncMatcher) {
+    throw ArgumentError('isNot cannot be used with AsyncMatchers');
+  }
+  return _IsNot(matcher);
+}
 
 class _IsNot extends Matcher {
   final Matcher _matcher;
@@ -108,6 +115,9 @@ class _AnyOf extends Matcher {
   @override
   bool matches(dynamic item, Map matchState) {
     for (var matcher in _matchers) {
+      if (matcher is AsyncMatcher) {
+        throw ArgumentError('anyOf cannot be used with AsyncMatchers');
+      }
       if (matcher.matches(item, matchState)) {
         return true;
       }

--- a/pkgs/matcher/pubspec.yaml
+++ b/pkgs/matcher/pubspec.yaml
@@ -1,5 +1,5 @@
 name: matcher
-version: 0.12.20
+version: 0.12.21-wip
 description: >-
   Support for specifying test expectations via an extensible Matcher class.
   Also includes a number of built-in Matcher implementations for common cases.

--- a/pkgs/matcher/test/expect_test.dart
+++ b/pkgs/matcher/test/expect_test.dart
@@ -34,9 +34,5 @@ void main() {
         throwsA(isTestFailure(anything)),
       );
     });
-
-    test('can be used with synchronous operators', () {
-      expect(() {}, isNot(throwsA(anything)));
-    });
   });
 }

--- a/pkgs/matcher/test/operator_matchers_test.dart
+++ b/pkgs/matcher/test/operator_matchers_test.dart
@@ -2,8 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:matcher/expect.dart' show expect, throwsA, throwsArgumentError;
 import 'package:matcher/matcher.dart';
-import 'package:test/test.dart' show expect, test, throwsArgumentError, throwsA;
+import 'package:test/test.dart' show test;
 
 import 'test_utils.dart';
 

--- a/pkgs/matcher/test/operator_matchers_test.dart
+++ b/pkgs/matcher/test/operator_matchers_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:matcher/matcher.dart';
-import 'package:test/test.dart' show expect, test, throwsArgumentError;
+import 'package:test/test.dart' show expect, test, throwsArgumentError, throwsA;
 
 import 'test_utils.dart';
 
@@ -86,4 +86,14 @@ void main() {
       throwsArgumentError,
     );
   });
+
+  test('isNot throws ArgumentError for AsyncMatcher', () {
+    expect(() => isNot(throwsA(anything)), throwsArgumentError);
+  });
+
+  test('anyOf throws ArgumentError for AsyncMatcher', () {
+    final matcher = anyOf(throwsA(anything));
+    expect(() => matcher.matches(null, {}), throwsArgumentError);
+  });
 }
+

--- a/pkgs/matcher/test/operator_matchers_test.dart
+++ b/pkgs/matcher/test/operator_matchers_test.dart
@@ -96,4 +96,3 @@ void main() {
     expect(() => matcher.matches(null, {}), throwsArgumentError);
   });
 }
-


### PR DESCRIPTION
Closes #1637

Async matchers are implemented as a hack where they usually appear to
succeed synchronously, and may report an error for the test case later.
This is incompatible with meta matchers or "operator" matchers `isNot`
and `anyOf` where the synchronous answer is trusted and other values are
derived from it. In the case of `isNot` this causes false positives, and
for `anyOf` it causes false negatives.

Historically it was infeasible to add knowledg about `AsyncMatcher` in
the definition of these operators, because async matching was
implemented in the test runner directly and the matchers exposed by the
test runner are a superset of those defined by the matcher package. Now
that `expect` and the async matchers are definied in `package:matcher`
it is possible to detect when an async matcher is used this way.

There is one async matcher when does often serve as a synchronous
matcher in practice - the `throwsA` matcher is used for both synchronous
and asynchronous errors, the same matcher is uesed for `Function()`,
`Future Function()` and `Future` values. I think the combination of
`throwsA` and `isNot` or `anyOf` is likely to be rare, but if errors
surface in practice we may need to add an exception for the `Throws`
matcher.
