### PR TITLE
Only print debug URL when debugging

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Suppress dart2js compiler output for successful compiles.
 * Include output from passing tests  messages within the `Passing tests` group
   in `GithubReporter`.
+* Only include VM debugger in output when using interactive debugging, suppress
+  it when only using coverage.
 
 ## 1.31.2
 

--- a/pkgs/test/test/runner/json_reporter_test.dart
+++ b/pkgs/test/test/runner/json_reporter_test.dart
@@ -6,6 +6,7 @@
 library;
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -851,6 +852,86 @@ void customTest(String name, dynamic Function() testFn) => test(name, testFn);
       args: ['-p', 'chrome', '--js-trace'],
     );
   }, tags: ['chrome']);
+
+  test('does not emit debug events when --coverage is enabled', () async {
+    var tempDir = await Directory.systemTemp.createTemp('coverage_json_test');
+    try {
+      await d.file('test.dart', '''
+        import 'package:test/test.dart';
+        void main() {
+          test('success', () {});
+        }
+      ''').create();
+
+      var test = await runTest([
+        'test.dart',
+        '--coverage',
+        tempDir.path,
+      ], reporter: 'json');
+      await test.shouldExit(0);
+
+      var stdoutLines = await test.stdoutStream().toList();
+      var events = [
+        for (var line in stdoutLines) jsonDecode(line) as Map<String, dynamic>,
+      ];
+      expect(events.where((e) => e['type'] == 'debug'), isEmpty);
+    } finally {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('emits debug events when --pause-after-load is enabled', () async {
+    await d.file('test.dart', '''
+      import 'package:test/test.dart';
+      void main() {
+        test('success', () {});
+      }
+    ''').create();
+
+    var test = await runTest([
+      'test.dart',
+      '--pause-after-load',
+    ], reporter: 'json');
+
+    await expectLater(test.stdout, emitsThrough(contains('"type":"debug"')));
+
+    test.stdin.writeln();
+    await test.shouldExit(0);
+  });
+
+  test(
+    'emits debug events when both --pause-after-load and --coverage are enabled',
+    () async {
+      var tempDir = await Directory.systemTemp.createTemp(
+        'coverage_pause_json_test',
+      );
+      try {
+        await d.file('test.dart', '''
+        import 'package:test/test.dart';
+        void main() {
+          test('success', () {});
+        }
+      ''').create();
+
+        var test = await runTest([
+          'test.dart',
+          '--pause-after-load',
+          '--coverage',
+          tempDir.path,
+        ], reporter: 'json');
+
+        await expectLater(
+          test.stdout,
+          emitsThrough(contains('"type":"debug"')),
+        );
+
+        test.stdin.writeln();
+        await test.shouldExit(0);
+      } finally {
+        await tempDir.delete(recursive: true);
+      }
+    },
+  );
 }
 
 /// Asserts that the tests defined by [tests] produce the JSON events in

--- a/pkgs/test/test/runner/json_reporter_test.dart
+++ b/pkgs/test/test/runner/json_reporter_test.dart
@@ -880,24 +880,29 @@ void customTest(String name, dynamic Function() testFn) => test(name, testFn);
     }
   });
 
-  test('emits debug events when --pause-after-load is enabled', () async {
-    await d.file('test.dart', '''
+  test(
+    'emits debug events when --pause-after-load is enabled',
+    () async {
+      await d.file('test.dart', '''
       import 'package:test/test.dart';
       void main() {
         test('success', () {});
       }
     ''').create();
 
-    var test = await runTest([
-      'test.dart',
-      '--pause-after-load',
-    ], reporter: 'json');
+      var test = await runTest([
+        'test.dart',
+        '--pause-after-load',
+      ], reporter: 'json');
 
-    await expectLater(test.stdout, emitsThrough(contains('"type":"debug"')));
+      await expectLater(test.stdout, emitsThrough(contains('"type":"debug"')));
 
-    test.stdin.writeln();
-    await test.shouldExit(0);
-  }, testOn: '!windows');
+      test.stdin.writeln();
+      await test.shouldExit(0);
+    },
+    // TODO(https://github.com/dart-lang/test/issues/1613): Fix pause after load tests on windows.
+    testOn: '!windows',
+  );
 
   test(
     'emits debug events when both --pause-after-load and --coverage are enabled',
@@ -931,6 +936,7 @@ void customTest(String name, dynamic Function() testFn) => test(name, testFn);
         await tempDir.delete(recursive: true);
       }
     },
+    // TODO(https://github.com/dart-lang/test/issues/1613): Fix pause after load tests on windows.
     testOn: '!windows',
   );
 }

--- a/pkgs/test/test/runner/json_reporter_test.dart
+++ b/pkgs/test/test/runner/json_reporter_test.dart
@@ -897,7 +897,7 @@ void customTest(String name, dynamic Function() testFn) => test(name, testFn);
 
     test.stdin.writeln();
     await test.shouldExit(0);
-  });
+  }, testOn: '!windows');
 
   test(
     'emits debug events when both --pause-after-load and --coverage are enabled',
@@ -931,6 +931,7 @@ void customTest(String name, dynamic Function() testFn) => test(name, testFn);
         await tempDir.delete(recursive: true);
       }
     },
+    testOn: '!windows',
   );
 }
 

--- a/pkgs/test_core/CHANGELOG.md
+++ b/pkgs/test_core/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Suppress dart2js compiler output for successful compiles.
 * Include passing test  messages within the `Passing tests` group in
   `GithubReporter`.
+* Only include VM debugger in output when using interactive debugging, suppress
+  it when only using coverage.
 
 ## 0.6.19
 

--- a/pkgs/test_core/lib/src/runner/configuration/reporters.dart
+++ b/pkgs/test_core/lib/src/runner/configuration/reporters.dart
@@ -91,7 +91,7 @@ final _allReporters = <String, ReporterDetails>{
     'A machine-readable format (see '
     'https://dart.dev/go/test-docs/json_reporter.md).',
     (config, engine, sink) =>
-        JsonReporter.watch(engine, sink, isDebugRun: config.debug),
+        JsonReporter.watch(engine, sink, isDebugRun: config.pauseAfterLoad),
   ),
   'silent': ReporterDetails(
     'A reporter with no output. '


### PR DESCRIPTION
Either `--coverage` and `--pause-after-load` are sufficient to enable
the `debug` state for the test runner, but in the case of `--coverage`
without interactive debugging the VM debugger URL is not relevant to the
user. Change the condition used to decide whether to include this URL in
the JSON reporter output to only when `--pause-after-load` is used.
