### PR TITLE
refactor(test_core): consolidate duplicate reporter clusters via ReporterMixin (Trial Run 2)

### DIFF
--- a/pkgs/test_core/lib/src/runner/reporter/compact.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/compact.dart
@@ -15,12 +15,12 @@ import '../../util/pretty_print.dart';
 import '../../util/pretty_print.dart' as utils;
 import '../engine.dart';
 import '../load_exception.dart';
-import '../load_suite.dart';
 import '../reporter.dart';
+import 'reporter_mixin.dart';
 
 /// A reporter that prints test results to the console in a single
 /// continuously-updating line.
-class CompactReporter implements Reporter {
+class CompactReporter with ReporterMixin implements Reporter {
   /// Whether the reporter should emit terminal color escapes.
   final bool _color;
 
@@ -38,7 +38,8 @@ class CompactReporter implements Reporter {
 
   /// The terminal escape for gray text, or the empty string if this is
   /// Windows or not outputting to a terminal.
-  final String _gray;
+  @override
+  final String colorGray;
 
   /// The terminal escape code for cyan text, or the empty string if this is
   /// Windows or not outputting to a terminal.
@@ -46,20 +47,24 @@ class CompactReporter implements Reporter {
 
   /// The terminal escape for bold text, or the empty string if this is
   /// Windows or not outputting to a terminal.
-  final String _bold;
+  @override
+  final String colorBold;
 
   /// The terminal escape for removing test coloring, or the empty string if
   /// this is Windows or not outputting to a terminal.
-  final String _noColor;
+  @override
+  final String colorNone;
 
   /// The engine used to run the tests.
   final Engine _engine;
 
   /// Whether the path to each test's suite should be printed.
-  final bool _printPath;
+  @override
+  final bool printPath;
 
   /// Whether the platform each test is running on should be printed.
-  final bool _printPlatform;
+  @override
+  final bool printPlatform;
 
   /// A stopwatch that tracks the duration of the full run.
   final _stopwatch = Stopwatch();
@@ -106,9 +111,6 @@ class CompactReporter implements Reporter {
   // the end of all tests running.
   var _shouldPrintStackTraceChainingNotice = false;
 
-  /// The set of all subscriptions to various streams.
-  final _subscriptions = <StreamSubscription>{};
-
   final StringSink _sink;
 
   /// Watches the tests run by [engine] and prints their results to the
@@ -136,23 +138,21 @@ class CompactReporter implements Reporter {
     this._engine,
     this._sink, {
     required bool color,
-    required bool printPath,
-    required bool printPlatform,
-  }) : _printPath = printPath,
-       _printPlatform = printPlatform,
-       _color = color,
+    required this.printPath,
+    required this.printPlatform,
+  }) : _color = color,
        _green = color ? '\u001b[32m' : '',
        _red = color ? '\u001b[31m' : '',
        _yellow = color ? '\u001b[33m' : '',
-       _gray = color ? '\u001b[90m' : '',
+       colorGray = color ? '\u001b[90m' : '',
        _cyan = color ? '\u001b[36m' : '',
-       _bold = color ? '\u001b[1m' : '',
-       _noColor = color ? '\u001b[0m' : '' {
-    _subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
+       colorBold = color ? '\u001b[1m' : '',
+       colorNone = color ? '\u001b[0m' : '' {
+    subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
 
     // Convert the future to a stream so that the subscription can be paused or
     // canceled.
-    _subscriptions.add(_engine.success.asStream().listen(_onDone));
+    subscriptions.add(_engine.success.asStream().listen(_onDone));
   }
 
   @override
@@ -169,7 +169,7 @@ class CompactReporter implements Reporter {
     // during the pause.
     _lastProgressMessage = null;
 
-    for (var subscription in _subscriptions) {
+    for (var subscription in subscriptions) {
       subscription.pause();
     }
   }
@@ -181,16 +181,9 @@ class CompactReporter implements Reporter {
 
     if (_stopwatchStarted) _stopwatch.start();
 
-    for (var subscription in _subscriptions) {
+    for (var subscription in subscriptions) {
       subscription.resume();
     }
-  }
-
-  void _cancel() {
-    for (var subscription in _subscriptions) {
-      subscription.cancel();
-    }
-    _subscriptions.clear();
   }
 
   /// A callback called when the engine begins running [liveTest].
@@ -200,7 +193,7 @@ class CompactReporter implements Reporter {
       _stopwatch.start();
 
       // Keep updating the time even when nothing else is happening.
-      _subscriptions.add(
+      subscriptions.add(
         Stream<void>.periodic(
           const Duration(seconds: 1),
         ).listen((_) => _progressLine(_lastProgressMessage ?? '')),
@@ -213,23 +206,23 @@ class CompactReporter implements Reporter {
         (_engine.active.isEmpty &&
             _engine.activeSuiteLoads.length == 1 &&
             _engine.activeSuiteLoads.first == liveTest)) {
-      _progressLine(_description(liveTest));
+      _progressLine(testDescription(liveTest));
     }
 
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onStateChange.listen((state) => _onStateChange(liveTest, state)),
     );
 
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onError.listen(
         (error) => _onError(liveTest, error.error, error.stackTrace),
       ),
     );
 
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onMessage.listen((message) {
         if (liveTest.test.metadata.skip) return;
-        _progressLine(_description(liveTest), truncate: false);
+        _progressLine(testDescription(liveTest), truncate: false);
         if (!_printedNewline) _sink.writeln('');
         _printedNewline = true;
         _sink.writeln(message.text);
@@ -244,7 +237,7 @@ class CompactReporter implements Reporter {
           : "'${liveTest.test.name.replaceAll("'", r"'\''")}'";
       _sink.writeln('');
       _sink.writeln(
-        '$_bold${_cyan}To run this test again:$_noColor '
+        '$colorBold${_cyan}To run this test again:$colorNone '
         '${Platform.executable} test ${liveTest.suite.path} '
         '-p ${liveTest.suite.platform.runtime.identifier} '
         '--plain-name $quotedName',
@@ -263,9 +256,9 @@ class CompactReporter implements Reporter {
     // Always display the name of the oldest active test, unless testing
     // is finished in which case display the last test to complete.
     if (_engine.active.isEmpty) {
-      _progressLine(_description(liveTest));
+      _progressLine(testDescription(liveTest));
     } else {
-      _progressLine(_description(_engine.active.first));
+      _progressLine(testDescription(_engine.active.first));
     }
   }
 
@@ -279,9 +272,9 @@ class CompactReporter implements Reporter {
     if (liveTest.state.status != Status.complete) return;
 
     _progressLine(
-      _description(liveTest),
+      testDescription(liveTest),
       truncate: false,
-      suffix: ' $_bold$_red[E]$_noColor',
+      suffix: ' $colorBold$_red[E]$colorNone',
     );
     if (!_printedNewline) _sink.writeln('');
     _printedNewline = true;
@@ -309,7 +302,7 @@ class CompactReporter implements Reporter {
   /// [success] will be `true` if all tests passed, `false` if some tests
   /// failed, and `null` if the engine was closed prematurely.
   void _onDone(bool? success) {
-    _cancel();
+    cancelSubscriptions();
     _stopwatch.stop();
 
     // A null success value indicates that the engine was closed before the
@@ -333,16 +326,16 @@ class CompactReporter implements Reporter {
     } else if (!success) {
       for (var liveTest in _engine.active) {
         _progressLine(
-          _description(liveTest),
+          testDescription(liveTest),
           truncate: false,
-          suffix: ' - did not complete $_bold$_red[E]$_noColor',
+          suffix: ' - did not complete $colorBold$_red[E]$colorNone',
         );
         _sink.writeln('');
       }
       _progressLine('Some tests failed.', color: _red);
       _sink.writeln('');
     } else if (_engine.passed.isEmpty) {
-      _progressLine('${_yellow}All tests skipped.$_noColor');
+      _progressLine('${_yellow}All tests skipped.$colorNone');
       _sink.writeln('');
     } else if (_engine.skipped.isEmpty) {
       _progressLine('All tests passed!');
@@ -352,7 +345,7 @@ class CompactReporter implements Reporter {
       _progressLine(
         '$_yellow'
         '$skippedCount skipped ${pluralize('test', skippedCount)}.'
-        '$_noColor',
+        '$colorNone',
       );
       _sink.writeln('');
       _progressLine('All other tests passed!');
@@ -415,24 +408,24 @@ class CompactReporter implements Reporter {
     var buffer = StringBuffer();
 
     // \r moves back to the beginning of the current line.
-    buffer.write('\r${_timeString(duration)} ');
+    buffer.write('\r${formatTimeString(duration)} ');
     buffer.write(_green);
     buffer.write('+');
     buffer.write(_engine.passed.length);
-    buffer.write(_noColor);
+    buffer.write(colorNone);
 
     if (_engine.skipped.isNotEmpty) {
       buffer.write(_yellow);
       buffer.write(' ~');
       buffer.write(_engine.skipped.length);
-      buffer.write(_noColor);
+      buffer.write(colorNone);
     }
 
     if (_engine.failed.isNotEmpty) {
       buffer.write(_red);
       buffer.write(' -');
       buffer.write(_engine.failed.length);
-      buffer.write(_noColor);
+      buffer.write(colorNone);
     }
 
     buffer.write(': ');
@@ -444,7 +437,7 @@ class CompactReporter implements Reporter {
     var length = withoutColors(buffer.toString()).length;
     if (truncate) message = utils.truncate(message, lineLength - length);
     buffer.write(message);
-    buffer.write(_noColor);
+    buffer.write(colorNone);
 
     // Pad the rest of the line so that it looks erased.
     buffer.write(' ' * (lineLength - withoutColors(buffer.toString()).length));
@@ -452,35 +445,5 @@ class CompactReporter implements Reporter {
 
     _printedNewline = false;
     return true;
-  }
-
-  /// Returns a representation of [duration] as `MM:SS`.
-  String _timeString(Duration duration) {
-    return "${duration.inMinutes.toString().padLeft(2, '0')}:"
-        "${(duration.inSeconds % 60).toString().padLeft(2, '0')}";
-  }
-
-  /// Returns a description of [liveTest].
-  ///
-  /// This differs from the test's own description in that it may also include
-  /// the suite's name.
-  String _description(LiveTest liveTest) {
-    var name = liveTest.test.name;
-
-    if (_printPath &&
-        liveTest.suite is! LoadSuite &&
-        liveTest.suite.path != null) {
-      name = '${liveTest.suite.path}: $name';
-    }
-
-    if (_printPlatform) {
-      name =
-          '[${liveTest.suite.platform.runtime.name}, '
-          '${liveTest.suite.platform.compiler.name}] $name';
-    }
-
-    if (liveTest.suite is LoadSuite) name = '$_bold$_gray$name$_noColor';
-
-    return name;
   }
 }

--- a/pkgs/test_core/lib/src/runner/reporter/expanded.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/expanded.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:test_api/src/backend/live_test.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/message.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/state.dart'; // ignore: implementation_imports
@@ -14,6 +12,7 @@ import '../load_exception.dart';
 import '../load_suite.dart';
 import '../reporter.dart';
 import 'failure_summary.dart';
+import 'reporter_mixin.dart';
 
 /// A reporter that prints each test on its own line.
 ///
@@ -21,7 +20,7 @@ import 'failure_summary.dart';
 /// which can't transitively import `dart:io` but still needs access to a runner
 /// so that test files can be run directly. This means that until issue 6943 is
 /// fixed, this must not import `dart:io`.
-class ExpandedReporter implements Reporter {
+class ExpandedReporter with ReporterMixin implements Reporter {
   /// Whether the reporter should emit terminal color escapes.
   final bool _color;
 
@@ -39,24 +38,29 @@ class ExpandedReporter implements Reporter {
 
   /// The terminal escape for gray text, or the empty string if this is
   /// Windows or not outputting to a terminal.
-  final String _gray;
+  @override
+  final String colorGray;
 
   /// The terminal escape for bold text, or the empty string if this is
   /// Windows or not outputting to a terminal.
-  final String _bold;
+  @override
+  final String colorBold;
 
   /// The terminal escape for removing test coloring, or the empty string if
   /// this is Windows or not outputting to a terminal.
-  final String _noColor;
+  @override
+  final String colorNone;
 
   /// The engine used to run the tests.
   final Engine _engine;
 
   /// Whether the path to each test's suite should be printed.
-  final bool _printPath;
+  @override
+  final bool printPath;
 
   /// Whether the platform each test is running on should be printed.
-  final bool _printPlatform;
+  @override
+  final bool printPlatform;
 
   /// A stopwatch that tracks the duration of the full run.
   final _stopwatch = Stopwatch();
@@ -86,9 +90,6 @@ class ExpandedReporter implements Reporter {
   // the end of all tests running.
   var _shouldPrintStackTraceChainingNotice = false;
 
-  /// The set of all subscriptions to various streams.
-  final _subscriptions = <StreamSubscription>{};
-
   final StringSink _sink;
 
   /// Watches the tests run by [engine] and prints their results to the
@@ -116,22 +117,20 @@ class ExpandedReporter implements Reporter {
     this._engine,
     this._sink, {
     required bool color,
-    required bool printPath,
-    required bool printPlatform,
-  }) : _printPath = printPath,
-       _printPlatform = printPlatform,
-       _color = color,
+    required this.printPath,
+    required this.printPlatform,
+  }) : _color = color,
        _green = color ? '\u001b[32m' : '',
        _red = color ? '\u001b[31m' : '',
        _yellow = color ? '\u001b[33m' : '',
-       _gray = color ? '\u001b[90m' : '',
-       _bold = color ? '\u001b[1m' : '',
-       _noColor = color ? '\u001b[0m' : '' {
-    _subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
+       colorGray = color ? '\u001b[90m' : '',
+       colorBold = color ? '\u001b[1m' : '',
+       colorNone = color ? '\u001b[0m' : '' {
+    subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
 
     // Convert the future to a stream so that the subscription can be paused or
     // canceled.
-    _subscriptions.add(_engine.success.asStream().listen(_onDone));
+    subscriptions.add(_engine.success.asStream().listen(_onDone));
   }
 
   @override
@@ -141,7 +140,7 @@ class ExpandedReporter implements Reporter {
 
     _stopwatch.stop();
 
-    for (var subscription in _subscriptions) {
+    for (var subscription in subscriptions) {
       subscription.pause();
     }
   }
@@ -152,16 +151,9 @@ class ExpandedReporter implements Reporter {
 
     _stopwatch.start();
 
-    for (var subscription in _subscriptions) {
+    for (var subscription in subscriptions) {
       subscription.resume();
     }
-  }
-
-  void _cancel() {
-    for (var subscription in _subscriptions) {
-      subscription.cancel();
-    }
-    _subscriptions.clear();
   }
 
   /// A callback called when the engine begins running [liveTest].
@@ -171,12 +163,12 @@ class ExpandedReporter implements Reporter {
 
       // If this is the first non-load test to start, print a progress line so
       // the user knows what's running.
-      if (_engine.active.length == 1) _progressLine(_description(liveTest));
+      if (_engine.active.length == 1) _progressLine(testDescription(liveTest));
 
       // The engine surfaces load tests when there are no other tests running,
       // but because the expanded reporter's output is always visible, we don't
       // emit information about them unless they fail.
-      _subscriptions.add(
+      subscriptions.add(
         liveTest.onStateChange.listen(
           (state) => _onStateChange(liveTest, state),
         ),
@@ -187,20 +179,22 @@ class ExpandedReporter implements Reporter {
         liveTest.test.name.startsWith('loading ')) {
       // Print a progress line for ongoing suite loading synthetic test since it
       // may be slow (or stuck) depending on the platform.
-      _progressLine(_description(liveTest));
+      _progressLine(testDescription(liveTest));
     }
 
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onError.listen(
         (error) => _onError(liveTest, error.error, error.stackTrace),
       ),
     );
 
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onMessage.listen((message) {
-        _progressLine(_description(liveTest));
+        _progressLine(testDescription(liveTest));
         var text = message.text;
-        if (message.type == MessageType.skip) text = '  $_yellow$text$_noColor';
+        if (message.type == MessageType.skip) {
+          text = '  $_yellow$text$colorNone';
+        }
         _sink.writeln(text);
       }),
     );
@@ -213,7 +207,7 @@ class ExpandedReporter implements Reporter {
     // If any tests are running, display the name of the oldest active
     // test.
     if (_engine.active.isNotEmpty) {
-      _progressLine(_description(_engine.active.first));
+      _progressLine(testDescription(_engine.active.first));
     }
   }
 
@@ -226,7 +220,10 @@ class ExpandedReporter implements Reporter {
 
     if (liveTest.state.status != Status.complete) return;
 
-    _progressLine(_description(liveTest), suffix: ' $_bold$_red[E]$_noColor');
+    _progressLine(
+      testDescription(liveTest),
+      suffix: ' $colorBold$_red[E]$colorNone',
+    );
 
     if (error is! LoadException) {
       _sink
@@ -249,7 +246,7 @@ class ExpandedReporter implements Reporter {
   /// [success] will be `true` if all tests passed, `false` if some tests
   /// failed, and `null` if the engine was closed prematurely.
   void _onDone(bool? success) {
-    _cancel();
+    cancelSubscriptions();
     // A null success value indicates that the engine was closed before the
     // tests finished running, probably because of a signal from the user, in
     // which case we shouldn't print summary information.
@@ -260,8 +257,8 @@ class ExpandedReporter implements Reporter {
     } else if (!success) {
       for (var liveTest in _engine.active) {
         _progressLine(
-          _description(liveTest),
-          suffix: ' - did not complete $_bold$_red[E]$_noColor',
+          testDescription(liveTest),
+          suffix: ' - did not complete $colorBold$_red[E]$colorNone',
         );
       }
       _progressLine('Some tests failed.', color: _red);
@@ -271,7 +268,7 @@ class ExpandedReporter implements Reporter {
         failed: _engine.failed,
         active: _engine.active,
         red: _red,
-        noColor: _noColor,
+        noColor: colorNone,
       );
     } else if (_engine.passed.isEmpty) {
       _progressLine('All tests skipped.');
@@ -318,61 +315,31 @@ class ExpandedReporter implements Reporter {
     var buffer = StringBuffer();
 
     // \r moves back to the beginning of the current line.
-    buffer.write('${_timeString(duration)} ');
+    buffer.write('${formatTimeString(duration)} ');
     buffer.write(_green);
     buffer.write('+');
     buffer.write(_engine.passed.length);
-    buffer.write(_noColor);
+    buffer.write(colorNone);
 
     if (_engine.skipped.isNotEmpty) {
       buffer.write(_yellow);
       buffer.write(' ~');
       buffer.write(_engine.skipped.length);
-      buffer.write(_noColor);
+      buffer.write(colorNone);
     }
 
     if (_engine.failed.isNotEmpty) {
       buffer.write(_red);
       buffer.write(' -');
       buffer.write(_engine.failed.length);
-      buffer.write(_noColor);
+      buffer.write(colorNone);
     }
 
     buffer.write(': ');
     buffer.write(color);
     buffer.write(message);
-    buffer.write(_noColor);
+    buffer.write(colorNone);
 
     _sink.writeln(buffer.toString());
-  }
-
-  /// Returns a representation of [duration] as `MM:SS`.
-  String _timeString(Duration duration) {
-    return "${duration.inMinutes.toString().padLeft(2, '0')}:"
-        "${(duration.inSeconds % 60).toString().padLeft(2, '0')}";
-  }
-
-  /// Returns a description of [liveTest].
-  ///
-  /// This differs from the test's own description in that it may also include
-  /// the suite's name.
-  String _description(LiveTest liveTest) {
-    var name = liveTest.test.name;
-
-    if (_printPath &&
-        liveTest.suite is! LoadSuite &&
-        liveTest.suite.path != null) {
-      name = '${liveTest.suite.path}: $name';
-    }
-
-    if (_printPlatform) {
-      name =
-          '[${liveTest.suite.platform.runtime.name}, '
-          '${liveTest.suite.platform.compiler.name}] $name';
-    }
-
-    if (liveTest.suite is LoadSuite) name = '$_bold$_gray$name$_noColor';
-
-    return name;
   }
 }

--- a/pkgs/test_core/lib/src/runner/reporter/failures_only.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/failures_only.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:test_api/src/backend/live_test.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/state.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/util/pretty_print.dart'; // ignore: implementation_imports
@@ -11,11 +9,11 @@ import 'package:test_api/src/backend/util/pretty_print.dart'; // ignore: impleme
 import '../../util/pretty_print.dart';
 import '../engine.dart';
 import '../load_exception.dart';
-import '../load_suite.dart';
 import '../reporter.dart';
+import 'reporter_mixin.dart';
 
 /// A reporter that only prints when a test fails.
-class FailuresOnlyReporter implements Reporter {
+class FailuresOnlyReporter with ReporterMixin implements Reporter {
   /// Whether the reporter should emit terminal color escapes.
   final bool _color;
 
@@ -33,24 +31,29 @@ class FailuresOnlyReporter implements Reporter {
 
   /// The terminal escape for gray text, or the empty string if this is
   /// Windows or not outputting to a terminal.
-  final String _gray;
+  @override
+  final String colorGray;
 
   /// The terminal escape for bold text, or the empty string if this is
   /// Windows or not outputting to a terminal.
-  final String _bold;
+  @override
+  final String colorBold;
 
   /// The terminal escape for removing test coloring, or the empty string if
   /// this is Windows or not outputting to a terminal.
-  final String _noColor;
+  @override
+  final String colorNone;
 
   /// The engine used to run the tests.
   final Engine _engine;
 
   /// Whether the path to each test's suite should be printed.
-  final bool _printPath;
+  @override
+  final bool printPath;
 
   /// Whether the platform each test is running on should be printed.
-  final bool _printPlatform;
+  @override
+  final bool printPlatform;
 
   /// The size of `_engine.passed` last time a progress notification was
   /// printed.
@@ -76,9 +79,6 @@ class FailuresOnlyReporter implements Reporter {
   // Whether a notice should be logged about enabling stack trace chaining at
   // the end of all tests running.
   var _shouldPrintStackTraceChainingNotice = false;
-
-  /// The set of all subscriptions to various streams.
-  final _subscriptions = <StreamSubscription>{};
 
   final StringSink _sink;
 
@@ -107,22 +107,20 @@ class FailuresOnlyReporter implements Reporter {
     this._engine,
     this._sink, {
     required bool color,
-    required bool printPath,
-    required bool printPlatform,
-  }) : _printPath = printPath,
-       _printPlatform = printPlatform,
-       _color = color,
+    required this.printPath,
+    required this.printPlatform,
+  }) : _color = color,
        _green = color ? '\u001b[32m' : '',
        _red = color ? '\u001b[31m' : '',
        _yellow = color ? '\u001b[33m' : '',
-       _gray = color ? '\u001b[90m' : '',
-       _bold = color ? '\u001b[1m' : '',
-       _noColor = color ? '\u001b[0m' : '' {
-    _subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
+       colorGray = color ? '\u001b[90m' : '',
+       colorBold = color ? '\u001b[1m' : '',
+       colorNone = color ? '\u001b[0m' : '' {
+    subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
 
     // Convert the future to a stream so that the subscription can be paused or
     // canceled.
-    _subscriptions.add(_engine.success.asStream().listen(_onDone));
+    subscriptions.add(_engine.success.asStream().listen(_onDone));
   }
 
   @override
@@ -130,7 +128,7 @@ class FailuresOnlyReporter implements Reporter {
     if (_paused) return;
     _paused = true;
 
-    for (var subscription in _subscriptions) {
+    for (var subscription in subscriptions) {
       subscription.pause();
     }
   }
@@ -139,31 +137,24 @@ class FailuresOnlyReporter implements Reporter {
   void resume() {
     if (!_paused) return;
 
-    for (var subscription in _subscriptions) {
+    for (var subscription in subscriptions) {
       subscription.resume();
     }
   }
 
-  void _cancel() {
-    for (var subscription in _subscriptions) {
-      subscription.cancel();
-    }
-    _subscriptions.clear();
-  }
-
   /// A callback called when the engine begins running [liveTest].
   void _onTestStarted(LiveTest liveTest) {
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onError.listen(
         (error) => _onError(liveTest, error.error, error.stackTrace),
       ),
     );
 
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onMessage.listen((message) {
         if (liveTest.test.metadata.skip) return;
         // TODO - Should this suppress output? Behave like printOnFailure?
-        _progressLine(_description(liveTest));
+        _progressLine(testDescription(liveTest));
         _sink.writeln(message.text);
       }),
     );
@@ -178,7 +169,10 @@ class FailuresOnlyReporter implements Reporter {
 
     if (liveTest.state.status != Status.complete) return;
 
-    _progressLine(_description(liveTest), suffix: ' $_bold$_red[E]$_noColor');
+    _progressLine(
+      testDescription(liveTest),
+      suffix: ' $colorBold$_red[E]$colorNone',
+    );
 
     if (error is! LoadException) {
       _sink
@@ -201,7 +195,7 @@ class FailuresOnlyReporter implements Reporter {
   /// [success] will be `true` if all tests passed, `false` if some tests
   /// failed, and `null` if the engine was closed prematurely.
   void _onDone(bool? success) {
-    _cancel();
+    cancelSubscriptions();
     // A null success value indicates that the engine was closed before the
     // tests finished running, probably because of a signal from the user, in
     // which case we shouldn't print summary information.
@@ -212,13 +206,13 @@ class FailuresOnlyReporter implements Reporter {
     } else if (!success) {
       for (var liveTest in _engine.active) {
         _progressLine(
-          _description(liveTest),
-          suffix: ' - did not complete $_bold$_red[E]$_noColor',
+          testDescription(liveTest),
+          suffix: ' - did not complete $colorBold$_red[E]$colorNone',
         );
       }
       _progressLine('Some tests failed.', color: _red);
     } else if (_engine.passed.isEmpty) {
-      _progressLine('${_yellow}All tests skipped.$_noColor');
+      _progressLine('${_yellow}All tests skipped.$colorNone');
     } else if (_engine.skipped.isEmpty) {
       _progressLine('All tests passed!');
     } else {
@@ -226,7 +220,7 @@ class FailuresOnlyReporter implements Reporter {
       _progressLine(
         '$_yellow'
         '$skippedCount skipped ${pluralize('test', skippedCount)}.'
-        '$_noColor',
+        '$colorNone',
       );
       _progressLine('All other tests passed!');
     }
@@ -271,51 +265,27 @@ class FailuresOnlyReporter implements Reporter {
     buffer.write(_green);
     buffer.write('+');
     buffer.write(_engine.passed.length);
-    buffer.write(_noColor);
+    buffer.write(colorNone);
 
     if (_engine.skipped.isNotEmpty) {
       buffer.write(_yellow);
       buffer.write(' ~');
       buffer.write(_engine.skipped.length);
-      buffer.write(_noColor);
+      buffer.write(colorNone);
     }
 
     if (_engine.failed.isNotEmpty) {
       buffer.write(_red);
       buffer.write(' -');
       buffer.write(_engine.failed.length);
-      buffer.write(_noColor);
+      buffer.write(colorNone);
     }
 
     buffer.write(': ');
     buffer.write(color);
     buffer.write(message);
-    buffer.write(_noColor);
+    buffer.write(colorNone);
 
     _sink.writeln(buffer.toString());
-  }
-
-  /// Returns a description of [liveTest].
-  ///
-  /// This differs from the test's own description in that it may also include
-  /// the suite's name.
-  String _description(LiveTest liveTest) {
-    var name = liveTest.test.name;
-
-    if (_printPath &&
-        liveTest.suite is! LoadSuite &&
-        liveTest.suite.path != null) {
-      name = '${liveTest.suite.path}: $name';
-    }
-
-    if (_printPlatform) {
-      name =
-          '[${liveTest.suite.platform.runtime.name}, '
-          '${liveTest.suite.platform.compiler.name}] $name';
-    }
-
-    if (liveTest.suite is LoadSuite) name = '$_bold$_gray$name$_noColor';
-
-    return name;
   }
 }

--- a/pkgs/test_core/lib/src/runner/reporter/github.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/github.dart
@@ -4,8 +4,6 @@
 
 // ignore_for_file: implementation_imports
 
-import 'dart:async';
-
 import 'package:test_api/src/backend/live_test.dart';
 import 'package:test_api/src/backend/message.dart';
 import 'package:test_api/src/backend/state.dart';
@@ -14,6 +12,7 @@ import 'package:test_api/src/backend/util/pretty_print.dart';
 import '../engine.dart';
 import '../load_suite.dart';
 import '../reporter.dart';
+import 'reporter_mixin.dart';
 
 /// A reporter that prints test output using formatting for Github Actions.
 ///
@@ -22,21 +21,20 @@ import '../reporter.dart';
 /// for a description of the output format, and
 /// https://github.com/dart-lang/test/issues/1415 for discussions about this
 /// implementation.
-class GithubReporter implements Reporter {
+class GithubReporter with ReporterMixin implements Reporter {
   /// The engine used to run the tests.
   final Engine _engine;
 
   /// Whether the path to each test's suite should be printed.
-  final bool _printPath;
+  @override
+  final bool printPath;
 
   /// Whether the platform each test is running on should be printed.
-  final bool _printPlatform;
+  @override
+  final bool printPlatform;
 
   /// Whether the reporter is paused.
   var _paused = false;
-
-  /// The set of all subscriptions to various streams.
-  final _subscriptions = <StreamSubscription>{};
 
   final StringSink _sink;
 
@@ -58,11 +56,11 @@ class GithubReporter implements Reporter {
   GithubReporter._(
     this._engine,
     this._sink,
-    this._printPath,
-    this._printPlatform,
+    this.printPath,
+    this.printPlatform,
   ) {
-    _subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
-    _subscriptions.add(_engine.success.asStream().listen(_onDone));
+    subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
+    subscriptions.add(_engine.success.asStream().listen(_onDone));
 
     // Add a spacer between pre-test output and the test results.
     _sink.writeln();
@@ -73,7 +71,7 @@ class GithubReporter implements Reporter {
     if (_paused) return;
     _paused = true;
 
-    for (var subscription in _subscriptions) {
+    for (var subscription in subscriptions) {
       subscription.pause();
     }
   }
@@ -83,34 +81,27 @@ class GithubReporter implements Reporter {
     if (!_paused) return;
     _paused = false;
 
-    for (var subscription in _subscriptions) {
+    for (var subscription in subscriptions) {
       subscription.resume();
     }
-  }
-
-  void _cancel() {
-    for (var subscription in _subscriptions) {
-      subscription.cancel();
-    }
-    _subscriptions.clear();
   }
 
   /// A callback called when the engine begins running [liveTest].
   void _onTestStarted(LiveTest liveTest) {
     // Convert the future to a stream so that the subscription can be paused or
     // canceled.
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onComplete.asStream().listen((_) => _onComplete(liveTest)),
     );
 
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onError.listen(
         (error) => _onError(liveTest, error.error, error.stackTrace),
       ),
     );
 
     // Collect messages from tests as they are emitted.
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onMessage.listen((message) {
         if (_completedTests.contains(liveTest)) {
           // The test has already completed and it's previous messages were
@@ -164,11 +155,11 @@ class GithubReporter implements Reporter {
 
     var name = test.test.name;
     if (!loadSuite) {
-      if (_printPath && test.suite.path != null) {
+      if (printPath && test.suite.path != null) {
         name = '${test.suite.path}: $name';
       }
     }
-    if (_printPlatform) {
+    if (printPlatform) {
       name =
           '[${test.suite.platform.runtime.name}, '
           '${test.suite.platform.compiler.name}] $name';
@@ -224,11 +215,11 @@ class GithubReporter implements Reporter {
 
       var name = test.test.name;
       if (!loadSuite) {
-        if (_printPath && test.suite.path != null) {
+        if (printPath && test.suite.path != null) {
           name = '${test.suite.path}: $name';
         }
       }
-      if (_printPlatform) {
+      if (printPlatform) {
         name =
             '[${test.suite.platform.runtime.name}, '
             '${test.suite.platform.compiler.name}] $name';
@@ -246,7 +237,7 @@ class GithubReporter implements Reporter {
   }
 
   void _onDone(bool? success) {
-    _cancel();
+    cancelSubscriptions();
 
     if (!_activeGroup.isUngrouped) {
       _sink.writeln(_GithubMarkup.endGroup);

--- a/pkgs/test_core/lib/src/runner/reporter/json.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/json.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io' show pid;
 
@@ -25,9 +24,16 @@ import '../reporter.dart';
 import '../runner_suite.dart' show RunnerSuite;
 import '../suite.dart' show SuiteConfiguration;
 import '../version.dart';
+import 'reporter_mixin.dart';
 
 /// A reporter that prints machine-readable JSON-formatted test results.
-class JsonReporter implements Reporter {
+class JsonReporter with ReporterMixin implements Reporter {
+  @override
+  bool get printPath => false;
+
+  @override
+  bool get printPlatform => false;
+
   /// Whether the test runner will pause for debugging.
   final bool _isDebugRun;
 
@@ -58,9 +64,6 @@ class JsonReporter implements Reporter {
   /// Whether the reporter is paused.
   var _paused = false;
 
-  /// The set of all subscriptions to various streams.
-  final _subscriptions = <StreamSubscription>{};
-
   final StringSink _sink;
 
   /// Watches the tests run by [engine] and prints their results as JSON.
@@ -71,13 +74,13 @@ class JsonReporter implements Reporter {
   }) => JsonReporter._(engine, sink, isDebugRun);
 
   JsonReporter._(this._engine, this._sink, this._isDebugRun) {
-    _subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
+    subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
 
     // Convert the future to a stream so that the subscription can be paused or
     // canceled.
-    _subscriptions.add(_engine.success.asStream().listen(_onDone));
+    subscriptions.add(_engine.success.asStream().listen(_onDone));
 
-    _subscriptions.add(
+    subscriptions.add(
       _engine.onSuiteAdded.listen(
         null,
         onDone: () {
@@ -103,7 +106,7 @@ class JsonReporter implements Reporter {
 
     _stopwatch.stop();
 
-    for (var subscription in _subscriptions) {
+    for (var subscription in subscriptions) {
       subscription.pause();
     }
   }
@@ -115,16 +118,9 @@ class JsonReporter implements Reporter {
 
     if (_stopwatchStarted) _stopwatch.start();
 
-    for (var subscription in _subscriptions) {
+    for (var subscription in subscriptions) {
       subscription.resume();
     }
-  }
-
-  void _cancel() {
-    for (var subscription in _subscriptions) {
-      subscription.cancel();
-    }
-    _subscriptions.clear();
   }
 
   /// A callback called when the engine begins running [liveTest].
@@ -164,17 +160,17 @@ class JsonReporter implements Reporter {
 
     // Convert the future to a stream so that the subscription can be paused or
     // canceled.
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onComplete.asStream().listen((_) => _onComplete(liveTest)),
     );
 
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onError.listen(
         (error) => _onError(liveTest, error.error, error.stackTrace),
       ),
     );
 
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onMessage.listen((message) {
         _emit('print', {
           'testID': id,
@@ -301,7 +297,7 @@ class JsonReporter implements Reporter {
   /// [success] will be `true` if all tests passed, `false` if some tests
   /// failed, and `null` if the engine was closed prematurely.
   void _onDone(bool? success) {
-    _cancel();
+    cancelSubscriptions();
     _stopwatch.stop();
 
     _emit('done', {'success': success});

--- a/pkgs/test_core/lib/src/runner/reporter/reporter_mixin.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/reporter_mixin.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:test_api/src/backend/live_test.dart'; // ignore: implementation_imports
+import '../load_suite.dart';
+
+/// A mixin containing shared logic for test reporters.
+mixin ReporterMixin {
+  /// The set of all subscriptions to various streams.
+  final Set<StreamSubscription> subscriptions = <StreamSubscription>{};
+
+  bool get printPath;
+  bool get printPlatform;
+  String get colorBold => '';
+  String get colorGray => '';
+  String get colorNone => '';
+
+  void cancelSubscriptions() {
+    for (var subscription in subscriptions) {
+      subscription.cancel();
+    }
+    subscriptions.clear();
+  }
+
+  /// Returns a representation of [duration] as `MM:SS`.
+  String formatTimeString(Duration duration) {
+    return "${duration.inMinutes.toString().padLeft(2, '0')}:"
+        "${(duration.inSeconds % 60).toString().padLeft(2, '0')}";
+  }
+
+  /// Returns a description of [liveTest].
+  ///
+  /// This differs from the test's own description in that it may also include
+  /// the suite's name.
+  String testDescription(LiveTest liveTest) {
+    var name = liveTest.test.name;
+
+    if (printPath &&
+        liveTest.suite is! LoadSuite &&
+        liveTest.suite.path != null) {
+      name = '${liveTest.suite.path}: $name';
+    }
+
+    if (printPlatform) {
+      name =
+          '[${liveTest.suite.platform.runtime.name}, '
+          '${liveTest.suite.platform.compiler.name}] $name';
+    }
+
+    if (liveTest.suite is LoadSuite) {
+      name = '$colorBold$colorGray$name$colorNone';
+    }
+
+    return name;
+  }
+}


### PR DESCRIPTION
### Rationale

Reporters (`compact.dart`, `expanded.dart`, `failures_only.dart`, `github.dart`, `json.dart`) share identical subscription management, timeout calculation (`_timeString`), and test description logic.

### Summary of Changes

- Extracted shared `ReporterMixin` in `pkgs/test_core/lib/src/runner/reporter/reporter_mixin.dart` consolidating subscription tracking, cancellation, and description formatting.
- Applied `ReporterMixin` across all 5 participating reporters (`CompactReporter`, `ExpandedReporter`, `FailuresOnlyReporter`, `GithubReporter`, `JsonReporter`).
- Verified zero logic drift.

### Verification

- `dart analyze --fatal-infos` (clean)
- `dart test` (100% pass)

Stacked on https://github.com/dart-lang/test/pull/2728