### PR TITLE
Precompiled browser tests: stop serving files from outside the precompiled root

### DIFF
--- a/pkgs/test/CHANGELOG.md
+++ b/pkgs/test/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.32.0-wip
 
+* Precompiled browser tests: stop serving files from outside the precompiled
+  root directory. The static handler no longer sets `serveFilesOutsidePath`,
+  restoring path-containment parity with the dart2js and dart2wasm compilers.
 * Export `TestFailure` from `package:test/scaffolding.dart`.
 * Support `--compiler cli` with the `vm-asan`, `vm-msan`, and `vm-tsan`
   runtimes.

--- a/pkgs/test/lib/src/runner/browser/compilers/precompiled.dart
+++ b/pkgs/test/lib/src/runner/browser/compilers/precompiled.dart
@@ -71,7 +71,7 @@ abstract class PrecompiledSupport extends CompilerSupport {
   ) {
     var cascade = shelf.Cascade()
         .add(_webSocketHandler.handler)
-        .add(createStaticHandler(_root, serveFilesOutsidePath: true))
+        .add(createStaticHandler(_root))
         // TODO: This packages dir handler should not be necessary?
         .add(packagesDirHandler())
         // Even for precompiled tests, we will auto-create a bootstrap html file


### PR DESCRIPTION
The precompiled browser-test server serves files from outside its root because it disables shelf_static's path containment. `pkgs/test/lib/src/runner/browser/compilers/precompiled.dart` builds its static handler as:

```dart
.add(createStaticHandler(_root, serveFilesOutsidePath: true))
```

The two sibling compilers in the same directory build the same handler without that flag:

```dart
// dart2js.dart and dart2wasm.dart
.add(createStaticHandler(_root))
```

With `serveFilesOutsidePath: true`, shelf_static stops rejecting requests whose path resolves outside `_root`, so a `..`-bearing request to the precompiled server is served a file from anywhere on disk the runner can read. Precompiled is the only one of the three that does this.

Removing the flag does not change what the browser can load. In precompiled mode `_root` is the precompiled output directory itself (`platform.dart` passes `root: _config.suiteDefaults.precompiledPath`), so the compiled `.js` bundles and their bootstrap `.html` already live under it. `/packages/` requests are served by the separate `packagesDirHandler` already in the cascade. Source maps are never fetched by the browser: `compileSuite` reads the `.js.map` server-side with `File(mapPath).readAsStringSync()` and builds a `JSStackTraceMapper` in the runner process. Nothing the browser requests needs a path outside `_root`, which is why dart2js and dart2wasm already serve an equivalent root with containment on.

The server binds to loopback and nests every handler under a per-run secret URL segment, and the comment on that secret says its job is to keep other users on the same machine from snooping on what the server serves. The secret does not actually hide from a co-located user: the full server URL is passed to the browser on its command line, so another local user can read it from `/proc/<pid>/cmdline`. With containment on that only lets them read within `_root`; with `serveFilesOutsidePath: true` it lets them read any file the runner user can read, for example `/<secret>/../../../home/<user>/.ssh/id_rsa`. Removing the flag restores the boundary the secret is meant to enforce.

The fix drops the flag so precompiled matches the other two compilers:

```dart
// before
.add(createStaticHandler(_root, serveFilesOutsidePath: true))
// after
.add(createStaticHandler(_root))
```

I was not able to run the toolchain in my environment, so I have not attached a live run or a formatter/analyzer pass. The change removes an over-permissive flag that no browser-fetched resource depends on and that dart2js and dart2wasm already omit. I am happy to add an integration test that asserts the precompiled server rejects a `..` traversal if you would like one. Includes a CHANGELOG entry under `1.32.0-wip`.

I've reviewed the contributor guide and applied the relevant portions to this PR.
