### PR TITLE
Ignore dart2js output for successful compiles

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -4,8 +4,9 @@
   when tests are run directly on platforms which support `dart:io`. The
   environment variable takes precedence over configuration in `dart_test.yaml`
   but is overridden by the `--reporter` flag when passed to the test runner.
-* Include passing test and suite loading messages within the `Passing tests`
-  group in `GithubReporter`.
+* Suppress dart2js compiler output for successful compiles.
+* Include output from passing tests  messages within the `Passing tests` group
+  in `GithubReporter`.
 
 ## 1.31.2
 

--- a/pkgs/test/test/runner/browser/loader_test.dart
+++ b/pkgs/test/test/runner/browser/loader_test.dart
@@ -174,9 +174,8 @@ void main() {
     var loadSuite = suites.first;
 
     var liveTest = (loadSuite.group.entries.single as Test).load(loadSuite);
-    // Skip the "Compiled" message from dart2js.
     expect(
-      liveTest.onMessage.skip(1).first.then((message) => message.text),
+      liveTest.onMessage.first.then((message) => message.text),
       completion(equals('print within test')),
     );
     await liveTest.run();

--- a/pkgs/test/test/runner/browser/runner_test.dart
+++ b/pkgs/test/test/runner/browser/runner_test.dart
@@ -41,7 +41,7 @@ void main() {
         containsInOrder([
           'Error: Compilation failed.',
           '-1: loading test.dart [E]',
-          'Failed to load "test.dart": dart2js failed.',
+          'Failed to load "test.dart": Bad state: dart2js failed.',
         ]),
       );
       await test.shouldExit(1);

--- a/pkgs/test/test/runner/json_reporter_test.dart
+++ b/pkgs/test/test/runner/json_reporter_test.dart
@@ -630,14 +630,6 @@ void main() {
             [
               suiteJson(0, platform: 'chrome'),
               testStartJson(1, 'loading test.dart', groupIDs: []),
-              printJson(
-                1,
-                isA<String>().having(
-                  (s) => s.split('\n'),
-                  'lines',
-                  contains(startsWith('Compiled')),
-                ),
-              ),
               testDoneJson(1, hidden: true),
             ],
             [
@@ -847,14 +839,6 @@ void customTest(String name, dynamic Function() testFn) => test(name, testFn);
         [
           suiteJson(0, platform: 'chrome'),
           testStartJson(1, 'loading test.dart', groupIDs: []),
-          printJson(
-            1,
-            isA<String>().having(
-              (s) => s.split('\n'),
-              'lines',
-              contains(startsWith('Compiled')),
-            ),
-          ),
           testDoneJson(1, hidden: true),
         ],
         [

--- a/pkgs/test/test/runner/node/runner_test.dart
+++ b/pkgs/test/test/runner/node/runner_test.dart
@@ -86,7 +86,7 @@ void main() {
         containsInOrder([
           'Error: Compilation failed.',
           '-1: loading test.dart [E]',
-          'Failed to load "test.dart": dart2js failed.',
+          'Failed to load "test.dart": Bad state: dart2js failed.',
         ]),
       );
       await test.shouldExit(1);

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## 0.6.20-wip
 
 * Add support for `DART_TEST_REPORTER` environment variable.
-* Include passing test and suite loading messages within the `Passing tests`
-  group in `GithubReporter`.
+* Suppress dart2js compiler output for successful compiles.
+* Include passing test  messages within the `Passing tests` group in
+  `GithubReporter`.
 
 ## 0.6.19
 

--- a/pkgs/test_core/lib/src/runner/dart2js_compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/dart2js_compiler_pool.dart
@@ -13,11 +13,6 @@ import '../util/package_config.dart';
 import 'compiler_pool.dart';
 import 'suite.dart';
 
-/// A regular expression matching the first status line printed by dart2js.
-final _dart2jsStatus = RegExp(
-  r'^Dart file \(.*\) compiled to JavaScript: .*\n?',
-);
-
 /// A pool of `dart2js` instances.
 ///
 /// This limits the number of compiler instances running concurrently.
@@ -88,10 +83,11 @@ class Dart2JsCompilerPool extends CompilerPool {
       _processes.remove(process);
       if (closed) return;
 
-      var output = buffer.toString().replaceFirst(_dart2jsStatus, '');
-      if (output.isNotEmpty) print(output);
-
-      if (exitCode != 0) throw 'dart2js failed.';
+      if (exitCode != 0) {
+        var output = buffer.toString();
+        if (output.isNotEmpty) print(output);
+        throw StateError('dart2js failed.');
+      }
 
       _fixSourceMap('$path.map');
     });

--- a/pkgs/test_core/lib/src/runner/wasm_compiler_pool.dart
+++ b/pkgs/test_core/lib/src/runner/wasm_compiler_pool.dart
@@ -77,10 +77,11 @@ class WasmCompilerPool extends CompilerPool {
       _processes.remove(process);
       if (closed) return;
 
-      var output = buffer.toString();
-      if (output.isNotEmpty) print(output);
-
-      if (exitCode != 0) throw StateError('dart2wasm failed.');
+      if (exitCode != 0) {
+        var output = buffer.toString();
+        if (output.isNotEmpty) print(output);
+        throw StateError('dart2wasm failed.');
+      }
     });
   }
 


### PR DESCRIPTION
Followup to #2699

The compiler output had some utility when dart2js could be slow for some
test runs, but it's likely ignored nearly always today.

Drop the output from successful compiles and output only when the exit
code indicates an error. Update test expectations accordingly.
