### PR TITLE
Add package:spectate with PrintSpy, CallCounter, and ExitSpy

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v6.7.2
+# Created with package:mono_repo v6.7.3
 name: Dart CI
 on:
   push:
@@ -26,7 +26,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:stable"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
@@ -39,20 +39,20 @@ jobs:
         with:
           persist-credentials: false
       - name: mono_repo self validate
-        run: dart pub global activate mono_repo 6.7.2
+        run: dart pub global activate mono_repo 6.7.3
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; linux; Dart 3.11.0; PKGS: integration_tests/regression, pkgs/checks, pkgs/checks_codegen, pkgs/matcher, pkgs/test_core; `dart analyze`"
+    name: "analyze_and_format; linux; Dart 3.11.0; PKGS: integration_tests/regression, pkgs/checks, pkgs/checks_codegen, pkgs/matcher, pkgs/spectate, pkgs/test_core; `dart analyze`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:integration_tests/regression-pkgs/checks-pkgs/checks_codegen-pkgs/matcher-pkgs/test_core;commands:analyze_1"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:integration_tests/regression-pkgs/checks-pkgs/checks_codegen-pkgs/matcher-pkgs/test_core
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:integration_tests/regression-pkgs/checks-pkgs/checks_codegen-pkgs/matcher-pkgs/spectate-pkgs/test_core;commands:analyze_1"
+          restore-keys: |-
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:integration_tests/regression-pkgs/checks-pkgs/checks_codegen-pkgs/matcher-pkgs/spectate-pkgs/test_core
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -101,6 +101,15 @@ jobs:
         run: dart analyze
         if: "always() && steps.pkgs_matcher_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/matcher
+      - id: pkgs_spectate_pub_upgrade
+        name: pkgs/spectate; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/spectate
+      - name: pkgs/spectate; dart analyze
+        run: dart analyze
+        if: "always() && steps.pkgs_spectate_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/spectate
       - id: pkgs_test_core_pub_upgrade
         name: pkgs/test_core; dart pub upgrade
         run: dart pub upgrade
@@ -119,7 +128,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:integration_tests/wasm;commands:format-analyze_0"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:integration_tests/wasm
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0
             os:ubuntu-latest;pub-cache-hosted
@@ -147,16 +156,16 @@ jobs:
         if: "always() && steps.integration_tests_wasm_pub_upgrade.conclusion == 'success'"
         working-directory: integration_tests/wasm
   job_004:
-    name: "analyze_and_format; linux; Dart dev; PKGS: integration_tests/regression, integration_tests/spawn_hybrid, integration_tests/wasm, pkgs/checks, pkgs/matcher, pkgs/test, pkgs/test_api, pkgs/test_core; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos`"
+    name: "analyze_and_format; linux; Dart dev; PKGS: integration_tests/regression, integration_tests/spawn_hybrid, integration_tests/wasm, pkgs/checks, pkgs/matcher, pkgs/spectate, pkgs/test, pkgs/test_api, pkgs/test_core; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:integration_tests/regression-integration_tests/spawn_hybrid-integration_tests/wasm-pkgs/checks-pkgs/matcher-pkgs/test-pkgs/test_api-pkgs/test_core;commands:format-analyze_0"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:integration_tests/regression-integration_tests/spawn_hybrid-integration_tests/wasm-pkgs/checks-pkgs/matcher-pkgs/test-pkgs/test_api-pkgs/test_core
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:integration_tests/regression-integration_tests/spawn_hybrid-integration_tests/wasm-pkgs/checks-pkgs/matcher-pkgs/spectate-pkgs/test-pkgs/test_api-pkgs/test_core;commands:format-analyze_0"
+          restore-keys: |-
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:integration_tests/regression-integration_tests/spawn_hybrid-integration_tests/wasm-pkgs/checks-pkgs/matcher-pkgs/spectate-pkgs/test-pkgs/test_api-pkgs/test_core
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -234,6 +243,19 @@ jobs:
         run: dart analyze --fatal-infos
         if: "always() && steps.pkgs_matcher_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/matcher
+      - id: pkgs_spectate_pub_upgrade
+        name: pkgs/spectate; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/spectate
+      - name: "pkgs/spectate; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.pkgs_spectate_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/spectate
+      - name: "pkgs/spectate; dart analyze --fatal-infos"
+        run: dart analyze --fatal-infos
+        if: "always() && steps.pkgs_spectate_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/spectate
       - id: pkgs_test_pub_upgrade
         name: pkgs/test; dart pub upgrade
         run: dart pub upgrade
@@ -282,7 +304,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/checks_codegen;commands:format-command_04-analyze_0"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/checks_codegen
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
@@ -374,7 +396,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:integration_tests/regression;commands:test_0"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:integration_tests/regression
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0
             os:ubuntu-latest;pub-cache-hosted
@@ -414,7 +436,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/checks;commands:test_0"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/checks
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0
             os:ubuntu-latest;pub-cache-hosted
@@ -454,7 +476,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/matcher;commands:test_0"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/matcher
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0
             os:ubuntu-latest;pub-cache-hosted
@@ -486,6 +508,46 @@ jobs:
       - job_006
       - job_007
   job_011:
+    name: "unit_test; linux; Dart 3.11.0; PKG: pkgs/spectate; `dart test`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/spectate;commands:test_0"
+          restore-keys: |-
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/spectate
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6afc89df92d6eb3834022f73cd65adc8cdfcb92d
+        with:
+          sdk: "3.11.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - id: pkgs_spectate_pub_upgrade
+        name: pkgs/spectate; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/spectate
+      - name: pkgs/spectate; dart test
+        run: dart test
+        if: "always() && steps.pkgs_spectate_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/spectate
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+  job_012:
     name: "unit_test; linux; Dart 3.11.0; PKG: pkgs/test_core; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -494,7 +556,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test_core;commands:test_0"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test_core
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0
             os:ubuntu-latest;pub-cache-hosted
@@ -525,7 +587,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_012:
+  job_013:
     name: "unit_test; linux; Dart 3.11.0; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
     runs-on: ubuntu-latest
     steps:
@@ -534,7 +596,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:integration_tests/spawn_hybrid;commands:test_1"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:integration_tests/spawn_hybrid
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0
             os:ubuntu-latest;pub-cache-hosted
@@ -565,7 +627,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_013:
+  job_014:
     name: "unit_test; linux; Dart 3.11.0; PKG: integration_tests/wasm; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --timeout=60s`"
     runs-on: ubuntu-latest
     steps:
@@ -574,7 +636,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:integration_tests/wasm;commands:command_01"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:integration_tests/wasm
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0
             os:ubuntu-latest;pub-cache-hosted
@@ -605,7 +667,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_014:
+  job_015:
     name: "unit_test; linux; Dart 3.11.0; PKG: pkgs/checks_codegen; `dart run build_runner build`, `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -614,7 +676,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/checks_codegen;commands:command_04-test_0"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/checks_codegen
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0
             os:ubuntu-latest;pub-cache-hosted
@@ -649,7 +711,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_015:
+  job_016:
     name: "unit_test; linux; Dart 3.11.0; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: ubuntu-latest
     steps:
@@ -658,7 +720,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test;commands:command_05"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0
             os:ubuntu-latest;pub-cache-hosted
@@ -689,7 +751,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_016:
+  job_017:
     name: "unit_test; linux; Dart 3.11.0; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: ubuntu-latest
     steps:
@@ -698,7 +760,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test;commands:command_06"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0
             os:ubuntu-latest;pub-cache-hosted
@@ -729,7 +791,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_017:
+  job_018:
     name: "unit_test; linux; Dart 3.11.0; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: ubuntu-latest
     steps:
@@ -738,7 +800,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test;commands:command_07"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0
             os:ubuntu-latest;pub-cache-hosted
