### PR TITLE
Group messages with passing tests

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -4,6 +4,8 @@
   when tests are run directly on platforms which support `dart:io`. The
   environment variable takes precedence over configuration in `dart_test.yaml`
   but is overridden by the `--reporter` flag when passed to the test runner.
+* Include passing test and suite loading messages within the `Passing tests`
+  group in `GithubReporter`.
 
 ## 1.31.2
 

--- a/pkgs/test/test/runner/github_reporter_test.dart
+++ b/pkgs/test/test/runner/github_reporter_test.dart
@@ -205,13 +205,34 @@ void main() {
           print("four");
         });''',
         '''
-        ::group::✅ test
+        ::group::✅ Passing tests
+        ✅ test
         one
         two
         three
         four
         ::endgroup::''',
         useContains: true,
+      );
+    });
+
+    test('includes prints from passing tests in passing tests group', () {
+      return _expectReport(
+        '''
+        test('pass 1', () {
+          print("print from pass 1");
+        });
+        test('pass 2', () {
+          print("print from pass 2");
+        });''',
+        '''
+        ::group::✅ Passing tests
+        ✅ pass 1
+        print from pass 1
+        ✅ pass 2
+        print from pass 2
+        ::endgroup::
+        🎉 2 tests passed.''',
       );
     });
 
@@ -387,14 +408,27 @@ void main() {
             test('test 1', () {});
           });''',
       '''
-          ::group::✅ one (setUpAll)
-          one
-          ::endgroup::
           ::group::✅ Passing tests
+          ✅ one (setUpAll)
+          one
           ✅ one test 1
-          ::endgroup::
-          ::group::✅ one (tearDownAll)
+          ✅ one (tearDownAll)
           two
+          ::endgroup::
+          🎉 1 test passed.''',
+    );
+  });
+
+  test('prints during suite load are included in passing tests group', () {
+    return _expectReport(
+      '''
+          print('loading output');
+          test('test 1', () {});''',
+      '''
+          ::group::✅ Passing tests
+          ✅ loading test.dart
+          loading output
+          ✅ test 1
           ::endgroup::
           🎉 1 test passed.''',
     );

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.6.20-wip
 
 * Add support for `DART_TEST_REPORTER` environment variable.
+* Include passing test and suite loading messages within the `Passing tests` group in `GithubReporter`.
 
 ## 0.6.19
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 0.6.20-wip
 
 * Add support for `DART_TEST_REPORTER` environment variable.
-* Include passing test and suite loading messages within the `Passing tests` group in `GithubReporter`.
+* Include passing test and suite loading messages within the `Passing tests`
+  group in `GithubReporter`.
 
 ## 0.6.19
 

--- a/pkgs/test_core/lib/src/runner/reporter/github.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/github.dart
@@ -185,7 +185,7 @@ class GithubReporter implements Reporter {
       for (var message in messages) {
         _sink.writeln(message.text);
       }
-    } else if (messages.isEmpty && errors.isEmpty) {
+    } else if (errors.isEmpty) {
       if (_activeGroup.isSkipped) {
         _sink.writeln(_GithubMarkup.endGroup);
       }
@@ -194,6 +194,9 @@ class GithubReporter implements Reporter {
         _activeGroup = _ReportGroup.passing;
       }
       _sink.writeln('$prefix $name$statusSuffix');
+      for (var message in messages) {
+        _sink.writeln(message.text);
+      }
     } else {
       if (!_activeGroup.isUngrouped) {
         _sink.writeln(_GithubMarkup.endGroup);


### PR DESCRIPTION
Closes #2636

Web tests unconditionally print information about the compile, so
treating messages during loading as separate output from passing tests
causes significantly longer output when web and VM tests are
interleaved.

Avoid closing groups for tests that print messages. This will impact
more than loading tests, but won't impact errors which are the important
output.
