### PR TITLE
Close receive port in VM platform on null isolate

### DIFF
--- a/pkgs/test_core/lib/src/runner/vm/platform.dart
+++ b/pkgs/test_core/lib/src/runner/vm/platform.dart
@@ -87,7 +87,10 @@ class VMPlatform extends PlatformPlugin {
           suiteConfig.metadata,
           platform.compiler,
         );
-        if (isolate == null) return null;
+        if (isolate == null) {
+          receivePort.close();
+          return null;
+        }
       } catch (error) {
         receivePort.close();
         rethrow;


### PR DESCRIPTION
This resolves flakiness in top_level_configuration_test.dart