@@ -769,7 +831,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_018:
+  job_019:
     name: "unit_test; linux; Dart 3.11.0; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 3`"
     runs-on: ubuntu-latest
     steps:
@@ -778,7 +840,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test;commands:command_08"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0
             os:ubuntu-latest;pub-cache-hosted
@@ -809,7 +871,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_019:
+  job_020:
     name: "unit_test; linux; Dart 3.11.0; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 4`"
     runs-on: ubuntu-latest
     steps:
@@ -818,7 +880,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test;commands:command_09"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0
             os:ubuntu-latest;pub-cache-hosted
@@ -849,7 +911,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_020:
+  job_021:
     name: "unit_test; linux; Dart 3.11.0; PKG: pkgs/test_api; `dart test --preset travis -x browser -c kernel,exe`"
     runs-on: ubuntu-latest
     steps:
@@ -858,7 +920,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test_api;commands:command_15"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test_api
             os:ubuntu-latest;pub-cache-hosted;sdk:3.11.0
             os:ubuntu-latest;pub-cache-hosted
@@ -889,7 +951,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_021:
+  job_022:
     name: "unit_test; linux; Dart dev; PKG: integration_tests/regression; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -898,7 +960,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:integration_tests/regression;commands:test_0"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:integration_tests/regression
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
@@ -929,7 +991,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_022:
+  job_023:
     name: "unit_test; linux; Dart dev; PKG: pkgs/checks; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -938,7 +1000,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/checks;commands:test_0"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/checks
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
@@ -969,7 +1031,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_023:
+  job_024:
     name: "unit_test; linux; Dart dev; PKG: pkgs/matcher; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -978,7 +1040,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/matcher;commands:test_0"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/matcher
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
@@ -1009,7 +1071,47 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_024:
+  job_025:
+    name: "unit_test; linux; Dart dev; PKG: pkgs/spectate; `dart test`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/spectate;commands:test_0"
+          restore-keys: |-
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/spectate
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6afc89df92d6eb3834022f73cd65adc8cdfcb92d
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - id: pkgs_spectate_pub_upgrade
+        name: pkgs/spectate; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/spectate
+      - name: pkgs/spectate; dart test
+        run: dart test
+        if: "always() && steps.pkgs_spectate_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/spectate
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+  job_026:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test_core; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -1018,7 +1120,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/test_core;commands:test_0"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/test_core
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
@@ -1049,7 +1151,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_025:
+  job_027:
     name: "unit_test; linux; Dart dev; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
     runs-on: ubuntu-latest
     steps:
@@ -1058,7 +1160,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:integration_tests/spawn_hybrid;commands:test_1"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:integration_tests/spawn_hybrid
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
@@ -1089,7 +1191,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_026:
+  job_028:
     name: "unit_test; linux; Dart dev; PKG: integration_tests/wasm; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --timeout=60s`"
     runs-on: ubuntu-latest
     steps:
@@ -1098,7 +1200,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:integration_tests/wasm;commands:command_01"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:integration_tests/wasm
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
@@ -1129,7 +1231,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_027:
+  job_029:
     name: "unit_test; linux; Dart dev; PKG: pkgs/checks_codegen; `dart run build_runner build`, `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -1138,7 +1240,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/checks_codegen;commands:command_04-test_0"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/checks_codegen
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
@@ -1173,7 +1275,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_028:
+  job_030:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: ubuntu-latest
     steps:
@@ -1182,7 +1284,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/test;commands:command_05"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/test
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
@@ -1213,7 +1315,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_029:
+  job_031:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: ubuntu-latest
     steps:
@@ -1222,7 +1324,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/test;commands:command_06"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/test
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
@@ -1253,7 +1355,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_030:
+  job_032:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: ubuntu-latest
     steps:
@@ -1262,7 +1364,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/test;commands:command_07"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/test
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
@@ -1293,7 +1395,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_031:
+  job_033:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 3`"
     runs-on: ubuntu-latest
     steps:
@@ -1302,7 +1404,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/test;commands:command_08"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/test
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
@@ -1333,7 +1435,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_032:
+  job_034:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test; `xvfb-run -s \"-screen 0 1024x768x24\" dart test --preset travis --total-shards 5 --shard-index 4`"
     runs-on: ubuntu-latest
     steps:
@@ -1342,7 +1444,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/test;commands:command_09"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/test
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
@@ -1373,7 +1475,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_033:
+  job_035:
     name: "unit_test; linux; Dart dev; PKG: pkgs/test_api; `dart test --preset travis -x browser -c kernel,exe`"
     runs-on: ubuntu-latest
     steps:
@@ -1382,7 +1484,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/test_api;commands:command_15"
-          restore-keys: |
+          restore-keys: |-
             os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/test_api
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
@@ -1413,7 +1515,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_034:
+  job_036:
     name: "unit_test; osx; Dart 3.11.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: macos-latest
     steps:
@@ -1422,7 +1524,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:macos-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test;commands:command_10"
-          restore-keys: |
+          restore-keys: |-
             os:macos-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test
             os:macos-latest;pub-cache-hosted;sdk:3.11.0
             os:macos-latest;pub-cache-hosted
@@ -1453,7 +1555,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_035:
+  job_037:
     name: "unit_test; osx; Dart 3.11.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: macos-latest
     steps:
@@ -1462,7 +1564,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:macos-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test;commands:command_11"
-          restore-keys: |
+          restore-keys: |-
             os:macos-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test
             os:macos-latest;pub-cache-hosted;sdk:3.11.0
             os:macos-latest;pub-cache-hosted
@@ -1493,7 +1595,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_036:
+  job_038:
     name: "unit_test; osx; Dart 3.11.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: macos-latest
     steps:
@@ -1502,7 +1604,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:macos-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test;commands:command_12"
-          restore-keys: |
+          restore-keys: |-
             os:macos-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test
             os:macos-latest;pub-cache-hosted;sdk:3.11.0
             os:macos-latest;pub-cache-hosted
@@ -1533,7 +1635,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_037:
+  job_039:
     name: "unit_test; osx; Dart 3.11.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 3`"
     runs-on: macos-latest
     steps:
@@ -1542,7 +1644,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:macos-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test;commands:command_13"
-          restore-keys: |
+          restore-keys: |-
             os:macos-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test
             os:macos-latest;pub-cache-hosted;sdk:3.11.0
             os:macos-latest;pub-cache-hosted
@@ -1573,7 +1675,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_038:
+  job_040:
     name: "unit_test; osx; Dart 3.11.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 4`"
     runs-on: macos-latest
     steps:
@@ -1582,7 +1684,7 @@ jobs:
         with:
           path: "~/.pub-cache/hosted"
           key: "os:macos-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test;commands:command_14"
-          restore-keys: |
+          restore-keys: |-
             os:macos-latest;pub-cache-hosted;sdk:3.11.0;packages:pkgs/test
             os:macos-latest;pub-cache-hosted;sdk:3.11.0
             os:macos-latest;pub-cache-hosted
@@ -1613,7 +1715,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_039:
+  job_041:
     name: "unit_test; windows; Dart 3.11.0; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
     runs-on: windows-latest
     steps:
@@ -1643,7 +1745,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_040:
+  job_042:
     name: "unit_test; windows; Dart 3.11.0; PKG: integration_tests/wasm; `dart test --timeout=60s`"
     runs-on: windows-latest
     steps:
@@ -1673,7 +1775,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_041:
+  job_043:
     name: "unit_test; windows; Dart 3.11.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 0`"
     runs-on: windows-latest
     steps:
@@ -1703,7 +1805,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_042:
+  job_044:
     name: "unit_test; windows; Dart 3.11.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 1`"
     runs-on: windows-latest
     steps:
@@ -1733,7 +1835,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_043:
+  job_045:
     name: "unit_test; windows; Dart 3.11.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 2`"
     runs-on: windows-latest
     steps:
