### PR TITLE
fix(node): update dart2wasm runner for new instantiation API

### DIFF
--- a/pkgs/test/lib/src/runner/node/platform.dart
+++ b/pkgs/test/lib/src/runner/node/platform.dart
@@ -294,7 +294,7 @@ const { once } = require('events');
 const { PassThrough } = require('stream');
 
 const main = async () => {
-  const { instantiate, invoke } = await import("./$loader");
+  const dart2wasmJsRuntime = await import("./$loader");
 
   const wasmContents = createReadStream(String.raw`$wasmPath.wasm`);
   const stream = new PassThrough();
@@ -309,9 +309,9 @@ const main = async () => {
       }
     }
   );
-  const instancePromise = WebAssembly.compileStreaming(response);
-  const module = await instantiate(instancePromise, {});
-  invoke(module);
+  const compiledModule = await dart2wasmJsRuntime.compileStreaming(response);
+  const instantiatedModule = await compiledModule.instantiate();
+  instantiatedModule.invokeMain();
 };
 
 main();

--- a/pkgs/test/test/runner/node/runner_test.dart
+++ b/pkgs/test/test/runner/node/runner_test.dart
@@ -167,24 +167,19 @@ void main() {
       await test.shouldExit(0);
     });
 
-    test(
-      'compiled with dart2wasm',
-      () async {
-        await d.file('test.dart', _success).create();
-        var test = await runTest([
-          '-p',
-          'node',
-          '--compiler',
-          'dart2wasm',
-          'test.dart',
-        ]);
+    test('compiled with dart2wasm', () async {
+      await d.file('test.dart', _success).create();
+      var test = await runTest([
+        '-p',
+        'node',
+        '--compiler',
+        'dart2wasm',
+        'test.dart',
+      ]);
 
-        expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
-        await test.shouldExit(0);
-      },
-      // https://github.com/dart-lang/test/issues/2679
-      skip: true /* skipBelowMajorNodeVersion(22) */,
-    );
+      expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
+      await test.shouldExit(0);
+    }, skip: skipBelowMajorNodeVersion(22));
   });
 
   test('defines a node environment constant', () async {


### PR DESCRIPTION
Update NodePlatform to import the generated JS runtime module and call `compileStreaming()`, `.instantiate()`, and `invokeMain()`.

Re-enable the skipped dart2wasm test in `runner_test.dart`.

fixes https://github.com/dart-lang/test/issues/2679