### PR TITLE
Disable chrome throttling options

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -11,6 +11,7 @@
   all tests with OS `'windows'` would previously still run browser tests on
   windows, but will now skip all tests including browser tests.
 * Use a DevTools URL instead of a defunct observatory URL.
+* Disable throttling in chrome launch arguments.
 
 ## 1.31.1
 

--- a/pkgs/test/lib/src/runner/browser/chromium.dart
+++ b/pkgs/test/lib/src/runner/browser/chromium.dart
@@ -42,6 +42,9 @@ enum ChromiumBasedBrowser {
       '--disable-default-apps',
       '--disable-translate',
       '--disable-dev-shm-usage',
+      '--disable-background-timer-throttling',
+      '--disable-blink-features=TimerThrottlingForBackgroundTabs',
+      '--disable-features=IntensiveWakeUpThrottling',
       if (settings!.headless && !configuration.pauseAfterLoad) ...[
         '--headless',
         '--disable-gpu',


### PR DESCRIPTION
I don't expect this to have an effect in typical tests, but in case a
test opens a new tab or similar it's a good idea to disable throttling
when the browser is controlled by automation.