@@ -1763,7 +1865,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_044:
+  job_046:
     name: "unit_test; windows; Dart 3.11.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 3`"
     runs-on: windows-latest
     steps:
@@ -1793,7 +1895,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_045:
+  job_047:
     name: "unit_test; windows; Dart 3.11.0; PKG: pkgs/test; `dart test --preset travis --total-shards 5 --shard-index 4`"
     runs-on: windows-latest
     steps:
@@ -1823,7 +1925,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_046:
+  job_048:
     name: "unit_test; windows; Dart dev; PKG: integration_tests/cross_compiler_hang; `dart test -p chrome,vm -c dart2js,exe -r expanded --suite-load-timeout=20s`"
     runs-on: windows-latest
     steps:
@@ -1853,7 +1955,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_047:
+  job_049:
     name: "unit_test; windows; Dart dev; PKG: integration_tests/spawn_hybrid; `dart test -p chrome,vm,node`"
     runs-on: windows-latest
     steps:
@@ -1883,7 +1985,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_048:
+  job_050:
     name: "unit_test; windows; Dart dev; PKG: integration_tests/wasm; `dart test --timeout=60s`"
     runs-on: windows-latest
     steps:
@@ -1913,7 +2015,7 @@ jobs:
       - job_005
       - job_006
       - job_007
-  job_049:
+  job_051:
     name: Notify failure
     runs-on: ubuntu-latest
     if: "(github.event_name == 'push' || github.event_name == 'schedule') && failure()"
@@ -1973,3 +2075,5 @@ jobs:
       - job_046
       - job_047
       - job_048
+      - job_049
+      - job_050

--- a/pkgs/spectate/CHANGELOG.md
+++ b/pkgs/spectate/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0-wip
+
+- Initial release with `PrintSpy`, `CallCounter`, and `ExitSpy`.

--- a/pkgs/spectate/LICENSE
+++ b/pkgs/spectate/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2014, the Dart project authors. 
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pkgs/spectate/README.md
+++ b/pkgs/spectate/README.md
@@ -1,0 +1,99 @@
+# package:spectate
+
+Utilities to spy on function calls, prints, and process exit in Dart tests and code.
+
+## Features
+
+- **`PrintSpy`**: Intercepts and records text passed to `print()` during function execution.
+  - Static methods `PrintSpy.spectate(void Function())` returning `Iterable<String>`.
+  - Static methods `PrintSpy.spectateAsync(FutureOr<void> Function())` returning `Stream<String>`.
+  - Function extensions `.spectatePrint` on functions with arity up to 5 (both sync and async), returning a tuple `(PrintSpy, WrappedFunction)`.
+  - Instance members `prints` (all printed lines), `calls` (prints grouped by invocation), and `callCount`.
+
+- **`CallCounter`**: Counts how many times a callback is invoked.
+  - Function extensions `.countCalls` on functions with arity up to 5 (both sync and async), returning a tuple `(CallCounter, WrappedFunction)`.
+  - Instance members `callCount` and `called`.
+
+- **`ExitSpy`** (in `package:spectate/io.dart`): Intercepts and records calls to `dart:io`'s `exit()`.
+  - Static methods `ExitSpy.spectate(void Function())` returning `int?`.
+  - Static methods `ExitSpy.spectateAsync(FutureOr<void> Function())` returning `Future<int?>`.
+  - Function extensions `.spectateExit` on functions with arity up to 5 (both sync and async), returning a tuple `(ExitSpy, WrappedFunction)`.
+  - Instance members `exitCodes`, `exitCode`, `exited`, and `callCount`.
+  - The main library `package:spectate/spectate.dart` does not import `dart:io` transitively, allowing use on all Dart platforms.
+
+## Usage
+
+### Spying on `print`
+
+```dart
+import 'package:spectate/spectate.dart';
+
+// Spectate an inline synchronous callback:
+final prints = PrintSpy.spectate(() {
+  print('hello');
+  print('world');
+});
+// prints contains ['hello', 'world']
+
+// Spectate an inline asynchronous callback:
+final printStream = PrintSpy.spectateAsync(() async {
+  print('async message');
+});
+await for (final message in printStream) {
+  print('Captured: $message');
+}
+
+// Wrap a function tear-off:
+void logger(String message) {
+  print('LOG: $message');
+}
+
+final (printSpy, callback) = logger.spectatePrint;
+callback('first');
+callback('second');
+
+print(printSpy.prints); // ['LOG: first', 'LOG: second']
+print(printSpy.callCount); // 2
+print(printSpy.calls); // [['LOG: first'], ['LOG: second']]
+```
+
+### Counting Calls
+
+```dart
+import 'package:spectate/spectate.dart';
+
+void handleEvent(int eventId) {
+  // ...
+}
+
+final (counter, callback) = handleEvent.countCalls;
+callback(1);
+callback(2);
+
+print(counter.callCount); // 2
+print(counter.called); // true
+```
+
+### Spying on `exit`
+
+```dart
+import 'dart:io';
+import 'package:spectate/io.dart';
+
+// Spectate an inline callback:
+final code = ExitSpy.spectate(() {
+  exit(0);
+});
+print(code); // 0
+
+// Wrap a function tear-off:
+void terminate(int code) {
+  exit(code);
+}
+
+final (exitSpy, callback) = terminate.spectateExit;
+callback(42);
+
+print(exitSpy.exited); // true
+print(exitSpy.exitCode); // 42
+```

--- a/pkgs/spectate/lib/io.dart
+++ b/pkgs/spectate/lib/io.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export 'src/exit_spy.dart';

--- a/pkgs/spectate/lib/spectate.dart
+++ b/pkgs/spectate/lib/spectate.dart
@@ -1,0 +1,6 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export 'src/call_counter.dart';
+export 'src/print_spy.dart';

