### PR TITLE
Launch browsers with redirecting files

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Suppress dart2js compiler output for successful compiles.
 * Include output from passing tests  messages within the `Passing tests` group
   in `GithubReporter`.
+* Use a redirect html file for browser tests to avoid leaking websocket details
+  through process starting arguments.
 
 ## 1.31.2
 

--- a/pkgs/test/lib/src/runner/browser/chrome.dart
+++ b/pkgs/test/lib/src/runner/browser/chrome.dart
@@ -170,8 +170,8 @@ Future<WipConnection> _connect(
     var tabs = await chromeConnection.getTabs();
     tab = tabs.firstWhereOrNull((tab) => tab.url == url.toString());
     if (tab == null) {
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-      if (attempt > 5) {
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+      if (attempt > 20) {
         throw StateError('Could not connect to test tab with url: $url');
       }
     }

--- a/pkgs/test/lib/src/runner/browser/chromium.dart
+++ b/pkgs/test/lib/src/runner/browser/chromium.dart
@@ -3,10 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
-import 'package:path/path.dart' as p;
 import 'package:test_api/src/backend/runtime.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/configuration.dart'; // ignore: implementation_imports
 import 'package:test_core/src/util/io.dart'; // ignore: implementation_imports
@@ -31,14 +29,9 @@ enum ChromiumBasedBrowser {
     settings ??= defaultSettings[runtime];
 
     var dir = createTempDir();
-    var redirect = p.join(dir, 'redirect.html');
-    File(redirect).writeAsStringSync(
-      '<script>location = ${jsonEncode(url.toString())}</script>',
-    );
-
     var args = [
       '--user-data-dir=$dir',
-      redirect,
+      url.toString(),
       '--enable-logging=stderr',
       '--v=0',
       '--disable-extensions',

--- a/pkgs/test/lib/src/runner/browser/chromium.dart
+++ b/pkgs/test/lib/src/runner/browser/chromium.dart
@@ -3,8 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
 import 'package:test_api/src/backend/runtime.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/configuration.dart'; // ignore: implementation_imports
 import 'package:test_core/src/util/io.dart'; // ignore: implementation_imports
@@ -29,9 +31,14 @@ enum ChromiumBasedBrowser {
     settings ??= defaultSettings[runtime];
 
     var dir = createTempDir();
+    var redirect = p.join(dir, 'redirect.html');
+    File(redirect).writeAsStringSync(
+      '<script>location = ${jsonEncode(url.toString())}</script>',
+    );
+
     var args = [
       '--user-data-dir=$dir',
-      url.toString(),
+      redirect,
       '--enable-logging=stderr',
       '--v=0',
       '--disable-extensions',

--- a/pkgs/test/lib/src/runner/browser/firefox.dart
+++ b/pkgs/test/lib/src/runner/browser/firefox.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -44,9 +45,14 @@ class Firefox extends Browser {
     var dir = createTempDir();
     File(p.join(dir, 'prefs.js')).writeAsStringSync(_preferences);
 
+    var redirect = p.join(dir, 'redirect.html');
+    File(redirect).writeAsStringSync(
+      '<script>location = ${jsonEncode(url.toString())}</script>',
+    );
+
     var process = await Process.start(
       settings.executable,
-      ['--profile', dir, url.toString(), '--no-remote', ...settings.arguments],
+      ['--profile', dir, redirect, '--no-remote', ...settings.arguments],
       environment: {'MOZ_CRASHREPORTER_DISABLE': '1', 'MOZ_AUTOMATION': '1'},
     );
 

--- a/pkgs/test/lib/src/runner/browser/firefox.dart
+++ b/pkgs/test/lib/src/runner/browser/firefox.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -45,14 +44,9 @@ class Firefox extends Browser {
     var dir = createTempDir();
     File(p.join(dir, 'prefs.js')).writeAsStringSync(_preferences);
 
-    var redirect = p.join(dir, 'redirect.html');
-    File(redirect).writeAsStringSync(
-      '<script>location = ${jsonEncode(url.toString())}</script>',
-    );
-
     var process = await Process.start(
       settings.executable,
-      ['--profile', dir, redirect, '--no-remote', ...settings.arguments],
+      ['--profile', dir, url.toString(), '--no-remote', ...settings.arguments],
       environment: {'MOZ_CRASHREPORTER_DISABLE': '1', 'MOZ_AUTOMATION': '1'},
     );
 

--- a/pkgs/test/test/runner/browser/chrome_test.dart
+++ b/pkgs/test/test/runner/browser/chrome_test.dart
@@ -6,6 +6,9 @@
 @Tags(['chrome'])
 library;
 
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
 import 'package:test/src/runner/browser/chrome.dart';
 import 'package:test/src/runner/executable_settings.dart';
 import 'package:test/test.dart';
@@ -110,4 +113,30 @@ void main() {
     expect(test.stdout, emitsThrough(contains('Failed to run Chrome:')));
     await test.shouldExit(1);
   });
+
+  test('does not pass target URL directly in command line arguments', () async {
+    var targetUrl = Uri.parse('http://localhost:12345/secret_token_12345');
+    var argsFile = p.join(d.sandbox, 'args.txt');
+    var scriptFile = p.join(d.sandbox, 'fake_chrome.sh');
+    await d.file('fake_chrome.sh', '''
+#!/bin/sh
+echo "\$@" > "$argsFile"
+''').create();
+    await Process.run('chmod', ['+x', scriptFile]);
+
+    var chrome = Chrome(
+      targetUrl,
+      configuration(),
+      settings: ExecutableSettings(
+        linuxExecutable: scriptFile,
+        macOSExecutable: scriptFile,
+        windowsExecutable: scriptFile,
+      ),
+    );
+    await chrome.onExit.catchError((_) {});
+
+    var argsText = await File(argsFile).readAsString();
+    expect(argsText, isNot(contains('secret_token_12345')));
+    expect(argsText, contains('redirect.html'));
+  }, testOn: '!windows');
 }

--- a/pkgs/test/test/runner/browser/firefox_test.dart
+++ b/pkgs/test/test/runner/browser/firefox_test.dart
@@ -5,6 +5,9 @@
 @Tags(['firefox'])
 library;
 
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
 import 'package:test/src/runner/browser/firefox.dart';
 import 'package:test/src/runner/executable_settings.dart';
 import 'package:test/test.dart';
@@ -123,4 +126,29 @@ void main() {
     expect(test.stdout, emitsThrough(contains('+1: All tests passed!')));
     await test.shouldExit(0);
   });
+
+  test('does not pass target URL directly in command line arguments', () async {
+    var targetUrl = Uri.parse('http://localhost:12345/secret_token_12345');
+    var argsFile = p.join(d.sandbox, 'args.txt');
+    var scriptFile = p.join(d.sandbox, 'fake_firefox.sh');
+    await d.file('fake_firefox.sh', '''
+#!/bin/sh
+echo "\$@" > "$argsFile"
+''').create();
+    await Process.run('chmod', ['+x', scriptFile]);
+
+    var firefox = Firefox(
+      targetUrl,
+      settings: ExecutableSettings(
+        linuxExecutable: scriptFile,
+        macOSExecutable: scriptFile,
+        windowsExecutable: scriptFile,
+      ),
+    );
+    await firefox.onExit.catchError((_) {});
+
+    var argsText = await File(argsFile).readAsString();
+    expect(argsText, isNot(contains('secret_token_12345')));
+    expect(argsText, contains('redirect.html'));
+  }, testOn: '!windows');
 }


### PR DESCRIPTION
The test runner creates a secret key used for communication with the
browsers to prevent third party processes from connecting as if they
were running test suites, but this key is current leaking through the
command arguments when starting the browser process. We are already
using temp directories which should prevent external reads and the
safari browser launcher already used this pattern. Extend the
`redirect.html` pattern to chromium and firefox browsers.
