### PR TITLE
Add `isNotA<R>()` extension

### DIFF
--- a/pkgs/checks/CHANGELOG.md
+++ b/pkgs/checks/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.3.2-wip
 
+- Add `isNotA<R>()` check extension as a convenience in place of
+  `not((it) => it.isA<R>())`.
 - Require Dart 3.11
 - Improve speed of pretty printing for large collections.
 - Improve formatting for failures involving unexpected exceptions.

--- a/pkgs/checks/lib/src/extensions/core.dart
+++ b/pkgs/checks/lib/src/extensions/core.dart
@@ -112,6 +112,16 @@ extension CoreChecks<T> on Subject<T> {
     }, atSameLevel: true);
   }
 
+  /// Expects that the value is not assignable to type [R].
+  void isNotA<R>() {
+    context.expect(() => ['is not a $R'], (actual) {
+      if (actual is R) {
+        return Rejection(which: ['is a $R']);
+      }
+      return null;
+    });
+  }
+
   /// Expects that the value is equal to [other] according to [operator ==].
   void equals(T other) {
     context.expect(() => prefixFirst('equals ', literal(other)), (actual) {

--- a/pkgs/checks/test/extensions/core_test.dart
+++ b/pkgs/checks/test/extensions/core_test.dart
@@ -14,6 +14,12 @@ void main() {
 
       check(1).isRejectedBy((it) => it.isA<String>(), which: ['Is a int']);
     });
+    test('isNotA', () {
+      check(1).isNotA<String>();
+
+      check(1).isRejectedBy((it) => it.isNotA<int>(), which: ['is a int']);
+      check(1).isRejectedBy((it) => it.isNotA<num>(), which: ['is a num']);
+    });
   });
   group('HasField', () {
     test('has', () {


### PR DESCRIPTION
Closes #2673

In a negative type check context it is not sensible to perform further
checks, but that may be tempting (potentially with autocomplete) in an
expression like `not((it) => it.isA<Foo>()`. Add an `isNotA<R>`
extension which does not return a subject.