--- a/pkgs/spectate/lib/src/call_counter.dart
+++ b/pkgs/spectate/lib/src/call_counter.dart
@@ -1,0 +1,167 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// A counter that records invocations of a wrapped callback.
+final class CallCounter {
+  int _callCount = 0;
+
+  CallCounter();
+
+  /// The number of times the callback has been called.
+  int get callCount => _callCount;
+
+  /// Whether the callback has been called at least once.
+  bool get called => _callCount > 0;
+
+  void _increment() {
+    _callCount++;
+  }
+}
+
+extension CallCounter0 on void Function() {
+  (CallCounter, void Function()) get countCalls {
+    final counter = CallCounter();
+    void wrapped() {
+      counter._increment();
+      this();
+    }
+
+    return (counter, wrapped);
+  }
+}
+
+extension CallCounterAsync0 on Future<void> Function() {
+  (CallCounter, Future<void> Function()) get countCalls {
+    final counter = CallCounter();
+    Future<void> wrapped() {
+      counter._increment();
+      return this();
+    }
+
+    return (counter, wrapped);
+  }
+}
+
+extension CallCounter1<T0> on void Function(T0) {
+  (CallCounter, void Function(T0)) get countCalls {
+    final counter = CallCounter();
+    void wrapped(T0 a0) {
+      counter._increment();
+      this(a0);
+    }
+
+    return (counter, wrapped);
+  }
+}
+
+extension CallCounterAsync1<T0> on Future<void> Function(T0) {
+  (CallCounter, Future<void> Function(T0)) get countCalls {
+    final counter = CallCounter();
+    Future<void> wrapped(T0 a0) {
+      counter._increment();
+      return this(a0);
+    }
+
+    return (counter, wrapped);
+  }
+}
+
+extension CallCounter2<T0, T1> on void Function(T0, T1) {
+  (CallCounter, void Function(T0, T1)) get countCalls {
+    final counter = CallCounter();
+    void wrapped(T0 a0, T1 a1) {
+      counter._increment();
+      this(a0, a1);
+    }
+
+    return (counter, wrapped);
+  }
+}
+
+extension CallCounterAsync2<T0, T1> on Future<void> Function(T0, T1) {
+  (CallCounter, Future<void> Function(T0, T1)) get countCalls {
+    final counter = CallCounter();
+    Future<void> wrapped(T0 a0, T1 a1) {
+      counter._increment();
+      return this(a0, a1);
+    }
+
+    return (counter, wrapped);
+  }
+}
+
+extension CallCounter3<T0, T1, T2> on void Function(T0, T1, T2) {
+  (CallCounter, void Function(T0, T1, T2)) get countCalls {
+    final counter = CallCounter();
+    void wrapped(T0 a0, T1 a1, T2 a2) {
+      counter._increment();
+      this(a0, a1, a2);
+    }
+
+    return (counter, wrapped);
+  }
+}
+
+extension CallCounterAsync3<T0, T1, T2> on Future<void> Function(T0, T1, T2) {
+  (CallCounter, Future<void> Function(T0, T1, T2)) get countCalls {
+    final counter = CallCounter();
+    Future<void> wrapped(T0 a0, T1 a1, T2 a2) {
+      counter._increment();
+      return this(a0, a1, a2);
+    }
+
+    return (counter, wrapped);
+  }
+}
+
+extension CallCounter4<T0, T1, T2, T3> on void Function(T0, T1, T2, T3) {
+  (CallCounter, void Function(T0, T1, T2, T3)) get countCalls {
+    final counter = CallCounter();
+    void wrapped(T0 a0, T1 a1, T2 a2, T3 a3) {
+      counter._increment();
+      this(a0, a1, a2, a3);
+    }
+
+    return (counter, wrapped);
+  }
+}
+
+extension CallCounterAsync4<T0, T1, T2, T3>
+    on Future<void> Function(T0, T1, T2, T3) {
+  (CallCounter, Future<void> Function(T0, T1, T2, T3)) get countCalls {
+    final counter = CallCounter();
+    Future<void> wrapped(T0 a0, T1 a1, T2 a2, T3 a3) {
+      counter._increment();
+      return this(a0, a1, a2, a3);
+    }
+
+    return (counter, wrapped);
+  }
+}
+
+extension CallCounter5<T0, T1, T2, T3, T4>
+    on void Function(T0, T1, T2, T3, T4) {
+  (CallCounter, void Function(T0, T1, T2, T3, T4)) get countCalls {
+    final counter = CallCounter();
+    void wrapped(T0 a0, T1 a1, T2 a2, T3 a3, T4 a4) {
+      counter._increment();
+      this(a0, a1, a2, a3, a4);
+    }
+
+    return (counter, wrapped);
+  }
+}
+
+extension CallCounterAsync5<T0, T1, T2, T3, T4>
+    on Future<void> Function(T0, T1, T2, T3, T4) {
+  (CallCounter, Future<void> Function(T0, T1, T2, T3, T4)) get countCalls {
+    final counter = CallCounter();
+    Future<void> wrapped(T0 a0, T1 a1, T2 a2, T3 a3, T4 a4) {
+      counter._increment();
+      return this(a0, a1, a2, a3, a4);
+    }
+
+    return (counter, wrapped);
+  }
+}

