### PR TITLE
Remove redundant tag

### DIFF
--- a/pkgs/test/test/runner/pause_after_load_test.dart
+++ b/pkgs/test/test/runner/pause_after_load_test.dart
@@ -228,7 +228,7 @@ void main() {
       );
       await test.shouldExit(0);
     },
-    tags: ['firefox', 'chrome', 'vm'],
+    tags: ['firefox', 'chrome'],
   );
 
   test(


### PR DESCRIPTION
This tag was added along with support for VM debugging, but it was
always redundant and likely introduced because of confusion over whether
it would impact whether this test case runs for VM tests. There is no
configuration in `dart_test.yaml` associated with this tag.

Removes a warning to make the test output be more fully grouped in the
github reporter output.
