### PR TITLE
refactor(test_core): consolidate duplicate reporter clusters via ReporterMixin (Trial Run 3)

### DIFF
--- a/pkgs/test_core/lib/src/runner/reporter/compact.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/compact.dart
@@ -11,16 +11,17 @@ import 'package:test_api/src/backend/state.dart'; // ignore: implementation_impo
 import 'package:test_api/src/backend/util/pretty_print.dart'; // ignore: implementation_imports
 
 import '../../util/io.dart';
-import '../../util/pretty_print.dart';
 import '../../util/pretty_print.dart' as utils;
+import '../../util/pretty_print.dart';
 import '../engine.dart';
 import '../load_exception.dart';
 import '../load_suite.dart';
 import '../reporter.dart';
+import 'reporter_mixin.dart';
 
 /// A reporter that prints test results to the console in a single
 /// continuously-updating line.
-class CompactReporter implements Reporter {
+class CompactReporter with ReporterMixin implements Reporter {
   /// Whether the reporter should emit terminal color escapes.
   final bool _color;
 
@@ -107,7 +108,6 @@ class CompactReporter implements Reporter {
   var _shouldPrintStackTraceChainingNotice = false;
 
   /// The set of all subscriptions to various streams.
-  final _subscriptions = <StreamSubscription>{};
 
   final StringSink _sink;
 
@@ -148,11 +148,11 @@ class CompactReporter implements Reporter {
        _cyan = color ? '\u001b[36m' : '',
        _bold = color ? '\u001b[1m' : '',
        _noColor = color ? '\u001b[0m' : '' {
-    _subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
+    subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
 
     // Convert the future to a stream so that the subscription can be paused or
     // canceled.
-    _subscriptions.add(_engine.success.asStream().listen(_onDone));
+    subscriptions.add(_engine.success.asStream().listen(_onDone));
   }
 
   @override
@@ -169,7 +169,7 @@ class CompactReporter implements Reporter {
     // during the pause.
     _lastProgressMessage = null;
 
-    for (var subscription in _subscriptions) {
+    for (var subscription in subscriptions) {
       subscription.pause();
     }
   }
@@ -181,16 +181,9 @@ class CompactReporter implements Reporter {
 
     if (_stopwatchStarted) _stopwatch.start();
 
-    for (var subscription in _subscriptions) {
+    for (var subscription in subscriptions) {
       subscription.resume();
     }
-  }
-
-  void _cancel() {
-    for (var subscription in _subscriptions) {
-      subscription.cancel();
-    }
-    _subscriptions.clear();
   }
 
   /// A callback called when the engine begins running [liveTest].
@@ -200,7 +193,7 @@ class CompactReporter implements Reporter {
       _stopwatch.start();
 
       // Keep updating the time even when nothing else is happening.
-      _subscriptions.add(
+      subscriptions.add(
         Stream<void>.periodic(
           const Duration(seconds: 1),
         ).listen((_) => _progressLine(_lastProgressMessage ?? '')),
@@ -216,17 +209,17 @@ class CompactReporter implements Reporter {
       _progressLine(_description(liveTest));
     }
 
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onStateChange.listen((state) => _onStateChange(liveTest, state)),
     );
 
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onError.listen(
         (error) => _onError(liveTest, error.error, error.stackTrace),
       ),
     );
 
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onMessage.listen((message) {
         if (liveTest.test.metadata.skip) return;
         _progressLine(_description(liveTest), truncate: false);
@@ -309,7 +302,7 @@ class CompactReporter implements Reporter {
   /// [success] will be `true` if all tests passed, `false` if some tests
   /// failed, and `null` if the engine was closed prematurely.
   void _onDone(bool? success) {
-    _cancel();
+    cancelSubscriptions();
     _stopwatch.stop();
 
     // A null success value indicates that the engine was closed before the

--- a/pkgs/test_core/lib/src/runner/reporter/expanded.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/expanded.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:test_api/src/backend/live_test.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/message.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/state.dart'; // ignore: implementation_imports
@@ -14,6 +12,7 @@ import '../load_exception.dart';
 import '../load_suite.dart';
 import '../reporter.dart';
 import 'failure_summary.dart';
+import 'reporter_mixin.dart';
 
 /// A reporter that prints each test on its own line.
 ///
@@ -21,7 +20,7 @@ import 'failure_summary.dart';
 /// which can't transitively import `dart:io` but still needs access to a runner
 /// so that test files can be run directly. This means that until issue 6943 is
 /// fixed, this must not import `dart:io`.
-class ExpandedReporter implements Reporter {
+class ExpandedReporter with ReporterMixin implements Reporter {
   /// Whether the reporter should emit terminal color escapes.
   final bool _color;
 
@@ -87,7 +86,6 @@ class ExpandedReporter implements Reporter {
   var _shouldPrintStackTraceChainingNotice = false;
 
   /// The set of all subscriptions to various streams.
-  final _subscriptions = <StreamSubscription>{};
 
   final StringSink _sink;
 
@@ -127,11 +125,11 @@ class ExpandedReporter implements Reporter {
        _gray = color ? '\u001b[90m' : '',
        _bold = color ? '\u001b[1m' : '',
        _noColor = color ? '\u001b[0m' : '' {
-    _subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
+    subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
 
     // Convert the future to a stream so that the subscription can be paused or
     // canceled.
-    _subscriptions.add(_engine.success.asStream().listen(_onDone));
+    subscriptions.add(_engine.success.asStream().listen(_onDone));
   }
 
   @override
@@ -141,7 +139,7 @@ class ExpandedReporter implements Reporter {
 
     _stopwatch.stop();
 
-    for (var subscription in _subscriptions) {
+    for (var subscription in subscriptions) {
       subscription.pause();
     }
   }
@@ -152,16 +150,9 @@ class ExpandedReporter implements Reporter {
 
     _stopwatch.start();
 
-    for (var subscription in _subscriptions) {
+    for (var subscription in subscriptions) {
       subscription.resume();
     }
-  }
-
-  void _cancel() {
-    for (var subscription in _subscriptions) {
-      subscription.cancel();
-    }
-    _subscriptions.clear();
   }
 
   /// A callback called when the engine begins running [liveTest].
@@ -176,7 +167,7 @@ class ExpandedReporter implements Reporter {
       // The engine surfaces load tests when there are no other tests running,
       // but because the expanded reporter's output is always visible, we don't
       // emit information about them unless they fail.
-      _subscriptions.add(
+      subscriptions.add(
         liveTest.onStateChange.listen(
           (state) => _onStateChange(liveTest, state),
         ),
@@ -190,13 +181,13 @@ class ExpandedReporter implements Reporter {
       _progressLine(_description(liveTest));
     }
 
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onError.listen(
         (error) => _onError(liveTest, error.error, error.stackTrace),
       ),
     );
 
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onMessage.listen((message) {
         _progressLine(_description(liveTest));
         var text = message.text;
@@ -249,7 +240,7 @@ class ExpandedReporter implements Reporter {
   /// [success] will be `true` if all tests passed, `false` if some tests
   /// failed, and `null` if the engine was closed prematurely.
   void _onDone(bool? success) {
-    _cancel();
+    cancelSubscriptions();
     // A null success value indicates that the engine was closed before the
     // tests finished running, probably because of a signal from the user, in
     // which case we shouldn't print summary information.

--- a/pkgs/test_core/lib/src/runner/reporter/failures_only.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/failures_only.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:test_api/src/backend/live_test.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/state.dart'; // ignore: implementation_imports
 import 'package:test_api/src/backend/util/pretty_print.dart'; // ignore: implementation_imports
@@ -13,9 +11,10 @@ import '../engine.dart';
 import '../load_exception.dart';
 import '../load_suite.dart';
 import '../reporter.dart';
+import 'reporter_mixin.dart';
 
 /// A reporter that only prints when a test fails.
-class FailuresOnlyReporter implements Reporter {
+class FailuresOnlyReporter with ReporterMixin implements Reporter {
   /// Whether the reporter should emit terminal color escapes.
   final bool _color;
 
@@ -78,7 +77,6 @@ class FailuresOnlyReporter implements Reporter {
   var _shouldPrintStackTraceChainingNotice = false;
 
   /// The set of all subscriptions to various streams.
-  final _subscriptions = <StreamSubscription>{};
 
   final StringSink _sink;
 
@@ -118,11 +116,11 @@ class FailuresOnlyReporter implements Reporter {
        _gray = color ? '\u001b[90m' : '',
        _bold = color ? '\u001b[1m' : '',
        _noColor = color ? '\u001b[0m' : '' {
-    _subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
+    subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
 
     // Convert the future to a stream so that the subscription can be paused or
     // canceled.
-    _subscriptions.add(_engine.success.asStream().listen(_onDone));
+    subscriptions.add(_engine.success.asStream().listen(_onDone));
   }
 
   @override
@@ -130,7 +128,7 @@ class FailuresOnlyReporter implements Reporter {
     if (_paused) return;
     _paused = true;
 
-    for (var subscription in _subscriptions) {
+    for (var subscription in subscriptions) {
       subscription.pause();
     }
   }
@@ -139,27 +137,20 @@ class FailuresOnlyReporter implements Reporter {
   void resume() {
     if (!_paused) return;
 
-    for (var subscription in _subscriptions) {
+    for (var subscription in subscriptions) {
       subscription.resume();
     }
   }
 
-  void _cancel() {
-    for (var subscription in _subscriptions) {
-      subscription.cancel();
-    }
-    _subscriptions.clear();
-  }
-
   /// A callback called when the engine begins running [liveTest].
   void _onTestStarted(LiveTest liveTest) {
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onError.listen(
         (error) => _onError(liveTest, error.error, error.stackTrace),
       ),
     );
 
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onMessage.listen((message) {
         if (liveTest.test.metadata.skip) return;
         // TODO - Should this suppress output? Behave like printOnFailure?
@@ -201,7 +192,7 @@ class FailuresOnlyReporter implements Reporter {
   /// [success] will be `true` if all tests passed, `false` if some tests
   /// failed, and `null` if the engine was closed prematurely.
   void _onDone(bool? success) {
-    _cancel();
+    cancelSubscriptions();
     // A null success value indicates that the engine was closed before the
     // tests finished running, probably because of a signal from the user, in
     // which case we shouldn't print summary information.

--- a/pkgs/test_core/lib/src/runner/reporter/github.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/github.dart
@@ -4,8 +4,6 @@
 
 // ignore_for_file: implementation_imports
 
-import 'dart:async';
-
 import 'package:test_api/src/backend/live_test.dart';
 import 'package:test_api/src/backend/message.dart';
 import 'package:test_api/src/backend/state.dart';
@@ -14,6 +12,7 @@ import 'package:test_api/src/backend/util/pretty_print.dart';
 import '../engine.dart';
 import '../load_suite.dart';
 import '../reporter.dart';
+import 'reporter_mixin.dart';
 
 /// A reporter that prints test output using formatting for Github Actions.
 ///
@@ -22,7 +21,7 @@ import '../reporter.dart';
 /// for a description of the output format, and
 /// https://github.com/dart-lang/test/issues/1415 for discussions about this
 /// implementation.
-class GithubReporter implements Reporter {
+class GithubReporter with ReporterMixin implements Reporter {
   /// The engine used to run the tests.
   final Engine _engine;
 
@@ -36,7 +35,6 @@ class GithubReporter implements Reporter {
   var _paused = false;
 
   /// The set of all subscriptions to various streams.
-  final _subscriptions = <StreamSubscription>{};
 
   final StringSink _sink;
 
@@ -61,8 +59,8 @@ class GithubReporter implements Reporter {
     this._printPath,
     this._printPlatform,
   ) {
-    _subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
-    _subscriptions.add(_engine.success.asStream().listen(_onDone));
+    subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
+    subscriptions.add(_engine.success.asStream().listen(_onDone));
 
     // Add a spacer between pre-test output and the test results.
     _sink.writeln();
@@ -73,7 +71,7 @@ class GithubReporter implements Reporter {
     if (_paused) return;
     _paused = true;
 
-    for (var subscription in _subscriptions) {
+    for (var subscription in subscriptions) {
       subscription.pause();
     }
   }
@@ -83,34 +81,27 @@ class GithubReporter implements Reporter {
     if (!_paused) return;
     _paused = false;
 
-    for (var subscription in _subscriptions) {
+    for (var subscription in subscriptions) {
       subscription.resume();
     }
-  }
-
-  void _cancel() {
-    for (var subscription in _subscriptions) {
-      subscription.cancel();
-    }
-    _subscriptions.clear();
   }
 
   /// A callback called when the engine begins running [liveTest].
   void _onTestStarted(LiveTest liveTest) {
     // Convert the future to a stream so that the subscription can be paused or
     // canceled.
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onComplete.asStream().listen((_) => _onComplete(liveTest)),
     );
 
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onError.listen(
         (error) => _onError(liveTest, error.error, error.stackTrace),
       ),
     );
 
     // Collect messages from tests as they are emitted.
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onMessage.listen((message) {
         if (_completedTests.contains(liveTest)) {
           // The test has already completed and it's previous messages were
@@ -246,7 +237,7 @@ class GithubReporter implements Reporter {
   }
 
   void _onDone(bool? success) {
-    _cancel();
+    cancelSubscriptions();
 
     if (!_activeGroup.isUngrouped) {
       _sink.writeln(_GithubMarkup.endGroup);

--- a/pkgs/test_core/lib/src/runner/reporter/json.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/json.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io' show pid;
 
@@ -25,9 +24,10 @@ import '../reporter.dart';
 import '../runner_suite.dart' show RunnerSuite;
 import '../suite.dart' show SuiteConfiguration;
 import '../version.dart';
+import 'reporter_mixin.dart';
 
 /// A reporter that prints machine-readable JSON-formatted test results.
-class JsonReporter implements Reporter {
+class JsonReporter with ReporterMixin implements Reporter {
   /// Whether the test runner will pause for debugging.
   final bool _isDebugRun;
 
@@ -59,7 +59,6 @@ class JsonReporter implements Reporter {
   var _paused = false;
 
   /// The set of all subscriptions to various streams.
-  final _subscriptions = <StreamSubscription>{};
 
   final StringSink _sink;
 
@@ -71,13 +70,13 @@ class JsonReporter implements Reporter {
   }) => JsonReporter._(engine, sink, isDebugRun);
 
   JsonReporter._(this._engine, this._sink, this._isDebugRun) {
-    _subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
+    subscriptions.add(_engine.onTestStarted.listen(_onTestStarted));
 
     // Convert the future to a stream so that the subscription can be paused or
     // canceled.
-    _subscriptions.add(_engine.success.asStream().listen(_onDone));
+    subscriptions.add(_engine.success.asStream().listen(_onDone));
 
-    _subscriptions.add(
+    subscriptions.add(
       _engine.onSuiteAdded.listen(
         null,
         onDone: () {
@@ -103,7 +102,7 @@ class JsonReporter implements Reporter {
 
     _stopwatch.stop();
 
-    for (var subscription in _subscriptions) {
+    for (var subscription in subscriptions) {
       subscription.pause();
     }
   }
@@ -115,16 +114,9 @@ class JsonReporter implements Reporter {
 
     if (_stopwatchStarted) _stopwatch.start();
 
-    for (var subscription in _subscriptions) {
+    for (var subscription in subscriptions) {
       subscription.resume();
     }
-  }
-
-  void _cancel() {
-    for (var subscription in _subscriptions) {
-      subscription.cancel();
-    }
-    _subscriptions.clear();
   }
 
   /// A callback called when the engine begins running [liveTest].
@@ -164,17 +156,17 @@ class JsonReporter implements Reporter {
 
     // Convert the future to a stream so that the subscription can be paused or
     // canceled.
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onComplete.asStream().listen((_) => _onComplete(liveTest)),
     );
 
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onError.listen(
         (error) => _onError(liveTest, error.error, error.stackTrace),
       ),
     );
 
-    _subscriptions.add(
+    subscriptions.add(
       liveTest.onMessage.listen((message) {
         _emit('print', {
           'testID': id,
@@ -301,7 +293,7 @@ class JsonReporter implements Reporter {
   /// [success] will be `true` if all tests passed, `false` if some tests
   /// failed, and `null` if the engine was closed prematurely.
   void _onDone(bool? success) {
-    _cancel();
+    cancelSubscriptions();
     _stopwatch.stop();
 
     _emit('done', {'success': success});

--- a/pkgs/test_core/lib/src/runner/reporter/reporter_mixin.dart
+++ b/pkgs/test_core/lib/src/runner/reporter/reporter_mixin.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+/// A mixin for reporters that manage stream subscriptions.
+mixin ReporterMixin {
+  /// The subscriptions associated with this reporter.
+  final subscriptions = <StreamSubscription<void>>{};
+
+  /// Cancels all subscriptions and clears the set.
+  void cancelSubscriptions() {
+    for (var subscription in subscriptions) {
+      subscription.cancel();
+    }
+    subscriptions.clear();
+  }
+}


### PR DESCRIPTION
### Rationale

Reporters (`compact.dart`, `expanded.dart`, `failures_only.dart`, `github.dart`, `json.dart`) share identical subscription management and cancellation boilerplate.

### Summary of Changes

- Extracted shared `ReporterMixin` in `pkgs/test_core/lib/src/runner/reporter/reporter_mixin.dart` consolidating subscription tracking and cancellation.
- Applied `ReporterMixin` across all 5 participating reporters (`CompactReporter`, `ExpandedReporter`, `FailuresOnlyReporter`, `GithubReporter`, `JsonReporter`).
- Verified zero logic drift.

### 🤖 Tool Provenance & Reproduction

Structural duplication analysis performed with
[`dedupe`](https://pub.dev/packages/dedupe) (`v0.1.0`).

To reproduce or re-run this duplication scan locally:

```bash
dart run dedupe@^0.1.0
```

### Verification

- `dart analyze --fatal-infos` (clean)
- `dart test` (100% pass)

Stacked on https://github.com/dart-lang/test/pull/2732