--- a/pkgs/spectate/lib/src/exit_spy.dart
+++ b/pkgs/spectate/lib/src/exit_spy.dart
@@ -1,0 +1,332 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+/// An exception thrown when [exit] is called while being spied on by [ExitSpy].
+final class ExitException implements Exception {
+  /// The exit code passed to [exit].
+  final int exitCode;
+
+  ExitException(this.exitCode);
+
+  @override
+  String toString() => 'ExitException: $exitCode';
+}
+
+/// A spy that records calls to [exit] during callbacks.
+final class ExitSpy {
+  final List<int> _exitCodes = [];
+
+  ExitSpy();
+
+  /// All exit codes passed to [exit] across all invocations of the spied callback.
+  Iterable<int> get exitCodes => _exitCodes;
+
+  /// The first exit code passed to [exit], or `null` if [exit] was not called.
+  int? get exitCode => _exitCodes.firstOrNull;
+
+  /// Whether [exit] was called at least once.
+  bool get exited => _exitCodes.isNotEmpty;
+
+  /// The number of times [exit] was called.
+  int get callCount => _exitCodes.length;
+
+  void _recordExit(int code) {
+    _exitCodes.add(code);
+  }
+
+  /// Runs [callback] synchronously and returns the exit code if [exit] was called,
+  /// or `null` if [callback] finished without calling [exit].
+  static int? spectate(void Function() callback) {
+    int? code;
+    try {
+      IOOverrides.runZoned(
+        callback,
+        exit: (exitCode) {
+          code = exitCode;
+          throw ExitException(exitCode);
+        },
+      );
+    } on ExitException {
+      // Normal interception of exit().
+    }
+    return code;
+  }
+
+  /// Runs [callback] asynchronously and returns the exit code if [exit] was called,
+  /// or `null` if [callback] finished without calling [exit].
+  static Future<int?> spectateAsync(FutureOr<void> Function() callback) async {
+    int? code;
+    try {
+      await IOOverrides.runZoned(
+        () async {
+          await callback();
+        },
+        exit: (exitCode) {
+          code = exitCode;
+          throw ExitException(exitCode);
+        },
+      );
+    } on ExitException {
+      // Normal interception of exit().
+    }
+    return code;
+  }
+}
+
+extension ExitSpy0 on void Function() {
+  (ExitSpy, void Function()) get spectateExit {
+    final spy = ExitSpy();
+    void wrapped() {
+      try {
+        IOOverrides.runZoned(
+          this,
+          exit: (code) {
+            spy._recordExit(code);
+            throw ExitException(code);
+          },
+        );
+      } on ExitException {
+        // Intercepted exit; return normally.
+      }
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension ExitSpyAsync0 on Future<void> Function() {
+  (ExitSpy, Future<void> Function()) get spectateExit {
+    final spy = ExitSpy();
+    Future<void> wrapped() async {
+      try {
+        await IOOverrides.runZoned(
+          this,
+          exit: (code) {
+            spy._recordExit(code);
+            throw ExitException(code);
+          },
+        );
+      } on ExitException {
+        // Intercepted exit; return normally.
+      }
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension ExitSpy1<T0> on void Function(T0) {
+  (ExitSpy, void Function(T0)) get spectateExit {
+    final spy = ExitSpy();
+    void wrapped(T0 a0) {
+      try {
+        IOOverrides.runZoned(
+          () => this(a0),
+          exit: (code) {
+            spy._recordExit(code);
+            throw ExitException(code);
+          },
+        );
+      } on ExitException {
+        // Intercepted exit; return normally.
+      }
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension ExitSpyAsync1<T0> on Future<void> Function(T0) {
+  (ExitSpy, Future<void> Function(T0)) get spectateExit {
+    final spy = ExitSpy();
+    Future<void> wrapped(T0 a0) async {
+      try {
+        await IOOverrides.runZoned(
+          () => this(a0),
+          exit: (code) {
+            spy._recordExit(code);
+            throw ExitException(code);
+          },
+        );
+      } on ExitException {
+        // Intercepted exit; return normally.
+      }
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension ExitSpy2<T0, T1> on void Function(T0, T1) {
+  (ExitSpy, void Function(T0, T1)) get spectateExit {
+    final spy = ExitSpy();
+    void wrapped(T0 a0, T1 a1) {
+      try {
+        IOOverrides.runZoned(
+          () => this(a0, a1),
+          exit: (code) {
+            spy._recordExit(code);
+            throw ExitException(code);
+          },
+        );
+      } on ExitException {
+        // Intercepted exit; return normally.
+      }
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension ExitSpyAsync2<T0, T1> on Future<void> Function(T0, T1) {
+  (ExitSpy, Future<void> Function(T0, T1)) get spectateExit {
+    final spy = ExitSpy();
+    Future<void> wrapped(T0 a0, T1 a1) async {
+      try {
+        await IOOverrides.runZoned(
+          () => this(a0, a1),
+          exit: (code) {
+            spy._recordExit(code);
+            throw ExitException(code);
+          },
+        );
+      } on ExitException {
+        // Intercepted exit; return normally.
+      }
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension ExitSpy3<T0, T1, T2> on void Function(T0, T1, T2) {
+  (ExitSpy, void Function(T0, T1, T2)) get spectateExit {
+    final spy = ExitSpy();
+    void wrapped(T0 a0, T1 a1, T2 a2) {
+      try {
+        IOOverrides.runZoned(
+          () => this(a0, a1, a2),
+          exit: (code) {
+            spy._recordExit(code);
+            throw ExitException(code);
+          },
+        );
+      } on ExitException {
+        // Intercepted exit; return normally.
+      }
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension ExitSpyAsync3<T0, T1, T2> on Future<void> Function(T0, T1, T2) {
+  (ExitSpy, Future<void> Function(T0, T1, T2)) get spectateExit {
+    final spy = ExitSpy();
+    Future<void> wrapped(T0 a0, T1 a1, T2 a2) async {
+      try {
+        await IOOverrides.runZoned(
+          () => this(a0, a1, a2),
+          exit: (code) {
+            spy._recordExit(code);
+            throw ExitException(code);
+          },
+        );
+      } on ExitException {
+        // Intercepted exit; return normally.
+      }
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension ExitSpy4<T0, T1, T2, T3> on void Function(T0, T1, T2, T3) {
+  (ExitSpy, void Function(T0, T1, T2, T3)) get spectateExit {
+    final spy = ExitSpy();
+    void wrapped(T0 a0, T1 a1, T2 a2, T3 a3) {
+      try {
+        IOOverrides.runZoned(
+          () => this(a0, a1, a2, a3),
+          exit: (code) {
+            spy._recordExit(code);
+            throw ExitException(code);
+          },
+        );
+      } on ExitException {
+        // Intercepted exit; return normally.
+      }
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension ExitSpyAsync4<T0, T1, T2, T3>
+    on Future<void> Function(T0, T1, T2, T3) {
+  (ExitSpy, Future<void> Function(T0, T1, T2, T3)) get spectateExit {
+    final spy = ExitSpy();
+    Future<void> wrapped(T0 a0, T1 a1, T2 a2, T3 a3) async {
+      try {
+        await IOOverrides.runZoned(
+          () => this(a0, a1, a2, a3),
+          exit: (code) {
+            spy._recordExit(code);
+            throw ExitException(code);
+          },
+        );
+      } on ExitException {
+        // Intercepted exit; return normally.
+      }
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension ExitSpy5<T0, T1, T2, T3, T4> on void Function(T0, T1, T2, T3, T4) {
+  (ExitSpy, void Function(T0, T1, T2, T3, T4)) get spectateExit {
+    final spy = ExitSpy();
+    void wrapped(T0 a0, T1 a1, T2 a2, T3 a3, T4 a4) {
+      try {
+        IOOverrides.runZoned(
+          () => this(a0, a1, a2, a3, a4),
+          exit: (code) {
+            spy._recordExit(code);
+            throw ExitException(code);
+          },
+        );
+      } on ExitException {
+        // Intercepted exit; return normally.
+      }
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension ExitSpyAsync5<T0, T1, T2, T3, T4>
+    on Future<void> Function(T0, T1, T2, T3, T4) {
+  (ExitSpy, Future<void> Function(T0, T1, T2, T3, T4)) get spectateExit {
+    final spy = ExitSpy();
+    Future<void> wrapped(T0 a0, T1 a1, T2 a2, T3 a3, T4 a4) async {
+      try {
+        await IOOverrides.runZoned(
+          () => this(a0, a1, a2, a3, a4),
+          exit: (code) {
+            spy._recordExit(code);
+            throw ExitException(code);
+          },
+        );
+      } on ExitException {
+        // Intercepted exit; return normally.
+      }
+    }
+
+    return (spy, wrapped);
+  }
+}

--- a/pkgs/spectate/lib/src/print_spy.dart
+++ b/pkgs/spectate/lib/src/print_spy.dart
@@ -1,0 +1,321 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+/// A spy that records text printed with `print` during callbacks.
+final class PrintSpy {
+  final List<String> _prints = [];
+  final List<List<String>> _calls = [];
+
+  PrintSpy();
+
+  /// All strings printed across all invocations of the spied callback.
+  Iterable<String> get prints => _prints;
+
+  /// The prints recorded for each individual invocation of the spied callback.
+  Iterable<Iterable<String>> get calls => _calls;
+
+  /// The number of times the spied callback was invoked.
+  int get callCount => _calls.length;
+
+  void _recordCall(List<String> callPrints) {
+    _calls.add(callPrints);
+  }
+
+  void _recordPrint(List<String> callPrints, String line) {
+    _prints.add(line);
+    callPrints.add(line);
+  }
+
+  /// Runs [callback] synchronously in a [Zone] and returns all text printed
+  /// using [print].
+  static Iterable<String> spectate(void Function() callback) {
+    final prints = <String>[];
+    runZoned(
+      callback,
+      zoneSpecification: ZoneSpecification(
+        print: (self, parent, zone, line) {
+          prints.add(line);
+        },
+      ),
+    );
+    return List.unmodifiable(prints);
+  }
+
+  /// Runs [callback] in a [Zone] and emits all text printed using [print] on
+  /// the returned [Stream].
+  static Stream<String> spectateAsync(FutureOr<void> Function() callback) {
+    final controller = StreamController<String>();
+    runZonedGuarded(
+      () async {
+        try {
+          await callback();
+          await controller.close();
+        } catch (error, stackTrace) {
+          if (!controller.isClosed) {
+            controller.addError(error, stackTrace);
+            await controller.close();
+          }
+        }
+      },
+      (error, stackTrace) {
+        if (!controller.isClosed) {
+          controller.addError(error, stackTrace);
+          controller.close();
+        }
+      },
+      zoneSpecification: ZoneSpecification(
+        print: (self, parent, zone, line) {
+          if (!controller.isClosed) {
+            controller.add(line);
+          }
+        },
+      ),
+    );
+    return controller.stream;
+  }
+}
+
+extension PrintSpy0 on void Function() {
+  (PrintSpy, void Function()) get spectatePrint {
+    final spy = PrintSpy();
+    void wrapped() {
+      final callPrints = <String>[];
+      spy._recordCall(callPrints);
+      runZoned(
+        this,
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, line) {
+            spy._recordPrint(callPrints, line);
+          },
+        ),
+      );
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension PrintSpyAsync0 on Future<void> Function() {
+  (PrintSpy, Future<void> Function()) get spectatePrint {
+    final spy = PrintSpy();
+    Future<void> wrapped() {
+      final callPrints = <String>[];
+      spy._recordCall(callPrints);
+      return runZoned(
+        this,
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, line) {
+            spy._recordPrint(callPrints, line);
+          },
+        ),
+      );
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension PrintSpy1<T0> on void Function(T0) {
+  (PrintSpy, void Function(T0)) get spectatePrint {
+    final spy = PrintSpy();
+    void wrapped(T0 a0) {
+      final callPrints = <String>[];
+      spy._recordCall(callPrints);
+      runZoned(
+        () => this(a0),
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, line) {
+            spy._recordPrint(callPrints, line);
+          },
+        ),
+      );
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension PrintSpyAsync1<T0> on Future<void> Function(T0) {
+  (PrintSpy, Future<void> Function(T0)) get spectatePrint {
+    final spy = PrintSpy();
+    Future<void> wrapped(T0 a0) {
+      final callPrints = <String>[];
+      spy._recordCall(callPrints);
+      return runZoned(
+        () => this(a0),
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, line) {
+            spy._recordPrint(callPrints, line);
+          },
+        ),
+      );
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension PrintSpy2<T0, T1> on void Function(T0, T1) {
+  (PrintSpy, void Function(T0, T1)) get spectatePrint {
+    final spy = PrintSpy();
+    void wrapped(T0 a0, T1 a1) {
+      final callPrints = <String>[];
+      spy._recordCall(callPrints);
+      runZoned(
+        () => this(a0, a1),
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, line) {
+            spy._recordPrint(callPrints, line);
+          },
+        ),
+      );
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension PrintSpyAsync2<T0, T1> on Future<void> Function(T0, T1) {
+  (PrintSpy, Future<void> Function(T0, T1)) get spectatePrint {
+    final spy = PrintSpy();
+    Future<void> wrapped(T0 a0, T1 a1) {
+      final callPrints = <String>[];
+      spy._recordCall(callPrints);
+      return runZoned(
+        () => this(a0, a1),
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, line) {
+            spy._recordPrint(callPrints, line);
+          },
+        ),
+      );
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension PrintSpy3<T0, T1, T2> on void Function(T0, T1, T2) {
+  (PrintSpy, void Function(T0, T1, T2)) get spectatePrint {
+    final spy = PrintSpy();
+    void wrapped(T0 a0, T1 a1, T2 a2) {
+      final callPrints = <String>[];
+      spy._recordCall(callPrints);
+      runZoned(
+        () => this(a0, a1, a2),
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, line) {
+            spy._recordPrint(callPrints, line);
+          },
+        ),
+      );
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension PrintSpyAsync3<T0, T1, T2> on Future<void> Function(T0, T1, T2) {
+  (PrintSpy, Future<void> Function(T0, T1, T2)) get spectatePrint {
+    final spy = PrintSpy();
+    Future<void> wrapped(T0 a0, T1 a1, T2 a2) {
+      final callPrints = <String>[];
+      spy._recordCall(callPrints);
+      return runZoned(
+        () => this(a0, a1, a2),
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, line) {
+            spy._recordPrint(callPrints, line);
+          },
+        ),
+      );
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension PrintSpy4<T0, T1, T2, T3> on void Function(T0, T1, T2, T3) {
+  (PrintSpy, void Function(T0, T1, T2, T3)) get spectatePrint {
+    final spy = PrintSpy();
+    void wrapped(T0 a0, T1 a1, T2 a2, T3 a3) {
+      final callPrints = <String>[];
+      spy._recordCall(callPrints);
+      runZoned(
+        () => this(a0, a1, a2, a3),
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, line) {
+            spy._recordPrint(callPrints, line);
+          },
+        ),
+      );
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension PrintSpyAsync4<T0, T1, T2, T3>
+    on Future<void> Function(T0, T1, T2, T3) {
+  (PrintSpy, Future<void> Function(T0, T1, T2, T3)) get spectatePrint {
+    final spy = PrintSpy();
+    Future<void> wrapped(T0 a0, T1 a1, T2 a2, T3 a3) {
+      final callPrints = <String>[];
+      spy._recordCall(callPrints);
+      return runZoned(
+        () => this(a0, a1, a2, a3),
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, line) {
+            spy._recordPrint(callPrints, line);
+          },
+        ),
+      );
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension PrintSpy5<T0, T1, T2, T3, T4> on void Function(T0, T1, T2, T3, T4) {
+  (PrintSpy, void Function(T0, T1, T2, T3, T4)) get spectatePrint {
+    final spy = PrintSpy();
+    void wrapped(T0 a0, T1 a1, T2 a2, T3 a3, T4 a4) {
+      final callPrints = <String>[];
+      spy._recordCall(callPrints);
+      runZoned(
+        () => this(a0, a1, a2, a3, a4),
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, line) {
+            spy._recordPrint(callPrints, line);
+          },
+        ),
+      );
+    }
+
+    return (spy, wrapped);
+  }
+}
+
+extension PrintSpyAsync5<T0, T1, T2, T3, T4>
+    on Future<void> Function(T0, T1, T2, T3, T4) {
+  (PrintSpy, Future<void> Function(T0, T1, T2, T3, T4)) get spectatePrint {
+    final spy = PrintSpy();
+    Future<void> wrapped(T0 a0, T1 a1, T2 a2, T3 a3, T4 a4) {
+      final callPrints = <String>[];
+      spy._recordCall(callPrints);
+      return runZoned(
+        () => this(a0, a1, a2, a3, a4),
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, line) {
+            spy._recordPrint(callPrints, line);
+          },
+        ),
+      );
+    }
+
+    return (spy, wrapped);
+  }
+}

--- a/pkgs/spectate/mono_pkg.yaml
+++ b/pkgs/spectate/mono_pkg.yaml
@@ -1,0 +1,15 @@
+# See https://pub.dev/packages/mono_repo
+
+stages:
+- analyze_and_format:
+  - group:
+    - format
+    - analyze: --fatal-infos
+    sdk: dev
+  - group:
+    - analyze
+    sdk: pubspec
+- unit_test:
+  - group:
+    - command: dart test
+    sdk: [dev, pubspec]

--- a/pkgs/spectate/pubspec.yaml
+++ b/pkgs/spectate/pubspec.yaml
@@ -1,0 +1,15 @@
+name: spectate
+version: 0.1.0-wip
+description: >-
+  Utilities to spy on function calls, prints, and process exit.
+repository: https://github.com/dart-lang/test/tree/master/pkgs/spectate
+issue_tracker: https://github.com/dart-lang/test/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aspectate
+
+resolution: workspace
+
+environment:
+  sdk: ^3.11.0
+
+dev_dependencies:
+  checks: ^0.4.0-wip
+  test: ^1.32.0-wip

--- a/pkgs/spectate/test/call_counter_test.dart
+++ b/pkgs/spectate/test/call_counter_test.dart
@@ -1,0 +1,176 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:checks/checks.dart';
+import 'package:spectate/spectate.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CallCounter synchronous extensions', () {
+    test('arity 0', () {
+      var executed = 0;
+      void fn() {
+        executed++;
+      }
+
+      final (counter, callback) = fn.countCalls;
+      check(counter.callCount).equals(0);
+      check(counter.called).isFalse;
+
+      callback();
+      check(counter.callCount).equals(1);
+      check(counter.called).isTrue;
+      check(executed).equals(1);
+
+      callback();
+      check(counter.callCount).equals(2);
+      check(executed).equals(2);
+    });
+
+    test('arity 1', () {
+      final received = <String>[];
+      void fn(String a) {
+        received.add(a);
+      }
+
+      final (counter, callback) = fn.countCalls;
+      callback('first');
+      callback('second');
+      check(counter.callCount).equals(2);
+      check(received).deepEquals(['first', 'second']);
+    });
+
+    test('arity 2', () {
+      final received = <(int, String)>[];
+      void fn(int a, String b) {
+        received.add((a, b));
+      }
+
+      final (counter, callback) = fn.countCalls;
+      callback(1, 'a');
+      check(counter.callCount).equals(1);
+      check(received).deepEquals([(1, 'a')]);
+    });
+
+    test('arity 3', () {
+      final received = <(int, String, bool)>[];
+      void fn(int a, String b, bool c) {
+        received.add((a, b, c));
+      }
+
+      final (counter, callback) = fn.countCalls;
+      callback(1, 'a', true);
+      check(counter.callCount).equals(1);
+      check(received).deepEquals([(1, 'a', true)]);
+    });
+
+    test('arity 4', () {
+      final received = <(int, String, bool, double)>[];
+      void fn(int a, String b, bool c, double d) {
+        received.add((a, b, c, d));
+      }
+
+      final (counter, callback) = fn.countCalls;
+      callback(1, 'a', true, 3.14);
+      check(counter.callCount).equals(1);
+      check(received).deepEquals([(1, 'a', true, 3.14)]);
+    });
+
+    test('arity 5', () {
+      final received = <(int, String, bool, double, String)>[];
+      void fn(int a, String b, bool c, double d, String e) {
+        received.add((a, b, c, d, e));
+      }
+
+      final (counter, callback) = fn.countCalls;
+      callback(1, 'a', true, 3.14, 'item');
+      check(counter.callCount).equals(1);
+      check(received).deepEquals([(1, 'a', true, 3.14, 'item')]);
+    });
+  });
+
+  group('CallCounter asynchronous extensions', () {
+    test('arity 0', () async {
+      var executed = 0;
+      Future<void> fn() async {
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        executed++;
+      }
+
+      final (counter, callback) = fn.countCalls;
+      check(counter.callCount).equals(0);
+
+      await callback();
+      check(counter.callCount).equals(1);
+      check(executed).equals(1);
+
+      await callback();
+      check(counter.callCount).equals(2);
+      check(executed).equals(2);
+    });
+
+    test('arity 1', () async {
+      final received = <String>[];
+      Future<void> fn(String a) async {
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+        received.add(a);
+      }
+
+      final (counter, callback) = fn.countCalls;
+      await callback('async one');
+      check(counter.callCount).equals(1);
+      check(received).deepEquals(['async one']);
+    });
+
+    test('arity 2', () async {
+      final received = <(int, String)>[];
+      Future<void> fn(int a, String b) async {
+        received.add((a, b));
+      }
+
+      final (counter, callback) = fn.countCalls;
+      await callback(1, 'b');
+      check(counter.callCount).equals(1);
+      check(received).deepEquals([(1, 'b')]);
+    });
+
+    test('arity 3', () async {
+      final received = <(int, String, bool)>[];
+      Future<void> fn(int a, String b, bool c) async {
+        received.add((a, b, c));
+      }
+
+      final (counter, callback) = fn.countCalls;
+      await callback(1, 'b', false);
+      check(counter.callCount).equals(1);
+      check(received).deepEquals([(1, 'b', false)]);
+    });
+
+    test('arity 4', () async {
+      final received = <(int, String, bool, double)>[];
+      Future<void> fn(int a, String b, bool c, double d) async {
+        received.add((a, b, c, d));
+      }
+
+      final (counter, callback) = fn.countCalls;
+      await callback(1, 'b', false, 1.2);
+      check(counter.callCount).equals(1);
+      check(received).deepEquals([(1, 'b', false, 1.2)]);
+    });
+
+    test('arity 5', () async {
+      final received = <(int, String, bool, double, String)>[];
+      Future<void> fn(int a, String b, bool c, double d, String e) async {
+        received.add((a, b, c, d, e));
+      }
+
+      final (counter, callback) = fn.countCalls;
+      await callback(1, 'b', false, 1.2, 'z');
+      check(counter.callCount).equals(1);
+      check(received).deepEquals([(1, 'b', false, 1.2, 'z')]);
+    });
+  });
+}

--- a/pkgs/spectate/test/exit_spy_test.dart
+++ b/pkgs/spectate/test/exit_spy_test.dart
@@ -1,0 +1,223 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:checks/checks.dart';
+import 'package:spectate/io.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ExitSpy.spectate', () {
+    test('captures exit code when exit() is called', () {
+      final code = ExitSpy.spectate(() {
+        exit(42);
+      });
+      check(code).equals(42);
+    });
+
+    test('returns null when exit() is not called', () {
+      final code = ExitSpy.spectate(() {});
+      check(code).isNull;
+    });
+
+    test('rethrows non-exit exceptions', () {
+      check(() {
+        ExitSpy.spectate(() {
+          throw const FormatException('invalid format');
+        });
+      }).throws<FormatException>();
+    });
+  });
+
+  group('ExitSpy.spectateAsync', () {
+    test(
+      'captures exit code when exit() is called in async callback',
+      () async {
+        final code = await ExitSpy.spectateAsync(() async {
+          await Future<void>.delayed(const Duration(milliseconds: 5));
+          exit(1);
+        });
+        check(code).equals(1);
+      },
+    );
+
+    test('returns null when exit() is not called', () async {
+      final code = await ExitSpy.spectateAsync(() async {
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      });
+      check(code).isNull;
+    });
+
+    test('rethrows non-exit exceptions asynchronously', () async {
+      await check(
+        ExitSpy.spectateAsync(() async {
+          throw const FormatException('invalid format');
+        }),
+      ).throws<FormatException>();
+    });
+  });
+
+  group('ExitSpy synchronous extensions', () {
+    test('arity 0', () {
+      var executedAfterExit = false;
+      void fn() {
+        if (!executedAfterExit) exit(0);
+        executedAfterExit = true;
+      }
+
+      final (spy, callback) = fn.spectateExit;
+      check(spy.exited).isFalse;
+      check(spy.exitCode).isNull;
+      check(spy.exitCodes).isEmpty;
+      check(spy.callCount).equals(0);
+
+      callback();
+      check(spy.exited).isTrue;
+      check(spy.exitCode).equals(0);
+      check(spy.exitCodes).deepEquals([0]);
+      check(spy.callCount).equals(1);
+      check(executedAfterExit).isFalse;
+    });
+
+    test('arity 1', () {
+      void fn(int code) {
+        exit(code);
+      }
+
+      final (spy, callback) = fn.spectateExit;
+      callback(123);
+      check(spy.exitCode).equals(123);
+      check(spy.exitCodes).deepEquals([123]);
+    });
+
+    test('arity 2', () {
+      void fn(String _, int code) {
+        exit(code);
+      }
+
+      final (spy, callback) = fn.spectateExit;
+      callback('ign', 2);
+      check(spy.exitCode).equals(2);
+    });
+
+    test('arity 3', () {
+      void fn(String _, bool _, int code) {
+        exit(code);
+      }
+
+      final (spy, callback) = fn.spectateExit;
+      callback('ign', true, 3);
+      check(spy.exitCode).equals(3);
+    });
+
+    test('arity 4', () {
+      void fn(String _, bool _, double _, int code) {
+        exit(code);
+      }
+
+      final (spy, callback) = fn.spectateExit;
+      callback('ign', true, 3.14, 4);
+      check(spy.exitCode).equals(4);
+    });
+
+    test('arity 5', () {
+      void fn(String _, bool _, double _, List<int> _, int code) {
+        exit(code);
+      }
+
+      final (spy, callback) = fn.spectateExit;
+      callback('ign', true, 3.14, const [], 5);
+      check(spy.exitCode).equals(5);
+    });
+
+    test('does not catch non-exit exceptions', () {
+      void fn() {
+        throw StateError('unhandled');
+      }
+
+      final (_, callback) = fn.spectateExit;
+      check(callback).throws<StateError>();
+    });
+  });
+
+  group('ExitSpy asynchronous extensions', () {
+    test('arity 0', () async {
+      var executedAfterExit = false;
+      Future<void> fn() async {
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        if (!executedAfterExit) exit(10);
+        executedAfterExit = true;
+      }
+
+      final (spy, callback) = fn.spectateExit;
+      await callback();
+      check(spy.exited).isTrue;
+      check(spy.exitCode).equals(10);
+      check(executedAfterExit).isFalse;
+    });
+
+    test('arity 1', () async {
+      Future<void> fn(int code) async {
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+        exit(code);
+      }
+
+      final (spy, callback) = fn.spectateExit;
+      await callback(11);
+      check(spy.exitCode).equals(11);
+    });
+
+    test('arity 2', () async {
+      Future<void> fn(String _, int code) async {
+        exit(code);
+      }
+
+      final (spy, callback) = fn.spectateExit;
+      await callback('ign', 12);
+      check(spy.exitCode).equals(12);
+    });
+
+    test('arity 3', () async {
+      Future<void> fn(String _, bool _, int code) async {
+        exit(code);
+      }
+
+      final (spy, callback) = fn.spectateExit;
+      await callback('ign', false, 13);
+      check(spy.exitCode).equals(13);
+    });
+
+    test('arity 4', () async {
+      Future<void> fn(String _, bool _, double _, int code) async {
+        exit(code);
+      }
+
+      final (spy, callback) = fn.spectateExit;
+      await callback('ign', false, 1.0, 14);
+      check(spy.exitCode).equals(14);
+    });
+
+    test('arity 5', () async {
+      Future<void> fn(String _, bool _, double _, String _, int code) async {
+        exit(code);
+      }
+
+      final (spy, callback) = fn.spectateExit;
+      await callback('ign', false, 1.0, 'a', 15);
+      check(spy.exitCode).equals(15);
+    });
+
+    test('does not catch non-exit exceptions', () async {
+      Future<void> fn() async {
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+        throw StateError('unhandled async');
+      }
+
+      final (_, callback) = fn.spectateExit;
+      await check(callback()).throws<StateError>();
+    });
+  });
+}

--- a/pkgs/spectate/test/print_spy_test.dart
+++ b/pkgs/spectate/test/print_spy_test.dart
@@ -1,0 +1,209 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:checks/checks.dart';
+import 'package:spectate/spectate.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PrintSpy.spectate', () {
+    test('captures prints from synchronous callback', () {
+      final prints = PrintSpy.spectate(() {
+        print('hello');
+        print('world');
+      });
+      check(prints).deepEquals(['hello', 'world']);
+    });
+
+    test('returns empty iterable when nothing is printed', () {
+      final prints = PrintSpy.spectate(() {});
+      check(prints).isEmpty;
+    });
+
+    test('rethrows exception thrown by callback', () {
+      check(() {
+        PrintSpy.spectate(() {
+          print('before error');
+          throw StateError('failure');
+        });
+      }).throws<StateError>();
+    });
+  });
+
+  group('PrintSpy.spectateAsync', () {
+    test('emits prints from asynchronous callback', () async {
+      final stream = PrintSpy.spectateAsync(() async {
+        print('first');
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        print('second');
+      });
+      check(await stream.toList()).deepEquals(['first', 'second']);
+    });
+
+    test('emits error if callback throws asynchronously', () async {
+      final stream = PrintSpy.spectateAsync(() async {
+        print('before error');
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        throw StateError('async failure');
+      });
+      final queue = check(stream).withQueue;
+      await queue.emits(Condition.it()..equals('before error'));
+      await queue.emitsError<StateError>();
+    });
+  });
+
+  group('PrintSpy synchronous extensions', () {
+    test('arity 0', () {
+      void fn() {
+        print('call 0');
+      }
+
+      final (spy, callback) = fn.spectatePrint;
+      check(spy.callCount).equals(0);
+      check(spy.prints).isEmpty;
+      check(spy.calls).isEmpty;
+
+      callback();
+      check(spy.callCount).equals(1);
+      check(spy.prints).deepEquals(['call 0']);
+      check(spy.calls).deepEquals([
+        ['call 0'],
+      ]);
+
+      callback();
+      check(spy.callCount).equals(2);
+      check(spy.prints).deepEquals(['call 0', 'call 0']);
+      check(spy.calls).deepEquals([
+        ['call 0'],
+        ['call 0'],
+      ]);
+    });
+
+    test('arity 1', () {
+      void fn(String a) {
+        print('arg: $a');
+      }
+
+      final (spy, callback) = fn.spectatePrint;
+      callback('one');
+      callback('two');
+      check(spy.callCount).equals(2);
+      check(spy.prints).deepEquals(['arg: one', 'arg: two']);
+      check(spy.calls).deepEquals([
+        ['arg: one'],
+        ['arg: two'],
+      ]);
+    });
+
+    test('arity 2', () {
+      void fn(String a, int b) {
+        print('$a:$b');
+      }
+
+      final (spy, callback) = fn.spectatePrint;
+      callback('val', 42);
+      check(spy.prints).deepEquals(['val:42']);
+    });
+
+    test('arity 3', () {
+      void fn(String a, int b, bool c) {
+        print('$a:$b:$c');
+      }
+
+      final (spy, callback) = fn.spectatePrint;
+      callback('val', 42, true);
+      check(spy.prints).deepEquals(['val:42:true']);
+    });
+
+    test('arity 4', () {
+      void fn(String a, int b, bool c, double d) {
+        print('$a:$b:$c:$d');
+      }
+
+      final (spy, callback) = fn.spectatePrint;
+      callback('val', 42, true, 3.14);
+      check(spy.prints).deepEquals(['val:42:true:3.14']);
+    });
+
+    test('arity 5', () {
+      void fn(String a, int b, bool c, double d, List<int> e) {
+        print('$a:$b:$c:$d:$e');
+      }
+
+      final (spy, callback) = fn.spectatePrint;
+      callback('val', 42, true, 3.14, [1]);
+      check(spy.prints).deepEquals(['val:42:true:3.14:[1]']);
+    });
+  });
+
+  group('PrintSpy asynchronous extensions', () {
+    test('arity 0', () async {
+      Future<void> fn() async {
+        print('async 0');
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        print('async 0 done');
+      }
+
+      final (spy, callback) = fn.spectatePrint;
+      await callback();
+      check(spy.callCount).equals(1);
+      check(spy.prints).deepEquals(['async 0', 'async 0 done']);
+      check(spy.calls).deepEquals([
+        ['async 0', 'async 0 done'],
+      ]);
+    });
+
+    test('arity 1', () async {
+      Future<void> fn(String a) async {
+        print('async $a');
+      }
+
+      final (spy, callback) = fn.spectatePrint;
+      await callback('hello');
+      check(spy.prints).deepEquals(['async hello']);
+    });
+
+    test('arity 2', () async {
+      Future<void> fn(String a, int b) async {
+        print('async $a:$b');
+      }
+
+      final (spy, callback) = fn.spectatePrint;
+      await callback('num', 7);
+      check(spy.prints).deepEquals(['async num:7']);
+    });
+
+    test('arity 3', () async {
+      Future<void> fn(String a, int b, bool c) async {
+        print('async $a:$b:$c');
+      }
+
+      final (spy, callback) = fn.spectatePrint;
+      await callback('val', 1, false);
+      check(spy.prints).deepEquals(['async val:1:false']);
+    });
+
+    test('arity 4', () async {
+      Future<void> fn(String a, int b, bool c, double d) async {
+        print('async $a:$b:$c:$d');
+      }
+
+      final (spy, callback) = fn.spectatePrint;
+      await callback('val', 1, false, 2.5);
+      check(spy.prints).deepEquals(['async val:1:false:2.5']);
+    });
+
+    test('arity 5', () async {
+      Future<void> fn(String a, int b, bool c, double d, String e) async {
+        print('async $a:$b:$c:$d:$e');
+      }
+
+      final (spy, callback) = fn.spectatePrint;
+      await callback('a', 1, true, 2.5, 'e');
+      check(spy.prints).deepEquals(['async a:1:true:2.5:e']);
+    });
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ workspace:
   - pkgs/checks
   - pkgs/checks_codegen
   - pkgs/checks_codegen/example
+  - pkgs/spectate
   - pkgs/test
   - pkgs/test_api
   - pkgs/test_core

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v6.7.2
+# Created with package:mono_repo v6.7.3
 
 # Support built in commands on windows out of the box.
 


### PR DESCRIPTION
Towards #994, #2671, #2742

The `prints` Matcher is not quite orthogonal to other expectations that
might be checked on a callback (#994).
The `expectAsync` pattern doesn't fit cleanly into the `package:checks`
patterns.

Solve both of these problems by implementing a separate, non-test
specific package which can "specate" on executing Dart code and record
details about the interactions. The records can then be checked with
typical expectation extensions.

TAG=agy
CONV=3f8ca85a-8236-4bd5-b7a1-26d64a8fb70a
