### PR TITLE
Keep the browser executable env override through a settings merge

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -19,6 +19,10 @@
   restricted temporary authentication file to prevent secret leakage in command
   line process arguments.
 * Enable asserts in the `exe` compiler.
+* Keep the `CHROME_EXECUTABLE`, `MS_EDGE_EXECUTABLE`, `FIREFOX_EXECUTABLE`, and
+  `SAFARI_EXECUTABLE` overrides working when the browser is also configured
+  through `override_platforms` or `define_platforms`. Any setting on those
+  platforms used to drop the variable.
 
 ## 1.31.2
 

--- a/pkgs/test/README.md
+++ b/pkgs/test/README.md
@@ -633,7 +633,10 @@ last, just as they would in nested groups. This means that for configuration
 like duration-based timeouts, the last matching value wins.
 
 You can also set up global platform-specific configuration using the
-[package configuration file][configuring platforms].
+[package configuration file][configuring platforms]. The `CHROME_EXECUTABLE`,
+`MS_EDGE_EXECUTABLE`, `FIREFOX_EXECUTABLE`, and `SAFARI_EXECUTABLE` environment
+variables point the runner at a browser binary somewhere else, and take
+precedence over that file.
 
 [configuring platforms]: https://github.com/dart-lang/test/blob/master/pkgs/test/doc/configuration.md#configuring-platforms
 

--- a/pkgs/test/doc/configuration.md
+++ b/pkgs/test/doc/configuration.md
@@ -712,7 +712,7 @@ This tells the test runner to use the `chromium` executable for Chrome tests. It
 calls that executable with the same logic and flags it normally uses for Chrome.
 
 Each platform can define exactly which settings it supports. All browsers and
-Node.js support [the same settings](#browser-and-node-js-settings), but the VM
+Node.js support [the same settings](#browser-and-nodejs-settings), but the VM
 doesn't support any settings and so can't be overridden.
 
 ### `define_platforms`
@@ -745,7 +745,7 @@ User-defined platforms also count as their parents, so Chromium will run tests
 that say `testOn: "chrome"` as well.
 
 Each platform can define exactly which settings it supports. All browsers and
-Node.js support [the same settings](#browser-and-node-js-settings), but the VM
+Node.js support [the same settings](#browser-and-nodejs-settings), but the VM
 doesn't support any settings and so can't be extended.
 
 This field is not supported in the
@@ -814,6 +814,21 @@ define_platforms:
     settings:
       executable: chromium
 ```
+
+Each built-in browser also reads an environment variable, which takes precedence
+over both the defaults above and anything `executable` sets:
+
+| Browser | Variable |
+| --- | --- |
+| Chrome | `CHROME_EXECUTABLE` |
+| Edge | `MS_EDGE_EXECUTABLE` |
+| Firefox | `FIREFOX_EXECUTABLE` |
+| Safari | `SAFARI_EXECUTABLE` |
+
+The value is used as the path, with no lookup of its own. This is meant for
+machines where the browser lives somewhere the defaults do not cover, such as a
+CI image that installs Chrome under its own prefix, without editing the config
+file that the rest of the project shares.
 
 #### `headless`
 

--- a/pkgs/test/lib/src/runner/executable_settings.dart
+++ b/pkgs/test/lib/src/runner/executable_settings.dart
@@ -232,6 +232,7 @@ class ExecutableSettings {
     linuxExecutable: other._linuxExecutable ?? _linuxExecutable,
     macOSExecutables: other._macOSExectuables ?? _macOSExectuables,
     windowsExecutable: other._windowsExecutable ?? _windowsExecutable,
+    environmentOverride: other._environmentOverride ?? _environmentOverride,
   );
 }
 

--- a/pkgs/test/test/runner/configuration/custom_platform_test.dart
+++ b/pkgs/test/test/runner/configuration/custom_platform_test.dart
@@ -403,7 +403,10 @@ void main() {
                   executable: _does_not_exist
           ''').create();
 
-          var test = await runTest(['-p', 'chrome', 'test.dart']);
+          var test = await runTest(
+            ['-p', 'chrome', 'test.dart'],
+            environment: {'CHROME_EXECUTABLE': '_does_not_exist'},
+          );
           expect(
             test.stdout,
             emitsThrough(contains('Failed to run Chrome: $noSuchFileMessage')),
@@ -926,7 +929,10 @@ void main() {
                   executable: _does_not_exist
           ''').create();
 
-          var test = await runTest(['-p', 'chromium', 'test.dart']);
+          var test = await runTest(
+            ['-p', 'chromium', 'test.dart'],
+            environment: {'CHROME_EXECUTABLE': '_does_not_exist'},
+          );
           expect(
             test.stdout,
             emitsThrough(contains('Failed to run Chrome: $noSuchFileMessage')),

--- a/pkgs/test/test/runner/configuration/custom_platform_test.dart
+++ b/pkgs/test/test/runner/configuration/custom_platform_test.dart
@@ -99,6 +99,27 @@ void main() {
         await test.shouldExit(0);
       }, tags: 'chrome');
 
+      test('with an executable from the environment', () async {
+        // The environment override is only reachable through the default
+        // settings, so it has to survive being merged with the user's.
+        await d.file('dart_test.yaml', '''
+          override_platforms:
+            chrome:
+              settings:
+                arguments: --disable-gpu
+        ''').create();
+
+        var test = await runTest(
+          ['-p', 'chrome', 'test.dart'],
+          environment: {'CHROME_EXECUTABLE': '_does_not_exist'},
+        );
+        expect(
+          test.stdout,
+          emitsThrough(contains('Failed to run Chrome: $noSuchFileMessage')),
+        );
+        await test.shouldExit(1);
+      }, tags: 'chrome');
+
       test('with non-headless mode', () async {
         await d.file('dart_test.yaml', '''
           override_platforms:


### PR DESCRIPTION
Fixes #2609

The docs half is the easy part. Neither `README.md` nor
`configuration.md` named the four variables. Both get them now, briefly
in the first and with the precedence spelled out in the second. The two
links to the browser settings section used the wrong anchor and went
nowhere.

Writing them down turned up a bug. `ExecutableSettings.merge` dropped
`_environmentOverride` when it rebuilt the settings, and
`customizePlatform` merges the defaults with whatever you configured.
Any browser setting at all silenced `CHROME_EXECUTABLE`, not just
`executable:`. `arguments:` on its own was enough. The fix is one line
in `merge`.

The new test in `custom_platform_test.dart` configures chrome with
`arguments:` and points `CHROME_EXECUTABLE` at a path that does not
exist. Without the fix the inner run launches real Chrome and exits 0.

Two tests in that file now set the variable themselves. 1.23.0
documented that it outranks the config file, and with the override
reaching the getter again, a machine that has it set would run a real
browser instead of the missing path they assert on. They point it at the
same missing path, which keeps their assertion working. What they no
longer cover is the key itself: the getter returns as soon as it finds
the variable and never reads `executable:`. `test_process` does expose
`includeParentEnvironment`, and `runTest` could pass it through to drop
one variable instead; pinning was the smaller change. Happy to do it
that way if you would rather those two kept testing the key.
