### PR TITLE
Disable more backgrounding features on chromium

### DIFF
--- a/pkgs/test/lib/src/runner/browser/chromium.dart
+++ b/pkgs/test/lib/src/runner/browser/chromium.dart
@@ -43,6 +43,8 @@ enum ChromiumBasedBrowser {
       '--disable-translate',
       '--disable-dev-shm-usage',
       '--disable-background-timer-throttling',
+      '--disable-backgrounding-occluded-windows',
+      '--disable-renderer-backgrounding',
       '--disable-blink-features=TimerThrottlingForBackgroundTabs',
       '--disable-features=IntensiveWakeUpThrottling',
       if (settings!.headless && !configuration.pauseAfterLoad) ...[


### PR DESCRIPTION
Add more flags to disable backgrounding when launching chromium based
browsers. These came up in an internal CL but should be helpful to
include externally.
