### PR TITLE
Export TestFailure from package:test_api/scaffolding.dart

### DIFF
--- a/pkgs/checks/CHANGELOG.md
+++ b/pkgs/checks/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.3.2-wip
 
+- Bump `test` dev dependency constraint.
 - Add `isNotA<R>()` check extension as a convenience in place of
   `not((it) => it.isA<R>())`.
 - Require Dart 3.11

--- a/pkgs/checks/pubspec.yaml
+++ b/pkgs/checks/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
   test_api: ">=0.5.0 <0.8.0"
 
 dev_dependencies:
-  test: ^1.21.3
+  test: ^1.32.0-wip

--- a/pkgs/checks/test/extensions/async_test.dart
+++ b/pkgs/checks/test/extensions/async_test.dart
@@ -8,7 +8,6 @@ import 'package:async/async.dart';
 import 'package:checks/checks.dart';
 import 'package:checks/context.dart';
 import 'package:test/scaffolding.dart';
-import 'package:test_api/hooks.dart';
 
 import '../test_shared.dart';
 

--- a/pkgs/checks/test/failure_message_test.dart
+++ b/pkgs/checks/test/failure_message_test.dart
@@ -1,6 +1,5 @@
 import 'package:checks/checks.dart';
 import 'package:test/scaffolding.dart';
-import 'package:test_api/hooks.dart' show TestFailure;
 
 void main() {
   group('failures', () {

--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.32.0-wip
 
+* Export `TestFailure` from `package:test/scaffolding.dart`.
 * Support `--compiler cli` with the `vm-asan`, `vm-msan`, and `vm-tsan`
   runtimes.
 * Add support for `DART_TEST_REPORTER` environment variable in test runner and

--- a/pkgs/test_api/CHANGELOG.md
+++ b/pkgs/test_api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Allow the `vmAsan`, `vmMsan`, and `vmTsan` runtimes to use the native CLI
   compiler.
+* Export `TestFailure` from `package:test_api/scaffolding.dart`.
 
 ## 0.7.13
 

--- a/pkgs/test_api/lib/scaffolding.dart
+++ b/pkgs/test_api/lib/scaffolding.dart
@@ -6,6 +6,7 @@
 /// {@canonicalFor retry.Retry}
 /// {@canonicalFor skip.Skip}
 /// {@canonicalFor tags.Tags}
+/// {@canonicalFor test_failure.TestFailure}
 /// {@canonicalFor test_on.TestOn}
 /// {@canonicalFor timeout.Timeout}
 library;
@@ -16,6 +17,7 @@ export 'src/backend/configuration/skip.dart' show Skip;
 export 'src/backend/configuration/tags.dart' show Tags;
 export 'src/backend/configuration/test_on.dart' show TestOn;
 export 'src/backend/configuration/timeout.dart' show Timeout;
+export 'src/backend/test_failure.dart' show TestFailure;
 export 'src/backend/test_location.dart' show TestLocation;
 export 'src/scaffolding/spawn_hybrid.dart' show spawnHybridCode, spawnHybridUri;
 export 'src/scaffolding/test_structure.dart'

--- a/pkgs/test_api/test/frontend/scaffolding_test.dart
+++ b/pkgs/test_api/test/frontend/scaffolding_test.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test_api/scaffolding.dart';
+
+void main() {
+  test('TestFailure is exported from package:test_api/scaffolding.dart', () {
+    final failure = TestFailure('custom failure');
+    if (failure.message != 'custom failure') {
+      throw Exception('Unexpected message: ${failure.message}');
+    }
+  });
+}


### PR DESCRIPTION
Re-export `TestFailure` in `package:test_api/scaffolding.dart` (which in turn
exports it in `package:test/scaffolding.dart`).

This allows users migrating from `package:test/test.dart` to
`package:test/scaffolding.dart` (such as when using `package:checks`) to
throw or handle `TestFailure` exceptions without needing an explicit import
of `package:test_api/hooks.dart`.

Closes #2073