### PR TITLE
Account for debugger during start

### DIFF
--- a/pkgs/test/lib/src/runner/browser/browser_manager.dart
+++ b/pkgs/test/lib/src/runner/browser/browser_manager.dart
@@ -133,9 +133,12 @@ class BrowserManager {
         });
 
     future
-        .then((webSocket) {
+        .then((webSocket) async {
           if (completer.isCompleted) return;
-          completer.complete(BrowserManager._(browser, runtime, webSocket));
+          var manager = BrowserManager._(browser, runtime, webSocket);
+          await manager._environment;
+          if (completer.isCompleted) return;
+          completer.complete(manager);
         })
         .onError((Object error, StackTrace stackTrace) {
           browser.close();
@@ -268,10 +271,6 @@ class BrowserManager {
     );
 
     var suite = _pool.withResource<RunnerSuite>(() async {
-      if (_browser case Chrome chrome) {
-        await chrome.whenReady;
-      }
-
       _channel.sink.add({
         'command': 'loadSuite',
         'url': url.toString(),

--- a/pkgs/test/lib/src/runner/browser/chrome.dart
+++ b/pkgs/test/lib/src/runner/browser/chrome.dart
@@ -36,12 +36,6 @@ class Chrome extends Browser {
   final Future<WipConnection?> _tabConnection;
   final Map<String, String> _idToUrl;
 
-  /// A future that completes when Chrome's DevTools connection and coverage
-  /// collection are ready, or immediately if DevTools is not enabled.
-  Future<void> get whenReady async {
-    await _tabConnection;
-  }
-
   /// Starts a new instance of Chrome open to the given [url], which may be a
   /// [Uri] or a [String].
   factory Chrome(
@@ -72,11 +66,13 @@ class Chrome extends Browser {
           );
 
           if (port != null) {
+            var connectionFuture = _connect(process, port, idToUrl, url);
             remoteDebuggerCompleter.complete(
-              getRemoteDebuggerUrl(Uri.parse('http://localhost:$port')),
+              connectionFuture.then((c) => c.$2),
             );
-
-            connectionCompleter.complete(_connect(process, port, idToUrl, url));
+            connectionCompleter.complete(
+              connectionFuture.then((c) => c.$1),
+            );
           } else {
             remoteDebuggerCompleter.complete(null);
             connectionCompleter.complete(null);
@@ -158,7 +154,7 @@ class Chrome extends Browser {
   }
 }
 
-Future<WipConnection> _connect(
+Future<(WipConnection, Uri)> _connect(
   Process process,
   int port,
   Map<String, String> idToUrl,
@@ -204,7 +200,11 @@ Future<WipConnection> _connect(
     {'detailed': true, 'callCount': false},
   );
 
-  return tabConnection;
+  var base = Uri.http('localhost:$port');
+  var devtoolsUrl = tab.devtoolsFrontendUrl;
+  var remoteDebuggerUrl =
+      devtoolsUrl != null ? base.resolve(devtoolsUrl) : base;
+  return (tabConnection, remoteDebuggerUrl);
 }
 
 extension on HttpClient {

--- a/pkgs/test/lib/src/runner/browser/chrome.dart
+++ b/pkgs/test/lib/src/runner/browser/chrome.dart
@@ -70,9 +70,7 @@ class Chrome extends Browser {
             remoteDebuggerCompleter.complete(
               connectionFuture.then((c) => c.$2),
             );
-            connectionCompleter.complete(
-              connectionFuture.then((c) => c.$1),
-            );
+            connectionCompleter.complete(connectionFuture.then((c) => c.$1));
           } else {
             remoteDebuggerCompleter.complete(null);
             connectionCompleter.complete(null);
@@ -202,8 +200,9 @@ Future<(WipConnection, Uri)> _connect(
 
   var base = Uri.http('localhost:$port');
   var devtoolsUrl = tab.devtoolsFrontendUrl;
-  var remoteDebuggerUrl =
-      devtoolsUrl != null ? base.resolve(devtoolsUrl) : base;
+  var remoteDebuggerUrl = devtoolsUrl != null
+      ? base.resolve(devtoolsUrl)
+      : base;
   return (tabConnection, remoteDebuggerUrl);
 }
 


### PR DESCRIPTION
Removes a type check and Chrome specific interaction.

- Wait for the `_environment` Future during startup in the browser manager.
- Set up remote debugger URL during start up for chrome.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.