### PR TITLE
Remove unnecessary remote debugging flag

### DIFF
--- a/pkgs/test/lib/src/runner/browser/chromium.dart
+++ b/pkgs/test/lib/src/runner/browser/chromium.dart
@@ -58,10 +58,6 @@ enum ChromiumBasedBrowser {
         '--headless',
         '--disable-gpu',
       ],
-      if (!configuration.debug)
-        // We don't actually connect to the remote debugger, but Chrome will
-        // close as soon as the page is loaded if we don't turn it on.
-        '--remote-debugging-port=0',
       ...settings.arguments,
       ...additionalArgs,
     ];


### PR DESCRIPTION
The comment above the argument is outdated - chromium based browsers
launched with the arguments we are using, including a unique user
profile directory not associated with any running browser instance, will
work without also opening a debugging port.
