### PR TITLE
Prepare to publish package:checks

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1824,7 +1824,7 @@ jobs:
       - job_006
       - job_007
   job_046:
-    name: "unit_test; windows; Dart dev; PKG: integration_tests/cross_compiler_hang; `dart test -p chrome,vm -c dart2js,exe -r expanded --suite-load-timeout=15s`"
+    name: "unit_test; windows; Dart dev; PKG: integration_tests/cross_compiler_hang; `dart test -p chrome,vm -c dart2js,exe -r expanded --suite-load-timeout=20s`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
@@ -1841,8 +1841,8 @@ jobs:
         run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: integration_tests/cross_compiler_hang
-      - name: "integration_tests/cross_compiler_hang; dart test -p chrome,vm -c dart2js,exe -r expanded --suite-load-timeout=15s"
-        run: "dart test -p chrome,vm -c dart2js,exe -r expanded --suite-load-timeout=15s"
+      - name: "integration_tests/cross_compiler_hang; dart test -p chrome,vm -c dart2js,exe -r expanded --suite-load-timeout=20s"
+        run: "dart test -p chrome,vm -c dart2js,exe -r expanded --suite-load-timeout=20s"
         if: "always() && steps.integration_tests_cross_compiler_hang_pub_upgrade.conclusion == 'success'"
         working-directory: integration_tests/cross_compiler_hang
     needs:

--- a/integration_tests/cross_compiler_hang/mono_pkg.yaml
+++ b/integration_tests/cross_compiler_hang/mono_pkg.yaml
@@ -5,7 +5,7 @@ sdk:
 
 stages:
 - unit_test:
-  - command: dart test -p chrome,vm -c dart2js,exe -r expanded --suite-load-timeout=15s
+  - command: dart test -p chrome,vm -c dart2js,exe -r expanded --suite-load-timeout=20s
     os:
     - windows
     sdk:

--- a/pkgs/checks/CHANGELOG.md
+++ b/pkgs/checks/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.2-wip
+## 0.3.2
 
 - Bump `test` dev dependency constraint.
 - Add `isNotA<R>()` check extension as a convenience in place of

--- a/pkgs/checks/pubspec.yaml
+++ b/pkgs/checks/pubspec.yaml
@@ -1,5 +1,5 @@
 name: checks
-version: 0.3.2-wip
+version: 0.3.2
 description: >-
   A framework for checking values against expectations and building custom
   expectations.

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -72,8 +72,8 @@ for PKG in ${PKGS}; do
         dart analyze || EXIT_CODE=$?
         ;;
       command_00)
-        echo 'dart test -p chrome,vm -c dart2js,exe -r expanded --suite-load-timeout=15s'
-        dart test -p chrome,vm -c dart2js,exe -r expanded --suite-load-timeout=15s || EXIT_CODE=$?
+        echo 'dart test -p chrome,vm -c dart2js,exe -r expanded --suite-load-timeout=20s'
+        dart test -p chrome,vm -c dart2js,exe -r expanded --suite-load-timeout=20s || EXIT_CODE=$?
         ;;
       command_01)
         echo 'xvfb-run -s "-screen 0 1024x768x24" dart test --timeout=60s'


### PR DESCRIPTION
Publish with a number of quality of life improvements before landing
changes planned for release with a breaking version bump.

Increase timeout for new socket hang test.
This is a new test that appears to have been too close to the limit
when it landed.