### PR TITLE
Fix race conditions in Chrome coverage collection

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -18,6 +18,8 @@
 * Pass Node.js test process connection configuration and secret token via a
   restricted temporary authentication file to prevent secret leakage in command
   line process arguments.
+* Fix race conditions in Chrome coverage collection where tests could finish
+  before DevTools connection and coverage profiling were initialized.
 
 ## 1.31.2
 

--- a/pkgs/test/lib/src/runner/browser/browser_manager.dart
+++ b/pkgs/test/lib/src/runner/browser/browser_manager.dart
@@ -133,9 +133,12 @@ class BrowserManager {
         });
 
     future
-        .then((webSocket) {
+        .then((webSocket) async {
           if (completer.isCompleted) return;
-          completer.complete(BrowserManager._(browser, runtime, webSocket));
+          var manager = BrowserManager._(browser, runtime, webSocket);
+          await manager._environment;
+          if (completer.isCompleted) return;
+          completer.complete(manager);
         })
         .onError((Object error, StackTrace stackTrace) {
           browser.close();
@@ -268,10 +271,6 @@ class BrowserManager {
     );
 
     var suite = _pool.withResource<RunnerSuite>(() async {
-      if (_browser case Chrome chrome) {
-        await chrome.whenReady;
-      }
-
       _channel.sink.add({
         'command': 'loadSuite',
         'url': url.toString(),

--- a/pkgs/test/lib/src/runner/browser/browser_manager.dart
+++ b/pkgs/test/lib/src/runner/browser/browser_manager.dart
@@ -268,6 +268,10 @@ class BrowserManager {
     );
 
     var suite = _pool.withResource<RunnerSuite>(() async {
+      if (_browser case Chrome chrome) {
+        await chrome.whenReady;
+      }
+
       _channel.sink.add({
         'command': 'loadSuite',
         'url': url.toString(),

--- a/pkgs/test/lib/src/runner/browser/chrome.dart
+++ b/pkgs/test/lib/src/runner/browser/chrome.dart
@@ -36,12 +36,6 @@ class Chrome extends Browser {
   final Future<WipConnection?> _tabConnection;
   final Map<String, String> _idToUrl;
 
-  /// A future that completes when Chrome's DevTools connection and coverage
-  /// collection are ready, or immediately if DevTools is not enabled.
-  Future<void> get whenReady async {
-    await _tabConnection;
-  }
-
   /// Starts a new instance of Chrome open to the given [url], which may be a
   /// [Uri] or a [String].
   factory Chrome(
@@ -72,11 +66,11 @@ class Chrome extends Browser {
           );
 
           if (port != null) {
+            var connectionFuture = _connect(process, port, idToUrl, url);
             remoteDebuggerCompleter.complete(
-              getRemoteDebuggerUrl(Uri.parse('http://localhost:$port')),
+              connectionFuture.then((c) => c.$2),
             );
-
-            connectionCompleter.complete(_connect(process, port, idToUrl, url));
+            connectionCompleter.complete(connectionFuture.then((c) => c.$1));
           } else {
             remoteDebuggerCompleter.complete(null);
             connectionCompleter.complete(null);
@@ -158,7 +152,7 @@ class Chrome extends Browser {
   }
 }
 
-Future<WipConnection> _connect(
+Future<(WipConnection, Uri)> _connect(
   Process process,
   int port,
   Map<String, String> idToUrl,
@@ -204,7 +198,12 @@ Future<WipConnection> _connect(
     {'detailed': true, 'callCount': false},
   );
 
-  return tabConnection;
+  var base = Uri.http('localhost:$port');
+  var devtoolsUrl = tab.devtoolsFrontendUrl;
+  var remoteDebuggerUrl = devtoolsUrl != null
+      ? base.resolve(devtoolsUrl)
+      : base;
+  return (tabConnection, remoteDebuggerUrl);
 }
 
 extension on HttpClient {

--- a/pkgs/test/lib/src/runner/browser/chrome.dart
+++ b/pkgs/test/lib/src/runner/browser/chrome.dart
@@ -33,8 +33,14 @@ class Chrome extends Browser {
   @override
   final Future<Uri?> remoteDebuggerUrl;
 
-  final Future<WipConnection> _tabConnection;
+  final Future<WipConnection?> _tabConnection;
   final Map<String, String> _idToUrl;
+
+  /// A future that completes when Chrome's DevTools connection and coverage
+  /// collection are ready, or immediately if DevTools is not enabled.
+  Future<void> get whenReady async {
+    await _tabConnection;
+  }
 
   /// Starts a new instance of Chrome open to the given [url], which may be a
   /// [Uri] or a [String].
@@ -45,7 +51,7 @@ class Chrome extends Browser {
   }) {
     settings ??= defaultSettings[Runtime.chrome]!;
     var remoteDebuggerCompleter = Completer<Uri?>.sync();
-    var connectionCompleter = Completer<WipConnection>();
+    var connectionCompleter = Completer<WipConnection?>();
     var idToUrl = <String, String>{};
     return Chrome._(
       () async {
@@ -73,6 +79,7 @@ class Chrome extends Browser {
             connectionCompleter.complete(_connect(process, port, idToUrl, url));
           } else {
             remoteDebuggerCompleter.complete(null);
+            connectionCompleter.complete(null);
           }
 
           return process;
@@ -91,6 +98,7 @@ class Chrome extends Browser {
   /// with `package:coverage`.
   Future<Map<String, dynamic>> gatherCoverage() async {
     var tabConnection = await _tabConnection;
+    if (tabConnection == null) return {};
     var response = await tabConnection.debugger.connection.sendCommand(
       'Profiler.takePreciseCoverage',
       {},
@@ -178,14 +186,16 @@ Future<WipConnection> _connect(
   }
   var tabConnection = await tab.connect();
 
-  // Enable debugging.
-  await tabConnection.debugger.enable();
-
   // Coverage reports are in terms of scriptIds so keep note of URLs.
+  // Register the listener before enabling the debugger so that initial
+  // script events sent during initialization are not missed.
   tabConnection.debugger.onScriptParsed.listen((data) {
     var script = data.script;
     if (script.url.isNotEmpty) idToUrl[script.scriptId] = script.url;
   });
+
+  // Enable debugging.
+  await tabConnection.debugger.enable();
 
   // Enable coverage collection.
   await tabConnection.debugger.connection.sendCommand('Profiler.enable', {});


### PR DESCRIPTION
Fixes race conditions causing intermittent empty coverage results in Chrome tests (e.g. in `test/runner/coverage_test.dart`):

1. **Await DevTools & profiler initialization before suite execution**: `BrowserManager.load` now awaits `Chrome.whenReady` before sending `'loadSuite'`, ensuring `Profiler.startPreciseCoverage` is active before the test script executes in the browser.
2. **Listen to `onScriptParsed` before enabling debugger**: Registers the `onScriptParsed` listener before calling `tabConnection.debugger.enable()`, preventing initial `Debugger.scriptParsed` events from being missed on the broadcast stream.