### PR TITLE
Use compact reporters by default for direct runs

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -16,6 +16,8 @@
 * Disable throttling in chrome launch arguments.
 * Allow package_config `3.x.x`.
 * Require `analyzer: '>=13.0.0 <15.0.0'`
+* Use the compact or failures-only reporters by default for tests run directly
+  instead of through the test runner.
 
 ## 1.31.1
 

--- a/pkgs/test/test/runner/runner_test.dart
+++ b/pkgs/test/test/runner/runner_test.dart
@@ -374,7 +374,13 @@ $_usage''');
       await d.file('test.dart', _success).create();
       var test = await runDart(['test.dart']);
 
-      expect(test.stdout, emitsThrough(contains('All tests passed!')));
+      expect(
+        test.stdout,
+        allOf(
+          neverEmits(contains('success')),
+          emitsThrough(contains('All tests passed!')),
+        ),
+      );
       await test.shouldExit(0);
     });
 
@@ -444,7 +450,15 @@ $_usage''');
 
     test('directly', () async {
       var test = await runDart(['test.dart']);
-      expect(test.stdout, emitsThrough(contains('All tests passed!')));
+
+      expect(
+        test.stdout,
+        allOf(
+          neverEmits(anyElement(contains('success 1'))),
+          neverEmits(anyElement(contains('success 2'))),
+          emits(contains('All tests passed!')),
+        ),
+      );
       await test.shouldExit(0);
     });
   });

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Allow package_config `3.x.x`.
 * Require `analyzer: '>=13.0.0 <15.0.0'`
 * Update `parse_metadata.dart` to be compatible with `analyzer >=13.0.0 <15.0.0`.
+* Use the compact or failures-only reporters by default for tests run directly
+  instead of through the test runner.
 
 ## 0.6.18
 

--- a/pkgs/test_core/lib/src/direct_run.dart
+++ b/pkgs/test_core/lib/src/direct_run.dart
@@ -8,7 +8,6 @@ import 'dart:collection';
 import 'package:path/path.dart' as p;
 import 'package:test_api/backend.dart';
 
-import 'runner/configuration.dart';
 import 'runner/engine.dart';
 import 'runner/plugin/environment.dart';
 import 'runner/reporter.dart';
@@ -16,7 +15,6 @@ import 'runner/reporter/direct.dart';
 import 'runner/runner_suite.dart';
 import 'runner/suite.dart';
 import 'util/os.dart';
-import 'util/print_sink.dart';
 
 /// Runs all unskipped test cases declared in [testMain].
 ///

--- a/pkgs/test_core/lib/src/direct_run.dart
+++ b/pkgs/test_core/lib/src/direct_run.dart
@@ -12,7 +12,7 @@ import 'runner/configuration.dart';
 import 'runner/engine.dart';
 import 'runner/plugin/environment.dart';
 import 'runner/reporter.dart';
-import 'runner/reporter/expanded.dart';
+import 'runner/reporter/direct.dart';
 import 'runner/runner_suite.dart';
 import 'runner/suite.dart';
 import 'util/os.dart';
@@ -64,13 +64,7 @@ Future<bool> _directRunTests(
   String? fullTestName,
   required bool allowDuplicateTestNames,
 }) async {
-  reporterFactory ??= (engine) => ExpandedReporter.watch(
-    engine,
-    PrintSink(),
-    color: Configuration.empty.color,
-    printPath: false,
-    printPlatform: false,
-  );
+  reporterFactory ??= createDirectReporter;
   final declarer = Declarer(
     fullTestName: fullTestName,
     allowDuplicateTestNames: allowDuplicateTestNames,

--- a/pkgs/test_core/lib/src/runner/reporter/direct.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/direct.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export 'direct_stub.dart' if (dart.library.io) 'direct_io.dart';

--- a/pkgs/test_core/lib/src/runner/reporter/direct.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/direct.dart
@@ -2,4 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/// A utility to pick a platform safe default reporter for cases where a test
+/// suite is run directly instead of through the test runner.
+library;
+
 export 'direct_stub.dart' if (dart.library.io) 'direct_io.dart';

--- a/pkgs/test_core/lib/src/runner/reporter/direct_io.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/direct_io.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../../util/io.dart';
+import '../../util/print_sink.dart';
+import '../engine.dart';
+import '../reporter.dart';
+import 'compact.dart';
+import 'failures_only.dart';
+
+Reporter createDirectReporter(Engine engine) => canUseSpecialChars
+    ? CompactReporter.watch(
+        engine,
+        PrintSink(),
+        color: true,
+        printPath: false,
+        printPlatform: false,
+      )
+    : FailuresOnlyReporter.watch(
+        engine,
+        PrintSink(),
+        color: false,
+        printPath: false,
+        printPlatform: false,
+      );

--- a/pkgs/test_core/lib/src/runner/reporter/direct_stub.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/direct_stub.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../../util/print_sink.dart';
+import '../engine.dart';
+import '../reporter.dart';
+import 'failures_only.dart';
+
+Reporter createDirectReporter(Engine engine) => FailuresOnlyReporter.watch(
+  engine,
+  PrintSink(),
+  color: false,
+  printPath: false,
+  printPlatform: false,
+);

--- a/pkgs/test_core/lib/src/scaffolding.dart
+++ b/pkgs/test_core/lib/src/scaffolding.dart
@@ -15,7 +15,6 @@ import 'runner/reporter/direct.dart';
 import 'runner/runner_suite.dart';
 import 'runner/suite.dart';
 import 'util/os.dart';
-import 'util/print_sink.dart';
 
 // Hide implementations which don't support being run directly.
 // This file is an almost direct copy of import below, but with the global

--- a/pkgs/test_core/lib/src/scaffolding.dart
+++ b/pkgs/test_core/lib/src/scaffolding.dart
@@ -11,7 +11,7 @@ import 'package:test_api/scaffolding.dart' show Timeout, pumpEventQueue;
 
 import 'runner/engine.dart';
 import 'runner/plugin/environment.dart';
-import 'runner/reporter/expanded.dart';
+import 'runner/reporter/direct.dart';
 import 'runner/runner_suite.dart';
 import 'runner/suite.dart';
 import 'util/os.dart';
@@ -58,13 +58,7 @@ Declarer get _declarer {
     var engine = Engine();
     engine.suiteSink.add(suite);
     engine.suiteSink.close();
-    ExpandedReporter.watch(
-      engine,
-      PrintSink(),
-      color: true,
-      printPath: false,
-      printPlatform: false,
-    );
+    createDirectReporter(engine);
 
     var success = await runZoned(
       () => Invoker.guard(engine.run),


### PR DESCRIPTION
Since we cannot import `dart:io` for tests running on the web we
historically defaulted to the expanded reporter as the only alternative
to the compact reporter. This doesn't match most users preferences since
it makes a verbose output in all cases.

Default instead to the failures only reporter which is quieter, and add
a platform specific library to automatically switch to the compact
reporter when it's supported by both the Dart platform and the runtime
environment.
